### PR TITLE
mcp: harden @seldonframe/mcp v1.0.0 for npm publish (Branch 1 of 2 — fixes P0 launch blocker)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "description": "SeldonFrame Business OS — one command creates a real hosted workspace on *.app.seldonframe.com with CRM, Cal.diy booking, Formbricks intake, and Brain v2. No key, no signup, no setup. Set SELDONFRAME_API_KEY only to unlock Pro capabilities (second workspace, custom domains, full Brain v2).",
   "homepage": "https://seldonframe.com",
-  "repository": "https://github.com/seldonframe/crm",
+  "repository": "https://github.com/seldonframe/seldonframe",
   "author": "SeldonFrame",
   "license": "MIT",
   "keywords": ["crm", "business-os", "booking", "intake", "brain"],

--- a/skills/mcp-server/README.md
+++ b/skills/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @seldonframe/mcp-server
+# @seldonframe/mcp
 
 Official SeldonFrame MCP server for Claude Code and Claude Desktop.
 
@@ -67,11 +67,16 @@ The repo ships a `.claude-plugin/plugin.json` at the root. From inside Claude Co
 /plugin install <path-to-repo>
 ```
 
-## Install via npm (once published)
+## Install via npm
 
 ```bash
-claude mcp add seldonframe -s user -- npx -y @seldonframe/mcp-server@latest
+claude mcp add seldonframe -- npx -y @seldonframe/mcp
 ```
+
+This is the canonical install command surfaced on the marketing site,
+the `/docs/quickstart` page, and the repo README. It uses `npx -y`
+so users never have to globally install anything; the latest version
+is fetched and run on demand.
 
 ## Environment
 

--- a/skills/mcp-server/package-lock.json
+++ b/skills/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@seldonframe/mcp-server",
-  "version": "1.7.0",
+  "name": "@seldonframe/mcp",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@seldonframe/mcp-server",
-      "version": "1.7.0",
+      "name": "@seldonframe/mcp",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
@@ -84,9 +84,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.7.tgz",
-      "integrity": "sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/skills/mcp-server/package.json
+++ b/skills/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@seldonframe/mcp-server",
-  "version": "2.1.0",
-  "description": "Official SeldonFrame MCP server. One command creates a real hosted workspace on *.app.seldonframe.com with CRM, Cal.diy booking, Formbricks intake, and Brain v2 — no key, no signup, no setup.",
+  "name": "@seldonframe/mcp",
+  "version": "1.0.0",
+  "description": "MCP server for SeldonFrame — AI-native Business OS platform. One command creates a real hosted workspace with CRM, booking, intake, and Brain v2.",
   "type": "module",
   "bin": {
     "seldonframe-mcp": "src/index.js"
@@ -23,14 +23,20 @@
     "mcp",
     "model-context-protocol",
     "seldonframe",
-    "claude",
-    "crm",
-    "business-os"
+    "ai",
+    "agents",
+    "business-os",
+    "claude-code",
+    "crm"
   ],
   "license": "MIT",
+  "homepage": "https://seldonframe.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/seldonframe/crm",
+    "url": "https://github.com/seldonframe/seldonframe",
     "directory": "skills/mcp-server"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/skills/mcp-server/src/welcome.js
+++ b/skills/mcp-server/src/welcome.js
@@ -1,4 +1,4 @@
-export const VERSION = "2.1.0";
+export const VERSION = "1.0.0";
 
 export const WELCOME_MARKDOWN = `# SeldonFrame — your AI-native Business OS
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1800,6 +1800,75 @@ C4 close-out with empirical SLICE 11 data.
 
 ---
 
+## L-29 — Distribution path must be tested end-to-end on a clean environment before any marketing claims reference it
+
+- **Trigger:** Pre-launch test protocol surfaced that the SeldonFrame
+  MCP install command shown on every marketing surface
+  (`claude mcp add seldonframe`) didn't work on a clean GitHub Codespaces
+  environment. The short form errored with "missing required argument
+  'commandOrUrl'", the corrected long form referenced an npm package
+  (`@seldonframe/mcp`) that was never published, and the MCP server
+  failed to spawn — Claude Code reported zero SeldonFrame tools available.
+
+  Root cause: the development environment uses a path-linked local MCP
+  server registration in `~/.claude.json` pointing at a worktree's
+  `skills/mcp-server/src/index.js`. Every dev-machine "test" of the
+  install command silently resolved through this local path instead of
+  exercising the published-package code path. SLICE 9 / 10 / 11 / repo-polish
+  / marketing-website all applied L-27 (Vercel preview verification) and
+  test-suite green bars correctly, but no slice ever validated the
+  `claude mcp add seldonframe` install path against a published artifact.
+
+  The gap was caught on day-1 of cleanroom protocol execution. Marketing
+  copy on landing page, `/docs/quickstart`, README hero, and the
+  How-it-works step-1 card all advertised an unfulfillable command.
+
+- **Rule:** Before any marketing surface (landing page, docs, README,
+  hero terminal, blog) shows an install command, that exact command
+  must succeed on a fresh environment with no local code, no cached
+  dependencies, and no pre-configured environment variables. The test
+  must be run by someone following only the published documentation.
+
+  **"Works on my machine" is not "works."** Distribution-path verification
+  is as important as architectural verification (L-27 Vercel-preview,
+  L-28 credential format-breaking).
+
+  **Cleanroom definition:** any of the following qualifies as a clean
+  environment for distribution verification:
+  - GitHub Codespaces created from `main`
+  - A fresh OS user account on a workstation
+  - A Docker container with only the published prereqs installed
+  - A throwaway VM (UTM, VirtualBox, cloud)
+
+  **The dev machine does not qualify**, even with `~/.claude` renamed
+  away — global npm packages, shell PATH entries, and existing process
+  env vars contaminate the test.
+
+  **Application:** any slice that introduces or modifies a
+  distribution-facing artifact (`npx`, `npm install`, `pip install`,
+  `docker run`, `claude mcp add`, `gh extension install`, etc.) MUST
+  include a cleanroom-test step in its green-bar checklist. The slice
+  is not done until the published artifact has been exercised by an
+  agent or human following only the public documentation.
+
+  **Audit-time application:** when scoping a slice that ships or
+  modifies a distribution artifact, the §3 schema section MUST include
+  "L-29 cleanroom verification" as an explicit completion gate, not
+  implicit. Pre-empts the launch-week discovery of the same gap.
+
+  **Sign-off requirement:** the cleanroom verification result (which
+  environment, what command, what outcome) is recorded in the slice's
+  close-out document. A green dev-machine test is not a sign-off
+  artifact for a distribution-facing change.
+
+  **Background:** the v1 launch-prep MCP install gap shipped through
+  five marketing surfaces because no slice ever ran the cleanroom
+  test. The pre-launch test protocol added in PR #8 codified this
+  step formally; L-29 elevates it from a launch-only protocol step
+  to a permanent green-bar discipline rule.
+
+---
+
 ## Template for new entries
 
 ```

--- a/tasks/npm-publish-instructions.md
+++ b/tasks/npm-publish-instructions.md
@@ -1,0 +1,209 @@
+# npm publish — manual instructions for `@seldonframe/mcp` v1.0.0
+
+**For:** Max
+**When to run:** after `claude/publish-mcp-package` is merged to `main`
+**Estimated time:** 10 minutes (5 min publish, 5 min verify)
+**Per:** L-29 — distribution path must be tested end-to-end on a clean environment before any marketing claims reference it.
+
+---
+
+## Pre-flight (one-time setup if you haven't done this before)
+
+### 1. Confirm npm account membership
+
+Verify you're a member of the `seldonframe` npm org:
+
+```bash
+npm org ls seldonframe
+```
+
+You should see your username with role `owner` or `admin`. If you see `404 Not Found` or you're listed as `developer` only, contact whoever owns the org. (When this doc was written, `npm org ls seldonframe` returned at least one `owner` from a non-authenticated query — the org is claimed.)
+
+### 2. Authenticate npm CLI
+
+```bash
+npm login
+```
+
+Use your npmjs.com credentials. After login, verify:
+
+```bash
+npm whoami    # should print your npm username
+```
+
+### 3. Enable 2FA for publish (recommended, not strictly required)
+
+If you've never enabled 2FA, do it at <https://www.npmjs.com/settings/~/profile> first. With 2FA on, `npm publish` will prompt for an OTP code — copy it from your authenticator app.
+
+---
+
+## Publish flow
+
+### Step 1 — Switch to the freshly-merged `main`
+
+```bash
+cd "/path/to/seldonframe"
+git fetch origin
+git checkout main
+git pull origin main
+```
+
+Verify the merge commit for `claude/publish-mcp-package` is at HEAD:
+
+```bash
+git log --oneline -3
+# Should show the merge commit referencing claude/publish-mcp-package
+```
+
+### Step 2 — `cd` into the package and verify package.json
+
+```bash
+cd skills/mcp-server
+cat package.json | head -10
+```
+
+Expected (verbatim — confirm before publishing):
+
+```json
+{
+  "name": "@seldonframe/mcp",
+  "version": "1.0.0",
+  ...
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+If `name`, `version`, or `publishConfig` look wrong, **stop** and investigate before publishing — npm publishes are not trivially reversible (unpublish has a 72-hour window and creates a permanent name reservation).
+
+### Step 3 — Dry-run the publish
+
+```bash
+npm publish --dry-run
+```
+
+Review the output:
+- `package size` should be ~22 KB (matches the local `npm pack` from the publish-prep branch)
+- `total files` should be 6 (`README.md`, `package.json`, `src/index.js`, `src/welcome.js`, `src/tools.js`, `src/client.js`)
+- No surprise files (no `node_modules`, no `.env`, no `tasks/`, no `package-lock.json`)
+
+If the file list looks wrong, **stop** — the `files` field in `package.json` (or an `.npmignore`) is misconfigured.
+
+### Step 4 — Real publish
+
+```bash
+npm publish --access public
+```
+
+If 2FA is on, you'll be prompted for an OTP. Copy from your authenticator.
+
+Successful output ends with:
+```
++ @seldonframe/mcp@1.0.0
+```
+
+If you see `403 Forbidden`, common causes:
+- Not logged in (`npm login` again)
+- Not a member of `@seldonframe` org with publish rights
+- Wrong scope or `publishConfig.access` not set to `public`
+
+---
+
+## Verify (mandatory — do not skip)
+
+This is the L-29 cleanroom verification step. It must be performed in an environment that has never run SeldonFrame development.
+
+### Option A — fresh GitHub Codespace (recommended, ~5 min)
+
+1. Open <https://github.com/codespaces/new?repo=seldonframe/seldonframe&ref=main>
+2. Create a new Codespace (DO NOT reuse an existing one — caches contaminate the test)
+3. In the Codespace terminal:
+
+```bash
+# Verify package is live on npm
+npm view @seldonframe/mcp
+# Should show: name, version 1.0.0, dist-tags, etc.
+
+# Install Claude Code (if not already there)
+npm install -g @anthropic-ai/claude-code
+
+# Set your Anthropic key (use the same key as your protocol test)
+export ANTHROPIC_API_KEY=sk-ant-api03-...
+
+# Register the MCP server using the canonical command
+claude mcp add seldonframe -- npx -y @seldonframe/mcp
+
+# Start Claude Code
+claude
+```
+
+4. Inside the Claude Code session, verify the server connects:
+
+```
+/mcp
+```
+
+Expected: `seldonframe   ✓ Connected` (NOT `Failed to reconnect`).
+
+5. Ask Claude to confirm tools are available:
+
+```
+What SeldonFrame tools do you have?
+```
+
+Expected: Claude lists at least `create_workspace`, `list_workspaces`, `query_brain` ... wait, that's stale. Should list `create_workspace`, `get_workspace_snapshot`, `install_caldiy_booking`, `install_formbricks_intake`, etc. (75 tools total).
+
+6. Smoke-test a tool call:
+
+```
+create_workspace({ name: "Cleanroom Test" })
+```
+
+Expected: Claude responds with workspace details — a `wsp_*` ID and live URLs at `cleanroom-test.app.seldonframe.com`.
+
+### Option B — fresh OS user account on your machine (~10 min)
+
+Same flow as Option A, but in a brand-new OS user. Slower setup, but works without internet for the npm prereqs (Codespaces sometimes has slow startup on first launch).
+
+---
+
+## After verify passes
+
+✅ **Reply `npm publish confirmed + cleanroom verified` in the active branch's PR / chat thread.**
+
+This unblocks Branch 2 (`claude/fix-marketing-install`) — the marketing-copy update that points all five user-facing surfaces (landing page hero + How-it-works step 1, `/docs/quickstart`, README) at the working install command.
+
+**Per L-29 + Max's two-branch sequencing rule:** marketing copy must NOT change until the npm package is live AND the install command has been verified to work in a cleanroom. Otherwise the marketing surfaces re-introduce the same launch-blocker for any user who reads the new copy before the package is live.
+
+---
+
+## If something goes wrong
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `403 Forbidden` on publish | Not logged in, or not a member of the org | `npm login` and verify `npm org ls seldonframe` |
+| `EPUBLISHCONFLICT` / "version already exists" | Someone (or a previous attempt) already published 1.0.0 | Bump to `1.0.1` in `package.json` and republish |
+| `npm view @seldonframe/mcp` returns 404 after publish | Registry propagation delay (rare) | Wait 60 seconds, retry. If still 404 after 5 min, escalate. |
+| `claude mcp add` succeeds but `/mcp` shows `Failed to reconnect` | npx download or server boot failed | In Codespace: `npx -y @seldonframe/mcp < /dev/null` to see the actual error |
+| Server boots but tool calls return network errors | `app.seldonframe.com/api/v1` unreachable from the Codespace | Verify `https://app.seldonframe.com` is up; check firewall / VPN |
+
+## Rollback
+
+If the package is published but unusable and you need to take it offline:
+
+```bash
+npm unpublish @seldonframe/mcp@1.0.0    # only works within 72h of publish
+```
+
+After 72h, you cannot unpublish — you must publish a new version. Mark the bad version as deprecated:
+
+```bash
+npm deprecate @seldonframe/mcp@1.0.0 "Broken — use 1.0.1+"
+```
+
+Then publish 1.0.1 with the fix.
+
+---
+
+*Doc generated by `claude/publish-mcp-package`. Update this file if the publish process changes.*


### PR DESCRIPTION
## Summary

Branch 1 of 2 in the P0 launch-blocker fix sequence (per investigation in `tasks/mcp-install-investigation.md`).

Hardens `skills/mcp-server/` for its first-ever npm publish as `@seldonframe/mcp@1.0.0`. After this PR merges, Max manually publishes via the new `tasks/npm-publish-instructions.md` doc and verifies in a fresh GitHub Codespace per L-29. Only then does Branch 2 (`claude/fix-marketing-install`) begin.

## Commits

| # | Commit | Scope |
|---|---|---|
| C1+C2 | `2434d6de` | Package metadata (rename to `@seldonframe/mcp`, version `1.0.0`, `publishConfig.access: public`, all keywords/repo/homepage). Welcome banner audited and confirmed already clean. |
| C3 | `cfd8b77c` | L-29 added to `tasks/lessons.md` |
| C4 | `8e8508d5` | `tasks/npm-publish-instructions.md` — manual publish + cleanroom-verify flow |

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo (no regression)
- `npm pack` produces a 22.1 KB / 6-file tarball under the right name
- Cleanroom-style local install + boot test exits 0

## What this does NOT do

- Does NOT publish to npm — Max does that manually post-merge per `tasks/npm-publish-instructions.md`
- Does NOT update marketing copy — that's Branch 2, gated on Max confirming the publish + cleanroom verification

## Sequencing (per Max's two-branch rule + new L-29)

1. ⏳ This PR merges
2. 🔑 Max runs `tasks/npm-publish-instructions.md` end-to-end (npm publish + Codespaces cleanroom verify)
3. ✅ Max replies "npm publish confirmed + cleanroom verified"
4. ⏳ Branch 2 starts (claude/fix-marketing-install — updates 5 marketing surfaces)
5. ⏳ Branch 2 merges
6. 🧪 Max re-runs pre-launch test protocol §3.1 from a NEW Codespace
7. ✅ Section 3.1 passes → unblocks remaining protocol sections + launch

Branch 2 is intentionally NOT started yet. The whole point of L-29 is to verify the distribution path works before any marketing claim references it.