### PR TITLE
Stripe price IDs + quickstart dual-path install (post-polish followups)

### DIFF
--- a/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
@@ -1,5 +1,7 @@
 // /docs/quickstart — the "Start for $0" CTA destination.
-// Workstream 2 — three-command install flow + prerequisites + next-steps.
+// Three steps. Step 1 has two install paths (app vs terminal) for users
+// who aren't terminal-comfortable. Steps 2-3 are natural-language prompts
+// that work in either path — no fake CLI commands.
 
 import type { Metadata } from "next";
 import { MarketingShell } from "../../marketing-shell";
@@ -7,7 +9,7 @@ import { MarketingShell } from "../../marketing-shell";
 export const metadata: Metadata = {
   title: "Quickstart — SeldonFrame",
   description:
-    "Three commands to install SeldonFrame, create your first workspace, and scaffold your first block.",
+    "Install SeldonFrame in 30 seconds, then describe your business in natural language. Works from the Claude Code desktop app or the terminal.",
 };
 
 const Section = ({
@@ -27,9 +29,42 @@ const Section = ({
     </span>
     <h3 className="text-[16px] font-semibold mb-2 text-[#fafafa] relative z-10">{title}</h3>
     <p className="text-[14px] text-[#a1a1aa] leading-[1.65] mb-3 relative z-10">{body}</p>
-    <code className="block p-3 bg-[#1a1a1e] rounded-[8px] font-mono text-[12px] text-[#1FAE85] overflow-x-auto leading-[1.5] relative z-10">
+    <code className="block p-3 bg-[#1a1a1e] rounded-[8px] font-mono text-[12px] text-[#1FAE85] overflow-x-auto leading-[1.5] relative z-10 whitespace-pre-wrap">
       {code}
     </code>
+  </div>
+);
+
+const InstallOption = ({
+  label,
+  recommended,
+  title,
+  body,
+  code,
+  caption,
+}: {
+  label: string;
+  recommended?: boolean;
+  title: string;
+  body: string;
+  code: string;
+  caption?: string;
+}) => (
+  <div className="bg-[#0d0d10] border border-white/5 rounded-[10px] p-5 md:p-6">
+    <div className="flex items-center gap-2 mb-2">
+      <span className="text-[10px] uppercase tracking-[0.14em] text-[#71717a] font-mono">{label}</span>
+      {recommended ? (
+        <span className="text-[10px] uppercase tracking-[0.12em] text-[#1FAE85] font-mono bg-[#1FAE85]/10 px-2 py-[2px] rounded-full">
+          Recommended
+        </span>
+      ) : null}
+    </div>
+    <h4 className="text-[15px] font-semibold text-[#fafafa] mb-2">{title}</h4>
+    <p className="text-[13px] text-[#a1a1aa] leading-[1.6] mb-3">{body}</p>
+    <code className="block p-3 bg-[#1a1a1e] rounded-[6px] font-mono text-[12px] text-[#1FAE85] overflow-x-auto leading-[1.5] whitespace-pre-wrap">
+      {code}
+    </code>
+    {caption ? <p className="text-[12px] text-[#71717a] mt-2 leading-[1.55]">{caption}</p> : null}
   </div>
 );
 
@@ -40,12 +75,13 @@ export default function QuickstartPage() {
         <header className="mb-10">
           <p className="text-[12px] uppercase tracking-[0.12em] text-[#71717a] font-mono mb-2">Docs · Quickstart</p>
           <h1 className="text-[clamp(30px,4vw,42px)] font-bold tracking-[-0.03em] text-[#fafafa] mb-4 leading-[1.15]">
-            Three commands. Six minutes. A working Business OS.
+            Install once. Describe your business. Ship in minutes.
           </h1>
           <p className="text-[16px] text-[#a1a1aa] leading-[1.7]">
-            SeldonFrame installs as an MCP server you wire into your IDE. After three
-            commands you have a branded workspace with a CRM, scaffolded blocks, and
-            agent flows — all controllable from natural language.
+            SeldonFrame plugs into Claude Code as an MCP server. After install, you describe
+            your business in natural language and Claude orchestrates the workspace creation,
+            block installs, and customization — same flow whether you&apos;re in the
+            Claude Code desktop app or the terminal.
           </p>
         </header>
 
@@ -131,23 +167,63 @@ export default function QuickstartPage() {
         </section>
 
         <section className="space-y-4 mb-12">
-          <Section
-            number={1}
-            title="Add SeldonFrame to your IDE"
-            body="The MCP server exposes SeldonFrame's primitive surface inside Claude Code. After this command, you can describe what you want and Claude will use SeldonFrame to build it."
-            code="claude mcp add seldonframe -- npx -y @seldonframe/mcp"
-          />
+          {/* Step 1 split into two install paths. The desktop-app path is
+              recommended for non-terminal-comfortable users; the terminal
+              path is for developers. The MCP registration is identical in
+              both — register once, use everywhere on the same machine. */}
+          <div className="bg-[#111113] border border-white/5 rounded-[12px] p-6 md:p-8 relative overflow-hidden">
+            <span className="absolute top-3 right-4 text-[44px] font-extrabold text-[#1FAE85] opacity-15 tracking-[-0.04em] leading-none">
+              1
+            </span>
+            <h3 className="text-[16px] font-semibold mb-2 text-[#fafafa] relative z-10">
+              Add SeldonFrame to Claude Code
+            </h3>
+            <p className="text-[14px] text-[#a1a1aa] leading-[1.65] mb-5 relative z-10">
+              The MCP server exposes SeldonFrame&apos;s primitive surface inside Claude Code.
+              Pick whichever path is comfortable — both register the same MCP and produce
+              the same result.
+            </p>
+
+            <div className="grid gap-4 md:grid-cols-2 relative z-10">
+              <InstallOption
+                label="Option A"
+                recommended
+                title="Claude Code desktop app"
+                body="Open Claude Code (download from claude.ai/code if you don't have it), then type:"
+                code={`Add SeldonFrame to my tools`}
+                caption="Claude Code reads this as a request to install an MCP server and runs the registration for you. No terminal required."
+              />
+              <InstallOption
+                label="Option B"
+                title="Terminal"
+                body="If you prefer the command line, run:"
+                code={`claude mcp add seldonframe -- npx -y @seldonframe/mcp\nclaude`}
+                caption="Requires Node.js 18+ and Claude Code CLI installed. The first command registers the MCP; the second starts a session."
+              />
+            </div>
+          </div>
+
           <Section
             number={2}
-            title="Create your workspace"
-            body="A workspace is a branded business OS — its own CRM, theme, customer portal, and agent flows. Your first workspace is free forever."
-            code='seldon init "my-workspace"'
+            title="Describe your business"
+            body="Paste this template into Claude Code (app or terminal — same prompt) and fill in your details:"
+            code={`Create a workspace for my business:
+- Business name: [your business name]
+- Industry: [hvac, dental, legal, coaching, real-estate, salon, ...]
+- Location: [city, state]
+- Operating hours: [Mon-Sat 7am-7pm]
+- Team size: [number]
+- Services offered: [3-5 main ones]
+- Website: [URL, optional]`}
           />
           <Section
             number={3}
-            title="Scaffold your first block"
-            body="Describe a capability — intake form, scheduling, equipment tracking — and SeldonFrame scaffolds production-ready code with admin UI, customer-portal surfaces, and tests."
-            code="seldon scaffold block customer-intake"
+            title="Watch Claude build it"
+            body="Claude Code chains the right tool calls automatically: creates the workspace, installs an industry-matched vertical pack, configures booking availability, seeds your Soul from your website (if provided), and customizes the intake form. Returns live URLs you can share immediately. Your first workspace is free forever."
+            code={`https://your-business.app.seldonframe.com           ← public home
+https://your-business.app.seldonframe.com/book      ← booking
+https://your-business.app.seldonframe.com/intake    ← intake form
+https://app.seldonframe.com/switch-workspace?...    ← admin dashboard`}
           />
         </section>
 

--- a/packages/crm/src/lib/billing/plans.ts
+++ b/packages/crm/src/lib/billing/plans.ts
@@ -22,7 +22,10 @@ export const PLANS: Plan[] = [
     type: "cloud",
     price: 49,
     yearlyPrice: 468,
-    stripePriceId: "",
+    // Live Stripe price (lookup_key: starter_monthly). Marketing surface
+    // labels this tier "Starter" — see /pricing and the landing
+    // Pricing component.
+    stripePriceId: "price_1TQzh7JOtNZA0x7xLOTicHkW",
     stripeYearlyPriceId: "",
     limits: {
       maxOrgs: 1,
@@ -38,7 +41,9 @@ export const PLANS: Plan[] = [
     type: "cloud",
     price: 99,
     yearlyPrice: 948,
-    stripePriceId: "",
+    // Live Stripe price (lookup_key: cloud_pro_monthly). Marketing surface
+    // labels this tier "Operator".
+    stripePriceId: "price_1TNY81JOtNZA0x7xsulCSP6x",
     stripeYearlyPriceId: "",
     limits: {
       maxOrgs: 1,
@@ -54,7 +59,9 @@ export const PLANS: Plan[] = [
     type: "pro",
     price: 149,
     yearlyPrice: 1428,
-    stripePriceId: "",
+    // Live Stripe price (lookup_key: pro_3_monthly). Marketing surface
+    // labels this tier "Agency".
+    stripePriceId: "price_1TQzjrJOtNZA0x7xV4UFxWrH",
     stripeYearlyPriceId: "",
     limits: {
       maxOrgs: 3,


### PR DESCRIPTION
## Summary

Two post-polish followups Max requested:

1. **Wire Stripe price IDs** for the new $49/$99/$149 tiers. The polish branch updated marketing copy to the new prices but `plans.ts` still had empty `stripePriceId` strings — any free→paid upgrade would have hit the existing "Stripe price id is missing" throw.
2. **Quickstart dual-path install** — Option A (Claude Code app, recommended) + Option B (terminal). Same MCP, same tools, same workspace creation. Removes the `seldon init` / `seldon scaffold` CLI references (that CLI doesn't exist — P2-10).

## Mapping (verified via `stripe-seed.ts` lookup_keys)

| Tier | plans.ts ID | Stripe price ID |
|---|---|---|
| Starter $49 | `cloud-starter` | `price_1TQzh7JOtNZA0x7xLOTicHkW` |
| Operator $99 | `cloud-pro` | `price_1TNY81JOtNZA0x7xsulCSP6x` |
| Agency $149 | `pro-3` | `price_1TQzjrJOtNZA0x7xV4UFxWrH` |

Other tiers (pro-5/10/20) + all yearly IDs left empty — not currently surfaced in marketing.

## Verification

- `pnpm typecheck` clean
- `pnpm test:unit` — 1858 pass / 0 fail / 12 todo
- `pnpm build` — `/docs/quickstart` static route compiles
