### PR TITLE
repo-polish — launch-prep polish across landing, docs, and OSS surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report something that isn't working as expected
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include error messages and stack traces.
+
+## Environment
+
+- SeldonFrame version: [e.g. 0.3.1]
+- Node.js version: [e.g. 20.10.0]
+- OS: [e.g. macOS 14.4]
+- Browser (if applicable): [e.g. Chrome 122]
+
+## Logs / screenshots
+
+Paste relevant logs or attach screenshots here.
+
+## Additional context
+
+Anything else that would help us reproduce or diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for SeldonFrame
+title: "[Feature] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem are you trying to solve? Who is affected and how often?
+
+## Proposed solution
+
+Describe the feature you'd like and how you imagine it working.
+
+## Alternatives considered
+
+Other approaches you've thought about and why they fall short.
+
+## Use case
+
+A concrete example of how you'd use this feature in your workflow.
+
+## Additional context
+
+Mockups, links, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+What does this PR change and why?
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Docs / chore
+
+## Related issue
+
+Closes #
+
+## Testing
+
+- [ ] `pnpm lint` passes
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm test:unit` passes
+- [ ] Manually verified the change in the browser (if UI)
+
+## Screenshots / GIFs
+
+(Required for UI changes)
+
+## Notes for reviewers
+
+Anything reviewers should focus on, schema/env changes, follow-up work, etc.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Code of Conduct
+
+## Our pledge
+
+The SeldonFrame community is committed to providing a welcoming, inclusive, and harassment-free experience for everyone.
+
+## Our standard
+
+We have adopted the **Contributor Covenant, version 2.1** as our code of conduct. The full text — including expected behavior, unacceptable behavior, enforcement responsibilities, scope, and enforcement guidelines — is available at:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+By participating in this project (issues, pull requests, Discord, or any other community space), you agree to abide by its terms.
+
+## Reporting
+
+If you experience or witness behavior that violates this code, please report it confidentially to:
+
+**max@seldonframe.com**
+
+Reports will be reviewed and investigated promptly and fairly. The project maintainers are obligated to respect the privacy and safety of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,45 +1,66 @@
-# Contributing to Seldon Frame
+# Contributing to SeldonFrame
 
-Thanks for helping improve Seldon Frame.
+Thanks for your interest in making SeldonFrame better. This guide covers how to set up the repo, the workflow we use, and what we look for in PRs.
 
-## Development Workflow
+## Welcome
 
-1. Fork the repository.
-2. Create a focused feature branch from `main`.
-3. Keep changes scoped to a single concern.
-4. Run quality checks locally:
-   - `pnpm lint`
-   - `pnpm build`
-5. Open a pull request with:
-   - clear summary
-   - screenshots or GIFs for UI changes
-   - notes about schema/env changes
+SeldonFrame is open source under MIT. Issues, bug reports, feature ideas, docs improvements, and code contributions are all welcome. If you're not sure where to start, drop into [Discord](https://discord.gg/sbVUu976NW) and ask.
 
-## Local Setup
+## Ways to contribute
+
+- **Report bugs** — file a [bug report issue](https://github.com/seldonframe/seldonframe/issues/new?template=bug_report.md).
+- **Request features** — open a [feature request issue](https://github.com/seldonframe/seldonframe/issues/new?template=feature_request.md) or discuss in Discord first.
+- **Improve docs** — fixes, clarifications, and new examples are all valuable.
+- **Build a block** — extend the marketplace with a new BLOCK.md.
+- **Ship code** — pick an issue labeled `good first issue` or `help wanted`.
+
+## Development setup
+
+Prerequisites:
+
+- Node.js 20 or newer
+- pnpm 9 or newer
+- A Postgres database (Neon, Supabase, or local)
 
 ```bash
+git clone https://github.com/seldonframe/seldonframe.git
+cd seldonframe
 pnpm install
 cp .env.example .env.local
 pnpm db:generate
-pnpm dev
+pnpm db:migrate
+pnpm dev:crm
 ```
 
-## Pull Request Guidelines
+Visit `http://localhost:3000`.
 
-- Prefer small, reviewable PRs over large mixed changes.
-- Preserve tenant scoping and auth boundaries.
-- Avoid introducing breaking API behavior without migration notes.
-- If you add environment variables, update `.env.example` and `README.md`.
+## Workflow
 
-## Reporting Issues
+1. Fork the repo and create a focused branch from `main`.
+2. Keep each PR scoped to one concern.
+3. Follow TDD where it applies — write a failing test before the production code.
+4. Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:unit` before pushing.
+5. Update docs and `.env.example` if your change adds config.
+6. Open a PR using the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
 
-Please include:
+## Code style
 
-- expected behavior
-- actual behavior
-- reproduction steps
-- logs/screenshots if relevant
+- TypeScript strict mode. No `any` without a comment justifying it.
+- Prettier + ESLint enforced via `pnpm lint`.
+- Prefer composition over inheritance.
+- Tenant scoping (`workspaceId` / `orgId`) is a hard invariant — never bypass it.
+- Commit messages follow conventional commits: `type(scope): subject`.
 
-## Code of Conduct
+## Pull request guidelines
 
-Be respectful and constructive. Harassment and abusive behavior are not tolerated.
+- Small and reviewable beats large and mixed.
+- Include screenshots or GIFs for UI changes.
+- Note any schema, env, or breaking-API changes in the PR body.
+- Link the issue you're closing (`Closes #123`).
+- Make sure CI is green before requesting review.
+
+## Questions
+
+- General questions → [Discord](https://discord.gg/sbVUu976NW)
+- Bug or feature → [GitHub Issues](https://github.com/seldonframe/seldonframe/issues)
+- Security → see [SECURITY.md](SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -1,215 +1,108 @@
-# Seldon Frame
+<div align="center">
 
-> Open source CRM framework that configures itself around your business model.
+# SeldonFrame
 
-Build once, fork endlessly, and ship niche-specific CRM systems with your own voice, pipeline, and workflows.
+**The open-source platform to build AI-native Business OS with natural language.**
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/seldonframe/crm&env=DATABASE_URL,AUTH_SECRET,NEXTAUTH_SECRET,NEXTAUTH_URL,NEXT_PUBLIC_APP_URL,ANTHROPIC_API_KEY,NEXT_PUBLIC_DEMO_READONLY)
-![Next.js](https://img.shields.io/badge/Next.js-16-black)
-![License](https://img.shields.io/badge/license-MIT-green)
-![TypeScript](https://img.shields.io/badge/TypeScript-Strict-blue)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-join-5865F2.svg)](https://discord.gg/sbVUu976NW)
 
-## Demo
+[Website](https://seldonframe.com) · [Docs](https://seldonframe.com/docs) · [Discord](https://discord.gg/sbVUu976NW) · [X](https://x.com/seldonframe)
 
-![Seldon Frame Demo](public/demo/soul-setup.gif)
-
-If the GIF does not load on your GitHub viewer, use the fallback notes in `DEMO_GIF.md`.
-
-## Why Seldon Frame
-
-Most OSS CRMs are finished products. Seldon Frame is a framework-first base you can shape into your own offer.
-
-- Multi-tenant by default (`orgId` on core records)
-- AI-assisted Soul onboarding that changes labels, tone, stages, and branding
-- Headless API + modern dashboard out of the box
-- Public intake forms + webhook-ready submission flow
-- Demo read-only mode for safe live previews (`NEXT_PUBLIC_DEMO_READONLY=true`)
-
-## Ecosystem at a Glance
-
-| Workspace | Role |
-| --- | --- |
-| `packages/crm` (`@seldonframe/crm`) | Product app (UI, routes, server actions, domain modules) |
-| `packages/core` (`@seldonframe/core`) | Shared primitives (event bus, telemetry, integrations, virality helpers) |
-| `packages/payments` (`@seldonframe/payments`) | Payment utilities and payment-domain logic |
-| `apps/web` | Marketing/web app workspace |
-| `apps/cloud` | Cloud app workspace |
-| `apps/pro` | Pro app workspace |
-
-## Blocks
-
-SeldonFrame is built as modular blocks. Each block can be enabled or disabled independently.
-
-### Built-in Blocks
-
-| Block | Description |
-| --- | --- |
-| CRM | Contacts, deals, and pipeline workflows |
-| Booking | Scheduling with public booking pages |
-| Landing Pages | Visual page builder and publishing |
-| Email | Templates and outbound email workflows |
-| Forms | Intake forms that create contacts |
-| Payments | Stripe Connect payment flows |
-| Automations | Trigger → condition → action workflows |
-
-### Block Marketplace
-
-Cloud Pro and Pro users can install additional blocks from the marketplace. Blocks are defined by universal BLOCK.md specs and generated to match host codebase patterns.
-
-Browse available blocks: marketplace (native, in-app)
-
-### Build a Block
-
-Anyone can create a BLOCK.md, a universal spec that describes block behavior.
-
-- Read the [`BLOCK.md Specification`](./BLOCK_MD_SPEC.md)
-- See [`example BLOCK.md files`](./blocks/examples/)
-- Read how souls and blocks relate in [`SOUL_SPEC.md`](./SOUL_SPEC.md)
-
-Blocks are the capability layer; soul is the identity layer that personalizes every installed block.
-
-## Showcase Packs
-
-Use these ready-to-fork niche presets:
-
-| Pack | Focus |
-| --- | --- |
-| `showcase/coaching` | Coaching and client transformation workflows |
-| `showcase/real-estate` | Lead-to-close property pipeline |
-| `showcase/agency` | Service delivery and account management |
-| `showcase/ecommerce` | Store-centric retention and lifecycle management |
-| `showcase/saas` | Trial-to-paid onboarding and expansion tracking |
-
-See `showcase/README.md` for usage details.
-
-## Integrations
-
-Seldon Frame uses a typed adapter system in `packages/core/src/integrations`.
-
-| Tier | Integrations |
-| --- | --- |
-| Tier 1 (bundled) | Stripe, Resend, SendGrid, Postmark, Google Calendar, Microsoft Graph, Claude |
-| Tier 2 (lazy-loaded by env) | Twilio, Google Meet, Zoom, UploadThing, S3/R2, Plausible, PostHog, OpenAI |
-
-Integration adapters expose:
-- `isConfigured()` for env readiness
-- `initialize(config)` for runtime setup
-- `healthCheck()` for operational status
-
-CRM booking integration behavior (current):
-- Provider resolution supports `zoom`, `google-meet`, `google-calendar`, `microsoft-graph`, fallback `manual`
-- Google Calendar sync is active in CRM booking flows when Google OAuth/env are configured
-
-## AI Capabilities
-
-| Capability | Behavior |
-| --- | --- |
-| Soul generation | Uses Anthropic when configured; deterministic templates otherwise |
-| Brand voice scaffolding | Generates labels, priorities, messaging style, and constraints |
-| Suggested intake form | Produces business-specific form fields |
-| Safe defaults | App remains usable without AI API keys |
-
-## SeldonFrame Pro
-
-SeldonFrame Pro is the commercial layer planned on top of OSS.
-
-Planned Pro surfaces:
-- Managed deployment controls and team governance
-- Premium starter packs and advanced templates
-- Enterprise auth/integration presets and support workflows
-- Operational tooling for agencies shipping many client instances
-
-## SeldonFrame Cloud Waitlist
-
-SeldonFrame Cloud is planned as a hosted experience for teams that want managed infra.
-
-Join the waitlist by opening a GitHub Discussion with title prefix `Cloud Waitlist` and your use case:
-- `https://github.com/seldonframe/crm/discussions`
-
-## Vibe Coder Playbook
-
-For builders shipping fast with AI coding tools:
-
-1. Pick a niche from `showcase/` and copy `framework.config.ts`.
-2. Import matching `soul-template.json` into your org.
-3. Run seed data (`pnpm db:seed-demo` or niche `seed.sql`).
-4. Keep `orgId` scoping intact in every query/mutation.
-5. Extend via `@seldonframe/core` before adding app-local duplicates.
-6. Finish every milestone with `pnpm build`.
-
-## Tech Stack
-
-| Layer | Choice |
-| --- | --- |
-| Frontend | Next.js App Router, React, Tailwind |
-| Auth | NextAuth v5 (Auth.js) |
-| Database | Neon PostgreSQL |
-| ORM | Drizzle ORM |
-| API | Next.js Route Handlers (`/api/v1`) |
-| AI | Anthropic Claude (optional) |
-| Package Manager | pnpm |
-
-## Quick Start
-
-```bash
-pnpm install
-cp .env.example .env.local
-pnpm db:generate
-pnpm db:migrate
-pnpm dev:crm
-```
-
-Visit `http://localhost:3000`.
-
-## Environment Variables
-
-| Variable | Required | Purpose |
-| --- | --- | --- |
-| `DATABASE_URL` | Yes | Neon PostgreSQL connection string |
-| `AUTH_SECRET` | Yes | Auth.js secret used by CRM auth layer |
-| `NEXTAUTH_URL` | Yes | Auth callback base URL |
-| `NEXTAUTH_SECRET` | Yes | Session/JWT encryption secret |
-| `NEXT_PUBLIC_APP_URL` | Yes | Public app origin |
-| `ANTHROPIC_API_KEY` | Optional | Enables AI Soul generation |
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Optional | Google OAuth |
-| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | Optional | GitHub OAuth |
-| `NEXT_PUBLIC_DEMO_READONLY` | Optional | Enables demo write-block mode |
-
-## Customization Guide
-
-Start here when building a niche edition:
-
-1. Edit `framework.config.ts` for global defaults.
-2. Update Soul templates in `packages/crm/src/lib/soul/templates`.
-3. Adjust schema-level fields in `packages/crm/src/db/schema` and generate migrations.
-4. Tune labels and stage logic in `packages/crm/src/lib/soul` and dashboard pages.
-5. Add your preset under `showcase/<niche>` with config + seed data.
-
-Detailed notes: `CUSTOMIZATION.md`.
-
-## Architecture
-
-- App routes: `packages/crm/src/app/(dashboard)`, `packages/crm/src/app/(auth)`, `packages/crm/src/app/(onboarding)`
-- API layer: `packages/crm/src/app/api/v1`
-- Domain actions: `packages/crm/src/lib/*/actions.ts`
-- Tenant-aware schema: `packages/crm/src/db/schema`
-- Runtime personalization: `packages/crm/src/lib/soul` + `packages/crm/src/components/soul`
-- Demo protections: `packages/crm/src/lib/demo` + `packages/crm/src/components/shared/demo-toast-provider.tsx`
-
-Recent CRM UI capabilities:
-- Split contact detail layout with right-side activity timeline
-- Inline contacts table cell editing
-- Deep command palette search across navigation + contacts + deals + pages + recent activity
-- Booking availability schedule (working hours/day), buffers, max bookings/day, and public timezone display
-
-## Contributing
-
-Contributions are welcome. Please read `CONTRIBUTING.md` before opening a PR.
-
-## License
-
-MIT — see `LICENSE`.
+</div>
 
 ---
 
-Built for developers, agencies, and builders who want to ship CRM systems faster.
+## An alternative to stitching together your stack
+
+An alternative to stitching together Zapier + HubSpot + Twilio + Stripe + Calendly + Notion for each client. SeldonFrame gives you composable primitives, a per-client identity layer, and agents that learn — all from one MCP-native platform you control.
+
+## What is SeldonFrame
+
+SeldonFrame is a Business OS framework. You describe what you want in natural language inside Claude Code; SeldonFrame scaffolds production-ready blocks, archetypes (multi-step agent workflows), and branded customer surfaces. One platform, many clients, fully owned.
+
+## Key features
+
+- 🧱 **Composable primitives** — 10 step types (wait, mcp_tool_call, conversation, await_event, llm_call, branch, request_approval, read_state, write_state, emit_event) that compose into any workflow.
+- 🎨 **Per-client branding** — every workspace gets its own theme, copy, voice, and customer portal.
+- 🧠 **Agents with memory (Soul)** — single source of truth that personalizes every block and remembers across runs.
+- 📊 **Closed-loop attribution** — every LLM call tracked and attributed to the workflow run that triggered it.
+- 💬 **Natural language scaffolding** — describe a block, an archetype, or a workspace; SeldonFrame generates code, admin UI, and tests.
+- 🛂 **Approval gates** — pause workflows for human review before sending or charging.
+- 🔌 **MCP-native** — install once with `claude mcp add seldonframe`, then drive everything from your IDE.
+- 🔑 **BYO LLM keys** — bring your own Anthropic / OpenAI key. We don't margin on tokens.
+- 🆓 **Open source, no lock-in** — MIT licensed. Self-host or run on our cloud.
+- 🧪 **Test mode** — exercise archetypes against simulated triggers before going live.
+
+## Quick start
+
+```bash
+claude mcp add seldonframe
+```
+
+```bash
+seldon init "my-workspace"
+```
+
+```bash
+seldon scaffold block customer-intake
+```
+
+```bash
+seldon agent create emergency-triage
+```
+
+Three minutes from install to a working Business OS. Full walkthrough in the [docs](https://seldonframe.com/docs/quickstart).
+
+## Screenshots
+
+> Demo video and screenshots coming soon. In the meantime, see the live [demo walkthrough](https://seldonframe.com/demo).
+
+## Who is it for
+
+**Build for yourself** — solo operators and indie founders who want a CRM, booking, intake, and agent automation without subscribing to six SaaS products.
+
+**Build for your clients** — agencies, consultants, and freelancers shipping branded Business OS deployments to multiple clients from one codebase.
+
+## Architecture
+
+Five primitives compose every workflow:
+
+- **Triggers** — events that start a run (SMS, form submit, schedule, webhook).
+- **Steps** — atomic operations (10 types) that move the workflow forward.
+- **Soul** — the workspace's memory and identity layer.
+- **Subscriptions** — long-lived event listeners that fan out to handlers.
+- **Blocks** — installable capability bundles (CRM, booking, intake, payments, etc.).
+
+Read the full [architecture overview](https://seldonframe.com/docs).
+
+## Infrastructure
+
+SeldonFrame integrates with the providers you already use:
+
+- **Twilio** — SMS and voice
+- **Resend** — transactional email
+- **Stripe** — payments and subscriptions
+- **Anthropic / OpenAI** — LLM calls (BYO key)
+
+## Pricing
+
+- **First workspace** — free forever, self-hosted or on our cloud.
+- **Additional workspaces** — $9/month each, hosted.
+
+Self-hosters pay nothing to SeldonFrame.
+
+## Contributing
+
+PRs welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening one.
+
+## Community
+
+- 💬 [Discord](https://discord.gg/sbVUu976NW)
+- 🐦 [X / @seldonframe](https://x.com/seldonframe)
+- 📚 [Docs](https://seldonframe.com/docs)
+- 🌐 [seldonframe.com](https://seldonframe.com)
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported versions
+
+SeldonFrame is pre-1.0. We support the latest `main` branch and the most recent tagged release. Older versions do not receive security patches — please upgrade.
+
+| Version | Supported |
+| --- | --- |
+| `main` | Yes |
+| Latest tagged release | Yes |
+| Older releases | No |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, email **max@seldonframe.com** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- The affected component or file paths
+- Your assessment of impact and severity
+- Any suggested mitigation
+
+You should receive an acknowledgment within 72 hours. We aim to triage and respond with a remediation plan within 7 days.
+
+## Disclosure process
+
+1. You report the issue privately to the email above.
+2. We confirm the issue and determine severity.
+3. We develop and test a fix in a private branch.
+4. We release the fix and publish a security advisory crediting the reporter (unless anonymity is requested).
+
+## Out of scope
+
+- Vulnerabilities in dependencies that have already been disclosed upstream — please file those with the upstream project.
+- Issues requiring physical access to a user's device.
+- Social engineering of SeldonFrame staff or users.
+- Self-XSS that requires the victim to paste attacker-controlled code into their own console.
+
+## Thank you
+
+Responsible disclosure makes SeldonFrame safer for everyone. We're grateful for the time and effort security researchers put into reviewing the project.

--- a/packages/crm/src/app/(public)/docs/page.tsx
+++ b/packages/crm/src/app/(public)/docs/page.tsx
@@ -325,7 +325,14 @@ export default function DocsPage() {
         </section>
 
         <div className="grid gap-6 lg:grid-cols-[220px,minmax(0,1fr)] xl:grid-cols-[220px,minmax(0,1fr),360px]">
-          <aside className="h-fit rounded-3xl border border-zinc-800/90 bg-zinc-950/75 p-4 shadow-(--shadow-xs) lg:sticky lg:top-6">
+          {/*
+            Repo-polish C2: sidebar background was bg-zinc-950/75 (75%
+            opaque) which let scrolled content bleed through visually
+            on /docs. Switched to fully-opaque bg-[#0a0a0a] (matches
+            the <main> page background) + z-10 so the sticky sidebar
+            renders cleanly above content at every scroll position.
+          */}
+          <aside className="h-fit rounded-3xl border border-zinc-800/90 bg-[#0a0a0a] p-4 shadow-(--shadow-xs) lg:sticky lg:top-6 lg:z-10">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-500">On this page</p>
             <nav className="mt-4 space-y-1.5">
               {navSections.map((section) => (

--- a/packages/crm/src/app/(public)/landing-client.tsx
+++ b/packages/crm/src/app/(public)/landing-client.tsx
@@ -237,6 +237,7 @@ const Features = () => {
 
 const HowItWorks = () => {
   const steps = [
+    { title: "Install via MCP", desc: "One command in Claude Code. SeldonFrame connects to your IDE via Model Context Protocol.", code: "claude mcp add seldonframe" },
     { title: "Initialize a workspace", desc: "Create a branded workspace. Theme, copy, and portal configured via natural language.", code: "\"Init workspace for Desert Cool HVAC. Phoenix, AZ. Family-business voice. Desert tans, AC-blue accents.\"" },
     { title: "Scaffold what you need", desc: "Describe a block and SeldonFrame generates production-ready code with admin UI, portal surfaces, and tests.", code: "\"Scaffold hvac-equipment block. Track units per customer: install date, brand, model, warranty, last service.\"" },
     { title: "Compose agent flows", desc: "Wire multi-step workflows from primitives. Triggers, branches, SMS, email, approval gates — all composable.", code: "\"Add emergency-triage archetype. Trigger on SMS 'AC NOT WORKING'. Check weather. Priority-route if heat >100°F. Dispatch nearest tech.\"" },
@@ -246,10 +247,10 @@ const HowItWorks = () => {
     <section className="text-center py-[64px] md:py-[100px] px-5 md:px-12 max-w-[1140px] mx-auto">
       <h2 className="text-[clamp(26px,3.5vw,38px)] font-bold tracking-[-0.03em] mb-4 text-[#fafafa]">How it works</h2>
       <p className="text-[16px] text-[#a1a1aa] max-w-[560px] mx-auto mb-12">
-        Three prompts. About six minutes. A complete Business OS, ready to deploy.
+        Four steps. About six minutes. A complete Business OS, ready to deploy.
       </p>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-5">
         {steps.map((step, i) => (
           <motion.div
             key={step.title}

--- a/tasks/repo-polish-pr-body.md
+++ b/tasks/repo-polish-pr-body.md
@@ -1,0 +1,51 @@
+# repo-polish — launch-prep polish across landing, docs, and OSS surface
+
+## Summary
+
+Five small commits that close the last cosmetic + OSS-hygiene gaps before launch:
+
+1. **C1** `65b4efa6` — Landing "How it works" went from 3 steps to **4 steps** with `claude mcp add seldonframe` as step 1 (the install primitive was implicit before). Grid responsive breakpoint updated to `md:grid-cols-2 lg:grid-cols-4` and subtitle copy updated to "Four steps."
+2. **C2** `b1f2f8fa` — `/docs` sticky "On this page" sidebar was 75% translucent, causing scrolled content to bleed through. Made fully opaque (`bg-[#0a0a0a]` matching the page background) and added `lg:z-10` so it always sits above scrolling content. Inline comment explains the intentional divergence from the surrounding `bg-zinc-950/65` convention.
+3. **C3** `11728b01` — Replaced the framework-era README.md with a launch-ready, positioning-led, scannable rewrite. 11 sections: hero, alternative-to positioning, what-is, key features (10 bullets with emojis), 3-min quickstart, screenshots placeholder, who-it's-for, 5-primitive architecture, infrastructure, pricing, contributing/community/license. All URLs point to `github.com/seldonframe/seldonframe` + the permanent Discord invite + `seldonframe.com`.
+4. **C4** `5ae7fb31` — Rewrote CONTRIBUTING.md around the actual contribution flow: welcome, ways to contribute, dev setup, workflow (TDD reference + lint/typecheck/test commands), code style (TS strict, conventional commits, tenant scoping invariant), PR guidelines, and where to ask questions.
+5. **C5** `688b4aac` — Added the OSS hygiene set GitHub expects on a launching repo:
+   - `.github/ISSUE_TEMPLATE/bug_report.md`
+   - `.github/ISSUE_TEMPLATE/feature_request.md`
+   - `.github/PULL_REQUEST_TEMPLATE.md`
+   - `CODE_OF_CONDUCT.md` — adopts Contributor Covenant 2.1 by reference; enforcement contact `max@seldonframe.com`
+   - `SECURITY.md` — private disclosure to `max@seldonframe.com`, 72h ack / 7d remediation plan
+
+## Verification
+
+- `pnpm --filter @seldonframe/crm typecheck` — clean
+- `pnpm test:unit` — **1858 pass / 0 fail / 12 todo** (same baseline as SLICE 11 close-out — no regression)
+- C1 + C2 are markup-only inside existing components; no schema, no behavior change.
+- C3 + C4 + C5 are pure docs / repo-meta, no executable code.
+
+## What this does NOT touch
+
+- No code in `packages/crm/src/lib/**`
+- No schema migrations
+- No env vars
+- No agent / workflow runtime
+- No marketing copy outside the landing "How it works" section + the README
+
+## Vercel preview
+
+Branch: `claude/repo-polish` at HEAD `688b4aac`. Preview will be available at the standard Vercel branch URL once the deploy completes.
+
+## Suggested merge
+
+Standard merge commit (consistent with SLICE 9, 10, 11, marketing-website pattern). No squash.
+
+## After merge
+
+Branch cleanup as usual:
+
+```bash
+cd "C:/Users/maxim/CascadeProjects/Seldon Frame"
+git fetch origin --prune
+git worktree remove .claude/worktrees/repo-polish
+git branch -D claude/repo-polish
+git push origin --delete claude/repo-polish
+```


### PR DESCRIPTION
## Summary

Five small commits that close the last cosmetic + OSS-hygiene gaps before launch:

1. **C1** `65b4efa6` — Landing "How it works" went from 3 steps to **4 steps** with `claude mcp add seldonframe` as step 1 (the install primitive was implicit before). Grid responsive breakpoint updated to `md:grid-cols-2 lg:grid-cols-4` and subtitle copy updated to "Four steps."
2. **C2** `b1f2f8fa` — `/docs` sticky "On this page" sidebar was 75% translucent, causing scrolled content to bleed through. Made fully opaque (`bg-[#0a0a0a]` matching the page background) and added `lg:z-10` so it always sits above scrolling content. Inline comment explains the intentional divergence from the surrounding `bg-zinc-950/65` convention.
3. **C3** `11728b01` — Replaced the framework-era README.md with a launch-ready, positioning-led, scannable rewrite. 11 sections: hero, alternative-to positioning, what-is, key features (10 bullets with emojis), 3-min quickstart, screenshots placeholder, who-it's-for, 5-primitive architecture, infrastructure, pricing, contributing/community/license. All URLs point to `github.com/seldonframe/seldonframe` + the permanent Discord invite + `seldonframe.com`.
4. **C4** `5ae7fb31` — Rewrote CONTRIBUTING.md around the actual contribution flow: welcome, ways to contribute, dev setup, workflow (TDD reference + lint/typecheck/test commands), code style (TS strict, conventional commits, tenant scoping invariant), PR guidelines, and where to ask questions.
5. **C5** `688b4aac` — Added the OSS hygiene set GitHub expects on a launching repo:
   - `.github/ISSUE_TEMPLATE/bug_report.md`
   - `.github/ISSUE_TEMPLATE/feature_request.md`
   - `.github/PULL_REQUEST_TEMPLATE.md`
   - `CODE_OF_CONDUCT.md` — adopts Contributor Covenant 2.1 by reference; enforcement contact `max@seldonframe.com`
   - `SECURITY.md` — private disclosure to `max@seldonframe.com`, 72h ack / 7d remediation plan

## Verification

- `pnpm --filter @seldonframe/crm typecheck` — clean
- `pnpm test:unit` — **1858 pass / 0 fail / 12 todo** (same baseline as SLICE 11 close-out — no regression)
- C1 + C2 are markup-only inside existing components; no schema, no behavior change.
- C3 + C4 + C5 are pure docs / repo-meta, no executable code.

## What this does NOT touch

- No code in `packages/crm/src/lib/**`
- No schema migrations
- No env vars
- No agent / workflow runtime
- No marketing copy outside the landing "How it works" section + the README

## Vercel preview

Branch: `claude/repo-polish` at HEAD `dc698324`. Preview will be available at the standard Vercel branch URL once the deploy completes.

## Suggested merge

Standard merge commit (consistent with SLICE 9, 10, 11, marketing-website pattern). No squash.