### PR TITLE
docs(install): canonical command on every marketing surface (Branch 2 of 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,17 @@ SeldonFrame is a Business OS framework. You describe what you want in natural la
 - 📊 **Closed-loop attribution** — every LLM call tracked and attributed to the workflow run that triggered it.
 - 💬 **Natural language scaffolding** — describe a block, an archetype, or a workspace; SeldonFrame generates code, admin UI, and tests.
 - 🛂 **Approval gates** — pause workflows for human review before sending or charging.
-- 🔌 **MCP-native** — install once with `claude mcp add seldonframe`, then drive everything from your IDE.
+- 🔌 **MCP-native** — install once with `claude mcp add seldonframe -- npx -y @seldonframe/mcp`, then drive everything from your IDE.
 - 🔑 **BYO LLM keys** — bring your own Anthropic / OpenAI key. We don't margin on tokens.
 - 🆓 **Open source, no lock-in** — MIT licensed. Self-host or run on our cloud.
 - 🧪 **Test mode** — exercise archetypes against simulated triggers before going live.
 
 ## Quick start
 
+Requires Node.js 18+ and Claude Code installed.
+
 ```bash
-claude mcp add seldonframe
+claude mcp add seldonframe -- npx -y @seldonframe/mcp
 ```
 
 ```bash

--- a/docs/pre-launch-test-protocol.md
+++ b/docs/pre-launch-test-protocol.md
@@ -211,7 +211,7 @@ Test the exact install flow from the quickstart page on the clean machine.
 ### 3.1 MCP installation
 
 ```bash
-claude mcp add seldonframe
+claude mcp add seldonframe -- npx -y @seldonframe/mcp
 ```
 
 - [ ] Command succeeds with exit code 0
@@ -556,7 +556,7 @@ Deliberately test things that might break. Good error messages are the differenc
 
 ### 7.1 Missing prerequisites
 
-- [ ] Run `claude mcp add seldonframe` **before installing Claude Code** (use a different fresh shell)
+- [ ] Run `claude mcp add seldonframe -- npx -y @seldonframe/mcp` **before installing Claude Code** (use a different fresh shell)
   - Error message observed:
   - Helpful? Y / N — if N, P1
 - [ ] Use Node.js 18 (downgrade temporarily) and try `seldon init`
@@ -610,7 +610,7 @@ Stopwatch the actual experience. Compare against marketing claims at the end.
 
 | Operation | Actual time | Notes |
 |---|---|---|
-| `claude mcp add seldonframe` → command finishes | | |
+| `claude mcp add seldonframe -- npx -y @seldonframe/mcp` → command finishes | | |
 | First workspace running (init succeeds + dashboard loads) | | |
 | First block scaffolded + UI rendering | | |
 | First agent flow composed + visible in `/agents` | | |

--- a/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
@@ -135,7 +135,7 @@ export default function QuickstartPage() {
             number={1}
             title="Add SeldonFrame to your IDE"
             body="The MCP server exposes SeldonFrame's primitive surface inside Claude Code. After this command, you can describe what you want and Claude will use SeldonFrame to build it."
-            code="claude mcp add seldonframe"
+            code="claude mcp add seldonframe -- npx -y @seldonframe/mcp"
           />
           <Section
             number={2}

--- a/packages/crm/src/app/(public)/landing-client.tsx
+++ b/packages/crm/src/app/(public)/landing-client.tsx
@@ -134,7 +134,7 @@ const Hero = () => {
         </div>
         <div className="p-5 font-mono text-[13px] leading-loose text-[#a1a1aa]">
           <span className="text-[#444]"># Add SeldonFrame to your IDE via MCP</span><br />
-          <span className="text-[#1FAE85]">$ claude mcp add seldonframe</span><br /><br />
+          <span className="text-[#1FAE85]">$ claude mcp add seldonframe -- npx -y @seldonframe/mcp</span><br /><br />
           <span className="text-[#444]"># Create a workspace</span><br />
           <span className="text-[#1FAE85]">$ seldon init &quot;Desert Cool HVAC&quot;</span><br /><br />
           <span className="text-[#444]"># Describe what you need — SeldonFrame builds it</span><br />
@@ -237,7 +237,7 @@ const Features = () => {
 
 const HowItWorks = () => {
   const steps = [
-    { title: "Install via MCP", desc: "One command in Claude Code. SeldonFrame connects to your IDE via Model Context Protocol.", code: "claude mcp add seldonframe" },
+    { title: "Install via MCP", desc: "One command in Claude Code. SeldonFrame connects to your IDE via Model Context Protocol.", code: "claude mcp add seldonframe -- npx -y @seldonframe/mcp" },
     { title: "Initialize a workspace", desc: "Create a branded workspace. Theme, copy, and portal configured via natural language.", code: "\"Init workspace for Desert Cool HVAC. Phoenix, AZ. Family-business voice. Desert tans, AC-blue accents.\"" },
     { title: "Scaffold what you need", desc: "Describe a block and SeldonFrame generates production-ready code with admin UI, portal surfaces, and tests.", code: "\"Scaffold hvac-equipment block. Track units per customer: install date, brand, model, warranty, last service.\"" },
     { title: "Compose agent flows", desc: "Wire multi-step workflows from primitives. Triggers, branches, SMS, email, approval gates — all composable.", code: "\"Add emergency-triage archetype. Trigger on SMS 'AC NOT WORKING'. Check weather. Priority-route if heat >100°F. Dispatch nearest tech.\"" },


### PR DESCRIPTION
## Summary

Branch 2 of 2 in the P0 launch-blocker fix sequence. After Branch 1 (PR #11) published `@seldonframe/mcp@1.0.1` to npm and synced production DB schema, every marketing surface now points users at the install command that actually works:
claude mcp add seldonframe -- npx -y @seldonframe/mcp

## What changed (4 files, 5 references)
| Surface | What |
|---|---|
| `README.md` | MCP-native feature bullet + Quick start (+ Node 18 prereq line) |
| `landing-client.tsx` | Hero terminal block + How-it-works step 1 card |
| `quickstart/page.tsx` | Section 1 install command |
| `pre-launch-test-protocol.md` | §3.1, §7.1 edge case, §8 timing table |
## What's intentionally NOT changed
- `tasks/lessons.md` (L-29 historical record — preserves "the old command was the bug")
- `tasks/repo-polish-pr-body.md` (historical PR body)
- `skills/mcp-server/src/index.js` (error message — already canonical)
- `skills/mcp-server/README.md` L14 (different `-- node ...` self-host command, intentional)
## Verification
- `pnpm typecheck` clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo (no regression)
- `pnpm build` — `/docs/quickstart` + landing routes both compile
- grep audit — zero naked `claude mcp add seldonframe` occurrences remain in user-facing content
## Why now (L-29 sequencing)
This branch was held until cleanroom verification on `@seldonframe/mcp@1.0.1`:
- ✅ Stdio test: `npx -y @seldonframe/mcp` boots, returns `serverInfo.version: "1.0.1"`, returns valid initialize response
- ✅ Backend test: `POST /api/v1/workspace/create` returns 200 with workspace metadata + URLs
- ✅ DB test: 15 of 16 missing migrations applied; production schema aligned
Marketing copy that pointed at a 404 package or schema-broken backend would have re-introduced the same launch-blocker every cleanroom test caught. We waited until the chain was green end-to-end.
## After merge
Final pre-launch gate: re-run pre-launch protocol §3.1 (and ideally a full §1-8 sweep) in a brand-new Codespace following the published marketing copy. If §3.1 succeeds end-to-end, **launch is GO** per the protocol's sign-off criteria.