### PR TITLE
feat(blueprint): Phase 1 research + Phase 2 schema + general/hvac templates

### DIFF
--- a/skills/templates/README.md
+++ b/skills/templates/README.md
@@ -1,0 +1,133 @@
+# Workspace blueprint templates
+
+This directory contains the deterministic blueprint system for SeldonFrame workspaces. One blueprint = one workspace. Same blueprint JSON → same rendered HTML/CSS for every surface, byte-for-byte.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| `schema.json` | JSON Schema (Draft 2020-12) defining the blueprint shape. The contract every renderer reads. |
+| `general.json` | Fallback blueprint. Industry-agnostic placeholder content. Used when Claude Code can't match a vertical pack. |
+| `hvac.json` | First vertical content pack. HVAC-specific copy, services, intake fields, admin objects. |
+| `README.md` | This file. |
+
+Future verticals (`dental.json`, `legal.json`, `salon.json`, `coaching.json`, etc.) live in this directory as full self-contained blueprints — not deltas, not extends.
+
+## How a workspace gets a blueprint
+
+When `create_workspace({ name, industry, ... })` is called, the MCP server:
+
+1. Reads the `industry` parameter from the call (or from rich `source` text via simple keyword match).
+2. Looks for a matching template file in `skills/templates/<industry>.json`.
+3. If found, loads that template as the starting point. Otherwise falls back to `general.json`.
+4. Replaces the `[Your Business Name]`, `[City]`, `[Owner Name]`, etc. placeholders with the actual business data Claude Code collected from the user.
+5. Customizes `workspace.theme.accent`, `workspace.contact.*`, and any landing.sections content the user provided.
+6. Persists the resolved blueprint to the workspace record.
+7. Returns workspace URLs that render from the blueprint.
+
+The blueprint is **immutable per render**. Operator edits go through tool calls (`update_landing_content`, `update_theme`, `customize_intake_form`, `configure_booking`) which produce a new blueprint version.
+
+## Renderer versioning
+
+Each surface declares a frozen renderer ID:
+
+```json
+"landing":   { "renderer": "general-service-v1", ... }
+"booking":   { "renderer": "calcom-month-v1", ... }
+"intake":    { "renderer": "formbricks-stack-v1", ... }
+"admin":     { "renderer": "twenty-shell-v1", ... }
+```
+
+A renderer ID is **frozen forever** once it ships. If we change the layout of `general-service-v1` in a way that's incompatible with existing blueprints, we ship `general-service-v2` and migrate blueprints explicitly. Old blueprints keep rendering with the old renderer.
+
+This is the load-bearing rule of the system. It's how "deterministic, byte-for-byte" stays true across years of iteration.
+
+## Adding a new vertical pack
+
+1. **Copy `general.json` to `<industry>.json`** (e.g. `dental.json`).
+2. **Replace the placeholder content** with industry-specific copy:
+   - `workspace.industry` — the industry slug
+   - `workspace.tagline` — one-liner that fits the vertical
+   - `workspace.theme.accent` — recommended palette per vertical (see "Recommended palettes" below)
+   - `workspace.contact.hours` — typical operating hours for the vertical
+   - `landing.sections` — vertical-appropriate sections (e.g. add `emergency-strip` for HVAC/plumbing/locksmith; swap services-grid for a portfolio for salons; rename "Services" to "Practice Areas" for legal)
+   - `landing.sections.services-grid.items` — vertical-specific services with sensible icons
+   - `landing.sections.faq.items` — vertical-specific common questions
+   - `booking.eventType` — the canonical first-touch booking for the vertical
+   - `booking.formFields` — fields a customer needs to provide before the visit
+   - `intake.questions` — vertical-specific intake (e.g. HVAC needs urgency + service address)
+   - `admin.objects` — additional vertical-specific objects (e.g. HVAC adds `service_calls`, `equipment`, `technicians`; dental might add `appointments`, `treatments`, `insurance_carriers`)
+3. **Validate against `schema.json`**:
+   ```bash
+   # Once the validation script ships in Phase 3:
+   pnpm template:validate skills/templates/<industry>.json
+   ```
+4. **Test render** (Phase 3): preview the resulting workspace URLs against the new template before committing.
+5. **Commit** with a message like `feat(templates): add dental vertical pack`.
+
+## Recommended palettes per vertical
+
+Per the design pattern research, the accent color should fit the trust signature of the vertical. Operators always override; these are the per-vertical defaults the templates ship with:
+
+| Vertical | Default `theme.accent` | Reasoning |
+|---|---|---|
+| `general` | `#1A1A1A` (near-black) | Monochrome, safe across all industries (Cal.com pattern). |
+| `hvac` | `#1E40AF` (deep blue) | Reliable, technical, "we know mechanical systems." |
+| `plumbing` | `#1E40AF` or `#0F172A` | Same as HVAC. |
+| `dental` | `#0D9488` (soft teal) | Clinical, calm, modern. |
+| `legal` | `#0F172A` (deep navy) | Authoritative, conservative. |
+| `salon` | `#1A1A1A` or `#7C3AED` | Monochrome for editorial salons; muted purple for full-service. |
+| `coaching` | `#C2410C` (terracotta) or `#15803D` (sage) | Warm, human. |
+| `real-estate` | `#0F172A` (navy) or `#7F1D1D` (deep red) | Professional + traditional. |
+| `auto-repair` | `#B91C1C` (deep red) | Industrial, urgent. |
+| `fitness` | `#15803D` (sage) or `#C2410C` (terracotta) | Energetic but not neon. |
+| `consulting` | `#1A1A1A` (monochrome) | Professional, flexible. |
+
+These are recommendations, not enforcements. The schema accepts any hex color as `theme.accent`.
+
+## What you should NOT add to a vertical pack
+
+Vertical packs are content packs — they change copy, icons, fields, and section selection. They do NOT introduce:
+
+- ❌ New section types (those go in `schema.json` + the `general-service-v1` renderer code)
+- ❌ New question field types (those go in `schema.json` + the `formbricks-stack-v1` renderer code)
+- ❌ New admin field types (those go in `schema.json` + the `twenty-shell-v1` renderer code)
+- ❌ Renderer overrides (renderer is the same `general-service-v1` for every vertical pack)
+- ❌ Custom CSS or JS hooks
+- ❌ Per-vertical layout changes (use section ordering and section variants instead — e.g. `hero.variant: "founder-portrait"` for coaching)
+
+If a vertical genuinely needs structural change, that's a renderer-version bump (`general-service-v2`), not a per-vertical override. Resist the temptation to ship `dental.json` with custom rendering hooks — every override that lands in templates breaks the deterministic-blueprint claim.
+
+## Validation
+
+The `$schema` field at the top of every template references the local `schema.json`. Editors with JSON Schema support (VS Code, IntelliJ, Cursor) auto-validate as you type.
+
+Before committing a new template:
+
+1. Editor schema validation passes.
+2. All required fields present.
+3. All `[Bracketed]` placeholders look intentional (no accidental empty strings).
+4. All `null` values are valid per their field's schema (e.g. `logoUrl: null` is fine; `name: null` is not).
+5. `accent` is a valid hex color (3 or 6 digits).
+6. `phone` numbers are E.164.
+7. `timezone` is a valid IANA identifier.
+
+Phase 3 ships a `pnpm template:validate` script that runs Ajv against every template and fails CI if any template doesn't conform.
+
+## Why this design
+
+Per Max's directive in the architectural brief:
+
+> Do NOT use an LLM to generate the design. The design is HANDCRAFTED based on proven patterns. Only the business DATA is dynamic.
+
+The blueprint is the seam between handcrafted design (renderer code, CSS tokens, section components) and dynamic business data (slot values from the blueprint JSON).
+
+LLM involvement happens at **blueprint generation time**, not at render time. Claude Code reads the natural-language business description, picks the right vertical pack, fills in the slots, and submits the blueprint. From that point forward, the rendering is pure: same JSON → same HTML, every time.
+
+This is what makes the system testable, debuggable, and trustworthy. A workspace's home page never "looks different today than it did yesterday" because no part of the design is generated at request time.
+
+## See also
+
+- `tasks/design-patterns-research.md` — Phase 1 research that informs this schema.
+- (Phase 3) `packages/crm/src/lib/blueprint/renderer/` — the deterministic renderer implementations.
+- (Phase 3) `packages/crm/scripts/template-validate.ts` — the Ajv-based validator.

--- a/skills/templates/general.json
+++ b/skills/templates/general.json
@@ -1,0 +1,330 @@
+{
+  "$schema": "./schema.json",
+  "version": 1,
+  "workspace": {
+    "name": "[Your Business Name]",
+    "industry": "general",
+    "tagline": "Local. Trusted. Fast.",
+    "theme": {
+      "mode": "light",
+      "accent": "#1A1A1A",
+      "displayFont": "cal-sans",
+      "bodyFont": "inter",
+      "radiusScale": "default",
+      "logoUrl": null,
+      "heroImageUrl": null
+    },
+    "contact": {
+      "phone": "+15555550100",
+      "emergencyPhone": null,
+      "email": null,
+      "address": {
+        "street": "[Street address]",
+        "city": "[City]",
+        "region": "[State or province]",
+        "postalCode": "[Postal code]",
+        "country": "US"
+      },
+      "hours": {
+        "mon": [9, 17],
+        "tue": [9, 17],
+        "wed": [9, 17],
+        "thu": [9, 17],
+        "fri": [9, 17],
+        "sat": null,
+        "sun": null
+      },
+      "timezone": "America/New_York",
+      "serviceArea": "[City] and surrounding area"
+    }
+  },
+  "landing": {
+    "renderer": "general-service-v1",
+    "sections": [
+      {
+        "type": "hero",
+        "eyebrow": "[City] · [Service Category]",
+        "headline": "Reliable [service] you can count on",
+        "subhead": "We help homeowners and businesses get [outcome] without the hassle. Free quote in under a day.",
+        "ctaPrimary": { "label": "Get a free quote", "href": "/intake", "kind": "primary" },
+        "ctaSecondary": { "label": "Call us", "href": "tel:+15555550100", "kind": "tel" },
+        "imageUrl": null,
+        "variant": "split-image-right"
+      },
+      {
+        "type": "trust-strip",
+        "items": [
+          { "icon": "Star", "label": "5-star rated by local customers" },
+          { "icon": "ShieldCheck", "label": "Licensed and insured" },
+          { "icon": "Clock", "label": "Same-day service available" }
+        ]
+      },
+      {
+        "type": "services-grid",
+        "headline": "Services",
+        "subhead": "What we do best.",
+        "layout": "grid-3",
+        "items": [
+          {
+            "icon": "Wrench",
+            "title": "Service one",
+            "description": "Brief description of your first core service. Two short sentences max."
+          },
+          {
+            "icon": "Settings",
+            "title": "Service two",
+            "description": "Brief description of your second core service."
+          },
+          {
+            "icon": "Sparkles",
+            "title": "Service three",
+            "description": "Brief description of your third core service."
+          }
+        ]
+      },
+      {
+        "type": "about",
+        "headline": "Why customers pick us",
+        "body": "Tell your story in 2-3 sentences. What's your background, why did you start the business, and what makes your work different from the competition? Speak to one person, not to everyone.",
+        "photoUrl": null,
+        "ownerName": "[Owner Name]",
+        "ownerTitle": "Owner"
+      },
+      {
+        "type": "mid-cta",
+        "headline": "Ready to get started?",
+        "subhead": "Tell us what you need and we'll send a free quote within 24 hours.",
+        "ctaPrimary": { "label": "Get a free quote", "href": "/intake", "kind": "primary" },
+        "ctaSecondary": { "label": "Call us", "href": "tel:+15555550100", "kind": "tel" },
+        "embedQuoteForm": true
+      },
+      {
+        "type": "testimonials",
+        "headline": "What our customers say",
+        "featured": {
+          "quote": "Replace this with a real customer quote that mentions a specific outcome (e.g. 'They fixed our problem in under an hour and the price matched the quote exactly').",
+          "authorName": "[Customer Name]",
+          "authorRole": "Customer in [City]",
+          "rating": 5,
+          "source": "google"
+        },
+        "items": [
+          {
+            "quote": "Short quote about the experience. Specific is better than glowing.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Homeowner",
+            "rating": 5,
+            "source": "google"
+          },
+          {
+            "quote": "Another short, specific quote.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Local business owner",
+            "rating": 5,
+            "source": "google"
+          },
+          {
+            "quote": "A third short, specific quote.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Customer since [Year]",
+            "rating": 5,
+            "source": "google"
+          }
+        ]
+      },
+      {
+        "type": "service-area",
+        "headline": "Service area",
+        "description": "We serve [City] and surrounding areas within roughly [N] miles."
+      },
+      {
+        "type": "faq",
+        "headline": "Frequently asked questions",
+        "items": [
+          {
+            "question": "How quickly can you come out?",
+            "answer": "Most jobs are scheduled within 24-48 hours. Same-day service is available for urgent issues — call us directly."
+          },
+          {
+            "question": "Do you charge for estimates?",
+            "answer": "No. Estimates are always free and there's no obligation to book."
+          },
+          {
+            "question": "Are you licensed and insured?",
+            "answer": "Yes. We're fully licensed in [State] and carry liability insurance for every job."
+          },
+          {
+            "question": "What payment methods do you accept?",
+            "answer": "We accept cash, check, all major credit cards, and offer financing on larger jobs."
+          }
+        ]
+      },
+      {
+        "type": "footer",
+        "showHours": true,
+        "showAddress": true,
+        "showServiceArea": true,
+        "social": [],
+        "legal": [
+          { "label": "Privacy", "href": "/privacy" },
+          { "label": "Terms", "href": "/terms" }
+        ]
+      }
+    ]
+  },
+  "booking": {
+    "renderer": "calcom-month-v1",
+    "eventType": {
+      "title": "Free consultation",
+      "description": "30-minute conversation to understand your needs and provide a quote.",
+      "durationMinutes": 30,
+      "location": { "kind": "phone" },
+      "bufferMinutes": 0
+    },
+    "availability": {
+      "weekly": {
+        "mon": [9, 17],
+        "tue": [9, 17],
+        "wed": [9, 17],
+        "thu": [9, 17],
+        "fri": [9, 17],
+        "sat": null,
+        "sun": null
+      },
+      "blackoutDates": [],
+      "leadTimeHours": 4,
+      "advanceWindowDays": 60
+    },
+    "formFields": [
+      { "id": "name",  "label": "Full name", "type": "text",  "required": true,  "placeholder": "Jane Smith" },
+      { "id": "email", "label": "Email",     "type": "email", "required": true,  "placeholder": "you@example.com" },
+      { "id": "phone", "label": "Phone",     "type": "phone", "required": false, "placeholder": "(555) 555-0100" },
+      { "id": "notes", "label": "What can we help with?", "type": "textarea", "required": false }
+    ],
+    "confirmation": {
+      "headline": "Your booking is confirmed",
+      "message": "We'll send a calendar invite shortly. If anything changes, just reply to that email.",
+      "successRedirectUrl": null
+    }
+  },
+  "intake": {
+    "renderer": "formbricks-stack-v1",
+    "title": "Tell us about your project",
+    "description": "Quick 5-question form. Takes about a minute.",
+    "questions": [
+      { "id": "fullName",   "type": "text",     "label": "What's your name?",     "required": true },
+      { "id": "phone",      "type": "phone",    "label": "Best phone to reach you?", "required": true },
+      { "id": "email",      "type": "email",    "label": "Email",                 "required": true },
+      {
+        "id": "service",
+        "type": "select",
+        "label": "What service do you need?",
+        "required": true,
+        "options": ["Service one", "Service two", "Service three", "Other / not sure"]
+      },
+      {
+        "id": "details",
+        "type": "textarea",
+        "label": "Tell us a bit about what you're looking for",
+        "helper": "A few sentences is plenty.",
+        "required": false,
+        "validation": { "maxLength": 1000 }
+      }
+    ],
+    "completion": {
+      "headline": "Got it — thanks!",
+      "message": "We'll be in touch within one business day. For urgent issues, give us a call at (555) 555-0100."
+    }
+  },
+  "admin": {
+    "renderer": "twenty-shell-v1",
+    "sidebarOrder": ["contacts", "deals", "activities"],
+    "objects": [
+      {
+        "id": "contacts",
+        "label": "Contacts",
+        "icon": "User",
+        "fields": [
+          { "id": "name",    "label": "Name",    "type": "text",  "required": true,  "showInSidebar": true },
+          { "id": "email",   "label": "Email",   "type": "email" },
+          { "id": "phone",   "label": "Phone",   "type": "phone" },
+          { "id": "company", "label": "Company", "type": "text" },
+          { "id": "source",  "label": "Source",  "type": "select", "options": ["Website", "Referral", "Walk-in", "Repeat customer", "Other"] },
+          { "id": "notes",   "label": "Notes",   "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "all-contacts",
+            "label": "All contacts",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["name", "email", "phone", "company", "source"],
+              "sortBy": { "field": "name", "direction": "asc" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "deals",
+        "label": "Deals",
+        "icon": "Briefcase",
+        "fields": [
+          { "id": "name",     "label": "Deal name", "type": "text",     "required": true,  "showInSidebar": true },
+          { "id": "contact",  "label": "Contact",   "type": "relation", "relationTo": "contacts", "showInSidebar": true },
+          { "id": "amount",   "label": "Amount",    "type": "currency" },
+          { "id": "stage",    "label": "Stage",     "type": "select",   "required": true,  "options": ["Lead", "Qualified", "Quote sent", "Won", "Lost"], "showInSidebar": true },
+          { "id": "close_date","label": "Close date","type": "date" }
+        ],
+        "views": [
+          {
+            "id": "pipeline",
+            "label": "Pipeline",
+            "kind": "kanban",
+            "isDefault": true,
+            "kanban": {
+              "stageField": "stage",
+              "stages": ["Lead", "Qualified", "Quote sent", "Won", "Lost"],
+              "cardFields": ["contact", "amount", "close_date"],
+              "aggregate": { "field": "amount", "kind": "sum" }
+            }
+          },
+          {
+            "id": "all-deals",
+            "label": "All deals",
+            "kind": "table",
+            "isDefault": false,
+            "table": {
+              "columns": ["name", "contact", "amount", "stage", "close_date"],
+              "sortBy": { "field": "close_date", "direction": "desc" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "activities",
+        "label": "Activities",
+        "icon": "Activity",
+        "fields": [
+          { "id": "subject",  "label": "Subject",   "type": "text",     "required": true,  "showInSidebar": true },
+          { "id": "kind",     "label": "Kind",      "type": "select",   "options": ["Call", "Email", "SMS", "Meeting", "Note"], "showInSidebar": true },
+          { "id": "contact",  "label": "Contact",   "type": "relation", "relationTo": "contacts" },
+          { "id": "occurred_at","label":"When",      "type": "datetime", "showInSidebar": true },
+          { "id": "body",     "label": "Notes",     "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "timeline",
+            "label": "Timeline",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["subject", "kind", "contact", "occurred_at"],
+              "sortBy": { "field": "occurred_at", "direction": "desc" }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/templates/hvac.json
+++ b/skills/templates/hvac.json
@@ -1,0 +1,487 @@
+{
+  "$schema": "./schema.json",
+  "version": 1,
+  "workspace": {
+    "name": "[Your HVAC Business]",
+    "industry": "hvac",
+    "tagline": "Cool homes, warm welcomes.",
+    "theme": {
+      "mode": "light",
+      "accent": "#1E40AF",
+      "displayFont": "cal-sans",
+      "bodyFont": "inter",
+      "radiusScale": "default",
+      "logoUrl": null,
+      "heroImageUrl": null
+    },
+    "contact": {
+      "phone": "+15555550100",
+      "emergencyPhone": "+15555550100",
+      "email": null,
+      "address": {
+        "street": "[Street address]",
+        "city": "[City]",
+        "region": "[State]",
+        "postalCode": "[Postal code]",
+        "country": "US"
+      },
+      "hours": {
+        "mon": [7, 19],
+        "tue": [7, 19],
+        "wed": [7, 19],
+        "thu": [7, 19],
+        "fri": [7, 19],
+        "sat": [7, 19],
+        "sun": null
+      },
+      "timezone": "America/Chicago",
+      "serviceArea": "[County] and surrounding counties — within roughly 40 miles"
+    }
+  },
+  "landing": {
+    "renderer": "general-service-v1",
+    "sections": [
+      {
+        "type": "emergency-strip",
+        "label": "24/7 Emergency Service"
+      },
+      {
+        "type": "hero",
+        "eyebrow": "[City] · HVAC repair, install, maintenance",
+        "headline": "A cool home in 24 hours",
+        "subhead": "Family-owned HVAC for [City] homeowners. Same-day repairs, honest quotes, no pressure to upsell.",
+        "ctaPrimary":   { "label": "Book a free estimate", "href": "/book", "kind": "primary" },
+        "ctaSecondary": { "label": "Call us now",          "href": "tel:+15555550100", "kind": "tel" },
+        "imageUrl": null,
+        "variant": "split-image-right"
+      },
+      {
+        "type": "trust-strip",
+        "items": [
+          { "icon": "Star",        "label": "4.9 stars · 1,200+ Google reviews" },
+          { "icon": "ShieldCheck", "label": "Licensed and insured in [State]" },
+          { "icon": "Award",       "label": "20+ years in [City]" },
+          { "icon": "BadgeCheck",  "label": "BBB A+ rated" }
+        ]
+      },
+      {
+        "type": "services-grid",
+        "headline": "What we fix and install",
+        "subhead": "Residential and light-commercial. Honest scope, no upsell.",
+        "layout": "grid-3",
+        "items": [
+          {
+            "icon": "Wind",
+            "title": "AC repair",
+            "description": "Same-day diagnosis and repair for any AC system. We carry common parts on the truck so most fixes are one-visit.",
+            "category": "Cooling"
+          },
+          {
+            "icon": "Flame",
+            "title": "Heating & furnace",
+            "description": "Furnace repair, heat pump tune-ups, and full replacements. Pre-season check to catch issues before winter.",
+            "category": "Heating"
+          },
+          {
+            "icon": "Settings2",
+            "title": "Full system install",
+            "description": "New HVAC system sized correctly for your home. We install Trane, Lennox, Goodman, and Mitsubishi mini-splits.",
+            "category": "Install"
+          },
+          {
+            "icon": "CalendarCheck",
+            "title": "Seasonal maintenance",
+            "description": "Twice-a-year tune-ups that keep your system running efficiently and catch small issues before they become emergencies.",
+            "category": "Maintenance"
+          },
+          {
+            "icon": "Wind",
+            "title": "Indoor air quality",
+            "description": "Whole-home filtration, humidity control, UV purifiers, and duct cleaning. Especially important if anyone in the house has allergies.",
+            "category": "IAQ"
+          },
+          {
+            "icon": "PhoneCall",
+            "title": "24/7 emergency dispatch",
+            "description": "Furnace dies on the coldest night of the year? AC dies in August? Call any time — we have an on-call tech every night.",
+            "category": "Emergency"
+          }
+        ]
+      },
+      {
+        "type": "about",
+        "headline": "Why neighbors call us first",
+        "body": "We're a family-owned HVAC company that's been serving [City] for over 20 years. We hire local techs, train them properly, and pay them well — which is why our team stays. When you call us, you get someone who's been doing this for years, not someone reading a script. We won't sell you a system you don't need, and we'll always quote a repair before recommending a replacement.",
+        "photoUrl": null,
+        "ownerName": "[Owner Name]",
+        "ownerTitle": "Owner & Lead Technician"
+      },
+      {
+        "type": "mid-cta",
+        "headline": "Get a free estimate today",
+        "subhead": "We'll come out, take a look, and give you an honest quote. No pressure, no obligation.",
+        "ctaPrimary":   { "label": "Book online",  "href": "/book", "kind": "primary" },
+        "ctaSecondary": { "label": "Call us now",  "href": "tel:+15555550100", "kind": "tel" },
+        "embedQuoteForm": true
+      },
+      {
+        "type": "testimonials",
+        "headline": "What [City] homeowners say",
+        "featured": {
+          "quote": "Our AC died on the hottest day of the summer with two kids and a dog at home. They had a tech at the door in under three hours and had the system running again before dinner. Fair price, no upsell. We've been customers ever since.",
+          "authorName": "[Customer Name]",
+          "authorRole": "Homeowner in [Neighborhood]",
+          "rating": 5,
+          "source": "google"
+        },
+        "items": [
+          {
+            "quote": "Replaced our 22-year-old furnace last fall. They quoted three options at three price points and explained the tradeoffs honestly. Install took one day. Bills are noticeably lower.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Homeowner",
+            "rating": 5,
+            "source": "google"
+          },
+          {
+            "quote": "I've used them for both repairs and yearly tune-ups for five years. Every tech who's come out has been on time, polite, and quick. They tell me when something doesn't need fixing yet — which is rare.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Homeowner",
+            "rating": 5,
+            "source": "google"
+          },
+          {
+            "quote": "Called at 11pm during a January cold snap. Tech was at the house by 12:30am, had heat back on by 1:15am. Charged the standard service rate, not a 'middle of the night' premium.",
+            "authorName": "[Customer Name]",
+            "authorRole": "Homeowner",
+            "rating": 5,
+            "source": "google"
+          }
+        ]
+      },
+      {
+        "type": "service-area",
+        "headline": "Service area",
+        "description": "We serve [County] and surrounding counties — typically within 40 miles of [City]. Outside that radius? Call us anyway; we'll often go the extra mile for an existing customer."
+      },
+      {
+        "type": "faq",
+        "headline": "Frequently asked questions",
+        "items": [
+          {
+            "question": "How soon can a technician come out?",
+            "answer": "For non-emergencies, usually within 24-48 hours. For emergencies (no heat in winter, no AC during a heat advisory), we aim for same-day and we'll let you know an honest ETA when you call."
+          },
+          {
+            "question": "Do you charge for estimates?",
+            "answer": "Quotes for new system installs are always free. Diagnostic visits for repair start at a flat rate — if you book the repair, we waive the diagnostic fee."
+          },
+          {
+            "question": "What brands do you install?",
+            "answer": "We're licensed dealers for Trane, Lennox, Goodman, and Mitsubishi (mini-splits). We'll match the brand to your home and budget — we don't get bigger commissions for one over the other."
+          },
+          {
+            "question": "How often should I get my system serviced?",
+            "answer": "Twice a year — once before summer, once before winter. Catching small issues during a 30-minute tune-up is dramatically cheaper than emergency repairs in July."
+          },
+          {
+            "question": "Is financing available for a new system?",
+            "answer": "Yes. We offer 0% financing for 12-18 months on qualifying installs, plus longer-term plans through a third-party lender. We'll walk you through the options before you decide."
+          },
+          {
+            "question": "Are you licensed and insured?",
+            "answer": "Yes — fully licensed in [State] (license #[Number]) and we carry $2M general liability + workers' comp on every tech."
+          }
+        ]
+      },
+      {
+        "type": "footer",
+        "showHours": true,
+        "showAddress": true,
+        "showServiceArea": true,
+        "social": [],
+        "legal": [
+          { "label": "Privacy", "href": "/privacy" },
+          { "label": "Terms",   "href": "/terms" }
+        ]
+      }
+    ]
+  },
+  "booking": {
+    "renderer": "calcom-month-v1",
+    "eventType": {
+      "title": "Free in-home estimate",
+      "description": "45-minute on-site visit. We'll diagnose the issue (or assess your home for a new system) and give you a written quote. No obligation.",
+      "durationMinutes": 45,
+      "location": { "kind": "on-site-customer" },
+      "bufferMinutes": 30
+    },
+    "availability": {
+      "weekly": {
+        "mon": [7, 19],
+        "tue": [7, 19],
+        "wed": [7, 19],
+        "thu": [7, 19],
+        "fri": [7, 19],
+        "sat": [8, 16],
+        "sun": null
+      },
+      "blackoutDates": [],
+      "leadTimeHours": 4,
+      "advanceWindowDays": 30
+    },
+    "formFields": [
+      { "id": "name",    "label": "Full name",       "type": "text",  "required": true,  "placeholder": "Jane Smith" },
+      { "id": "email",   "label": "Email",           "type": "email", "required": true,  "placeholder": "you@example.com" },
+      { "id": "phone",   "label": "Best phone",      "type": "phone", "required": true,  "placeholder": "(555) 555-0100" },
+      { "id": "address", "label": "Service address", "type": "text",  "required": true,  "placeholder": "123 Main St, [City]" },
+      {
+        "id": "service",
+        "label": "What can we help with?",
+        "type": "select",
+        "required": true,
+        "options": ["AC not cooling", "Heating not working", "New system install", "Seasonal tune-up", "Indoor air quality", "Other"]
+      },
+      {
+        "id": "notes",
+        "label": "Anything else we should know?",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "System age, recent issues, accessibility, pets at home, etc."
+      }
+    ],
+    "confirmation": {
+      "headline": "Your estimate is booked",
+      "message": "We'll send a confirmation email and call about an hour before the visit. If anything changes, just call us at (555) 555-0100.",
+      "successRedirectUrl": null
+    }
+  },
+  "intake": {
+    "renderer": "formbricks-stack-v1",
+    "title": "Tell us about the job",
+    "description": "Quick form. Takes about a minute. We'll call back within an hour during business hours.",
+    "questions": [
+      { "id": "fullName", "type": "text",  "label": "What's your name?",         "required": true },
+      { "id": "phone",    "type": "phone", "label": "Best phone to reach you?",  "required": true,
+        "helper": "We'll call back within an hour during business hours." },
+      { "id": "email",    "type": "email", "label": "Email",                     "required": false },
+      { "id": "address",  "type": "text",  "label": "Service address",           "required": true,
+        "helper": "Just the street and city is fine." },
+      {
+        "id": "issueType",
+        "type": "multi-select",
+        "label": "What's going on?",
+        "helper": "Pick all that apply.",
+        "required": true,
+        "options": [
+          "AC not cooling",
+          "Heating not working",
+          "Strange noise or smell",
+          "Thermostat issue",
+          "New system installation",
+          "Seasonal tune-up",
+          "Indoor air quality concern",
+          "Other"
+        ]
+      },
+      {
+        "id": "urgency",
+        "type": "select",
+        "label": "How urgent is this?",
+        "required": true,
+        "options": [
+          "Emergency — today if possible",
+          "Urgent — this week",
+          "Routine — within the next few weeks"
+        ]
+      },
+      {
+        "id": "details",
+        "type": "textarea",
+        "label": "Anything else we should know before we arrive?",
+        "helper": "System age, recent repairs, pets at home, accessibility — anything that helps us prepare.",
+        "required": false,
+        "validation": { "maxLength": 1000 }
+      }
+    ],
+    "completion": {
+      "headline": "Thanks — we'll be in touch shortly",
+      "message": "If your issue is an emergency, call us right now at (555) 555-0100. Otherwise we'll reach out within one business hour."
+    }
+  },
+  "admin": {
+    "renderer": "twenty-shell-v1",
+    "sidebarOrder": ["contacts", "deals", "service_calls", "equipment", "technicians", "activities"],
+    "objects": [
+      {
+        "id": "contacts",
+        "label": "Contacts",
+        "icon": "User",
+        "fields": [
+          { "id": "name",    "label": "Name",    "type": "text",  "required": true,  "showInSidebar": true },
+          { "id": "email",   "label": "Email",   "type": "email" },
+          { "id": "phone",   "label": "Phone",   "type": "phone", "showInSidebar": true },
+          { "id": "address", "label": "Service address", "type": "text",     "showInSidebar": true },
+          { "id": "source",  "label": "Source",  "type": "select", "options": ["Website", "Referral", "Google", "Repeat customer", "Other"] },
+          { "id": "notes",   "label": "Notes",   "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "all-contacts",
+            "label": "All contacts",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["name", "phone", "address", "source"],
+              "sortBy": { "field": "name", "direction": "asc" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "deals",
+        "label": "Deals",
+        "icon": "Briefcase",
+        "fields": [
+          { "id": "name",      "label": "Deal name", "type": "text",     "required": true,  "showInSidebar": true },
+          { "id": "contact",   "label": "Contact",   "type": "relation", "relationTo": "contacts", "showInSidebar": true },
+          { "id": "amount",    "label": "Amount",    "type": "currency" },
+          { "id": "stage",     "label": "Stage",     "type": "select",   "required": true,
+            "options": ["Lead", "Estimate scheduled", "Quoted", "Approved", "Installed", "Lost"], "showInSidebar": true },
+          { "id": "service",   "label": "Service type", "type": "select",
+            "options": ["AC repair", "Heating repair", "New install", "Maintenance", "IAQ", "Emergency"] },
+          { "id": "close_date", "label": "Expected close", "type": "date" }
+        ],
+        "views": [
+          {
+            "id": "pipeline",
+            "label": "Pipeline",
+            "kind": "kanban",
+            "isDefault": true,
+            "kanban": {
+              "stageField": "stage",
+              "stages": ["Lead", "Estimate scheduled", "Quoted", "Approved", "Installed", "Lost"],
+              "cardFields": ["contact", "amount", "service"],
+              "aggregate": { "field": "amount", "kind": "sum" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "service_calls",
+        "label": "Service calls",
+        "icon": "Wrench",
+        "fields": [
+          { "id": "scheduled_for", "label": "When",     "type": "datetime", "required": true,  "showInSidebar": true },
+          { "id": "contact",      "label": "Customer", "type": "relation", "relationTo": "contacts", "required": true, "showInSidebar": true },
+          { "id": "technician",   "label": "Tech",     "type": "relation", "relationTo": "technicians", "showInSidebar": true },
+          { "id": "service",      "label": "Service",  "type": "select",
+            "options": ["AC repair", "Heating repair", "New install", "Maintenance", "IAQ", "Emergency"], "required": true },
+          { "id": "status",       "label": "Status",   "type": "select",
+            "options": ["Scheduled", "On the way", "On site", "Complete", "Rescheduled", "Cancelled"], "required": true, "showInSidebar": true },
+          { "id": "urgency",      "label": "Urgency",  "type": "select", "options": ["Routine", "Urgent", "Emergency"] },
+          { "id": "notes",        "label": "Notes",    "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "today",
+            "label": "Today",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["scheduled_for", "contact", "technician", "service", "status", "urgency"],
+              "sortBy": { "field": "scheduled_for", "direction": "asc" }
+            }
+          },
+          {
+            "id": "by-status",
+            "label": "By status",
+            "kind": "kanban",
+            "kanban": {
+              "stageField": "status",
+              "stages": ["Scheduled", "On the way", "On site", "Complete"],
+              "cardFields": ["contact", "service", "technician"]
+            }
+          }
+        ]
+      },
+      {
+        "id": "equipment",
+        "label": "Equipment",
+        "icon": "Settings2",
+        "fields": [
+          { "id": "contact",       "label": "Customer", "type": "relation", "relationTo": "contacts", "required": true, "showInSidebar": true },
+          { "id": "kind",          "label": "Type",     "type": "select",
+            "options": ["Central AC", "Furnace", "Heat pump", "Mini-split", "Boiler", "Air handler", "Thermostat", "Other"], "required": true, "showInSidebar": true },
+          { "id": "brand",         "label": "Brand",    "type": "text",     "showInSidebar": true },
+          { "id": "model",         "label": "Model",    "type": "text" },
+          { "id": "serial",        "label": "Serial",   "type": "text" },
+          { "id": "installed_at",   "label": "Installed", "type": "date" },
+          { "id": "warranty_until", "label": "Warranty until", "type": "date" },
+          { "id": "last_serviced",  "label": "Last serviced", "type": "date" },
+          { "id": "notes",         "label": "Notes",    "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "all-equipment",
+            "label": "All equipment",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["contact", "kind", "brand", "installed_at", "warranty_until", "last_serviced"],
+              "sortBy": { "field": "last_serviced", "direction": "desc" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "technicians",
+        "label": "Technicians",
+        "icon": "HardHat",
+        "fields": [
+          { "id": "name",       "label": "Name",  "type": "text",  "required": true,  "showInSidebar": true },
+          { "id": "phone",      "label": "Phone", "type": "phone", "showInSidebar": true },
+          { "id": "role",       "label": "Role",  "type": "select",
+            "options": ["Service tech", "Install tech", "Lead tech", "Dispatcher", "Apprentice"], "showInSidebar": true },
+          { "id": "active",     "label": "Active", "type": "boolean" }
+        ],
+        "views": [
+          {
+            "id": "roster",
+            "label": "Roster",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["name", "phone", "role", "active"],
+              "sortBy": { "field": "name", "direction": "asc" }
+            }
+          }
+        ]
+      },
+      {
+        "id": "activities",
+        "label": "Activities",
+        "icon": "Activity",
+        "fields": [
+          { "id": "subject",   "label": "Subject", "type": "text",     "required": true,  "showInSidebar": true },
+          { "id": "kind",      "label": "Kind",    "type": "select",
+            "options": ["Call", "Email", "SMS", "Visit", "Note"], "showInSidebar": true },
+          { "id": "contact",   "label": "Contact", "type": "relation", "relationTo": "contacts" },
+          { "id": "occurred_at","label": "When",    "type": "datetime", "showInSidebar": true },
+          { "id": "body",      "label": "Notes",   "type": "longtext" }
+        ],
+        "views": [
+          {
+            "id": "timeline",
+            "label": "Timeline",
+            "kind": "table",
+            "isDefault": true,
+            "table": {
+              "columns": ["subject", "kind", "contact", "occurred_at"],
+              "sortBy": { "field": "occurred_at", "direction": "desc" }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/skills/templates/schema.json
+++ b/skills/templates/schema.json
@@ -1,0 +1,784 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://seldonframe.com/schemas/blueprint/v1.json",
+  "title": "SeldonFrame Workspace Blueprint",
+  "description": "Deterministic blueprint that every customer-facing workspace surface (landing, booking, intake, admin) renders from. One blueprint = one workspace. Content packs (e.g. hvac.json) are full self-contained blueprints, not deltas. Claude Code generates a blueprint from a natural-language business description by starting from a content pack and replacing the business-data slots.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "workspace", "landing", "booking", "intake", "admin"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference (e.g. ./schema.json or https://seldonframe.com/schemas/blueprint/v1.json). Ignored by validators; useful for editor IntelliSense."
+    },
+    "version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Bumped when the blueprint shape changes incompatibly. Renderer versions (e.g. general-service-v1) are independent."
+    },
+    "workspace": { "$ref": "#/$defs/Workspace" },
+    "landing":   { "$ref": "#/$defs/Landing" },
+    "booking":   { "$ref": "#/$defs/Booking" },
+    "intake":    { "$ref": "#/$defs/Intake" },
+    "admin":     { "$ref": "#/$defs/Admin" }
+  },
+
+  "$defs": {
+
+    "HexColor": {
+      "type": "string",
+      "pattern": "^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$",
+      "description": "CSS hex color. 3 or 6 digits."
+    },
+
+    "URL": {
+      "type": "string",
+      "format": "uri",
+      "description": "Absolute URL with scheme (https:// preferred)."
+    },
+
+    "OptionalURL": {
+      "anyOf": [
+        { "$ref": "#/$defs/URL" },
+        { "type": "null" }
+      ]
+    },
+
+    "PhoneE164": {
+      "type": "string",
+      "pattern": "^\\+[1-9]\\d{1,14}$",
+      "description": "E.164 phone number, e.g. +18175551234."
+    },
+
+    "Slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "minLength": 1,
+      "maxLength": 63,
+      "description": "URL-safe lowercase slug (a-z, 0-9, hyphens). No leading/trailing hyphen, no consecutive hyphens."
+    },
+
+    "IANATimezone": {
+      "type": "string",
+      "pattern": "^[A-Za-z]+(?:/[A-Za-z_]+)+$|^UTC$",
+      "examples": ["America/Chicago", "America/New_York", "Europe/Paris", "UTC"],
+      "description": "IANA timezone identifier."
+    },
+
+    "DayHourRange": {
+      "description": "A single day's open hours as a tuple of [openHour, closeHour] in 24h local time. null = closed.",
+      "anyOf": [
+        { "type": "null" },
+        {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "integer", "minimum": 0, "maximum": 24 }
+        }
+      ]
+    },
+
+    "WeeklyHours": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+      "properties": {
+        "mon": { "$ref": "#/$defs/DayHourRange" },
+        "tue": { "$ref": "#/$defs/DayHourRange" },
+        "wed": { "$ref": "#/$defs/DayHourRange" },
+        "thu": { "$ref": "#/$defs/DayHourRange" },
+        "fri": { "$ref": "#/$defs/DayHourRange" },
+        "sat": { "$ref": "#/$defs/DayHourRange" },
+        "sun": { "$ref": "#/$defs/DayHourRange" }
+      }
+    },
+
+    "Address": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["street", "city", "region", "postalCode", "country"],
+      "properties": {
+        "street":      { "type": "string", "minLength": 1 },
+        "city":        { "type": "string", "minLength": 1 },
+        "region":      { "type": "string", "minLength": 1, "description": "State, province, or region." },
+        "postalCode":  { "type": "string", "minLength": 1 },
+        "country":     { "type": "string", "minLength": 2, "description": "ISO 3166-1 alpha-2 (e.g. US, CA) or full name." }
+      }
+    },
+
+    "Workspace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "industry", "theme", "contact"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64,
+          "description": "Human-readable business name. Drives all heading slots."
+        },
+        "slug": {
+          "$ref": "#/$defs/Slug",
+          "description": "Optional URL-safe slug. Derived from name if absent."
+        },
+        "tagline": {
+          "type": "string",
+          "maxLength": 120,
+          "description": "Optional short tagline shown under workspace name."
+        },
+        "industry": {
+          "type": "string",
+          "minLength": 1,
+          "examples": ["general", "hvac", "dental", "legal", "salon", "coaching", "real-estate", "auto-repair", "fitness", "consulting"],
+          "description": "Free-form industry label. Drives content-pack matching when Claude Code picks a starter blueprint. New verticals do NOT require a schema update."
+        },
+        "theme":   { "$ref": "#/$defs/Theme" },
+        "contact": { "$ref": "#/$defs/Contact" }
+      }
+    },
+
+    "Theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "accent"],
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["light", "dark"],
+          "description": "Default rendering mode. v1 ships light only; dark is reserved for v2."
+        },
+        "accent": {
+          "$ref": "#/$defs/HexColor",
+          "description": "Single brand accent color. Operator picks ONE; the renderer derives accent-soft, accent-hover, ring, and accent-foreground via APCA contrast."
+        },
+        "displayFont": {
+          "type": "string",
+          "enum": ["cal-sans", "geist"],
+          "default": "cal-sans",
+          "description": "Display font (titles, hero, big numbers). Cal Sans is the v1 default per design research."
+        },
+        "bodyFont": {
+          "type": "string",
+          "enum": ["inter"],
+          "default": "inter",
+          "description": "Body font. Inter only in v1."
+        },
+        "radiusScale": {
+          "type": "string",
+          "enum": ["default", "minimal", "rounded"],
+          "default": "default",
+          "description": "default = xs:2 sm:4 md:8 lg:12 xl:20 pill:999. minimal = halve all values. rounded = 1.5x."
+        },
+        "logoUrl":      { "$ref": "#/$defs/OptionalURL", "description": "Workspace logo. Empty state demands an upload." },
+        "heroImageUrl": { "$ref": "#/$defs/OptionalURL", "description": "Landing hero image. Real photo of team or office strongly preferred over stock." }
+      }
+    },
+
+    "Contact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["phone", "address", "hours", "timezone"],
+      "properties": {
+        "phone":        { "$ref": "#/$defs/PhoneE164" },
+        "emergencyPhone": {
+          "anyOf": [{ "$ref": "#/$defs/PhoneE164" }, { "type": "null" }],
+          "description": "Optional after-hours emergency line. Triggers the emergency strip on the landing page when set."
+        },
+        "email": {
+          "anyOf": [
+            { "type": "string", "format": "email" },
+            { "type": "null" }
+          ]
+        },
+        "address":      { "$ref": "#/$defs/Address" },
+        "hours":        { "$ref": "#/$defs/WeeklyHours" },
+        "timezone":     { "$ref": "#/$defs/IANATimezone" },
+        "serviceArea": {
+          "type": "string",
+          "description": "Free-form description of service area shown on landing footer + booking confirmation. e.g. 'Tarrant + Dallas counties' or 'Within 25 miles of downtown Atlanta'."
+        }
+      }
+    },
+
+    "CTA": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "href":  { "type": "string", "minLength": 1, "description": "Internal route (/book) or absolute URL or tel: link." },
+        "kind":  {
+          "type": "string",
+          "enum": ["primary", "secondary", "ghost", "tel"],
+          "default": "primary"
+        }
+      }
+    },
+
+    "Landing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["renderer", "sections"],
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "const": "general-service-v1",
+          "description": "Frozen renderer ID. v1 ships exactly one renderer; future renderers (v2, vertical-specific) get new IDs and never break v1 blueprints."
+        },
+        "sections": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Ordered array of sections. The renderer renders sections in the given order. Operators can omit sections they don't want; required sections per the canonical service-business order are recommended but not enforced.",
+          "items": {
+            "oneOf": [
+              { "$ref": "#/$defs/SectionEmergencyStrip" },
+              { "$ref": "#/$defs/SectionHero" },
+              { "$ref": "#/$defs/SectionTrustStrip" },
+              { "$ref": "#/$defs/SectionServicesGrid" },
+              { "$ref": "#/$defs/SectionAbout" },
+              { "$ref": "#/$defs/SectionMidCta" },
+              { "$ref": "#/$defs/SectionTestimonials" },
+              { "$ref": "#/$defs/SectionServiceArea" },
+              { "$ref": "#/$defs/SectionFaq" },
+              { "$ref": "#/$defs/SectionFooter" }
+            ]
+          }
+        }
+      }
+    },
+
+    "SectionEmergencyStrip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "label"],
+      "properties": {
+        "type":        { "const": "emergency-strip" },
+        "label":       { "type": "string", "minLength": 1, "description": "e.g. '24/7 Emergency Service'" },
+        "phoneLabel":  { "type": "string", "description": "Optional override for the phone display. Defaults to workspace.contact.emergencyPhone." }
+      },
+      "description": "Red/orange-accented strip ABOVE the hero for emergency-driven trades (HVAC, plumbing, locksmith). Only rendered if workspace.contact.emergencyPhone is set."
+    },
+
+    "SectionHero": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "headline", "ctaPrimary"],
+      "properties": {
+        "type":        { "const": "hero" },
+        "eyebrow":     { "type": "string", "description": "Small uppercase preheading (e.g. 'Dallas-Fort Worth · HVAC')." },
+        "headline":    { "type": "string", "minLength": 1, "maxLength": 80, "description": "≤8 words, outcome-oriented. Includes location explicitly." },
+        "subhead":     { "type": "string", "maxLength": 240, "description": "1-2 lines proof or scope." },
+        "ctaPrimary":  { "$ref": "#/$defs/CTA" },
+        "ctaSecondary":{ "$ref": "#/$defs/CTA" },
+        "imageUrl":    { "$ref": "#/$defs/OptionalURL", "description": "Real photo of team or office. Stock photo is a measurable conversion killer." },
+        "variant":     {
+          "type": "string",
+          "enum": ["split-image-right", "full-bleed", "founder-portrait"],
+          "default": "split-image-right",
+          "description": "split-image-right = HVAC/dental/legal default. full-bleed = salon/bridal. founder-portrait = coaching."
+        }
+      }
+    },
+
+    "SectionTrustStrip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "items"],
+      "properties": {
+        "type": { "const": "trust-strip" },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["label"],
+            "properties": {
+              "icon":  { "type": "string", "description": "Lucide icon name." },
+              "label": { "type": "string", "minLength": 1, "description": "e.g. '4.9 stars · 1,200+ reviews', 'BBB A+', '20 years in DFW'." }
+            }
+          }
+        }
+      }
+    },
+
+    "SectionServicesGrid": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "items"],
+      "properties": {
+        "type": { "const": "services-grid" },
+        "headline": { "type": "string", "default": "Services" },
+        "subhead":  { "type": "string" },
+        "layout": {
+          "type": "string",
+          "enum": ["grid-3", "grid-4", "tabs"],
+          "default": "grid-3",
+          "description": "grid-3 is dominant. grid-4 only if exactly 4. tabs for generalists with 6+ services grouped by category."
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 12,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["title", "description"],
+            "properties": {
+              "icon":         { "type": "string", "description": "Lucide icon name (line style, single weight)." },
+              "title":        { "type": "string", "minLength": 1, "maxLength": 40 },
+              "description":  { "type": "string", "minLength": 1, "maxLength": 200 },
+              "priceFrom":    { "type": "string", "description": "Optional 'From $89' or 'Free estimate'. Skip for variable-scope verticals." },
+              "category":     { "type": "string", "description": "Used when layout = tabs." },
+              "learnMoreUrl": { "$ref": "#/$defs/OptionalURL" }
+            }
+          }
+        }
+      }
+    },
+
+    "SectionAbout": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "headline", "body"],
+      "properties": {
+        "type":       { "const": "about" },
+        "headline":   { "type": "string", "minLength": 1 },
+        "body":       { "type": "string", "minLength": 1, "description": "1-2 paragraphs. Humanize the brand." },
+        "photoUrl":   { "$ref": "#/$defs/OptionalURL", "description": "Real photo of team or owner. Empty state demands upload." },
+        "ownerName":  { "type": "string" },
+        "ownerTitle": { "type": "string", "examples": ["Owner", "Founder", "Lead Dentist", "Head Stylist"] }
+      }
+    },
+
+    "SectionMidCta": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "headline"],
+      "properties": {
+        "type":     { "const": "mid-cta" },
+        "headline": { "type": "string", "minLength": 1 },
+        "subhead":  { "type": "string" },
+        "ctaPrimary":   { "$ref": "#/$defs/CTA" },
+        "ctaSecondary": { "$ref": "#/$defs/CTA" },
+        "embedQuoteForm": {
+          "type": "boolean",
+          "default": true,
+          "description": "When true, renders the quote/booking form INLINE rather than behind a button. Inline > modal-button > separate page for conversion."
+        }
+      }
+    },
+
+    "SectionTestimonials": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "items"],
+      "properties": {
+        "type":     { "const": "testimonials" },
+        "headline": { "type": "string", "default": "What our customers say" },
+        "featured": {
+          "$ref": "#/$defs/Testimonial",
+          "description": "Single highlighted quote at the top of the section."
+        },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 9,
+          "description": "3-up grid below the featured quote. NEVER carousel — users skip carousels.",
+          "items": { "$ref": "#/$defs/Testimonial" }
+        }
+      }
+    },
+
+    "Testimonial": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["quote", "authorName"],
+      "properties": {
+        "quote":       { "type": "string", "minLength": 1, "maxLength": 400 },
+        "authorName":  { "type": "string", "minLength": 1 },
+        "authorRole":  { "type": "string", "description": "e.g. 'Customer in Arlington', 'Homeowner since 2019'." },
+        "avatarUrl":   { "$ref": "#/$defs/OptionalURL" },
+        "rating":      { "type": "integer", "minimum": 1, "maximum": 5 },
+        "source": {
+          "type": "string",
+          "enum": ["google", "yelp", "facebook", "direct", "verified"],
+          "description": "Drives the trust badge under the quote."
+        }
+      }
+    },
+
+    "SectionServiceArea": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "description"],
+      "properties": {
+        "type":        { "const": "service-area" },
+        "headline":    { "type": "string", "default": "Service area" },
+        "description": { "type": "string", "minLength": 1 },
+        "mapEmbedUrl": { "$ref": "#/$defs/OptionalURL", "description": "Google Maps embed URL." },
+        "cities":      {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional explicit list of cities served, rendered as a tag cloud."
+        }
+      }
+    },
+
+    "SectionFaq": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "items"],
+      "properties": {
+        "type":     { "const": "faq" },
+        "headline": { "type": "string", "default": "Frequently asked questions" },
+        "items": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 12,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["question", "answer"],
+            "properties": {
+              "question": { "type": "string", "minLength": 1 },
+              "answer":   { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      },
+      "description": "Always rendered as accordion. Two-column Q&A reads as legal copy and depresses scroll depth."
+    },
+
+    "SectionFooter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type":         { "const": "footer" },
+        "showHours":    { "type": "boolean", "default": true },
+        "showAddress":  { "type": "boolean", "default": true },
+        "showServiceArea": { "type": "boolean", "default": true },
+        "social": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["network", "url"],
+            "properties": {
+              "network": { "type": "string", "enum": ["facebook", "instagram", "x", "linkedin", "youtube", "tiktok", "google"] },
+              "url":     { "$ref": "#/$defs/URL" }
+            }
+          }
+        },
+        "legal": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["label", "href"],
+            "properties": {
+              "label": { "type": "string" },
+              "href":  { "type": "string" }
+            }
+          },
+          "description": "Privacy, Terms, Accessibility, etc."
+        }
+      }
+    },
+
+    "Booking": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["renderer", "eventType", "availability", "formFields", "confirmation"],
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "const": "calcom-month-v1"
+        },
+        "eventType": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["title", "durationMinutes"],
+          "properties": {
+            "title": { "type": "string", "minLength": 1, "examples": ["Free in-home estimate", "Consultation", "Cleaning + Exam"] },
+            "description": { "type": "string", "maxLength": 500 },
+            "durationMinutes": { "type": "integer", "minimum": 5, "maximum": 480 },
+            "location": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["kind"],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": ["on-site-customer", "on-site-business", "phone", "video", "hybrid"],
+                  "description": "on-site-customer = tech goes to customer (HVAC, lawn). on-site-business = customer comes to business (salon, dental). phone/video for consults."
+                },
+                "videoProvider": {
+                  "type": "string",
+                  "enum": ["zoom", "google-meet", "microsoft-teams", "manual"],
+                  "description": "Required if kind=video or kind=hybrid."
+                }
+              }
+            },
+            "bufferMinutes": { "type": "integer", "minimum": 0, "default": 0, "description": "Buffer between bookings (drive time, cleanup)." }
+          }
+        },
+        "availability": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["weekly"],
+          "properties": {
+            "weekly": { "$ref": "#/$defs/WeeklyHours" },
+            "blackoutDates": {
+              "type": "array",
+              "items": { "type": "string", "format": "date" },
+              "description": "ISO YYYY-MM-DD dates when no bookings can be made."
+            },
+            "leadTimeHours":   { "type": "integer", "minimum": 0, "default": 4, "description": "Minimum hours of notice before a booking." },
+            "advanceWindowDays": { "type": "integer", "minimum": 1, "default": 60, "description": "How far into the future bookings are allowed." }
+          }
+        },
+        "formFields": {
+          "type": "array",
+          "minItems": 2,
+          "description": "Booking form. name + email always required as first two; others appended.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "label", "type"],
+            "properties": {
+              "id":       { "type": "string", "minLength": 1 },
+              "label":    { "type": "string", "minLength": 1 },
+              "type":     { "type": "string", "enum": ["text", "email", "phone", "textarea", "select"] },
+              "required": { "type": "boolean", "default": false },
+              "placeholder": { "type": "string" },
+              "options":  { "type": "array", "items": { "type": "string" }, "description": "Required if type=select." }
+            }
+          }
+        },
+        "confirmation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["headline"],
+          "properties": {
+            "headline": { "type": "string", "default": "Your booking is confirmed" },
+            "message":  { "type": "string", "description": "Optional follow-up note shown on the in-page success step." },
+            "successRedirectUrl": {
+              "$ref": "#/$defs/OptionalURL",
+              "description": "Optional redirect after a brief delay. Empty = stay on the in-page success step."
+            }
+          }
+        }
+      }
+    },
+
+    "Intake": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["renderer", "title", "questions", "completion"],
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "const": "formbricks-stack-v1"
+        },
+        "title":       { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "questions": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/IntakeQuestion" }
+        },
+        "completion": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["headline"],
+          "properties": {
+            "headline": { "type": "string", "default": "Thank you" },
+            "message":  { "type": "string" },
+            "cta":      { "$ref": "#/$defs/CTA" }
+          }
+        }
+      }
+    },
+
+    "IntakeQuestion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "label"],
+      "properties": {
+        "id":       { "type": "string", "minLength": 1, "pattern": "^[a-zA-Z][a-zA-Z0-9_]*$" },
+        "type":     { "type": "string", "enum": ["text", "textarea", "email", "phone", "number", "select", "multi-select", "rating", "date"] },
+        "label":    { "type": "string", "minLength": 1 },
+        "helper":   { "type": "string" },
+        "required": { "type": "boolean", "default": true, "description": "Per the inverted required-signaling pattern: required is the default. Optional fields opt out." },
+        "options": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Required if type=select or type=multi-select."
+        },
+        "ratingScale": {
+          "type": "string",
+          "enum": ["number-1-5", "number-1-10", "stars-1-5"],
+          "description": "Required if type=rating. v1 ships number scales by default."
+        },
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "minLength": { "type": "integer", "minimum": 0 },
+            "maxLength": { "type": "integer", "minimum": 1 },
+            "min":       { "type": "number", "description": "For type=number." },
+            "max":       { "type": "number" },
+            "pattern":   { "type": "string", "description": "Regex pattern." }
+          }
+        },
+        "showIf": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["questionId", "operator", "value"],
+          "properties": {
+            "questionId": { "type": "string" },
+            "operator":   { "type": "string", "enum": ["equals", "not-equals", "contains", "greater-than", "less-than"] },
+            "value":      {}
+          },
+          "description": "Simple show-if condition only. v1 doesn't support compound logic; add later if user research demands."
+        }
+      }
+    },
+
+    "Admin": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["renderer", "objects", "sidebarOrder"],
+      "properties": {
+        "renderer": {
+          "type": "string",
+          "const": "twenty-shell-v1"
+        },
+        "objects": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/AdminObject" }
+        },
+        "sidebarOrder": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Object IDs in their sidebar display order."
+        }
+      }
+    },
+
+    "AdminObject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "icon", "fields", "views"],
+      "properties": {
+        "id":    { "type": "string", "pattern": "^[a-z][a-z0-9_]*$", "description": "Snake-case object id, e.g. 'contacts', 'service_calls'." },
+        "label": { "type": "string", "minLength": 1, "description": "Plural display label, e.g. 'Contacts', 'Service Calls'." },
+        "icon":  { "type": "string", "description": "Lucide icon name." },
+        "fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/AdminField" }
+        },
+        "views": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/AdminView" }
+        }
+      }
+    },
+
+    "AdminField": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "type"],
+      "properties": {
+        "id":     { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+        "label":  { "type": "string", "minLength": 1 },
+        "type":   {
+          "type": "string",
+          "enum": ["text", "longtext", "email", "phone", "url", "number", "currency", "date", "datetime", "boolean", "select", "multi-select", "relation"]
+        },
+        "required": { "type": "boolean", "default": false },
+        "options": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "For type=select or multi-select."
+        },
+        "relationTo": {
+          "type": "string",
+          "description": "For type=relation: the target object id."
+        },
+        "showInSidebar": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, this field shows as a chip in the record-page header (Twenty 'show page chips' pattern)."
+        }
+      }
+    },
+
+    "AdminView": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "label", "kind"],
+      "properties": {
+        "id":    { "type": "string", "pattern": "^[a-z][a-z0-9_-]*$" },
+        "label": { "type": "string", "minLength": 1 },
+        "kind":  { "type": "string", "enum": ["table", "kanban", "calendar"] },
+        "isDefault": { "type": "boolean", "default": false, "description": "First view shown when the object is opened." },
+        "table": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "columns": {
+              "type": "array",
+              "items": { "type": "string", "description": "Field id." }
+            },
+            "sortBy": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "field":     { "type": "string" },
+                "direction": { "type": "string", "enum": ["asc", "desc"] }
+              }
+            },
+            "groupBy": { "type": "string", "description": "Field id to group rows by (must be type=select)." }
+          },
+          "description": "Required when kind=table."
+        },
+        "kanban": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["stageField", "stages"],
+          "properties": {
+            "stageField": { "type": "string", "description": "The select field that defines columns. Must be type=select." },
+            "stages": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 9,
+              "description": "Recommended 5-7 per Twenty research. Hard cap 9.",
+              "items": { "type": "string" }
+            },
+            "cardFields": {
+              "type": "array",
+              "items": { "type": "string" },
+              "description": "Field ids shown on each kanban card (2-4 fields recommended)."
+            },
+            "aggregate": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["field", "kind"],
+              "properties": {
+                "field": { "type": "string", "description": "Numeric field id, e.g. 'amount'." },
+                "kind":  { "type": "string", "enum": ["count", "sum", "avg", "min", "max"] }
+              }
+            }
+          },
+          "description": "Required when kind=kanban."
+        }
+      }
+    }
+  }
+}

--- a/tasks/design-patterns-research.md
+++ b/tasks/design-patterns-research.md
@@ -1,0 +1,682 @@
+# Design pattern research — workspace blueprint system
+
+**Status:** Phase 1 (research only). No code changes pending Max's review.
+**Date:** 2026-04-28
+**Branch:** `claude/blueprint-research`
+**Scope:** Extract design DNA from Cal.com, Twenty, Formbricks, and best-in-class service-business landing pages to inform a deterministic workspace blueprint system. Each surface (booking, admin, intake, landing) re-implemented in SeldonFrame's codebase from these patterns — no source code copied.
+
+---
+
+## TL;DR
+
+Across all four surfaces, the same handful of decisions separate "premium product" from "Bootstrap template": **muted off-white surfaces over pure white, hairline 1px borders instead of shadows, restrained brand color (one accent maximum), Inter or Inter+display-serif typography at a 1.25 modular scale, generous whitespace, and CSS-variable token systems that flex per workspace.** SeldonFrame should adopt **one unified token taxonomy** (semantic aliases over Radix Colors P3), one font pair (Geist/Cal Sans display + Inter body), one radius scale (xs:2 sm:4 md:8 lg:12 xl:20 pill:999), and one spacing rhythm — and reuse them across the booking, admin, intake, and landing surfaces. The blueprint JSON's job is to inject the dynamic business data into pre-designed slots; the design itself is handcrafted, not generated.
+
+---
+
+## 1. Cross-cutting design system (the spine all four surfaces share)
+
+This is the most important section of the document. Without a unified token + font + spacing system, the four surfaces will visually drift even if each is individually polished.
+
+### 1.1 Color token taxonomy
+
+Adopted from Twenty's Radix-P3-derived semantic aliases, validated against Cal.com's `bg-default/subtle/emphasis` system. Recommended `--sf-*` prefix for namespacing.
+
+| Token | Light | Dark | Used on |
+|---|---|---|---|
+| `--sf-bg-primary` | `gray1` ≈ `#FFFFFF` | `gray1` ≈ `#171717` | page surface |
+| `--sf-bg-secondary` | `gray2` ≈ `#FCFCFC` | `gray2` ≈ `#1B1B1B` | sidebar, panel, surfaces-on-surface |
+| `--sf-bg-muted` | `gray3` ≈ `#F9F9F9` | `gray4` ≈ `#1D1D1D` | hover, inactive |
+| `--sf-bg-emphasis` | `gray5` ≈ `#EBEBEB` | `gray5` ≈ `#222222` | active state, strong hover |
+| `--sf-fg-primary` | `gray12` ≈ `#333333` | `gray12` ≈ `#EBEBEB` | body text |
+| `--sf-fg-emphasis` | `near-black` | `white` | titles, primary copy |
+| `--sf-fg-muted` | `gray11` ≈ `#666666` | `gray11` ≈ `#B3B3B3` | meta, captions |
+| `--sf-fg-subtle` | `gray9` ≈ `#999999` | `gray9` ≈ `#999999` | placeholders, disabled |
+| `--sf-border-subtle` | `gray4` ≈ `#F1F1F1` | `gray4` | hairlines |
+| `--sf-border-default` | `gray5` ≈ `#EBEBEB` | `gray5` | inputs, cards |
+| `--sf-border-strong` | `gray6` ≈ `#D6D6D6` | `gray6` | focus, hover |
+| `--sf-accent` | operator-chosen (default `gray12`) | inverted | CTA, primary action |
+| `--sf-accent-soft` | derived (accent at L92%) | derived (L18%) | accent-tinted surfaces |
+| `--sf-accent-fg` | derived via APCA | derived via APCA | text-on-accent (white or near-black) |
+| `--sf-success` | `green9` P3 | `green9` | confirmations |
+| `--sf-warning` | `orange9` P3 | `orange9` | scheduled-but-pending |
+| `--sf-danger` | `red9` P3 | `red9` | errors, destructive |
+| `--sf-ring` | `accent at α 0.5` | `accent at α 0.5` | focus rings |
+
+Key non-obvious decisions:
+- **Foreground is NEVER pure black**, it's `gray12` (`#333`). 6% delta. Reads as premium vs. harsh.
+- **Page background is `#FFFFFF` for admin/booking but `#FAFAF7` (warm off-white) for the public landing page.** Pure white reads as "Wix template" on a service-business home; the warm tint reads as "agency-built." Admin/booking inherit Twenty/Cal.com's pure-white because the data density requires maximum contrast.
+- **Default brand accent is `gray12`** (monochrome, à la Cal.com). Operator picks one accent; everything else derives. No gradients, no second accent.
+- **Display-P3 source colors**, with sRGB fallback via `@supports (color: color(display-p3 ...))`. Wide-gamut on modern displays without falling apart on Windows Chromium.
+
+### 1.2 Typography
+
+Two fonts only:
+- **Display (titles, hero, big numbers):** Cal Sans (BSD-licensed, calcom/sans) OR Geist (free, mature). Pick one and commit.
+- **Body (everything else):** Inter at 400 / 500 / 600. No italics by default. No 700 weight unless on display.
+
+Type scale (modular ratio 1.25):
+| Token | px | rem | Usage |
+|---|---|---|---|
+| `--sf-text-xxs` | 11 | 0.6875 | badges, micro-caps |
+| `--sf-text-xs` | 12 | 0.75 | sidebar items, meta |
+| `--sf-text-sm` | 14 | 0.875 | body in dense surfaces (admin tables) |
+| `--sf-text-md` | 16 | 1.0 | body in low-density (intake, landing body) |
+| `--sf-text-lg` | 18 | 1.125 | body emphasis, lead |
+| `--sf-text-xl` | 20 | 1.25 | h3 |
+| `--sf-text-2xl` | 24 | 1.5 | h2 — record titles, event titles, section headers |
+| `--sf-text-3xl` | 32 | 2.0 | h1 — hero on landing |
+| `--sf-text-4xl` | 44 | 2.75 | landing hero only |
+
+Body line-heights: `1.55` (sm/md), `1.4` (lg/xl), `1.2` (2xl+).
+
+Critical: configure font-feature-settings on Cal Sans (`cv01–cv06, ss02, ss03`) or it looks subtly off. Inter gets `tabular-nums` only on tables.
+
+### 1.3 Radius + spacing + elevation
+
+Radius scale (semantic, not Tailwind defaults):
+| Token | px | Usage |
+|---|---|---|
+| `--sf-radius-xs` | 2 | tags, status pills (square-ish) |
+| `--sf-radius-sm` | 4 | buttons, chips, slot pills |
+| `--sf-radius-md` | 8 | cards, dropdowns, inputs |
+| `--sf-radius-lg` | 12 | major surface containers (booker shell, landing cards) |
+| `--sf-radius-xl` | 20 | modals, hero image cards |
+| `--sf-radius-pill` | 999 | filter pills, "Required" pill |
+| `--sf-radius-round` | 100% | avatars |
+
+Spacing rhythm: Tailwind's default spacing scale (`gap-1 ... gap-12`) — but with strict discipline:
+- `gap-2` for icon+label rows
+- `gap-4` is the dominant inter-element gap
+- `gap-6` for section subdivisions
+- `gap-8` for major section breaks
+- Outer page padding: `p-6` mobile, `p-8` desktop, `p-12` on the booker/landing shell
+
+Elevation system (the key restraint rule from Twenty + Cal.com):
+- **Static surfaces have NO shadow.** They use 1px `--sf-border-subtle` strokes.
+- **Floating layers** (dropdowns, popovers): `shadow-sm` + 1px border.
+- **Modals**: 3-stop shadow stack (`0 0 8px gray7-α, 0 8px 64px -16px gray10-α, 0 24px 56px -16px gray5-α`). This is the only place the elevation budget gets spent.
+- **Dragged elements** (kanban cards): `shadow-md` while dragging only.
+- Never `shadow-lg`. Never double borders. Never glossy shadows.
+
+### 1.4 Density per surface
+
+| Surface | Row height | Cell padding | Outer padding |
+|---|---|---|---|
+| Booking | event card 56px, slot pill 44px | `px-4 py-3` | `p-8` shell |
+| Admin tables | 32px row | `px-3 py-2` (~6/8 px) | `p-6` page |
+| Admin record page | n/a | `px-4 py-3` widget | `p-8` page |
+| Intake | n/a (one card) | `px-4` viewport, `space-y-4` | `p-6` outer card |
+| Landing | n/a | `px-4 sm:px-6 lg:px-8` | `py-16` section, `py-24` hero |
+
+The admin density (32px rows) matches Twenty exactly. The other three are looser because their content surface differs.
+
+### 1.5 Responsive philosophy
+
+- **Mobile-first** in CSS (default styles target mobile; `md:`/`lg:` breakpoints add desktop).
+- Only **two meaningful breakpoints** matter for layout shifts:
+  - `md` (768px) — landing page goes from stacked to side-by-side hero, services grid goes from 1-col to 2-col.
+  - `lg` (1024px) — booking shell goes from stacked to 2/3-col, admin sidebar collapses to icon-only on tablet, landing services grid to 3-col.
+- Below `lg`, every multi-column surface stacks vertically. No horizontal scrolls except admin tables (which keep a sticky-left first column).
+
+### 1.6 Slot system (the dynamic surface)
+
+This is the contract between blueprint JSON and rendered HTML. **Static structure ≠ dynamic data.** The blueprint provides values for these slots only; everything else is hardcoded.
+
+Common slots across all surfaces:
+| Slot | Type | Source in blueprint |
+|---|---|---|
+| `workspace.name` | string | `workspace.name` |
+| `workspace.tagline` | string (optional) | `workspace.tagline` |
+| `workspace.logo` | URL or null | `workspace.theme.logoUrl` |
+| `workspace.accent` | hex | `workspace.theme.accentColor` |
+| `workspace.contact.phone` | E.164 string | `workspace.contact.phone` |
+| `workspace.contact.address` | object {street, city, state, zip} | `workspace.contact.address` |
+| `workspace.contact.hours` | object {monday: "7-19", ...} | `workspace.contact.hours` |
+| `workspace.contact.serviceArea` | string (e.g. "Tarrant + Dallas counties") | `workspace.contact.serviceArea` |
+
+Surface-specific slots: documented per-surface below.
+
+---
+
+## 2. Booking surface (Cal.com patterns)
+
+### 2.1 Layout structure
+
+Public booking page at `<slug>.app.seldonframe.com/book`. CSS-Grid driven, with named template areas that change based on state:
+
+```
+state = browsing       state = selecting_time      state = booking
+┌────────┬─────┐       ┌────────┬─────┬────┐       ┌────────┬─────┬────┐
+│  meta  │main │       │  meta  │main │slot│       │  meta  │main │form│
+└────────┴─────┘       └────────┴─────┴────┘       └────────┴─────┴────┘
+  240px   480px         240px   420px 280px         240px   420px 380px
+```
+
+Section ordering within each region:
+1. **Header strip** (full-width, optional): workspace logo + name. Hidden on `?embed=1`.
+2. **Meta sidebar** (left column, 240–424px): avatar/logo, event title (h2 Cal Sans 24px), short description, then icon+label rows (Duration, Location, Host), Timezone selector at the bottom.
+3. **Main** (center, 420–480px): month name + chevrons, weekday header row, 6×7 date grid. Available dates emphasized.
+4. **Timeslots** (right, 240–280px, only after a date is picked): sticky header with selected date + 12h/24h toggle, vertical scroll list of time pills.
+5. **Form** (replaces timeslots after slot picked): name, email, notes, optional custom questions, primary "Confirm" CTA + "Back" link.
+6. **Confirmation** (in-place, replaces form): check icon, "Meeting scheduled" heading, summary card, "Add to calendar" dropdown (Google/Outlook/iCal), Reschedule, Cancel.
+
+Mobile (<lg): all four areas stack vertically. Date click → page scrolls to slots. Slot click → page scrolls to form.
+
+### 2.2 Component hierarchy
+
+```
+BookerStoreProvider (Zustand: state, layout, selectedDate, selectedSlot)
+└── BookerShell (rounded-lg border-subtle p-8 max-w-screen-lg)
+    ├── BookerSection[area="header"] (optional)
+    ├── BookerSection[area="meta"]
+    │   └── EventMeta
+    │       ├── Avatar / Title / Description
+    │       ├── EventDetailsList (Duration, Location, Host)
+    │       └── TimezoneSelect
+    ├── BookerSection[area="main"]
+    │   └── DatePicker (MonthView)
+    │       ├── MonthChevrons
+    │       ├── WeekdayHeader (Mon..Sun)
+    │       └── DateGrid (42 cells, "available" emphasis)
+    ├── BookerSection[area="timeslots"]
+    │   └── AvailableTimeSlots
+    │       ├── DateLabelRow (selected date + 12h/24h toggle)
+    │       └── SlotList (scrollable pill stack)
+    └── BookEventForm (state="booking")
+        ├── FormFields (name, email, notes, custom Q&A)
+        ├── BackButton
+        └── ConfirmButton
+```
+
+### 2.3 Slot positions
+
+| Slot | Source in blueprint |
+|---|---|
+| `event.title` | `booking.event_type.title` (e.g. "Free in-home estimate") |
+| `event.description` | `booking.event_type.description` |
+| `event.duration_minutes` | `booking.event_type.duration_minutes` |
+| `event.location` | `booking.event_type.location` (e.g. "On-site at customer address") |
+| `availability.weekly` | `booking.availability` (per-weekday hour ranges) |
+| `availability.timezone` | `workspace.contact.timezone` |
+| `form.fields` | `booking.form_fields` (name + email always; custom appended) |
+| `confirmation.message` | `booking.confirmation_message` |
+| `confirmation.success_redirect_url` | `booking.success_redirect_url` (optional) |
+
+### 2.4 Tailwind class conventions
+
+- Container shell: `rounded-lg border border-[--sf-border-subtle] bg-[--sf-bg-primary] shadow-sm p-6 md:p-8`
+- Slot pill: `rounded-md border border-[--sf-border-default] bg-[--sf-bg-secondary] px-4 py-3 text-sm font-medium hover:bg-[--sf-bg-muted]`
+- Selected date cell: `bg-[--sf-accent] text-[--sf-accent-fg]` (otherwise transparent on hover-bg)
+- Confirm button: `bg-[--sf-accent] text-[--sf-accent-fg] rounded-md px-4 py-2.5 font-medium hover:bg-[--sf-accent]/90`
+- Sidebar meta row: `flex items-center gap-2 text-sm text-[--sf-fg-muted]`
+- Grid layout: native CSS `grid-template-areas` with CSS-var widths (NOT Tailwind grid-cols-N)
+
+### 2.5 Timezone handling
+
+- Auto-detect via `Intl.DateTimeFormat().resolvedOptions().timeZone` on first visit.
+- Persist in `localStorage` (key `sf.timezone`).
+- URL param `tz=<IANA>` overrides for the session BUT does not write back to localStorage (embed-friendly).
+- Visible position: bottom of meta sidebar.
+- Re-render the slot list on TZ change (not just labels — host availability rules can flip).
+
+### 2.6 The 3-5 design decisions to copy
+
+1. **Monochrome brand by default.** Black on white (light) / white on black (dark). Accent only used on date-active state. Workspace operator can override with one color; everything else derives.
+2. **Hairline borders + minimal shadow.** `border-subtle` + `shadow-sm` is the entire elevation system. Reflows are CSS-var-driven, not className swaps.
+3. **Whitespace ratio favors the calendar.** Sidebar narrow, calendar wide, slots narrow. Let the calendar breathe. Generous outer padding (24-48px).
+4. **Cal Sans display + Inter body.** Free, BSD/SIL, instantly premium. Half the perceived quality is the display font.
+5. **In-page success step**, not a redirect. Animates over the form region; better for embeds + analytics + flow.
+
+### 2.7 Skip / DON'T copy
+
+- The `customClassNames` API surface (50+ keys) — Cal.com built it for embedded-atom customers. SeldonFrame is first-party; use slot props.
+- The plugin/app-store architecture in `packages/app-store/`.
+- Three layouts (`MONTH_VIEW`, `WEEK_VIEW`, `COLUMN_VIEW`). Ship `MONTH_VIEW` only at first.
+- Client-side slot reservation (`useSlotReservationId`). Solve double-booking server-side with a 409 on conflict.
+
+---
+
+## 3. Admin surface (Twenty patterns)
+
+### 3.1 App shell layout
+
+Single left sidebar, no top bar. Full-bleed content right.
+
+Sidebar order (top → bottom):
+1. **Workspace switcher** (top-left, click to switch workspaces).
+2. **Search trigger** (Cmd+K opens command palette).
+3. **Favorites** (user-pinned views, records).
+4. **Workspace objects** (Contacts, Deals, Activities, custom objects). Drag-reorderable, foldable into named folders ("Sales", "Operations").
+5. **Settings/Wrench** for theme + billing.
+6. **Profile menu** at bottom-left.
+
+Breadcrumbs (`Workspace › Contacts › Jane Doe`) inline at top of content area when inside a record.
+
+### 3.2 Table view
+
+Custom-built (no library). The "Figma-quality" feel comes from these specific behaviors:
+- **Hover-to-reveal column resizer**: 1px drag affordance appears between headers on hover only. No permanent grippers.
+- **Hover-only checkbox column**: 24px-wide, fades in on row hover.
+- **Cell-as-editor**: every cell IS an inline editor. Single click → 2px accent outline. Double-click or Enter → type-specific editor swap (text, date, currency, multi-select pills, relation chip-picker). Esc reverts. Enter commits + moves down. Tab moves right.
+- **Sticky-left first column** (record name) stays visible during horizontal scroll.
+- **Filter chips above the table** with inline edit + "X" remove. Sort chips show arrow.
+- **Group-by** collapsible groups based on a Select field. Group headers show count + sum/avg.
+- **Selection**: checkbox + shift+click range + Cmd+A. Selection bar slides up from bottom with bulk actions.
+- **Virtualization** for >500 rows. Infinite scroll with "Load more" sentinel — no traditional pager.
+
+Cell padding: `px-3 py-2` (~6/8 px). Row height: 32px. Tabular-nums on Inter for numeric columns.
+
+### 3.3 Record detail page
+
+Two-column layout:
+- **Header**: large emoji/icon + record title (h1, font-weight 600, 24px), inline-editable. Below: "show page chips" — key fields (status pill, owner avatar, amount) as compact inline cells.
+- **Tabs row** (Overview, Notes, Tasks, Emails, Files, Activity). Active tab: 2px bottom border. No background fill.
+- **Main content (left ~60%)**: stack of widgets — Fields (grouped), Related records (mini-tables), Notes, Files, Charts, Activity timeline. Drag-positionable in layout-edit mode.
+- **Right side panel (~40%)**: contextual related-records + activity feed. Resizable.
+- **No edit-mode toggle.** Hover-to-reveal-edit on every field. Layout-edit (re-arranging widgets) is a separate Cmd+K command.
+
+### 3.4 Kanban / board view
+
+Board view from a Select field on the object (typically `stage`).
+- **Column header**: stage name + record count + aggregate (sum, avg, min, max) right-aligned.
+- **Card**: ~280px wide, 1px gray5 border, 8px radius, gray1 fill, 12px padding. Title semibold + 2-4 muted-gray meta rows. Avatar/logo top-right.
+- **Drag-and-drop**: HTML5 DnD. Drop targets show 2px accent dashed outline. Dragged card lifts with `shadow-md`.
+- **Card-add**: "+" in column header opens inline create-card row at top of column. No modal.
+- **Empty column**: dashed-border drop zone, "Drop cards here" muted text.
+- Recommended: 5-7 stages.
+
+### 3.5 Slot positions
+
+| Slot | Source in blueprint |
+|---|---|
+| `workspace.name` | sidebar header |
+| `objects[]` | sidebar items (with icon, label, sort order) |
+| `objects[].fields[]` | column definitions for table view, field groups for record page |
+| `objects[].views[]` | named saved views (table, kanban, calendar) per object |
+| `objects[].pipelines[]` | kanban stage definitions |
+| `record.fields[]` | dynamic per-record field values |
+| `record.related[]` | related-records in side panel |
+
+### 3.6 Tailwind conventions
+
+- Sidebar item: `flex items-center gap-2 rounded-sm px-3 py-1.5 text-sm hover:bg-[--sf-bg-muted]` (active: `bg-[--sf-bg-emphasis] text-[--sf-fg-emphasis]`)
+- Table cell: `px-3 py-2 text-sm border-b border-[--sf-border-subtle] hover:bg-[--sf-bg-muted]`
+- Status pill: `inline-flex items-center rounded-pill border border-[--sf-border-subtle] bg-[--accent-soft] px-2.5 py-0.5 text-xxs font-medium text-[--accent]` (using Radix `*3` bg + `*11` fg)
+- Kanban card: `rounded-md border border-[--sf-border-default] bg-[--sf-bg-primary] p-3`
+- Modal: `rounded-xl bg-[--sf-bg-primary] p-6` + the 3-stop shadow stack
+- Avatar (square for orgs): `rounded-md` + initial-color hash. Avatar (circle for people): `rounded-full`.
+
+### 3.7 The 3-5 design decisions to copy
+
+1. **Cell-is-editor pattern** — table cells and record page fields use the SAME `<RecordCell>` component. Identical hover affordance, focus ring, keyboard semantics. The unification is invisible-but-massive.
+2. **Border-not-shadow aesthetic** — 1px gray5 strokes for 95% of containment. Shadow only for floating layers. This single rule kills the "card-and-shadow CRM" look.
+3. **Radix P3 level-9 as accent ceiling** — never go darker than `*9` for primary. Display-P3 source = subtle vibrancy on modern displays.
+4. **Tabs + Widgets, not Tabs + Form** — record page is a content surface (Notion-like), not a database form (Salesforce-like). Drag widgets, hide fields per tab. Layout is data.
+5. **Density at 32px row** — slightly tighter than Notion, with 6/8 px cell padding + tabular-nums Inter. Professional but not Excel-grim.
+
+Bonus: **Cmd+K everywhere** — single search/jump/customize entry replaces ribbon + breadcrumb + search.
+
+### 3.8 Skip / DON'T copy
+
+- The GraphQL metadata engine (`twenty-server`'s schema-generation pipeline). Their per-tenant runtime GraphQL schema is overkill — SeldonFrame's data model is BLOCK.md, not a runtime metadata table.
+- Linaria CSS-in-JS. Stick with Tailwind 4 + shadcn — same token set, deeper ecosystem.
+- Jotai everywhere. Twenty has 100+ atoms; React Query + a few Zustand slices is enough.
+- Their workflow/automations subsystem (BullMQ + workflow engine). SeldonFrame already has its own.
+- The in-app data-modeler. SeldonFrame edits its blueprint as code — no in-app field-add modal.
+
+---
+
+## 4. Intake surface (Formbricks patterns)
+
+### 4.1 Multi-step flow
+
+One question per card by default, with a stacked-cards container that visually layers prev/current/next behind each other and animates forward on advance.
+
+State = `{ currentBlockId: string | "start" | <ending-id> }`. Progress = `(idx + 1) / total_blocks`.
+
+Progress indicator: 2px-tall horizontal bar at top of card, with 500ms width transition. **No "Step 3 of 7" counter.** Welcome = 0%, ending = 100%.
+
+Forward/back: submit button is the primary CTA per card; back button is a quiet ghost button to its left. Same row, opposite alignments. Last question's submit label flips from `Next` → `Finish`.
+
+Required signaling **inverted from Bootstrap norm**: required is the default (no asterisk). A tiny "Required" pill sits ABOVE the headline text only when `required && isQuestionCard`, at `text-xxs leading-6 opacity-60`. The visual quietude is what makes the cards feel calm.
+
+### 4.2 Question card layout
+
+```
+┌───────────────────────────────────────┐  ScrollableContainer max-height: 60dvh
+│  [optional media: image or video]      │  with edge-fade gradients at top/bottom
+│                                        │  + floating "scroll to bottom" button
+│  • Required (tiny pill if required)    │
+│  Question headline (h2, 24px, label)   │
+│  Helper text (muted, smaller)          │
+│                                        │
+│  [Input — type-specific]               │
+│                                        │
+│  Inline error (red, no icon)           │
+│  Inline char counter (muted, right)    │
+└───────────────────────────────────────┘
+        Back ←                Next →    ← Action row OUTSIDE scroll container
+```
+
+Card padding: `px-4` viewport, `space-y-4` between header and input. Card max-width: 640px outer (mobile = full-width).
+
+ScrollableContainer is the polish: top/bottom gradient masks fade content into the scroll region. Content never blows out the card; overflow looks intentional.
+
+### 4.3 Field type components
+
+Common shell: `ElementHeader` (label + helper) → input → inline error → optional inline char counter.
+
+Type-specific:
+- **Text / textarea / email / number / phone / url**: shared `<Input>` shell, `bg-[--sf-bg-secondary] border border-[--sf-border-default] rounded-md px-3 py-2 text-sm focus:ring-2 focus:ring-[--sf-ring]`. No floating label — label always above. Helper text below label, NOT next to input.
+- **Single select (radio)**: clickable bordered tile per option. Selected = `bg-[--sf-accent-soft] border-[--sf-accent]`. Optional "Other" reveals an inline `<Input>` below the group.
+- **Single select (dropdown)**: dropdown for >7 options, opens with search input at top.
+- **Multi-select**: same tile list, checkbox-style. "None of the above" supports mutual exclusivity.
+- **Rating / NPS**: number scale (row of equal-width pill buttons), star icons, or smiley faces. NPS = number scale 0-10 with low/high labels beneath. **Pick one for v1** — number is most universal.
+- **Date picker**: inline calendar grid (react-day-picker style). Values stored as ISO `YYYY-MM-DD`.
+- **File upload**: drag-and-drop dashed-border zone. Uploaded files appear as small bordered tiles with delete X.
+
+Visual difference from plain Bootstrap: input bg is `gray2` not `gray1`, focus ring is brand-colored with offset, default radius is `8px`. Spacing is `space-y-4` between header and input wrapper.
+
+### 4.4 Slot positions
+
+| Slot | Source in blueprint |
+|---|---|
+| `intake.title` | `intake.title` |
+| `intake.description` | `intake.description` |
+| `intake.questions[]` | array of question blocks |
+| `intake.questions[].id` | unique id |
+| `intake.questions[].type` | text / textarea / email / select / multi-select / rating / date |
+| `intake.questions[].label` | question headline |
+| `intake.questions[].helper` | optional helper |
+| `intake.questions[].required` | bool |
+| `intake.questions[].options` | for select / multi-select / rating |
+| `intake.questions[].validation` | regex / min / max (per type) |
+| `intake.questions[].logic` | optional show-if conditions |
+| `intake.completion.headline` | thank-you headline |
+| `intake.completion.message` | thank-you body |
+| `intake.completion.cta` | optional follow-up CTA (label + URL) |
+| `intake.theme` | inherited from `workspace.theme` |
+
+### 4.5 Theming
+
+Pure CSS-variable surface. NO React theme provider. The runtime emits a `#sf-intake` style scope and exposes `--sf-*` tokens. Tailwind utility classes mapped to vars in config.
+
+Operator changes brand color → updates one var → 25 components reflect it without re-render. Including the SVG checkmark on thank-you, the rating star fill, and the scrollbar thumb (Webkit + Firefox).
+
+### 4.6 Conditional logic
+
+Builder UX (in the operator's admin, NOT runtime): "If [question1] [equals] [option A] AND [question2] [is greater than] [5] → then [Jump to question 7]". `+ AND` / `+ OR` to add subconditions.
+
+Runtime: hidden questions are **skipped silently** — survey navigates past, response data omits them entirely (no "inactive" placeholder shown).
+
+For SeldonFrame v1: ship simple show-if conditions only. Skip `calculate`, `setVariable`, `recall` (token replacement). Add later if user research demands.
+
+### 4.7 Accessibility
+
+- Headline rendered as `<label htmlFor={id}>` — real HTML association.
+- `aria-required={required}` on inputs.
+- Focus ring: `focus:ring-2 focus:ring-offset-2 focus:ring-[--sf-ring] focus:outline-hidden`.
+- Keyboard: `Enter` advances. `Cmd/Ctrl + Enter` always submits (document-level handler). Tab order explicit.
+- Per-card autofocus: first input focused 200ms after mount.
+- `aria-describedby` linking error to input — Formbricks gap; we should fix.
+
+### 4.8 The 3-5 design decisions to copy
+
+1. **Stacked-cards container** with prev/next layered behind current. Survey feels like a deck being riffled, not a page reload.
+2. **Inverted required signaling** — required is ambient, optional gets called out (via no pill). Calmer than the asterisk-everywhere norm.
+3. **ScrollableContainer with edge gradients** — long questions never blow out the card; gradient masks make overflow look intentional.
+4. **CSS-variable-only theme surface** — operators change brand color via one var, 25 components reflect it without re-render.
+5. **Per-card autofocus + Cmd/Ctrl+Enter** — power users get keyboard-only flow without learning curve. The difference between "I filled out a form" and "I had a conversation."
+
+### 4.9 Skip / DON'T copy
+
+- The Preact-in-iframe SDK delivery model. SeldonFrame intake renders inside the workspace app — normal React component.
+- The `ResponseQueue` + offline storage. First-run intake submits once, online; offline queueing is overkill.
+- The full `evaluateLogic` engine with variables, recall, and `calculate` actions. Show-if is enough for v1.
+- `react-i18next` for single-locale launch.
+- Their `ttc` (time-to-completion) tracking and analytics ingestion in every element.
+- The headline DOMPurify sanitization — only needed if blueprint allows rich HTML; plain strings don't.
+
+---
+
+## 5. Landing surface (composite patterns from Tailwind UI + best service-business sites)
+
+### 5.1 Section ordering (canonical)
+
+The order that converts on service-business landing pages:
+
+1. **Sticky header** — logo, nav, **phone number visible**, primary CTA ("Book" / "Get Quote")
+2. **Hero** — eyebrow (city/service) + H1 (outcome-oriented, ≤8 words) + subhead (proof or scope) + CTA pair (primary book + secondary `tel:`) + visual (real photo, not stock)
+3. **Trust strip** (immediately under hero) — Google stars + review count + years in business + accreditations
+4. **Services grid** — 3-column dominant; 4-col if exactly 4 services; group with Tabs if 6+
+5. **Why us / About** — real team photo + founder/owner story (humanizes the brand)
+6. **Mid-page conversion CTA** — embedded form (NOT modal-only) with phone alternative
+7. **Testimonials** — single highlighted quote + 3-up grid (NOT carousel)
+8. **Service area / map**
+9. **FAQ** (accordion only)
+10. **Footer** — NAP (name/address/phone), hours, social, secondary nav
+
+Vertical-specific exceptions:
+- **Emergency trades** (HVAC, plumbing): emergency phone strip ABOVE the hero, red/orange-accented
+- **Bridal / luxury salons**: portfolio gallery ABOVE services (aesthetic IS the proof)
+- **Legal**: "Services" → "Practice Areas" + "As Seen In" press strip
+- **Coaching**: portrait of founder elevated into hero
+
+### 5.2 Hero pattern
+
+Structure:
+- `<eyebrow>Atlanta · Family Dentistry</eyebrow>` (small uppercase gray)
+- `<h1>A cool home in 24 hours</h1>` (large, display font, outcome-oriented)
+- `<p>Subhead: 1-2 lines, proof or scope</p>`
+- `<CTA pair>Book online | (555) 123-4567</CTA pair>` (primary + tel: secondary)
+- `<HeroImage>` real photo of team or office, color-graded to palette
+
+Mobile considerations:
+- Phone number sticky in bottom bar (full-width "Call Now") — never buried in hamburger
+- Headline ≤ 8 words to fit 2 lines on 360px without orphaning
+- CTAs stack with full thumb-width (≥ 44px touch target)
+- Hero image becomes 16:9 banner above text (never side-by-side at small widths)
+
+The 3 things great heroes do that mediocre ones don't:
+1. **State location explicitly** in H1 ("Atlanta family dentistry," not "Family dentistry"). Local trust starts in H1.
+2. **Real photo of actual team or office** above the fold — stock photography is a measurable conversion killer.
+3. **Pair booking CTA with click-to-call alternative.** People who won't fill a form will tap a number; people who hate phones will book.
+
+### 5.3 Services grid
+
+3-column default. Card structure: line-icon (single accent color) + 2-3 word title + 1-2 line description + "Learn more" link. Price-from optional (works for salons/dental, not HVAC/legal where scope varies).
+
+Inline CTA per card hurts more than helps. **One CTA at the bottom of the section converts better.**
+
+Generalist trap: listing 15 services flat signals "we're not great at any of these." Group with `Tabs` (e.g. Heating / Cooling / Indoor Air for HVAC) or split "Core services" + "Also offered."
+
+### 5.4 Trust signals
+
+Three placements:
+1. **Thin trust strip** directly under hero (single line: "4.9 stars · 1,200+ Google reviews · BBB A+ · 20 years in DFW")
+2. **Floating low-corner widget** on desktop (Nina Madden's pattern)
+3. **Inside testimonials section**
+
+Testimonials that convert:
+- **Single highlighted quote** at top + **3-up grid** below. Carousels look elegant and underperform.
+- Each card: avatar (real photo, not initials), full name, location/role, 2-3 sentence quote, 5-star visual, "verified" / Google badge.
+
+Accreditations: monochrome (or grayscale on hover) row of BBB, Google Reviews, vendor partners (Trane, Lennox, Invisalign, Aveda, Avvo). Place in trust strip OR just above footer. Never full-color saturation.
+
+**The legitimacy multiplier**: trust signals work when **proximate to a CTA**. A "Book now" surrounded by 4.9 stars / 1,200 reviews / 20 years / BBB A+ converts dramatically better than the same button alone.
+
+### 5.5 Local-business specifics
+
+- Phone in **top-right of header** as `tel:` link with phone icon. Sticky bottom bar on mobile.
+- **Service-area map**: embedded Google Map with polygon or city list.
+- **Hours**: in footer + near booking CTA. Dynamic "Open now / Closed" badge converts.
+- **Address**: NAP block in footer, schema-marked.
+- **Click-to-call mobile pattern**: full-width "Call (555) 123-4567" button hero on mobile only.
+- **Emergency / after-hours**: separate red/orange-accented strip ("24/7 Emergency · 555-123-4567"), visually breaks page palette.
+
+### 5.6 Slot positions
+
+| Slot | Source in blueprint |
+|---|---|
+| `landing.hero.eyebrow` | derived from `workspace.industry` + `workspace.contact.serviceArea` |
+| `landing.hero.headline` | `landing.hero.headline` (operator-editable) |
+| `landing.hero.subhead` | `landing.hero.subhead` |
+| `landing.hero.cta_primary` | `landing.hero.cta_primary` (default "Book online") |
+| `landing.hero.image_url` | `workspace.theme.heroImageUrl` (with empty-state placeholder demanding upload) |
+| `landing.trust_strip[]` | computed: stars + review count + years + accreditations |
+| `landing.services[]` | array of `{icon, title, description, learn_more_url?, price_from?}` |
+| `landing.about` | `{photo_url, headline, body, owner_name?, owner_title?}` |
+| `landing.testimonials[]` | array of `{quote, author_name, author_role, avatar_url, source}` |
+| `landing.faq[]` | array of `{question, answer}` |
+| `landing.contact.phone` | shared from workspace |
+| `landing.contact.address` | shared from workspace |
+| `landing.contact.hours` | shared from workspace |
+| `landing.emergency_strip` | optional `{label, phone, accent_color}` (HVAC/plumbing) |
+
+### 5.7 Tailwind UI patterns to base on
+
+The composition that covers all 10 verticals named in the brief (HVAC, dental, legal, salon, etc.):
+- **Hero Sections → Split layout (image right)** — workhorse for HVAC/dental/legal/coaching
+- **Feature Sections → Three-column grid with icon-led features** — services grid
+- **Testimonials → Single featured + grid** — single highlighted quote + 3-up
+- **CTA Sections → Split CTA** — paired with inline form OR phone callout
+- **FAQs → Accordion**
+- **Logo Clouds → Horizontal logo row** — accreditations / vendor partners
+- **Footers → Multi-column footer (4-5 columns)** — NAP, hours, services, areas, social
+
+shadcn primitives: `Card`, `Button`, `Badge`, `Avatar`, `Accordion`, `Tabs`, `Separator`, `Sheet` (mobile nav), `Dialog` (quote modal), `Form` + `Input` + `Textarea` + `Select`, `Sonner` (toast), `Carousel` (portfolio only — NOT testimonials).
+
+### 5.8 The 3-5 design decisions that convert
+
+1. **Phone number in header AND sticky mobile call bar.** Not in hamburger, not footer alone. Largest single conversion lift on local-service sites.
+2. **Real photo of actual team or owner above the fold or in About strip.** Stock photography is a measurable conversion killer.
+3. **Trust strip directly under hero**: stars + reviews + years + accreditations. Proximity of proof to first CTA = multiplier.
+4. **Single quote/booking CTA mid-page with form embedded** (not button to modal). Embedded > button-to-modal > separate page.
+5. **Service area + hours visible**, not buried. Eliminates the #1 abandonment reason: "are they open / do they cover me?"
+
+### 5.9 Skip / DON'T copy from SaaS landing pages
+
+- **Three-tier pricing comparison.** Service businesses sell quotes/visits, not tiers. Price-from inside service cards if at all.
+- **"Trusted by" startup logo wall.** Service businesses don't have customer logos; they have Google reviews and vendor accreditations.
+- **Animated gradient hero, particle backgrounds, floating 3D mockups.** Reads as tech-bro, not local trust.
+- **"Book a demo" / "Start free trial" CTAs.** Always "Book now" / "Get a quote" / "Call us today."
+- **Long product-feature deep-dives.** Replace with crisp service descriptions; depth lives on per-service subpages (out of v1 scope).
+- **Newsletter signup as primary conversion.** Service businesses don't run newsletters; they run booking flows.
+
+### 5.10 General template + light vertical overlays
+
+**Recommendation: ship ONE general "service business" template** as the deterministic default — every workspace gets this on `create_workspace`. Then ship **light vertical overlays** that change *content tokens, not structure*:
+- HVAC: adds emergency strip + service-area map
+- Dental: swaps "Services" → "Treatments", adds Invisalign-style partner logos
+- Legal: swaps "Services" → "Practice Areas", adds "As Seen In" strip
+- Salon: adds portfolio carousel above services grid
+- Coaching: elevates founder photo into hero
+
+Structural skeleton stays identical. Avoid building 10 distinct vertical templates; build one + 10 content packs. Matches the deterministic-blueprint principle.
+
+---
+
+## 6. Phase 2 schema implications
+
+This document is the spec; Phase 2 turns it into JSON. Some structural decisions surface during research:
+
+### 6.1 The blueprint is a tree of typed sections
+
+Top-level shape:
+```
+{
+  "version": 1,
+  "workspace": { name, industry, theme, contact },
+  "landing":   { renderer: "general-service-v1", sections: [...], slots: {...} },
+  "booking":   { renderer: "calcom-month-v1",    event_type, availability, form_fields, confirmation },
+  "intake":    { renderer: "formbricks-stack-v1", title, questions[], completion },
+  "admin":     { renderer: "twenty-shell-v1",    objects[], sidebar_order, default_views }
+}
+```
+
+Each `renderer` value maps to a frozen TS component set. Versioned (`-v1`) so future renderers can ship without breaking existing blueprints.
+
+### 6.2 Theme is shared, surfaces inherit
+
+`workspace.theme` defines the token overrides ONCE:
+```
+{
+  "mode": "light" | "dark",
+  "accent": "#1E40AF",
+  "logo_url": "...",
+  "hero_image_url": "...",
+  "display_font": "cal-sans" | "geist",
+  "body_font": "inter",
+  "radius": "default" | "minimal" | "rounded"
+}
+```
+
+All four surfaces consume from the same token resolution. Operator picks one accent → it propagates to landing CTAs, booking confirm button, intake submit button, admin focus rings.
+
+### 6.3 Rendering is deterministic
+
+Same blueprint JSON → same HTML/CSS, byte-for-byte. No LLM in the rendering path. The blueprint is generated/edited (potentially by Claude Code from natural-language input), but the rendering is hand-written components reading typed fields.
+
+This is the load-bearing claim of the system. Implications:
+- Renderer functions are pure: `(blueprint, theme) => HTMLString`.
+- Tests assert byte-equality of output for fixed input.
+- Updating a renderer (`general-service-v1` → `general-service-v2`) is an explicit blueprint migration.
+
+### 6.4 First template = "general"
+
+Per Max's "DO NOT build a generic template engine" constraint: ship ONE polished general template (general-service-v1) before any vertical overlays. Test it with HVAC, dental, salon, legal, coaching, and validate it survives all five before adding vertical-specific renderers.
+
+If general-v1 covers 90% of cases and vertical overlays are content-only (logos, copy, sections), the system stays simple. If it doesn't, that's a Phase 3 finding to revisit.
+
+### 6.5 Light mode default
+
+All four surfaces default to light mode. Dark mode is an opt-in `workspace.theme.mode = "dark"`. Reasons:
+- Service businesses' customers expect light mode (warm, trustworthy)
+- Twenty's premium feel is in its light mode
+- Cal.com and Formbricks both default light
+- Dark mode is a tax (every component must be tested twice); ship light first, validate, add dark later
+
+### 6.6 Admin access for guest workspaces
+
+Per the cleanroom finding: admin URL pattern is `app.seldonframe.com/switch-workspace?to=<orgId>&next=<path>`, which requires login + membership. For guest workspaces (created without `SELDONFRAME_API_KEY`), there's currently no membership → admin denies.
+
+Bearer-token-only admin would unblock guest operators viewing their own workspace data without a signup. Schema implication:
+```
+{
+  "admin": {
+    "auth_modes": ["session", "bearer"],
+    "guest_workspace_bearer_url": "https://app.seldonframe.com/g/<wsp_id>?token=<bearer>"
+  }
+}
+```
+
+This is a Phase 3 implementation question, not a Phase 2 schema question. Flagged here so it doesn't get lost.
+
+---
+
+## 7. Open questions for Max before Phase 2 starts
+
+1. **Display font: Cal Sans or Geist?** Both BSD-license-compatible. Cal Sans has more personality on titles; Geist is more neutral. Pick one; we'll use it everywhere display-typeset.
+2. **Token prefix: `--sf-*` or something else?** Recommended `--sf-*` to avoid clashing with shadcn defaults. Confirm or override.
+3. **Single accent or accent + secondary?** I recommend single (per Cal.com/Twenty discipline). Operator picks one, system derives soft/hover/ring. Confirm.
+4. **Off-white landing background `#FAFAF7`** vs pure white. I recommend warm off-white for landing only; admin/booking stay pure white. Confirm.
+5. **Vertical overlay strategy: content packs vs distinct renderers?** I recommend content packs (one structural template, vertical-specific copy/icons/sections). Confirm.
+6. **Dark mode in v1 or v2?** I recommend v2 — ship light mode polished first, add dark later.
+7. **Bearer-token admin for guest workspaces?** Phase 3 question but it affects schema shape — keep option in mind.
+8. **One-renderer-per-surface or pluggable?** I recommend frozen `*-v1` renderers per surface for v1, with versioning slot for future. Confirm.
+
+---
+
+## 8. What's next
+
+Per Max's spec: STOP after Phase 1.
+
+Pending review:
+- This document (full pattern research)
+- The 8 open questions above
+
+Once approved:
+- Phase 2: define the JSON schema + write `skills/templates/schema.json`, `skills/templates/general.json`, `skills/templates/hvac.json`
+- Phase 3: implement the template renderer, update `buildSeededHomeHtml()`, propagate theme to all surfaces
+
+Length cap reached. Standing by for review.


### PR DESCRIPTION
## Summary

Two-phase deliverable for the workspace blueprint system per the architectural directive.

**Phase 1** — research doc (`tasks/design-patterns-research.md`, 682 lines): synthesizes design DNA from Cal.com (booking), Twenty (admin), Formbricks (intake), and 12 best-in-class service-business landing pages. 8 directional decisions surfaced; all 8 approved.

**Phase 2** — schema + first two templates (`skills/templates/`, 1,734 lines): JSON Schema Draft 2020-12 covering all 5 surfaces (workspace, landing, booking, intake, admin) with 10 section types under landing. `general.json` is the fallback; `hvac.json` is the first vertical content pack. Both Ajv-validated.

## Approved decisions implemented

1. Cal Sans display + Inter body
2. `--sf-*` token prefix
3. Single accent (operator-chosen, system derives)
4. Warm off-white `#FAFAF7` for landing only; admin/booking pure white
5. Content packs (one structural template, vertical-specific copy)
6. Light mode default for v1; dark mode reserved for v2
7. Bearer-token admin for guest workspaces (Phase 3)
8. Frozen `*-v1` renderers per surface

## Verification

- Both templates validate against the schema via Ajv (Draft 2020-12 + formats)
- 8 issues caught during authoring; all fixed before commit
- 1,734 lines of JSON across 4 files; pure data, no runtime code

## What's gated on this review

Phase 3: the renderer code + `buildSeededHomeHtml()` + bearer-token admin + the in-repo validation script.
