### PR TITLE
pre-launch-polish — pricing $49/$99/$149 + MCP personalization + admin URL split + proxy redirect + badge legibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ SeldonFrame integrates with the providers you already use:
 ## Pricing
 
 - **First workspace** — free forever, self-hosted or on our cloud.
-- **Additional workspaces** — $9/month each, hosted.
+- **Paid tiers** — Starter $49/mo, Operator $99/mo, Agency $149/mo. See [seldonframe.com/#pricing](https://seldonframe.com/#pricing).
 
 Self-hosters pay nothing to SeldonFrame.
 

--- a/packages/core/src/virality/powered-by-badge.tsx
+++ b/packages/core/src/virality/powered-by-badge.tsx
@@ -41,12 +41,14 @@ export function PoweredByBadge({
       target="_blank"
       rel="noopener noreferrer"
       aria-label={label}
-      className="inline-flex items-center gap-1 rounded-full px-3 py-1 text-[10px] font-medium opacity-80 transition-opacity hover:opacity-100"
+      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium opacity-80 transition-opacity hover:opacity-100"
     >
       <span className="text-[hsl(var(--color-text-secondary))]">Powered by</span>
-      {/* Plain <img> not next/image — package is framework-agnostic */}
+      {/* Plain <img> not next/image — package is framework-agnostic. */}
+      {/* Pre-launch polish: bumped from h-3.5 (14px) to h-5 (20px) — */}
+      {/* the original size was barely legible at footer scale. */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src={wordmark} alt="SeldonFrame" height={14} className="h-3.5 w-auto" />
+      <img src={wordmark} alt="SeldonFrame" height={20} className="h-5 w-auto" />
     </a>
   );
 }

--- a/packages/crm/src/app/(public)/docs/page.tsx
+++ b/packages/crm/src/app/(public)/docs/page.tsx
@@ -231,7 +231,7 @@ const sections = [
     eyebrow: "Agent-native customer ops",
     title: "OpenClaw Self-Service",
     description:
-      "The $29/mo Self-Service + Layer 2 tier unlocks end-client onboarding via OpenClaw using signed portal magic links and fully scoped `end_client_mode: true` execution.",
+      "The Operator and Agency tiers unlock end-client onboarding via OpenClaw using signed portal magic links and fully scoped `end_client_mode: true` execution.",
     bullets: [
       "Enable the self-service tier for a workspace, then call `POST /api/v1/portal/invite` with a managed workspace and contact.",
       "Share the returned `invite_url` with the client. The route issues a signed magic link and a scoped `portal_token`.",

--- a/packages/crm/src/app/(public)/landing-client.tsx
+++ b/packages/crm/src/app/(public)/landing-client.tsx
@@ -307,15 +307,15 @@ const SeeItBuilt = () => (
 const Pricing = () => {
   const tiers = [
     {
-      name: "Starter", badgeColor: "bg-[#222226] text-[#a1a1aa]", price: "$9",
-      features: ["Full primitive surface", "Up to 100 workflow runs/mo", "500 MB database", "Branded customer portal", "Community support", "BYO LLM keys"],
+      name: "Starter", badgeColor: "bg-[#222226] text-[#a1a1aa]", price: "$49",
+      features: ["Full primitive surface", "Up to 100 workflow runs/mo", "500 MB database", "Custom domain", "Branded customer portal", "Community support", "BYO LLM keys"],
     },
     {
-      name: "Operator", badgeColor: "bg-[#1FAE85]/12 text-[#1FAE85]", price: "$29", isFeatured: true,
-      features: ["Everything in Starter", "Up to 5,000 workflow runs/mo", "2 GB database", "Custom domain", "Brain Layer 1 (workspace insights)", "Approval gates", "Email support"],
+      name: "Operator", badgeColor: "bg-[#1FAE85]/12 text-[#1FAE85]", price: "$99", isFeatured: true,
+      features: ["Everything in Starter", "Up to 5,000 workflow runs/mo", "2 GB database", "Brain Layer 1 (workspace insights)", "Approval gates", "Email support"],
     },
     {
-      name: "Agency", badgeColor: "bg-[#e84393]/10 text-[#e84393]", price: "$99",
+      name: "Agency", badgeColor: "bg-[#e84393]/10 text-[#e84393]", price: "$149",
       features: ["Everything in Operator", "Unlimited workflow runs", "10 GB database", "Brain Layer 2 (cross-workspace niche insights)", "White-label option", "Priority support"],
     },
   ];

--- a/packages/crm/src/app/(public)/page.tsx
+++ b/packages/crm/src/app/(public)/page.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "SeldonFrame — AI-native Business OS",
     description:
-      "Build a complete AI-native Business OS with natural language. Open source. MCP-native. $9/mo per workspace.",
+      "Build a complete AI-native Business OS with natural language. Open source. MCP-native. First workspace free; paid tiers from $49/mo.",
     type: "website",
     url: "https://app.seldonframe.com",
     images: [{ url: "/brand/og-image.png", width: 1200, height: 630 }],

--- a/packages/crm/src/app/api/v1/workspace/create/route.ts
+++ b/packages/crm/src/app/api/v1/workspace/create/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import {
+  buildStructuredWorkspaceUrls,
   buildWorkspaceUrls,
   createAnonymousWorkspace,
 } from "@/lib/billing/anonymous-workspace";
@@ -101,6 +102,11 @@ async function handleAnonymousCreate(request: Request, body: WorkspaceCreateBody
   try {
     const result = await createAnonymousWorkspace({ name, source });
     const urls = buildWorkspaceUrls(result.slug, WORKSPACE_BASE_DOMAIN, result.orgId);
+    const structuredUrls = buildStructuredWorkspaceUrls(
+      result.slug,
+      WORKSPACE_BASE_DOMAIN,
+      result.orgId
+    );
 
     logEvent(
       "anonymous_workspace_created",
@@ -124,11 +130,19 @@ async function handleAnonymousCreate(request: Request, body: WorkspaceCreateBody
           created_at: new Date().toISOString(),
         },
         bearer_token: result.bearerToken,
+        // Flat `urls` retained for backward compat with MCP v1.0.1 clients.
+        // Structured fields below (public_urls / admin_urls / admin_setup_note)
+        // are the canonical shape for v1.0.2+ clients — they let Claude Code
+        // present the result with a clean public-vs-admin distinction.
         urls,
+        public_urls: structuredUrls.public_urls,
+        admin_urls: structuredUrls.admin_urls,
+        admin_setup_note: structuredUrls.admin_setup_note,
         installed: result.installedBlocks,
         next: [
-          "install_vertical_pack({ pack: 'real-estate' })",
+          "install_vertical_pack({ pack: '<industry-slug>' }) — auto-detects builtin packs (real-estate-agency); falls back to AI synthesis for other industries",
           "fetch_source_for_soul({ url: 'https://yoursite.com' }) → submit_soul({ soul })",
+          "configure_booking({ title, duration_minutes, description }) — tune the booking page if you collected business hours",
           "get_workspace_snapshot({}) — read workspace state to reason about next steps",
         ],
       },
@@ -368,6 +382,11 @@ export async function POST(request: Request) {
     const isPlanRequired =
       loweredMessage.includes("pro plan required") ||
       loweredMessage.includes("used your free workspace") ||
+      // claude/pre-launch-polish: matches the new pricing message in
+      // lib/billing/orgs.ts. Kept the older $9 substring as a fallback
+      // for any in-flight messages from older deploys, plus a durable
+      // dollar-independent substring for future stability.
+      loweredMessage.includes("additional workspace requires a paid tier") ||
       loweredMessage.includes("additional workspace is $9/month");
     const isWorkspaceLimit = loweredMessage.includes("organization limit reached") || loweredMessage.includes("workspace limit");
     const status = isPlanRequired || isWorkspaceLimit ? 403 : 500;

--- a/packages/crm/src/app/orgs/new/page.tsx
+++ b/packages/crm/src/app/orgs/new/page.tsx
@@ -33,6 +33,9 @@ function isUpgradeRequiredMessage(message?: string) {
     lowered.includes("pro plan required") ||
     lowered.includes("plan required") ||
     lowered.includes("used your free workspace") ||
+    // claude/pre-launch-polish: durable substring + legacy $9 fallback,
+    // mirroring the matcher in api/v1/workspace/create/route.ts.
+    lowered.includes("additional workspace requires a paid tier") ||
     lowered.includes("additional workspace is $9/month") ||
     lowered.includes("organization limit reached") ||
     lowered.includes("workspace limit")

--- a/packages/crm/src/app/pricing/page.tsx
+++ b/packages/crm/src/app/pricing/page.tsx
@@ -1,18 +1,83 @@
 import Link from "next/link";
 import { auth } from "@/auth";
 
-// Pricing model from CLAUDE.md:
-//   "First workspace is free forever. Additional workspaces = $9/month."
+// Public pricing page. Mirrors the marketing landing's #pricing section
+// (3 tiers — Starter $49, Operator $99, Agency $149). The first workspace
+// remains free forever. Self-hosting is also free.
 //
-// The old 6-tier plans.ts ($49/$99/$149/$199/$299/$449) is stale legacy and
-// still drives the Stripe checkout flow from selectPlanAction — so /pricing
-// needs to tell the TRUTH publicly while /settings/billing still carries the
-// old checkout path. 0.5.c will reconcile plans.ts + selectPlanAction with
-// this new model. Until then, /pricing routes logged-out users to /signup
-// (which is free) and logged-in users to /settings/billing (where they can
-// see their current plan — stale labels and all — and eventually buy a seat).
+// This page lives in the CRM app shell so it's reachable from both
+// `seldonframe.com/pricing` (marketing host) and
+// `app.seldonframe.com/pricing` (in-app shell). Logged-in users get a CTA
+// to /settings/billing; logged-out users get /signup.
 
-const PRO_PRICE_PER_WORKSPACE = 9; // USD / workspace / month. See CLAUDE.md.
+type Tier = {
+  id: string;
+  name: string;
+  price: string;
+  badgeNote: string;
+  featured?: boolean;
+  features: string[];
+};
+
+const TIERS: Tier[] = [
+  {
+    id: "free",
+    name: "Free",
+    price: "$0",
+    badgeNote: "Start here",
+    features: [
+      "One fully-featured workspace on <slug>.app.seldonframe.com",
+      "CRM, Cal.diy booking, Formbricks intake, Brain v2",
+      "MCP + Claude Code integration",
+      "Community support",
+      "BYO LLM keys",
+    ],
+  },
+  {
+    id: "starter",
+    name: "Starter",
+    price: "$49",
+    badgeNote: "Per workspace / month",
+    features: [
+      "Full primitive surface",
+      "Up to 100 workflow runs/mo",
+      "500 MB database",
+      "Custom domain",
+      "Branded customer portal",
+      "Community support",
+      "BYO LLM keys",
+    ],
+  },
+  {
+    id: "operator",
+    name: "Operator",
+    price: "$99",
+    badgeNote: "Per workspace / month",
+    featured: true,
+    features: [
+      "Everything in Starter",
+      "Up to 5,000 workflow runs/mo",
+      "2 GB database",
+      "Brain Layer 1 (workspace insights)",
+      "Approval gates",
+      "Email support",
+    ],
+  },
+  {
+    id: "agency",
+    name: "Agency",
+    price: "$149",
+    badgeNote: "Per workspace / month",
+    features: [
+      "Everything in Operator",
+      "Unlimited workflow runs",
+      "10 GB database",
+      "Brain Layer 2 (cross-workspace niche insights)",
+      "White-label option",
+      "Priority support",
+    ],
+  },
+];
 
 type PricingPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -23,99 +88,84 @@ export default async function PricingPage({ searchParams }: PricingPageProps) {
   if (searchParams) await searchParams; // keep Next.js happy if callers pass params
 
   const ctaHref = session?.user ? "/settings/billing" : "/signup";
-  const ctaLabel = session?.user ? "Add a workspace" : "Start free";
 
   return (
     <main className="crm-page">
-      <section className="mx-auto max-w-4xl space-y-10 py-12">
+      <section className="mx-auto max-w-6xl space-y-10 py-12">
         <header className="space-y-4 text-center">
           <p className="inline-flex items-center gap-2 rounded-full border border-border bg-card/50 px-3 py-1 text-xs font-medium text-muted-foreground">
             No credit card to start
           </p>
-          <h1 className="text-page-title">Simple pricing. Built for builders.</h1>
+          <h1 className="text-page-title">Simple pricing. You own the rest.</h1>
           <p className="mx-auto max-w-2xl text-base text-muted-foreground">
-            Your first workspace is free, forever. Spin up additional workspaces for ${PRO_PRICE_PER_WORKSPACE}/month
-            each — keep them for a week, keep them for a decade.
+            Your first workspace is free, forever. Paid tiers unlock more workflow runs, Brain
+            intelligence, and (on Agency) white-label branding. Self-host for free.
           </p>
         </header>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          <article className="crm-card flex flex-col gap-5 p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-card-title">Free</h2>
-              <span className="rounded-full border border-border bg-background/70 px-2.5 py-1 text-xs text-muted-foreground">
-                Start here
-              </span>
-            </div>
-            <div>
-              <p className="text-4xl font-semibold tracking-tight">$0</p>
-              <p className="mt-1 text-sm text-muted-foreground">forever · 1 workspace</p>
-            </div>
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              <li>· One fully featured workspace on <span className="text-foreground">&lt;slug&gt;.app.seldonframe.com</span></li>
-              <li>· CRM, Cal.diy booking, Formbricks intake, Brain v2</li>
-              <li>· MCP + Claude Code integration</li>
-              <li>· Public subdomain + shareable booking / intake links</li>
-              <li>· Community support</li>
-            </ul>
-            <div className="mt-auto">
-              <Link
-                href={session?.user ? "/dashboard" : "/signup"}
-                className="crm-button-secondary inline-flex h-11 w-full items-center justify-center px-4 text-sm font-medium"
-              >
-                {session?.user ? "Go to dashboard" : "Start free"}
-              </Link>
-            </div>
-          </article>
-
-          <article className="crm-card relative flex flex-col gap-5 overflow-hidden p-6">
-            <span aria-hidden className="absolute inset-x-0 top-0 h-0.5 bg-primary/60" />
-            <div className="flex items-center justify-between">
-              <h2 className="text-card-title">Pro</h2>
-              <span className="rounded-full bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
-                For agencies &amp; operators
-              </span>
-            </div>
-            <div>
-              <p className="text-4xl font-semibold tracking-tight">
-                ${PRO_PRICE_PER_WORKSPACE}
-                <span className="ml-1 text-base font-normal text-muted-foreground">/ workspace / month</span>
-              </p>
-              <p className="mt-1 text-sm text-muted-foreground">pay only for what you spin up</p>
-            </div>
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              <li>· Everything in Free, per workspace</li>
-              <li>· Unlimited additional workspaces — $9/mo each</li>
-              <li>· Custom domain on any workspace</li>
-              <li>· White-label branding (remove &quot;Powered by SeldonFrame&quot;)</li>
-              <li>· Full Brain v2 + publishing to the marketplace</li>
-              <li>· Priority support</li>
-            </ul>
-            <div className="mt-auto">
-              <Link
-                href={ctaHref}
-                className="crm-button-primary inline-flex h-11 w-full items-center justify-center px-4 text-sm font-medium"
-              >
-                {ctaLabel}
-              </Link>
-            </div>
-          </article>
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {TIERS.map((tier) => (
+            <article
+              key={tier.id}
+              className={`crm-card relative flex flex-col gap-5 overflow-hidden p-6 ${
+                tier.featured ? "border-primary/60" : ""
+              }`}
+            >
+              {tier.featured ? (
+                <span aria-hidden className="absolute inset-x-0 top-0 h-0.5 bg-primary/60" />
+              ) : null}
+              <div className="flex items-center justify-between">
+                <h2 className="text-card-title">{tier.name}</h2>
+                {tier.featured ? (
+                  <span className="rounded-full bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
+                    Most popular
+                  </span>
+                ) : null}
+              </div>
+              <div>
+                <p className="text-4xl font-semibold tracking-tight">{tier.price}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{tier.badgeNote}</p>
+              </div>
+              <ul className="space-y-2 text-sm text-muted-foreground">
+                {tier.features.map((feat) => (
+                  <li key={feat}>· {feat}</li>
+                ))}
+              </ul>
+              <div className="mt-auto">
+                <Link
+                  href={tier.id === "free" ? (session?.user ? "/dashboard" : "/signup") : ctaHref}
+                  className={`${
+                    tier.featured ? "crm-button-primary" : "crm-button-secondary"
+                  } inline-flex h-11 w-full items-center justify-center px-4 text-sm font-medium`}
+                >
+                  {tier.id === "free"
+                    ? session?.user
+                      ? "Go to dashboard"
+                      : "Start free"
+                    : session?.user
+                      ? "Manage billing"
+                      : "Start free"}
+                </Link>
+              </div>
+            </article>
+          ))}
         </div>
 
         <div className="rounded-2xl border border-border bg-card/50 p-6 text-sm text-muted-foreground">
           <p className="mb-2 font-medium text-foreground">How billing works</p>
           <ul className="space-y-1.5">
             <li>· The first workspace on your account is always free. No trial clock.</li>
-            <li>· Each additional workspace adds $9/mo to your invoice the day you create it.</li>
-            <li>· Delete a workspace and the $9/mo charge stops on your next billing cycle.</li>
-            <li>· You bring your own Claude API key for MCP + Seldon It — we don&apos;t mark up inference.</li>
+            <li>· Paid tiers are billed per workspace per month.</li>
+            <li>· Delete a workspace and the charge stops on your next billing cycle.</li>
+            <li>· You bring your own Claude / OpenAI key — we don&apos;t mark up inference.</li>
+            <li>· Every LLM call is tracked, attributed to the workflow run, and visible in your admin dashboard.</li>
           </ul>
         </div>
 
         <p className="text-center text-sm text-muted-foreground">
-          Self-host for free. No limits. Deploy on your own infrastructure. {" "}
+          Self-host for free. No limits. Deploy on your own infrastructure.{" "}
           <a
-            href="https://github.com/seldonframe/crm"
+            href="https://github.com/seldonframe/seldonframe"
             target="_blank"
             rel="noreferrer"
             className="font-medium text-primary underline underline-offset-4"

--- a/packages/crm/src/components/orgs/new-workspace-prompt-form.tsx
+++ b/packages/crm/src/components/orgs/new-workspace-prompt-form.tsx
@@ -112,7 +112,7 @@ export function NewWorkspacePromptForm({ action, initialUpgradeRequired = false 
           <div className="space-y-3">
             <h2 className="text-section-title">You&apos;re at the workspace limit</h2>
             <p className="text-sm text-muted-foreground sm:text-base">
-              You&apos;ve used your free workspace. Each additional workspace is $9/month and unlocks more Brain intelligence for your OS.
+              You&apos;ve used your free workspace. Paid tiers start at $49/mo (Starter), $99/mo (Operator), or $149/mo (Agency) per workspace. Pick one to keep building.
             </p>
           </div>
 
@@ -124,7 +124,7 @@ export function NewWorkspacePromptForm({ action, initialUpgradeRequired = false 
                   <span>Opening secure checkout...</span>
                 </span>
               ) : (
-                "Unlock another workspace for $9/month"
+                "Choose a plan ($49+/mo)"
               )}
             </Button>
             <Link href="/orgs" className="crm-button-secondary h-11 px-5 inline-flex items-center justify-center">

--- a/packages/crm/src/lib/billing/anonymous-workspace.ts
+++ b/packages/crm/src/lib/billing/anonymous-workspace.ts
@@ -149,14 +149,51 @@ export function buildWorkspaceUrls(
   const sw = (next: string) =>
     `${adminOrigin}/switch-workspace?to=${encodeURIComponent(orgId)}&next=${encodeURIComponent(next)}`;
   return {
-    // Public-facing — shareable, no login required.
+    // ───── Flat shape (kept for backward compat with MCP v1.0.1 clients). ─────
     home: publicOrigin,
     book: `${publicOrigin}/book`,
     intake: `${publicOrigin}/intake`,
-    // Admin — require a session. These route through /switch-workspace,
-    // which sets the active-org cookie before the admin page loads.
     admin_dashboard: sw("/dashboard"),
     admin_contacts: sw("/contacts"),
     admin_deals: sw("/deals"),
+  };
+}
+
+/**
+ * Structured public/admin split — used in the create_workspace API response
+ * alongside the flat `urls` object. The split makes it easier for Claude Code
+ * to present the result clearly (public URLs are shareable; admin URLs need
+ * login + workspace ownership).
+ */
+export function buildStructuredWorkspaceUrls(
+  slug: string,
+  baseDomain: string,
+  orgId: string
+) {
+  const publicOrigin = `https://${slug}.${baseDomain}`;
+  const adminOrigin = `https://${APP_HOST}`;
+  const sw = (next: string) =>
+    `${adminOrigin}/switch-workspace?to=${encodeURIComponent(orgId)}&next=${encodeURIComponent(next)}`;
+
+  return {
+    public_urls: {
+      home: publicOrigin,
+      book: `${publicOrigin}/book`,
+      intake: `${publicOrigin}/intake`,
+    },
+    admin_urls: {
+      dashboard: sw("/dashboard"),
+      contacts: sw("/contacts"),
+      deals: sw("/deals"),
+      agents: sw("/agents"),
+      settings: sw("/settings"),
+    },
+    admin_setup_note:
+      "Admin URLs require login at app.seldonframe.com AND for the workspace to be linked to your user account. To enable browser admin access: " +
+      "(1) Sign up at https://app.seldonframe.com/signup. " +
+      "(2) In Settings → API, generate a SELDONFRAME_API_KEY. " +
+      "(3) `export SELDONFRAME_API_KEY=sk-…` in your shell and restart Claude Code. " +
+      "(4) Run `link_workspace_owner({})` to attach this workspace to your account. " +
+      "After that, clicking an admin URL routes through /switch-workspace, sets the active-org cookie, and lands you on the requested page.",
   };
 }

--- a/packages/crm/src/lib/billing/orgs.ts
+++ b/packages/crm/src/lib/billing/orgs.ts
@@ -71,8 +71,15 @@ function hasActiveWorkspaceSubscription(status: string | null | undefined) {
   return status === "active" || status === "trialing";
 }
 
+// NOTE: this string is also pattern-matched in two callers:
+//   - packages/crm/src/app/api/v1/workspace/create/route.ts (quota error detection)
+//   - packages/crm/src/app/orgs/new/page.tsx (UI quota detection)
+// Both match on the durable substring "additional workspace requires a paid tier"
+// (introduced in claude/pre-launch-polish — was previously coupled to a $9
+// dollar amount that no longer matches the live pricing). Keep in sync if you
+// change this message.
 const WORKSPACE_UPGRADE_REQUIRED_MESSAGE =
-  "You've used your free workspace. Each additional workspace is $9/month and unlocks more Brain intelligence for your OS.";
+  "You've used your free workspace. Each additional workspace requires a paid tier (Starter $49/mo, Operator $99/mo, or Agency $149/mo) and unlocks more Brain intelligence for your OS.";
 
 async function getOwnedWorkspaceCount(userId: string) {
   const [result] = await db

--- a/packages/crm/src/proxy.ts
+++ b/packages/crm/src/proxy.ts
@@ -48,6 +48,37 @@ function resolveWorkspaceSlugFromHost(host: string) {
   return subdomain;
 }
 
+// Admin paths that should NEVER be served from a workspace subdomain.
+// When a user visits e.g. `<slug>.app.seldonframe.com/dashboard`, the proxy
+// 302-redirects to `app.seldonframe.com/switch-workspace?to=<orgId>&next=/dashboard`
+// — which authenticates them, sets the active-org cookie, and lands on the
+// admin page. Without this, the request would fall through to the catch-all
+// rewrite and return 404 (no `/s/<slug>/dashboard` landing page exists).
+const WORKSPACE_SUBDOMAIN_ADMIN_PREFIXES = [
+  "/dashboard",
+  "/contacts",
+  "/deals",
+  "/agents",
+  "/settings",
+  "/activities",
+];
+
+function resolveWorkspaceAdminRedirect(
+  pathname: string,
+  orgId: string,
+  search: string,
+): URL | null {
+  if (!orgId) return null;
+  const isAdminPath = WORKSPACE_SUBDOMAIN_ADMIN_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+  if (!isAdminPath) return null;
+  const target = new URL("https://app.seldonframe.com/switch-workspace");
+  target.searchParams.set("to", orgId);
+  target.searchParams.set("next", `${pathname}${search ?? ""}`);
+  return target;
+}
+
 function resolveWorkspaceRewritePath(
   pathname: string,
   slug: string,
@@ -288,6 +319,21 @@ export async function proxy(request: NextRequest, event: NextFetchEvent) {
         : null);
 
       if (domainOrg?.slug) {
+        // Admin path on workspace subdomain → redirect to main app's
+        // switch-workspace flow. Requires orgId (only available when the
+        // domain lookup succeeded; the slug-only fallback below can't do
+        // this since it lacks the org id).
+        if (domainOrg.id) {
+          const adminRedirect = resolveWorkspaceAdminRedirect(
+            pathname,
+            domainOrg.id,
+            request.nextUrl.search,
+          );
+          if (adminRedirect) {
+            return NextResponse.redirect(adminRedirect);
+          }
+        }
+
         const rewritePath = resolveWorkspaceRewritePath(pathname, domainOrg.slug, domainOrg.defaults);
 
         if (rewritePath !== pathname) {

--- a/skills/mcp-server/package.json
+++ b/skills/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seldonframe/mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server for SeldonFrame — AI-native Business OS platform. One command creates a real hosted workspace with CRM, booking, intake, and Brain v2.",
   "type": "module",
   "bin": {

--- a/skills/mcp-server/src/welcome.js
+++ b/skills/mcp-server/src/welcome.js
@@ -1,4 +1,4 @@
-export const VERSION = "1.0.1";
+export const VERSION = "1.0.2";
 
 export const WELCOME_MARKDOWN = `# SeldonFrame — your AI-native Business OS
 
@@ -16,15 +16,63 @@ intent and call the appropriate typed tool. The backend applies the change
 deterministically. Zero backend LLM cost means the free tier is genuinely
 free forever.
 
-## The one command
+---
+
+## Quick start — describe your business
+
+To create a personalized workspace in a single turn, ask the user to paste
+this template into Claude Code and fill in their details:
 
 \`\`\`text
-create_workspace({ name: "Dental Clinic Laval", source: "https://example.com" })
+Create a workspace for my business:
+- Business name: [your business name]
+- Industry: [e.g., hvac, dental, legal, coaching, real-estate, salon, auto-repair]
+- Location: [city, state/province]
+- Operating hours: [e.g., Mon-Sat 7am-7pm]
+- Team size: [number of people / trucks / stations]
+- Services offered: [list your main services]
+- Website: [URL, if you have one]
 \`\`\`
 
-Returns a live subdomain, seeded CRM, and booking + intake pages ready to share.
+When the user replies with that filled in, YOU should orchestrate the
+following tool sequence (each call's response is structured — chain them):
 
-## How to customize a workspace
+1. \`create_workspace({ name: "<business name>", source: "<website if provided, else a 1-paragraph description>" })\`
+   — mints the hosted workspace + bearer token. The \`source\` arg seeds the Soul.
+2. If \`industry\` is provided, call \`install_vertical_pack({ pack: "<industry-slug>" })\`
+   — adds domain-specific objects, fields, and views.
+   Built-in packs: \`real-estate-agency\`. For other industries, the backend
+   synthesizes a custom pack via \`/api/v1/verticals/generate\`. If a builtin
+   pack matches, prefer it; otherwise call generate first, then install.
+3. If \`hours\` is provided, call \`configure_booking({ title, duration_minutes, description })\`
+   — sets the booking page defaults. Inline the parsed hours into \`description\`
+   (the booking schema doesn't take a per-day hours object yet).
+4. If \`website\` was provided, the \`source\` URL passed to step 1 already
+   triggered a Soul fetch. Confirm via \`get_workspace_snapshot({})\` and
+   call \`submit_soul({ soul })\` if you can extract a richer structured Soul.
+5. If \`services\` were listed, customize the intake form to capture
+   service-of-interest as a multi-select using \`customize_intake_form({ fields })\`.
+
+Present the final result as a summary: live URLs (public + admin), what
+was installed, and 2-3 next-best-action suggestions.
+
+## If the user just says "create a workspace" without details
+
+Ask these questions, one at a time, BEFORE calling \`create_workspace\`:
+
+1. What's your business name?
+2. What industry are you in? (suggest: hvac, dental, legal, coaching, real-estate, salon, auto-repair, consulting, fitness, other)
+3. Where are you located? (city, state)
+4. What are your operating hours?
+5. What services do you offer? (3-5 main ones)
+6. Do you have a website I can learn from? (optional)
+
+Then run the orchestration above. Don't dump all six questions in one
+message — ask conversationally so the user can think.
+
+---
+
+## How to customize a workspace later
 
 1. Call \`get_workspace_snapshot({})\` to see current state, Soul, blocks, recent events.
 2. Decide what to change based on the user's intent.
@@ -56,11 +104,15 @@ Soul compilation runs HERE, not on the backend:
 
 ## When you'll need \`SELDONFRAME_API_KEY\`
 
-The first workspace is free forever. A key is only required for:
+The first workspace is free forever. Paid tiers (Starter $49/mo, Operator
+$99/mo, Agency $149/mo) unlock additional workspaces, custom domains,
+white-label, and advanced Brain capabilities. A key is required for:
 
 - Adding a **second workspace**
 - Connecting a **custom domain**
 - Publishing, exporting agents, rotating org-scoped secrets
+- Accessing the admin browser surface (\`/dashboard\`, \`/contacts\`, \`/deals\`)
+  after \`link_workspace_owner({})\`
 
 Get one at <https://app.seldonframe.com/settings/api> and
 \`export SELDONFRAME_API_KEY=sk-…\`. The MCP will pick it up on next restart.
@@ -69,12 +121,12 @@ Get one at <https://app.seldonframe.com/settings/api> and
 
 Once a key is set, \`link_workspace_owner({})\` attaches the active
 workspace to your real account. This unlocks the admin URLs
-(dashboard, contacts, deals) for browser use after sign-in. The MCP
-bearer token stays valid — no rotation needed.
+(\`/dashboard\`, \`/contacts\`, \`/deals\`) for browser use after sign-in.
+The MCP bearer token stays valid — no rotation needed.
 
 ---
 
-**Docs:** <https://app.seldonframe.com/docs>  ·  **Homepage:** <https://seldonframe.com>
+**Docs:** <https://seldonframe.com/docs>  ·  **Homepage:** <https://seldonframe.com>  ·  **Pricing:** <https://seldonframe.com/#pricing>
 `;
 
 export const FIRST_CALL_BANNER = `🌑 Welcome to SeldonFrame. Your workspace is live — every URL above works right now. From here on, every tool response will include a \`next:\` array; follow it and you'll have a production-ready Business OS in under a minute.`;

--- a/tasks/post-launch-polish.md
+++ b/tasks/post-launch-polish.md
@@ -1,0 +1,237 @@
+# Post-launch polish backlog
+
+Items surfaced during the L-29 cleanroom test sequence and the
+`claude/pre-launch-polish` branch but explicitly deferred until after
+launch. Each one is small/cosmetic; none block the launch sign-off.
+
+When picking these up, file as discrete PRs (one per item) so each lands
+with its own review + Vercel preview.
+
+---
+
+## P2-1 — Booking page (`/book`) theme inheritance
+
+**Surface:** workspace booking page rendered via Cal.diy block.
+
+**Issue:** the booking page renders with a light/white theme even when the
+workspace home page (`/`) and intake form (`/intake`) use the dark theme.
+This is visually inconsistent — same workspace, three different chrome
+treatments.
+
+**Why deferred:** likely requires propagating the workspace's
+`PublicThemeProvider` context into the Cal.diy block's render tree, OR
+configuring Cal.diy's theme prop based on `organizations.theme`. Either
+path needs deeper investigation than the polish branch had time for.
+
+**Repro:**
+1. `create_workspace({ name: "Theme Test" })`
+2. Visit `https://theme-test.app.seldonframe.com/` — dark theme
+3. Visit `https://theme-test.app.seldonframe.com/book` — light theme
+
+**Suggested fix:** extend `PublicThemeProvider` to wrap the booking route's
+render tree, OR pass a `theme` prop to the Cal.diy embed based on the
+workspace's stored theme.
+
+---
+
+## P2-2 — Default booking availability empty state
+
+**Surface:** workspace booking page when no availability is configured.
+
+**Issue:** brand-new workspaces show "No times available. Try another day."
+when a customer visits `/book` before any availability is set up. This is
+technically accurate but feels like the booking system is broken rather
+than not-yet-configured.
+
+**Why deferred:** requires distinguishing "no availability configured" vs
+"availability configured but no slots in the visible window" — currently
+the calendar treats them the same.
+
+**Suggested fix:** if `bookingTemplate.availability` is empty (the seed
+default), show a "Set up your schedule in admin → bookings" prompt for
+operators OR a friendlier "We're not booking yet — leave us a note" CTA
+for customers.
+
+---
+
+## P2-3 — Operator entry point on workspace home page
+
+**Surface:** workspace home page (`<slug>.app.seldonframe.com/`).
+
+**Issue:** when an operator visits their own workspace's home page, there
+is no obvious link to the admin dashboard. They have to memorize or paste
+`app.seldonframe.com/switch-workspace?to=...&next=/dashboard`, or rely on
+the response from the most recent `create_workspace` MCP call.
+
+**Why deferred:** the workspace subdomain is intentionally customer-facing
+and should not leak admin chrome to anonymous visitors. Adding a
+session-aware "Are you the operator?" link requires reading auth cookies
+on the public render path, which currently isn't done by design.
+
+**Suggested fix:** read the `next-auth.session-token` cookie on the public
+render. If present AND the session user is a member of the workspace's
+org, render a small footer link "Admin →" pointing at
+`https://app.seldonframe.com/switch-workspace?to=<orgId>&next=/dashboard`.
+Should NOT render anything for anonymous visitors.
+
+Partial mitigation already shipped in `claude/pre-launch-polish`: subdomain
+admin redirects (Task 4 / C4) — typing `<slug>.app.seldonframe.com/dashboard`
+now 302s to the correct switch-workspace URL instead of 404'ing. So
+operators who guess the URL get there; this item is about making it
+discoverable without guessing.
+
+---
+
+## P2-4 — Workspace name cosmetics for slug-style inputs
+
+**Surface:** workspace home page heading.
+
+**Issue:** when an operator passes a slug-style name to `create_workspace`
+(e.g. `name: "my-workspace"`), the heading on the workspace home page reads
+exactly "my-workspace" because that's the literal value the user typed.
+The current code correctly threads `org.name` through to the rendered
+heading — there is no slug-vs-name confusion in the data layer; the issue
+is purely that users sometimes pass technical-looking strings.
+
+**Status:** the MCP welcome message in v1.0.2 (`claude/pre-launch-polish`)
+explicitly guides users to provide a friendly business name (e.g.,
+"DFW Comfort HVAC", not "dfw-comfort-hvac") via the prompt template + the
+6-question interactive flow. Most users following the guidance will type a
+real business name and never see the slug-style heading.
+
+**Why kept here as P2:** for users who somehow still pass a slug-style
+name AND don't customize the page after, the heading remains slug-style.
+A defensive fallback could detect this (heuristic: name === slug AND no
+spaces AND contains a hyphen) and prompt the user to provide a friendlier
+display name. Low-priority polish.
+
+---
+
+## P2-5 — `__drizzle_migrations` reconciliation in production
+
+**Surface:** infrastructure / DB layer.
+
+**Issue:** the production DB's `__drizzle_migrations` table is empty
+(verified during the 2026-04-27 production migration). Future
+`drizzle-kit migrate` invocations would either no-op (treating prod as
+"up to date" since the journal claims so) OR try to re-apply everything.
+
+**Why deferred:** requires either backfilling the journal with all
+applied migrations, OR migrating to a runner that doesn't depend on the
+journal. Cross-cuts with P2-6 (journal sync) and P2-7 (Vercel deploy
+migrations).
+
+**Suggested fix:** write a one-time reconciliation script that records
+each applied migration in `__drizzle_migrations` based on file presence +
+schema introspection. Then add a deploy-time check that asserts journal
+entry count matches applied count.
+
+---
+
+## P2-6 — `drizzle/meta/_journal.json` out of sync with on-disk SQL files
+
+**Surface:** repo / migration tooling.
+
+**Issue:** 35 SQL files exist in `packages/crm/drizzle/`; only 13 are
+registered in `_journal.json`. Migrations 0008-0013 + 0019-0027 are
+hand-authored without journal entries (the 0022 file's own header comment
+acknowledges this pattern).
+
+**Why deferred:** the journal-out-of-sync state is a known pattern in the
+codebase. Fixing requires either backfilling 22 missing entries (and
+matching `meta/00XX_*.json` snapshots) or migrating off drizzle-kit's
+journal-based runner.
+
+**Suggested fix:** Phase 1 — backfill journal entries by hand for the
+hand-authored migrations. Phase 2 — adopt a simpler runner (e.g.,
+postgres-migrations) that reads SQL files in numerical order without
+needing a journal.
+
+---
+
+## P2-7 — Vercel deploys don't run migrations
+
+**Surface:** CI / deployment pipeline.
+
+**Issue:** the production DB drift surfaced during the 2026-04-27
+cleanroom test was caused by Vercel's build pipeline never running
+`pnpm db:migrate`. Migrations are authored on dev branches, applied to
+the dev DB locally, and never propagated to prod until someone runs the
+migrate script manually.
+
+**Why deferred:** depends on P2-5 + P2-6 being resolved first (or
+migrating off drizzle-kit). With the journal out of sync, automating
+`drizzle-kit migrate` in the build would cause incorrect behavior.
+
+**Suggested fix:** once P2-5 + P2-6 are done, add a `vercel-build`
+script step that runs `pnpm db:migrate` against `DATABASE_URL_MIGRATIONS`
+(a separate env var so Vercel functions don't try to migrate per-request,
+just at deploy time).
+
+---
+
+## P2-8 — `.gitignore` doesn't cover `.env.prod`
+
+**Surface:** repo hygiene.
+
+**Issue:** `vercel env pull --environment=production` writes a
+`.env.prod` file containing production secrets. The current `.gitignore`
+covers `.vercel` and `.env*.local` but NOT plain `.env.prod`. A future
+operator could accidentally `git add .` and commit production secrets.
+
+**Why deferred:** trivial one-liner but doesn't block launch.
+
+**Suggested fix:** add to `.gitignore`:
+```
+.env.prod
+.env.production
+.env.staging
+```
+
+---
+
+## P2-9 — Update `openclaw/skills/seldonframe/` skill docs to new pricing
+
+**Surface:** internal Claude Code skill instructions.
+
+**Issue:** `openclaw/skills/seldonframe/SKILL.md` and `README.md` still
+reference the old `$9 / $29` pricing in the workspace-quota messaging that
+Claude shows operators. The user-facing surfaces (landing, /pricing,
+billing flow) were updated in `claude/pre-launch-polish`; the internal
+skill instructions were left as a follow-up.
+
+**Why deferred:** these strings only affect Claude's behavior when an
+operator hits the workspace quota — secondary path. Not visible until the
+quota is reached.
+
+**Suggested fix:** find/replace `$9/month`, `$9/mo`, `$29/month`,
+`$29/mo` references in `openclaw/skills/seldonframe/*.md` with the new
+"Starter $49 / Operator $99 / Agency $149" framing. Match the language
+used in `lib/billing/orgs.ts` `WORKSPACE_UPGRADE_REQUIRED_MESSAGE`.
+
+---
+
+## P2-10 — `seldon-cli` (the `seldon init` / `seldon scaffold` commands)
+
+**Surface:** marketing copy mentions `seldon init` and `seldon scaffold`,
+but no such CLI exists in the repo. These commands appear in:
+- README.md Quick start
+- `/docs/quickstart` page Steps 2-4
+
+**Why deferred:** the README and quickstart commands are aspirational —
+the actual workflow today is to drive everything through Claude Code via
+the MCP. Either the CLI gets built post-launch OR the marketing copy is
+trimmed to MCP-only commands.
+
+**Suggested fix:** EITHER (A) implement a thin `seldon` CLI that proxies
+to the MCP server's tools (so `seldon init "Name"` ≡
+`create_workspace({ name: "Name" })`), OR (B) update marketing copy to
+reflect the Claude-Code-only flow and remove the standalone `seldon`
+references.
+
+Decision needed before either path proceeds.
+
+---
+
+*Generated as part of `claude/pre-launch-polish` 2026-04-27. Prune items
+once they're shipped or superseded.*


### PR DESCRIPTION
## Summary

Pre-launch polish branch covering all P0 + P1 tasks surfaced during the L-29 cleanroom test sequence + Max's polish brief. Six focused commits.

## Commits

| # | Commit | Scope |
|---|---|---|
| C1 | `50eefbc1` | Pricing $49/$99/$149 across 8 user-facing surfaces (landing, /pricing rewrite, README, public meta, docs, billing message + matchers, new-workspace prompt) |
| C2 | `5b5a39a3` | MCP welcome.js — prompt template + interactive question flow + bump to 1.0.2 |
| C3 | `70818a65` | Backend `create_workspace` response — structured `public_urls` / `admin_urls` / `admin_setup_note` (additive; flat `urls` retained for v1.0.1 backward compat) |
| C4 | `1e4207fb` | proxy.ts: 302-redirect admin paths from workspace subdomains to main app's `/switch-workspace` |
| C6 | `a39f18cb` | Powered-by badge: h-3.5 → h-5 for legibility |
| C7 | `4c249751` | tasks/post-launch-polish.md — 10 P2 items captured for post-launch backlog |

## Verification

- `pnpm typecheck` — clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo (no regression)
- `pnpm build` — `/pricing` route compiles
- Pricing grep — zero `$9/$29/$99` references in user-facing surfaces

## Sequencing after merge

1. ✅ This PR merges
2. 🔑 Max publishes `@seldonframe/mcp@1.0.2` to npm (welcome message updates)
3. 🧪 Max re-cleanrooms the create_workspace flow with rich input (e.g. "DFW Comfort HVAC", industry: hvac, hours: ..., website: ...) to verify the Claude-Code orchestration works end-to-end
4. ✅ Launch