### PR TITLE
mcp: runtime Node version gate + bump to 1.0.1 (P0 cleanroom-test fix)

### DIFF
--- a/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
@@ -67,11 +67,65 @@ export default function QuickstartPage() {
             </li>
             <li className="flex items-start gap-2">
               <span className="text-[#1FAE85] text-[12px] font-bold mt-[3px] shrink-0">✓</span>
-              <span>Node.js 20 or newer</span>
+              <span>Node.js 18 or newer (Node 20 recommended)</span>
             </li>
             <li className="flex items-start gap-2">
               <span className="text-[#1FAE85] text-[12px] font-bold mt-[3px] shrink-0">✓</span>
               <span>An Anthropic API key (BYO — SeldonFrame doesn&apos;t margin on tokens)</span>
+            </li>
+          </ul>
+        </section>
+
+        {/*
+          Codespaces / WSL / SSH-remote callout. Surfaces friction
+          surfaced by the L-29 cleanroom test (Findings #1, #2, #3, #8
+          in the pre-launch test protocol). Better to warn users
+          upfront than have them discover the gotchas mid-install.
+        */}
+        <section className="mb-10 bg-[#111113] border border-[#fbbf24]/20 rounded-[12px] p-5 md:p-6">
+          <p className="text-[12px] uppercase tracking-[0.12em] text-[#fbbf24] font-mono mb-3">
+            Running in Codespaces, WSL, or SSH remote?
+          </p>
+          <ul className="space-y-2 text-[13px] text-[#a1a1aa] leading-[1.65]">
+            <li className="flex items-start gap-2">
+              <span className="text-[#a1a1aa] mt-[2px] shrink-0">·</span>
+              <span>
+                <strong className="text-[#d4d4d8]">Node version:</strong> Codespaces default
+                images sometimes ship Node 16. SeldonFrame requires Node 18+. Run{" "}
+                <code className="font-mono text-[#1FAE85]">nvm install 20 &amp;&amp; nvm use 20</code>{" "}
+                if{" "}
+                <code className="font-mono text-[#1FAE85]">node --version</code> shows v16 or v17.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-[#a1a1aa] mt-[2px] shrink-0">·</span>
+              <span>
+                <strong className="text-[#d4d4d8]">Claude Code OAuth:</strong> the OAuth callback
+                points at <code className="font-mono text-[#1FAE85]">localhost</code>, which
+                your local browser can&apos;t reach when Claude Code runs in a remote VM. Use
+                the API key path instead:{" "}
+                <code className="font-mono text-[#1FAE85]">export ANTHROPIC_API_KEY=sk-ant-...</code>
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-[#a1a1aa] mt-[2px] shrink-0">·</span>
+              <span>
+                <strong className="text-[#d4d4d8]">Web-terminal paste:</strong> some
+                browser-based terminals block <code className="font-mono text-[#1FAE85]">Ctrl+V</code>.
+                Use{" "}
+                <code className="font-mono text-[#1FAE85]">Ctrl+Shift+V</code> or right-click → Paste.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="text-[#a1a1aa] mt-[2px] shrink-0">·</span>
+              <span>
+                <strong className="text-[#d4d4d8]">npm cache 404 after publish:</strong> if
+                you ever query a package before it&apos;s published, npm caches the 404.
+                After publishing, run{" "}
+                <code className="font-mono text-[#1FAE85]">npm cache clean --force</code>{" "}
+                if{" "}
+                <code className="font-mono text-[#1FAE85]">npm view</code> still 404s.
+              </span>
             </li>
           </ul>
         </section>

--- a/skills/mcp-server/package-lock.json
+++ b/skills/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seldonframe/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seldonframe/mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"

--- a/skills/mcp-server/package.json
+++ b/skills/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seldonframe/mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server for SeldonFrame — AI-native Business OS platform. One command creates a real hosted workspace with CRM, booking, intake, and Brain v2.",
   "type": "module",
   "bin": {

--- a/skills/mcp-server/src/index.js
+++ b/skills/mcp-server/src/index.js
@@ -1,12 +1,44 @@
 #!/usr/bin/env node
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import {
-  CallToolRequestSchema,
-  ListToolsRequestSchema,
-} from "@modelcontextprotocol/sdk/types.js";
-import { WELCOME_MARKDOWN, VERSION } from "./welcome.js";
-import { TOOLS, TOOL_MAP } from "./tools.js";
+
+// Node version gate — must run before any imports that could fail or
+// reach for fetch(). Without this, Node 16 users get a cryptic
+// "fetch is not defined" crash the moment the first tool calls the
+// SeldonFrame API.
+//
+// Per L-29 the cleanroom test in GitHub Codespaces (default image
+// ships Node v16.20.2 in some configurations) surfaced this
+// immediately on @seldonframe/mcp@1.0.0. Strict requirement is
+// documented in engines.node = ">=18" and reinforced here at runtime
+// so users get actionable next-steps instead of a stack trace.
+//
+// Implementation note: we use dynamic `await import()` for the SDK
+// modules below specifically so this gate runs BEFORE any SDK code
+// executes. Static `import` statements at the top of an ESM module
+// are hoisted and evaluated before any module-body code, which would
+// defeat the gate if the SDK ever started failing at import-time on
+// older Node versions.
+const [nodeMajor] = process.versions.node.split(".").map(Number);
+if (nodeMajor < 18) {
+  process.stderr.write(
+    `\n  SeldonFrame MCP requires Node.js 18 or later.\n` +
+      `  You are running Node.js ${process.versions.node}.\n\n` +
+      `  To fix:\n` +
+      `    nvm install 18 && nvm use 18\n` +
+      `  Or:\n` +
+      `    nvm install 20 && nvm use 20\n\n` +
+      `  Then retry:\n` +
+      `    claude mcp add seldonframe -- npx -y @seldonframe/mcp\n\n`,
+  );
+  process.exit(1);
+}
+
+const { Server } = await import("@modelcontextprotocol/sdk/server/index.js");
+const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
+const { CallToolRequestSchema, ListToolsRequestSchema } = await import(
+  "@modelcontextprotocol/sdk/types.js"
+);
+const { WELCOME_MARKDOWN, VERSION } = await import("./welcome.js");
+const { TOOLS, TOOL_MAP } = await import("./tools.js");
 
 const server = new Server(
   { name: "seldonframe", version: VERSION },

--- a/skills/mcp-server/src/welcome.js
+++ b/skills/mcp-server/src/welcome.js
@@ -1,4 +1,4 @@
-export const VERSION = "1.0.0";
+export const VERSION = "1.0.1";
 
 export const WELCOME_MARKDOWN = `# SeldonFrame — your AI-native Business OS
 

--- a/tasks/npm-publish-instructions.md
+++ b/tasks/npm-publish-instructions.md
@@ -1,9 +1,12 @@
-# npm publish — manual instructions for `@seldonframe/mcp` v1.0.0
+# npm publish — manual instructions for `@seldonframe/mcp`
 
+**Current target version:** `1.0.1` (Node-compat fix — see `claude/mcp-fix-node-compat`).
 **For:** Max
-**When to run:** after `claude/publish-mcp-package` is merged to `main`
-**Estimated time:** 10 minutes (5 min publish, 5 min verify)
+**When to run:** after the relevant publish-prep branch is merged to `main`.
+**Estimated time:** 10 minutes (5 min publish, 5 min verify).
 **Per:** L-29 — distribution path must be tested end-to-end on a clean environment before any marketing claims reference it.
+
+> **History:** `1.0.0` was published 2026-04-27 from `claude/publish-mcp-package` and surfaced a Node-16 fetch crash within hours via cleanroom test. `1.0.1` adds a runtime Node version gate so users on Node < 18 get a clear actionable error instead of `fetch is not defined`.
 
 ---
 
@@ -98,15 +101,42 @@ npm publish --access public
 
 If 2FA is on, you'll be prompted for an OTP. Copy from your authenticator.
 
-Successful output ends with:
+Successful output ends with (version will be whatever is in `package.json`):
 ```
-+ @seldonframe/mcp@1.0.0
++ @seldonframe/mcp@1.0.1
 ```
 
 If you see `403 Forbidden`, common causes:
 - Not logged in (`npm login` again)
 - Not a member of `@seldonframe` org with publish rights
 - Wrong scope or `publishConfig.access` not set to `public`
+
+### Step 4.5 — Confirm the package is reachable (NOT just published)
+
+```bash
+npm view @seldonframe/mcp
+```
+
+⚠ **npm caches negative (404) responses.** If you queried the package BEFORE publishing (e.g. ran `npm view` to confirm it was unpublished), npm may serve that cached 404 for several minutes after a successful publish. This is a known footgun, **not a publish failure.**
+
+**Fix:**
+
+```bash
+npm cache clean --force
+npm view @seldonframe/mcp
+```
+
+**Definitive registry check (bypasses local npm cache entirely):**
+
+```bash
+curl -s https://registry.npmjs.org/@seldonframe/mcp | head -c 200
+```
+
+If `curl` shows real metadata but `npm view` still 404s → it's a local cache issue. Clean and retry as above.
+
+If `curl` ALSO returns 404 after several minutes → the publish didn't actually take. Re-run `npm publish --access public` and watch for any error.
+
+---
 
 ---
 
@@ -118,12 +148,17 @@ This is the L-29 cleanroom verification step. It must be performed in an environ
 
 1. Open <https://github.com/codespaces/new?repo=seldonframe/seldonframe&ref=main>
 2. Create a new Codespace (DO NOT reuse an existing one — caches contaminate the test)
-3. In the Codespace terminal:
+3. In the Codespace terminal — **first ensure Node 18+** (Codespaces default image may ship Node 16):
 
 ```bash
+node --version
+# If < 18:
+nvm install 20 && nvm use 20
+node --version    # should now show v20.x
+
 # Verify package is live on npm
 npm view @seldonframe/mcp
-# Should show: name, version 1.0.0, dist-tags, etc.
+# Should show: name, version 1.0.1, dist-tags, etc.
 
 # Install Claude Code (if not already there)
 npm install -g @anthropic-ai/claude-code
@@ -183,9 +218,10 @@ This unblocks Branch 2 (`claude/fix-marketing-install`) — the marketing-copy u
 | Symptom | Likely cause | Action |
 |---|---|---|
 | `403 Forbidden` on publish | Not logged in, or not a member of the org | `npm login` and verify `npm org ls seldonframe` |
-| `EPUBLISHCONFLICT` / "version already exists" | Someone (or a previous attempt) already published 1.0.0 | Bump to `1.0.1` in `package.json` and republish |
-| `npm view @seldonframe/mcp` returns 404 after publish | Registry propagation delay (rare) | Wait 60 seconds, retry. If still 404 after 5 min, escalate. |
-| `claude mcp add` succeeds but `/mcp` shows `Failed to reconnect` | npx download or server boot failed | In Codespace: `npx -y @seldonframe/mcp < /dev/null` to see the actual error |
+| `EPUBLISHCONFLICT` / "version already exists" | A prior `npm publish` already shipped this version | Bump to the next patch (e.g. `1.0.2`) in `package.json` and republish |
+| `npm view @seldonframe/mcp` returns 404 after publish | Local npm cache holds a stale 404 from before publish | `npm cache clean --force` then retry. Or use `curl https://registry.npmjs.org/@seldonframe/mcp` to bypass the cache. |
+| `claude mcp add` succeeds but `/mcp` shows `Failed to reconnect` on Node < 18 | Server intentionally exits with the version-gate error | Upgrade Node: `nvm install 20 && nvm use 20`. Then re-add the MCP and restart Claude Code. |
+| `claude mcp add` succeeds but `/mcp` shows `Failed to reconnect` on Node 18+ | npx download or server boot failed for a different reason | In Codespace: `npx -y @seldonframe/mcp < /dev/null` to see the actual error |
 | Server boots but tool calls return network errors | `app.seldonframe.com/api/v1` unreachable from the Codespace | Verify `https://app.seldonframe.com` is up; check firewall / VPN |
 
 ## Rollback


### PR DESCRIPTION
## Summary

P0 fix surfaced by the L-29 cleanroom test on the published `@seldonframe/mcp@1.0.0`. The package crashed on Node 16 with `fetch is not defined` — Codespaces default images sometimes ship Node 16, so a non-trivial fraction of new users would have hit this on day one.

This PR adds a strict runtime Node version gate (Option C from the investigation), bumps to v1.0.1, and documents the operational gotchas surfaced during the v1.0.0 publish run.

## Commits

| # | Commit | Scope |
|---|---|---|
| C1+C3 | `4857de08` | Node version gate (dynamic imports, hoisting-safe) + bump to 1.0.1 |
| C2 | `a086c849` | Publish instructions: npm cache 404 fix + Node 18 prereq + 1.0.1 refs |
| C4 | `1b36d1b3` | `/docs/quickstart` Codespaces / WSL / SSH-remote callout |

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo (no regression)
- `pnpm build` — `/docs/quickstart` static route compiles
- `npm pack` — `seldonframe-mcp-1.0.1.tgz`
- Local boot test on Node 24 — clean exit 0
- Simulated Node 16 path — clear error block, exit 1

## What this PR does NOT do

- Does NOT publish to npm — Max does that manually post-merge per `tasks/npm-publish-instructions.md`
- Does NOT update marketing copy on landing/README — that's the next branch (`claude/fix-marketing-install`), gated on Max confirming the v1.0.1 publish + cleanroom verification

## Sequencing

1. ⏳ This PR merges
2. 🔑 Max runs `tasks/npm-publish-instructions.md` end-to-end:
   - `cd skills/mcp-server`
   - `npm publish --access public`
   - Should succeed with `+ @seldonframe/mcp@1.0.1`
3. 🧪 Max creates a BRAND NEW Codespace (not the contaminated bookish-fortnight or glorious-yodel ones), runs:
   - `nvm install 20 && nvm use 20` (or confirms Node ≥18 already)
   - `npm cache clean --force` (avoid the stale-404 footgun)
   - `claude mcp add seldonframe -- npx -y @seldonframe/mcp`
   - `claude` → `/mcp` → expect `✓ Connected`
   - `create_workspace({ name: "Cleanroom Test" })` → expect live URLs
4. ✅ Max replies "v1.0.1 confirmed + cleanroom verified"
5. ⏳ Branch 2 (`claude/fix-marketing-install`) updates 5 marketing surfaces
6. ⏳ Branch 2 merges
7. 🧪 Max re-runs pre-launch protocol §3.1 from yet ANOTHER fresh Codespace
8. ✅ Section 3.1 passes → unblocks remaining protocol sections + launch