### PR TITLE
mcp: Node 18 gate + 1.0.1 publish + production DB migration log (P0 cleanroom-test fixes)

### DIFF
--- a/packages/crm/scripts/apply-prod-migrations-resume.mjs
+++ b/packages/crm/scripts/apply-prod-migrations-resume.mjs
@@ -1,0 +1,113 @@
+// Resume migration applier — picks up after the 0015 false-positive.
+// Phase 2 first-run state (verified via diag-prod-pre-15.mjs +
+// verify-state.mjs):
+//   0012 brain_event_salience          ✅ applied
+//   0013 brain_feedback_score           ✅ applied
+//   0014 workspace_secrets              ✅ applied
+//   0015 workspace_bearer_tokens        ✅ SKIP — already fully applied
+//                                          before this session (column +
+//                                          index both present)
+//   0016 → 0027                         ⏳ apply now
+//
+// Same per-file BEGIN/COMMIT atomicity. Stops at first real error.
+
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { Client } from "@neondatabase/serverless";
+
+const envFile = resolve(process.cwd(), ".env.prod");
+const envText = readFileSync(envFile, "utf8");
+const dbLine = envText.split(/\r?\n/).find((l) => l.startsWith("DATABASE_URL="));
+if (!dbLine) {
+  console.error("DATABASE_URL not found in .env.prod");
+  process.exit(1);
+}
+const DATABASE_URL = dbLine
+  .replace(/^DATABASE_URL=/, "")
+  .replace(/^"|"$/g, "");
+
+const MIGRATIONS_DIR = resolve(process.cwd(), "drizzle");
+
+// 0012-0014 already applied + 0015 already applied (skipped per Path A).
+const MIGRATIONS = [
+  "0016_phase3_email_conversations_suppression.sql",
+  "0017_phase4_sms_messages_events.sql",
+  "0018_phase5_invoices_subscriptions.sql",
+  "0019_workflow_tables.sql",
+  "0020_workflow_step_results.sql",
+  "0021_block_subscriptions.sql",
+  "0022_organizations_timezone.sql",
+  "0023_scheduled_triggers.sql",
+  "0024_message_triggers.sql",
+  "0025_workspace_test_mode.sql",
+  "0026_workflow_runs_cost_observability.sql",
+  "0027_workflow_approvals.sql",
+];
+
+function splitStatements(sql) {
+  return sql
+    .split(/-->\s*statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+const client = new Client({ connectionString: DATABASE_URL });
+await client.connect();
+
+console.log(
+  `Connected. Resume mode: applying ${MIGRATIONS.length} migrations (0016 → 0027).\n`,
+);
+
+let appliedCount = 0;
+const log = [];
+
+for (const filename of MIGRATIONS) {
+  const filepath = join(MIGRATIONS_DIR, filename);
+  const sqlText = readFileSync(filepath, "utf8");
+  const statements = splitStatements(sqlText);
+
+  process.stdout.write(
+    `→ ${filename.padEnd(50)} (${String(sqlText.length).padStart(5)}B, ${statements.length} stmt)`,
+  );
+
+  const start = Date.now();
+  try {
+    await client.query("BEGIN");
+    for (const stmt of statements) {
+      await client.query(stmt);
+    }
+    await client.query("COMMIT");
+    const elapsed = Date.now() - start;
+    console.log(`  ✓ ${elapsed}ms`);
+    log.push({ filename, statements: statements.length, elapsedMs: elapsed, status: "ok" });
+    appliedCount++;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore rollback failure
+    }
+    console.log("  ✗ FAILED");
+    console.error(`\n  Error: ${err.message}`);
+    if (err.position) console.error(`  Position: ${err.position}`);
+    if (err.detail) console.error(`  Detail: ${err.detail}`);
+    if (err.hint) console.error(`  Hint: ${err.hint}`);
+    console.error(
+      `\n  ${appliedCount} of ${MIGRATIONS.length} applied successfully before this failure.`,
+    );
+    console.error(`  Stopping. Restore from Neon backup branch if needed.\n`);
+    log.push({ filename, status: "failed", error: err.message });
+    await client.end();
+    console.log("\n=== APPLY LOG ===");
+    console.log(JSON.stringify(log, null, 2));
+    process.exit(1);
+  }
+}
+
+await client.end();
+
+console.log(
+  `\n✓ All ${appliedCount}/${MIGRATIONS.length} resume-batch migrations applied successfully.`,
+);
+console.log("\n=== APPLY LOG ===");
+console.log(JSON.stringify(log, null, 2));

--- a/packages/crm/scripts/apply-prod-migrations.mjs
+++ b/packages/crm/scripts/apply-prod-migrations.mjs
@@ -1,0 +1,120 @@
+// One-shot production migration applier.
+// Reads DATABASE_URL from .env.prod (pulled via `vercel env pull`).
+// Applies migrations 0012 → 0027 in numerical order, each in its own
+// transaction. Stops at the first error (does NOT continue past failure).
+//
+// NOT a general-purpose migration runner — drizzle-kit's journal is
+// out of sync (only 13 of 35 migrations registered), so this bypasses
+// drizzle-kit and applies SQL files directly.
+//
+// Usage (from packages/crm):
+//   node scripts/apply-prod-migrations.mjs
+
+import { readFileSync } from "node:fs";
+import { resolve, join } from "node:path";
+import { Client } from "@neondatabase/serverless";
+
+const envFile = resolve(process.cwd(), ".env.prod");
+const envText = readFileSync(envFile, "utf8");
+const dbLine = envText.split(/\r?\n/).find((l) => l.startsWith("DATABASE_URL="));
+if (!dbLine) {
+  console.error("DATABASE_URL not found in .env.prod");
+  process.exit(1);
+}
+const DATABASE_URL = dbLine
+  .replace(/^DATABASE_URL=/, "")
+  .replace(/^"|"$/g, "");
+
+const MIGRATIONS_DIR = resolve(process.cwd(), "drizzle");
+
+// Apply in numerical order. Order matters: foreign keys in later
+// migrations reference tables created in earlier ones (e.g. 0021 FKs
+// to workflow_event_log from 0019; 0026 FKs to workflow_runs from 0019).
+const MIGRATIONS = [
+  "0012_brain_event_salience.sql",
+  "0013_brain_feedback_score.sql",
+  "0014_workspace_secrets.sql",
+  "0015_workspace_bearer_tokens.sql",
+  "0016_phase3_email_conversations_suppression.sql",
+  "0017_phase4_sms_messages_events.sql",
+  "0018_phase5_invoices_subscriptions.sql",
+  "0019_workflow_tables.sql",
+  "0020_workflow_step_results.sql",
+  "0021_block_subscriptions.sql",
+  "0022_organizations_timezone.sql",
+  "0023_scheduled_triggers.sql",
+  "0024_message_triggers.sql",
+  "0025_workspace_test_mode.sql",
+  "0026_workflow_runs_cost_observability.sql",
+  "0027_workflow_approvals.sql",
+];
+
+// Drizzle separates statements within a file with the comment
+// `--> statement-breakpoint`. We split on it and run each statement
+// as its own query inside a single per-file transaction. This is
+// exactly what drizzle-kit migrate does internally.
+function splitStatements(sql) {
+  return sql
+    .split(/-->\s*statement-breakpoint/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+const client = new Client({ connectionString: DATABASE_URL });
+await client.connect();
+
+console.log(`Connected to production. Applying ${MIGRATIONS.length} migrations.\n`);
+
+let appliedCount = 0;
+const log = [];
+
+for (const filename of MIGRATIONS) {
+  const filepath = join(MIGRATIONS_DIR, filename);
+  const sqlText = readFileSync(filepath, "utf8");
+  const statements = splitStatements(sqlText);
+
+  process.stdout.write(
+    `→ ${filename}  (${sqlText.length}B, ${statements.length} stmt)`,
+  );
+
+  const start = Date.now();
+  try {
+    await client.query("BEGIN");
+    for (const stmt of statements) {
+      await client.query(stmt);
+    }
+    await client.query("COMMIT");
+    const elapsed = Date.now() - start;
+    console.log(`  ✓ ${elapsed}ms`);
+    log.push({ filename, statements: statements.length, elapsedMs: elapsed, status: "ok" });
+    appliedCount++;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore rollback failure
+    }
+    console.log("  ✗ FAILED");
+    console.error(`\n  Error: ${err.message}`);
+    if (err.position) console.error(`  Position: ${err.position}`);
+    if (err.detail) console.error(`  Detail: ${err.detail}`);
+    if (err.hint) console.error(`  Hint: ${err.hint}`);
+    console.error(
+      `\n  ${appliedCount} of ${MIGRATIONS.length} applied successfully before this failure.`,
+    );
+    console.error(`  Stopping. Restore from Neon backup branch if needed.\n`);
+    log.push({ filename, status: "failed", error: err.message });
+    await client.end();
+    console.log("\n=== APPLY LOG ===");
+    console.log(JSON.stringify(log, null, 2));
+    process.exit(1);
+  }
+}
+
+await client.end();
+
+console.log(
+  `\n✓ All ${appliedCount}/${MIGRATIONS.length} migrations applied successfully.`,
+);
+console.log("\n=== APPLY LOG ===");
+console.log(JSON.stringify(log, null, 2));

--- a/packages/crm/scripts/diag-prod-pre-15.mjs
+++ b/packages/crm/scripts/diag-prod-pre-15.mjs
@@ -1,0 +1,96 @@
+// Diagnose what 0015 still needs after the partial-apply discovery.
+// 0015 has 2 statements:
+//   (1) ALTER TABLE api_keys ADD COLUMN kind text DEFAULT 'user' NOT NULL;
+//   (2) CREATE INDEX api_keys_kind_prefix_idx ON api_keys (kind, key_prefix);
+// We know (1) is already done. Check (2) and any other columns/indexes
+// that subsequent migrations might also have partially applied.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { neon } from "@neondatabase/serverless";
+
+const envText = readFileSync(resolve(process.cwd(), ".env.prod"), "utf8");
+const DATABASE_URL = envText
+  .split(/\r?\n/)
+  .find((l) => l.startsWith("DATABASE_URL="))
+  .replace(/^DATABASE_URL=/, "")
+  .replace(/^"|"$/g, "");
+
+const sql = neon(DATABASE_URL);
+
+console.log("=== api_keys columns (does 'kind' really exist?) ===");
+const apiKeysCols = await sql`
+  SELECT column_name, data_type, column_default
+  FROM information_schema.columns
+  WHERE table_name = 'api_keys'
+  ORDER BY ordinal_position
+`;
+for (const c of apiKeysCols) {
+  console.log(`  ${c.column_name.padEnd(20)} ${c.data_type.padEnd(15)} default=${c.column_default ?? "—"}`);
+}
+
+console.log("\n=== api_keys indexes ===");
+const idx = await sql`
+  SELECT indexname, indexdef
+  FROM pg_indexes
+  WHERE tablename = 'api_keys'
+  ORDER BY indexname
+`;
+for (const i of idx) {
+  console.log(`  ${i.indexname}`);
+  console.log(`    ${i.indexdef}`);
+}
+
+console.log("\n=== Quick check: are 0016/0017/0018 tables present? (sanity for the rest) ===");
+const tables = await sql`
+  SELECT table_name FROM information_schema.tables
+  WHERE table_schema = 'public'
+    AND table_name IN (
+      'email_events', 'conversations', 'conversation_messages', 'suppression_list',
+      'sms_messages', 'sms_events',
+      'invoices', 'invoice_items', 'subscriptions',
+      'workflow_runs', 'workflow_waits', 'workflow_event_log',
+      'workflow_step_results',
+      'block_subscription_registry', 'block_subscription_deliveries',
+      'scheduled_triggers', 'scheduled_trigger_fires',
+      'message_triggers', 'message_trigger_fires',
+      'workflow_approvals',
+      'workspace_secrets'
+    )
+  ORDER BY table_name
+`;
+const present = new Set(tables.map((t) => t.table_name));
+const expected = [
+  "email_events", "conversations", "conversation_messages", "suppression_list",
+  "sms_messages", "sms_events",
+  "invoices", "invoice_items", "subscriptions",
+  "workflow_runs", "workflow_waits", "workflow_event_log",
+  "workflow_step_results",
+  "block_subscription_registry", "block_subscription_deliveries",
+  "scheduled_triggers", "scheduled_trigger_fires",
+  "message_triggers", "message_trigger_fires",
+  "workflow_approvals",
+  "workspace_secrets",
+];
+for (const name of expected) {
+  console.log(`  ${name.padEnd(35)} ${present.has(name) ? "PRESENT ✓" : "MISSING ✗"}`);
+}
+
+console.log("\n=== organizations columns post-0012/13/14 apply ===");
+const orgCols = await sql`
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'organizations' AND column_name IN ('timezone', 'test_mode')
+`;
+const orgColsPresent = new Set(orgCols.map((c) => c.column_name));
+console.log(`  timezone (0022):  ${orgColsPresent.has("timezone") ? "PRESENT ✓" : "MISSING ✗"}`);
+console.log(`  test_mode (0025): ${orgColsPresent.has("test_mode") ? "PRESENT ✓" : "MISSING ✗"}`);
+
+console.log("\n=== brain_events columns post-0012/13 apply ===");
+const brainCols = await sql`
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'brain_events'
+    AND column_name IN ('salience', 'feedback_score')
+`;
+const bSet = new Set(brainCols.map((c) => c.column_name));
+console.log(`  salience (0012):       ${bSet.has("salience") ? "PRESENT ✓" : "MISSING ✗"}`);
+console.log(`  feedback_score (0013): ${bSet.has("feedback_score") ? "PRESENT ✓" : "MISSING ✗"}`);

--- a/packages/crm/scripts/diag-prod-schema.mjs
+++ b/packages/crm/scripts/diag-prod-schema.mjs
@@ -1,0 +1,112 @@
+// One-shot read-only diagnostic for production DB.
+// Reads DATABASE_URL from .env.prod (pulled via `vercel env pull`).
+// Runs 3 SELECT-only queries to map the migration drift.
+// Does NOT write anything. Safe to run multiple times.
+//
+// Usage (from packages/crm):
+//   node scripts/diag-prod-schema.mjs
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { neon } from "@neondatabase/serverless";
+
+const envFile = resolve(process.cwd(), ".env.prod");
+const envText = readFileSync(envFile, "utf8");
+const dbLine = envText.split(/\r?\n/).find((l) => l.startsWith("DATABASE_URL="));
+if (!dbLine) {
+  console.error("DATABASE_URL not found in .env.prod");
+  process.exit(1);
+}
+const DATABASE_URL = dbLine
+  .replace(/^DATABASE_URL=/, "")
+  .replace(/^"|"$/g, "");
+
+const sql = neon(DATABASE_URL);
+
+async function main() {
+  console.log("=== Q1: __drizzle_migrations content ===");
+  try {
+    const rows = await sql`
+      SELECT id, hash, created_at
+      FROM __drizzle_migrations
+      ORDER BY created_at
+    `;
+    console.log(`Total rows: ${rows.length}`);
+    for (const r of rows) {
+      console.log(
+        `  id=${r.id}  created_at=${r.created_at}  hash=${String(r.hash).slice(0, 12)}…`,
+      );
+    }
+  } catch (err) {
+    console.log(`__drizzle_migrations table error: ${err.message}`);
+  }
+
+  console.log("\n=== Q2: organizations columns ===");
+  const orgCols = await sql`
+    SELECT column_name, data_type, is_nullable, column_default
+    FROM information_schema.columns
+    WHERE table_name = 'organizations'
+    ORDER BY ordinal_position
+  `;
+  console.log(`Total columns: ${orgCols.length}`);
+  for (const c of orgCols) {
+    console.log(
+      `  ${c.column_name.padEnd(35)} ${c.data_type.padEnd(20)} nullable=${c.is_nullable.padEnd(3)} default=${
+        c.column_default ?? "—"
+      }`,
+    );
+  }
+  const hasTz = orgCols.some((c) => c.column_name === "timezone");
+  console.log(`  timezone column present: ${hasTz ? "YES ✓" : "NO ✗ (this is the bug)"}`);
+
+  console.log("\n=== Q3: tables in public schema ===");
+  const tables = await sql`
+    SELECT table_name FROM information_schema.tables
+    WHERE table_schema = 'public'
+    ORDER BY table_name
+  `;
+  console.log(`Total tables: ${tables.length}`);
+  for (const t of tables) console.log(`  ${t.table_name}`);
+
+  console.log("\n=== Q4: SLICE 5/9/10/11 expected tables (presence check) ===");
+  const expected = [
+    "workflow_runs", // 0019
+    "workflow_step_results", // 0020
+    "block_subscriptions", // 0021
+    "scheduled_triggers", // 0023
+    "message_triggers", // 0024
+    "workflow_approvals", // 0027
+    "preview_sessions", // 0011
+    "brain_event_salience", // 0012
+    "brain_feedback_score", // 0013
+    "workspace_secrets", // 0014
+    "workspace_bearer_tokens", // 0015
+    "email_conversations", // 0016 (subset)
+    "sms_messages", // 0017 (subset)
+    "invoices", // 0018 (subset)
+  ];
+  const present = new Set(tables.map((t) => t.table_name));
+  for (const name of expected) {
+    console.log(`  ${name.padEnd(35)} ${present.has(name) ? "YES ✓" : "MISSING ✗"}`);
+  }
+
+  console.log("\n=== Q5: drizzle migration tracking schema ===");
+  const trackingCols = await sql`
+    SELECT column_name, data_type
+    FROM information_schema.columns
+    WHERE table_name = '__drizzle_migrations'
+    ORDER BY ordinal_position
+  `;
+  if (trackingCols.length === 0) {
+    console.log("  __drizzle_migrations table does NOT exist");
+  } else {
+    for (const c of trackingCols) console.log(`  ${c.column_name}  ${c.data_type}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("FATAL:", err);
+    process.exit(1);
+  });

--- a/packages/crm/scripts/verify-state.mjs
+++ b/packages/crm/scripts/verify-state.mjs
@@ -1,0 +1,37 @@
+// Quick post-apply state verifier. Used to confirm what 0012/0013/0014
+// actually did before continuing with 0015+.
+import { readFileSync } from "node:fs";
+import { neon } from "@neondatabase/serverless";
+
+const env = readFileSync(".env.prod", "utf8");
+const url = env
+  .split(/\r?\n/)
+  .find((l) => l.startsWith("DATABASE_URL="))
+  .replace(/^DATABASE_URL=/, "")
+  .replace(/^"|"$/g, "");
+const sql = neon(url);
+
+const brainCols = await sql`
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'brain_events'
+    AND column_name IN ('salience_score', 'feedback_score')
+`;
+console.log("brain_events 0012/0013 columns:", brainCols.map((c) => c.column_name));
+
+const wsCols = await sql`
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'workspace_secrets' ORDER BY ordinal_position
+`;
+console.log("workspace_secrets (0014) columns:", wsCols.map((c) => c.column_name));
+
+const apiCols = await sql`
+  SELECT column_name FROM information_schema.columns
+  WHERE table_name = 'api_keys' AND column_name = 'kind'
+`;
+console.log("api_keys.kind (0015):", apiCols.length > 0 ? "PRESENT" : "MISSING");
+
+const apiIdx = await sql`
+  SELECT indexname FROM pg_indexes
+  WHERE tablename = 'api_keys' AND indexname = 'api_keys_kind_prefix_idx'
+`;
+console.log("api_keys_kind_prefix_idx (0015):", apiIdx.length > 0 ? "PRESENT" : "MISSING");

--- a/tasks/prod-migration-log-2026-04-27.md
+++ b/tasks/prod-migration-log-2026-04-27.md
@@ -1,0 +1,130 @@
+# Production DB migration log — 2026-04-27
+
+**Operator:** Max (with Claude assist)
+**Production DB:** Neon, host `ep-young-water-am8zkako-pooler.c-5.us-east-1.aws.neon.tech`
+**Backup:** Neon branch `pre-migration-backup-2026-04-27` (created BEFORE any writes; snapshot point for rollback)
+**Trigger:** Pre-launch test protocol cleanroom run on the published `@seldonframe/mcp@1.0.0` returned `column "timezone" of relation "organizations" does not exist` from `POST /api/v1/workspace/create`. Surfaced massive prod-vs-dev schema drift.
+
+---
+
+## Summary
+
+Production database was ~15 migrations behind the application code. All `INSERT INTO organizations` requests for new workspaces were failing because the model expected columns the DB didn't have.
+
+Applied migrations 0012 through 0027 in numerical order via direct SQL execution (NOT `drizzle-kit migrate` — see "Why not drizzle-kit migrate" below). 15 migrations effectively applied; 1 skipped (already done in production).
+
+After migration, the same `POST /api/v1/workspace/create` request that previously returned the schema error now returns 200 with full workspace metadata.
+
+---
+
+## Pre-state (Phase 1 diagnostic, ran via `scripts/diag-prod-schema.mjs`)
+
+- `__drizzle_migrations` table exists but never populated (drizzle never tracked anything in this prod DB)
+- `organizations` table had 21 columns; missing `timezone` (0022) and `test_mode` (0025)
+- 13 of 14 expected post-0011 tables were missing (only `preview_sessions` from 0011 was present)
+- Production effectively at migration `0011_preview_sessions` + the duplicate-prefix "second" siblings of 0001-0007 (`seldon_usage`, `marketplace_blocks`, `generated_blocks`, etc.)
+
+## Apply log
+
+Each migration was applied in its own transaction (`BEGIN ... COMMIT`). On any failure within a file, the file was rolled back as a unit and the run halted.
+
+| File | Statements | Elapsed | Outcome |
+|---|---|---|---|
+| `0012_brain_event_salience.sql` | 1 | 301 ms | ✅ Applied (used `IF NOT EXISTS` — idempotent) |
+| `0013_brain_feedback_score.sql` | 1 | 306 ms | ✅ Applied (used `IF NOT EXISTS`) |
+| `0014_workspace_secrets.sql` | 7 | 832 ms | ✅ Applied — created `workspace_secrets` table + 3 FKs + 3 indexes |
+| `0015_workspace_bearer_tokens.sql` | — | — | ⏭ **SKIPPED** — `api_keys.kind` column AND `api_keys_kind_prefix_idx` index were both already present in production from a prior partial-apply (mechanism unknown — possibly manual psql or `drizzle-kit push`). Verified via `scripts/diag-prod-pre-15.mjs`. |
+| `0016_phase3_email_conversations_suppression.sql` | 21 | 2044 ms | ✅ Applied — `email_events`, `conversations`, `conversation_messages`, `suppression_list` |
+| `0017_phase4_sms_messages_events.sql` | 20 | 822 ms | ✅ Applied — `sms_messages`, `sms_events` |
+| `0018_phase5_invoices_subscriptions.sql` | 29 | 1125 ms | ✅ Applied — `invoices`, `invoice_items`, `subscriptions`, `payment_events` |
+| `0019_workflow_tables.sql` | 14 | 568 ms | ✅ Applied — `workflow_runs`, `workflow_waits`, `workflow_event_log` |
+| `0020_workflow_step_results.sql` | 3 | 193 ms | ✅ Applied — `workflow_step_results` |
+| `0021_block_subscriptions.sql` | 11 | 496 ms | ✅ Applied — `block_subscription_registry`, `block_subscription_deliveries` |
+| `0022_organizations_timezone.sql` | 1 | 120 ms | ✅ Applied — **THE FIX** — `organizations.timezone text NOT NULL DEFAULT 'UTC'` |
+| `0023_scheduled_triggers.sql` | 1 | 111 ms | ✅ Applied — `scheduled_triggers`, `scheduled_trigger_fires` |
+| `0024_message_triggers.sql` | 1 | 144 ms | ✅ Applied — `message_triggers`, `message_trigger_fires` |
+| `0025_workspace_test_mode.sql` | 1 | 118 ms | ✅ Applied — `organizations.test_mode boolean NOT NULL DEFAULT false` |
+| `0026_workflow_runs_cost_observability.sql` | 1 | 100 ms | ✅ Applied — added cost columns to `workflow_runs` (per SLICE 11) |
+| `0027_workflow_approvals.sql` | 1 | 134 ms | ✅ Applied — `workflow_approvals` |
+
+**Total:** 15 of 16 applied, 1 skipped, 0 failed. Total apply time: ~7.5 seconds.
+
+## Why not `drizzle-kit migrate`?
+
+The drizzle journal (`packages/crm/drizzle/meta/_journal.json`) registers only 13 of 35 migrations on disk. `drizzle-kit migrate` would consult the journal and either:
+- Refuse to apply anything (because journal says it's "up to date"), OR
+- Try to apply only journal-registered migrations and miss the unjournaled ones
+
+The 0022 migration's own header comment confirms this is a known pattern: *"Authored manually (drizzle-kit journal out of sync; same pattern as 0019 / 0020 / 0021)"*. So we bypassed drizzle-kit entirely and applied the SQL files directly.
+
+The journal sync issue is a separate post-launch tech debt item — see "Open follow-ups" below.
+
+## Verification
+
+### Direct API smoke test
+
+```
+$ curl -X POST https://app.seldonframe.com/api/v1/workspace/create \
+    -H "Content-Type: application/json" \
+    -d '{"name": "post-migration verify"}'
+```
+
+Returned 200 OK with workspace metadata, including `id`, `slug`, `bearer_token`, and all four URL surfaces (home, book, intake, admin_dashboard). Pre-migration this same request returned a Postgres schema error.
+
+Workspace `7be829ae-cd4a-4227-946b-38354dbba608` was created during verification at `2026-04-27T12:10:49.881Z`. It can be cleaned up post-launch if you want a tidy production data state, but it's harmless data.
+
+### Schema diff confirmed
+
+`organizations` now has `timezone` and `test_mode` columns. All `0019-0021` workflow tables, `0023-0024` trigger tables, and `0027` workflow_approvals table are present.
+
+## Operational scripts created (kept for future reference)
+
+| Script | Purpose |
+|---|---|
+| `packages/crm/scripts/diag-prod-schema.mjs` | Read-only diagnostic — Q1-Q5 on production schema state |
+| `packages/crm/scripts/diag-prod-pre-15.mjs` | Read-only — confirms 0015's effects already in production (after first-apply false positive) |
+| `packages/crm/scripts/verify-state.mjs` | Read-only — confirms 0012/0013/0014/0015 effects post-apply |
+| `packages/crm/scripts/apply-prod-migrations.mjs` | Apply 0012→0027 in order, transactional, stops at first error. **First-run version**, halted at 0015. |
+| `packages/crm/scripts/apply-prod-migrations-resume.mjs` | Resume from 0016, skip 0015. Successful run. |
+
+All scripts read `DATABASE_URL` from `.env.prod` (which was deleted post-migration per Phase 4 cleanup).
+
+## Open follow-ups (NOT blocking launch)
+
+### F1 — `_journal.json` is out of sync with on-disk SQL files
+
+35 SQL files exist but only 13 are in the journal. Long-term fix: either backfill the journal entries (and matching `meta/00XX_*.json` snapshots), or migrate to a simpler runner that doesn't need a journal. **Tech debt — file as a post-launch issue.**
+
+### F2 — Drizzle's `__drizzle_migrations` tracking table is empty in production
+
+This means future `drizzle-kit migrate` runs would either no-op (if it sees the journal as "applied") or try to re-apply everything from scratch. We should reconcile this table to reflect reality before any future drizzle-kit-based migration. **Tech debt — post-launch.**
+
+### F3 — Duplicate-prefix migration files (0001-0007 pairs)
+
+7 pairs of files share the same numeric prefix (e.g. `0001_solid_gateway.sql` AND `0001_soul_package_tracking.sql`). Both versions of each pair were applied to production via some past mechanism. Long-term: consolidate or rename. **Tech debt — post-launch.**
+
+### F4 — Vercel deploys don't run migrations
+
+This is the root cause of how production drifted ~15 migrations behind dev. Either:
+- Add a `pnpm db:migrate` step to the Vercel build (depends on F1+F2 being resolved first), OR
+- Document a manual "apply migrations before deploying" checklist as part of release process, OR
+- Set up a separate CI workflow that runs migrations on a schedule or via manual trigger before promotion to production.
+**Process gap — post-launch priority since launch is imminent and we just synced manually.**
+
+### F5 — `.gitignore` doesn't cover plain `.env.prod`
+
+Current `.gitignore` patterns: `.env*.local` and `.vercel`. `.env.prod` (created by `vercel env pull --environment=production`) is NOT ignored. The file was deleted post-cleanup, but a future operator could accidentally commit it. **One-line `.gitignore` fix — post-launch.**
+
+### F6 — Document the manual migration runbook
+
+This file IS that runbook for the current event. For future migrations, lift the pattern into a reusable playbook at `tasks/runbook-prod-migration.md`. **Post-launch.**
+
+## L-29 reflection
+
+This is the second P0 surfaced by the cleanroom test. First was Node-16 incompatibility in the published MCP (fixed in v1.0.1). Second was this schema drift. Both would have launched silently and broken every new signup.
+
+The L-29 cleanroom discipline paid for itself twice in one afternoon.
+
+---
+
+*Migration completed at approximately 2026-04-27T12:10 UTC. Production now schema-aligned with main HEAD.*


### PR DESCRIPTION
## Summary

Two P0s surfaced by the L-29 pre-launch cleanroom test, fixed in the same afternoon:

1. `@seldonframe/mcp@1.0.0` crashed on Node 16 with `fetch is not defined`. Fixed in v1.0.1 with a runtime version gate. Package published.
2. Production database was ~15 migrations behind dev — `POST /api/v1/workspace/create` returned a Postgres schema error for the missing `organizations.timezone` column. Fixed via direct SQL apply against Neon prod.

Both would have launched silently and broken every new signup.

## Commits

| # | Commit | Scope |
|---|---|---|
| 1 | `4857de08` | Node version gate + bump to 1.0.1 |
| 2 | `a086c849` | `tasks/npm-publish-instructions.md` — npm cache 404 fix + Node 18 prereq |
| 3 | `1b36d1b3` | `/docs/quickstart` Codespaces / WSL / SSH-remote callout |
| 4 | `783f929b` | Production migration log + 5 operational scripts |

## What this PR does NOT do

- Does NOT publish to npm — already published manually as `@seldonframe/mcp@1.0.1`
- Does NOT update marketing surfaces (Branch 2 — gated on cleanroom verify of v1.0.1)

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo (no regression)
- `pnpm build` — `/docs/quickstart` static route compiles
- `npm pack` — 22.0 KB tarball, 6 files, name `@seldonframe/mcp@1.0.1`
- Local boot test on Node 24 — clean exit 0
- Simulated Node 16 path — clear error, exit 1
- **Production DB**: `POST /api/v1/workspace/create` now returns 200 with workspace metadata (smoking-gun query that originally failed)

## Backup point for production

Neon branch `pre-migration-backup-2026-04-27` snapshot — rollback target if any downstream surface in prod surfaces a regression. Keep until launch + 1 week.

## Sequencing after merge

1. ✅ This PR merges
2. ⏳ Max performs cleanroom verify on @seldonframe/mcp@1.0.1 in a NEW Codespace (per L-29)
3. ⏳ Branch 2 (`claude/fix-marketing-install`) — 5 marketing surfaces updated to canonical install command
4. ⏳ Final pre-launch protocol §3.1 re-run from another fresh Codespace
5. ✅ Launch