### PR TITLE
feat: 5 health/wellness landing templates + /clients/new finalizing-CTA fix

### DIFF
--- a/docs/superpowers/plans/2026-06-03-health-vertical-templates.md
+++ b/docs/superpowers/plans/2026-06-03-health-vertical-templates.md
@@ -1,0 +1,137 @@
+# Health & Wellness Landing Templates — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire 5 premium Claude Design health/wellness full-page landing templates into the SeldonFrame create-workspace pipeline so vertical-appropriate templates render at `/w/[slug]`, themed per-business via the archetype system.
+
+**Architecture:** Each template is a self-contained, server-rendered React package with a shared entry signature `({ data, ctas, theme })`, consuming the business **soul** and theming 100% via injected `--sf-*` CSS variables. A registry maps template IDs → components; a thin dispatch in `app/(public)/w/[slug]/page.tsx` renders the chosen template (loading soul + theme directly) and falls back to the existing landing-r1 renderer when no new template is selected. Template selection is persisted on `organizations.theme.landingTemplate` and chosen at creation from a vertical→template map.
+
+**Tech stack:** Next.js App Router (RSC), TypeScript, styled-jsx (global), Drizzle (Neon Postgres), Vitest.
+
+**Source of T5 deliverable:** `C:/Users/maxim/CascadeProjects/hw-templates/templates/05-earthy-modern-clinical/react/` (verified against the contract: shared API, theme-only colors, graceful fallbacks, house rules, container queries).
+
+---
+
+## Key decisions (locked)
+
+1. **Template data source = the r1 landing payload** (NOT `organizations.soul`). Finding during pilot: `organizations.soul` is the `OrgSoul` CRM-personality shape (pipeline, voice, entityLabels, `services`) — it lacks the phone/faqs/testimonials/photos/reviews the templates need. The clean, already-populated source is the **r1 landing payload** (`landing_pages.blueprintJson`, slug `r1`) — the extracted, cleaned hero/services/testimonials/faq/footer that `/w/[slug]` already loads via `loadLandingPayload(slug)`. So the new templates are **alternative renderers of the same r1 content**: map `R1LandingPayload → template Soul`. Consequence: a workspace must have an r1 landing to render a new template — true for every real-pipeline workspace; the 5 old health workspaces (built via `create_full_workspace`, no r1 row) get one in Phase 3, or the pilot proof targets a workspace that already has one (e.g. resultspt).
+2. **Template home:** `packages/crm/src/components/landing-templates/<id>/` (mirrors `landing-r1/`). Shared contract files (`types.ts`) are **byte-identical** across all five.
+3. **Selection persisted** at `organizations.theme.landingTemplate` (theme JSON is already extensible; no migration needed).
+4. **Dispatch precedence** in `/w/[slug]`: if `theme.landingTemplate` is a registered template AND a soul exists → render new template; else → existing landing-r1 path (unchanged).
+5. **Offerings normalization:** souls in the wild carry `offerings` as EITHER `string[]` (older `submit_soul`/`create_full_workspace`) OR `object[]` (Phase U extraction). The soul→template mapper MUST normalize both to the template's `{ name, description?, price?, ... }[]`.
+6. **Theme key adapter:** archetype palette `{ primary, secondary, background, text, border }` + `fonts:{ headline, body }` → template `SfTheme` `{ primary, secondary, bg, text, border, fontHeadline, fontBody }`.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `components/landing-templates/_contract/types.ts` | Shared `Soul`, `CTAs`, `SfTheme`, `TemplateProps` (single source; templates import from here) |
+| `components/landing-templates/earthy-modern-clinical/*` | T5 ported package (sections, css, theme, ui, interactive, icons, EarthyModernClinical.tsx) |
+| `components/landing-templates/registry.ts` | `LANDING_TEMPLATES` map id→component, `isLandingTemplateId()` guard, `TEMPLATE_BY_VERTICAL` map |
+| `lib/landing/template-adapters.ts` | `archetypeToSfTheme(theme)`, `soulToTemplateData(soul)` (with offerings normalization), `buildTemplateCtas(slug, orgId)` |
+| `lib/landing/template-adapters.test.ts` | Unit tests for both adapters incl. string[]-offerings + missing-field cases |
+| `lib/landing/public-workspace.ts` | `getPublicWorkspaceForTemplate(slug)` → `{ orgId, soul, theme } | null` (org-by-slug + soul + theme) |
+| `app/(public)/w/[slug]/page.tsx` | Add template dispatch ahead of the landing-r1 render |
+| `lib/workspace/aesthetic-archetypes.ts` | Add/extend `pickLandingTemplate({ vertical, archetype })` for creation-time selection |
+| (create pipeline) `lib/.../run-create-from-url.ts` + paste | Persist `theme.landingTemplate` at the `landing_built` step |
+
+---
+
+## Phase 0 — T5 pilot (do now; proves the whole path end-to-end)
+
+### Task 0.1: Shared contract + port T5 package
+
+**Files:**
+- Create: `packages/crm/src/components/landing-templates/_contract/types.ts`
+- Create: `packages/crm/src/components/landing-templates/earthy-modern-clinical/{EarthyModernClinical.tsx,sections.tsx,interactive.tsx,ui.tsx,icons.tsx,css.ts,theme.ts,Styles.tsx,fixture.ts}`
+
+- [ ] **Step 1:** Copy the 11 files from `hw-templates/.../05-earthy-modern-clinical/react/` into `earthy-modern-clinical/`. Move `types.ts` to `_contract/types.ts`; update each file's `./types` import to `../_contract/types`.
+- [ ] **Step 2:** Rename the default export to a named export `EarthyModernClinical` (registry imports by name). Keep the `({ data, ctas, theme })` signature.
+- [ ] **Step 3:** Confirm `"use client"` only on `interactive.tsx` + `ui.tsx`; `Styles.tsx` uses `<style jsx global>`.
+- [ ] **Step 4:** `pnpm -C packages/crm typecheck` → PASS.
+- [ ] **Step 5:** Commit `feat(landing-templates): port T5 Earthy Modern Clinical package`.
+
+### Task 0.2: Registry + vertical map
+
+**Files:**
+- Create: `packages/crm/src/components/landing-templates/registry.ts`
+
+- [ ] **Step 1:** Export `LANDING_TEMPLATES = { "earthy-modern-clinical": EarthyModernClinical } as const satisfies Record<string, ComponentType<TemplateProps>>`, `type LandingTemplateId`, and `isLandingTemplateId(v): v is LandingTemplateId`.
+- [ ] **Step 2:** Export `TEMPLATE_BY_VERTICAL: Record<string, LandingTemplateId>` seeded with chiropractic/physiotherapy/sports-medicine/"" → `earthy-modern-clinical` (others added with T1–T4).
+- [ ] **Step 3:** typecheck → PASS. Commit.
+
+### Task 0.3: Adapters
+
+**Files:**
+- `packages/crm/src/lib/landing/template-adapters.ts` ✅ **DONE** — `archetypeToSfTheme(archetypeId)` (looks up `ARCHETYPES[id]`, maps palette+fonts → SfTheme) and `buildTemplateCtas(slug, orgId, phone?)` (workspace URLs + `tel:` href). Typechecks.
+- Create: `packages/crm/src/lib/landing/r1-payload-to-template.ts` + `.test.ts` (the remaining mapper).
+
+- [ ] **Step 1 (RED):** Write tests for `r1PayloadToTemplateData(payload): Soul`:
+  - hero → `business_name`, `tagline`, `soul_description`, `review_rating`, `review_count`, hero photo (role "hero").
+  - services items → `offerings: [{ name, description?, price?, duration_minutes? }]` (normalize r1 service shape; tolerate string-only).
+  - testimonials/faq/footer → `testimonials`, `faqs`, `phone`/`email`/`address`/`service_area`, service photos by role.
+- [ ] **Step 2:** Run tests → FAIL (module not implemented).
+- [ ] **Step 3 (GREEN):** Implement `r1PayloadToTemplateData` against the `R1LandingPayload` sub-types (`lib/landing/r1-payload-generator.ts` / `_shared/types.ts`). Map photos to `{ url, alt, role }`; missing → omit (template renders themed placeholder).
+- [ ] **Step 4:** Run tests → PASS. typecheck → PASS. Commit.
+
+### Task 0.4: Template choice resolver (no separate soul loader)
+
+The data + archetype + orgId already come from `loadLandingPayload(slug)`. We only additionally need the persisted template id.
+
+**Files:**
+- Modify: `packages/crm/src/lib/landing/r1-save.ts` — extend `loadLandingPayload` to also `select` `organizations.theme` (or add `getLandingTemplateId(orgId)`), returning `theme?.landingTemplate`.
+
+- [ ] **Step 1:** Surface `landingTemplate` (string | undefined) alongside the existing `{ payload, archetype, orgId, seo }` return.
+- [ ] **Step 2:** typecheck → PASS. Commit.
+
+### Task 0.5: Dispatch in /w/[slug]
+
+**Files:**
+- Modify: `packages/crm/src/app/(public)/w/[slug]/page.tsx`
+
+- [ ] **Step 1:** After `loadLandingPayload(slug)` returns `{ payload, archetype, orgId, landingTemplate }`, if `isLandingTemplateId(landingTemplate)`, render:
+  ```tsx
+  const Tpl = LANDING_TEMPLATES[landingTemplate];
+  const data = r1PayloadToTemplateData(payload);
+  return <Tpl data={data} ctas={buildTemplateCtas(slug, orgId, data.phone)} theme={archetypeToSfTheme(archetype)} />;
+  ```
+  `generateMetadata` already reads from `payload`/`seo`, so it keeps working unchanged.
+- [ ] **Step 2:** Else fall through to the existing landing-r1 render (unchanged).
+- [ ] **Step 3:** Render the chatbot embed script on the template path too (`getPublicChatbotEmbed(orgId)`).
+- [ ] **Step 4:** typecheck → PASS. Commit.
+
+### Task 0.6: Manual pilot proof
+
+- [ ] **Step 1:** On a health workspace WITH a soul (e.g. Austin Family Chiropractic, org `8efdb7a1-…`), set `theme = jsonb_set(theme, '{landingTemplate}', '"earthy-modern-clinical"')` and `{aestheticArchetype}` if absent, via Neon SQL.
+- [ ] **Step 2:** Deploy the branch preview; visit `/w/austin-family-chiropractic`. Confirm T5 renders with that workspace's real soul, themed, with graceful placeholders. (Manual — surface to user.)
+
+---
+
+## Phase 1 — Generalize to T1–T4 (when Claude Design delivers)
+
+- [ ] Port each package under `landing-templates/<id>/` reusing `_contract/types.ts` (must be identical API).
+- [ ] Add each to `LANDING_TEMPLATES` + extend `TEMPLATE_BY_VERTICAL` (massage→editorial-bodywork, derm/medspa→clinical-luxe, women's-wellness→warm-wellness, holistic/osteo→cinematic-sanctuary).
+- [ ] Per-template: typecheck + preview render with its matching soul.
+
+## Phase 2 — Creation-pipeline selection
+
+- [ ] Add `pickLandingTemplate({ vertical, archetype })` in `aesthetic-archetypes.ts` (vertical-first via `TEMPLATE_BY_VERTICAL`, archetype fallback).
+- [ ] In the create-from-url + create-from-paste flows, at the `landing_built` step, persist `theme.landingTemplate = pickLandingTemplate(...)` alongside the existing r1 landing write (so new workspaces auto-select).
+- [ ] Verify a fresh `/clients/new` build for a chiro URL selects + renders T5.
+
+## Phase 3 — Re-render the 5 Austin workspaces + cleanup
+
+- [ ] For each of the 5 health workspaces: ensure soul present (done), set `theme.landingTemplate` via the vertical map, confirm `/w/<slug>` renders the right template.
+- [ ] Decide subdomain vs `/w/` canonical (the old `*.app.seldonframe.com/l/home` template pages still exist) — point the workspace's public URL to `/w/<slug>`.
+- [ ] Remove the stale `source:"template"` `home` landing rows if they conflict.
+
+---
+
+## Self-review
+
+- **Spec coverage:** all 5 templates, creation-time selection, /w dispatch, re-render of the 5 workspaces — covered.
+- **Type consistency:** `TemplateProps`/`Soul`/`SfTheme` defined once in `_contract/types.ts`; registry typed to `ComponentType<TemplateProps>`; adapters return those exact types.
+- **Risk — offerings shape:** addressed by normalization in `soulToTemplateData` (Task 0.3) + a dedicated test.
+- **Risk — workspace with no r1 row:** addressed by loading soul directly (Task 0.4), not the r1 payload.

--- a/packages/crm/src/app/(dashboard)/clients/new/build-animation/build-stage-v2.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/build-animation/build-stage-v2.tsx
@@ -391,6 +391,14 @@ export function BuildStageV2({ active, input, eventSource, revealLinks }: BuildS
   const publishDomain = inferPublishSubdomain(input ?? { kind: "url", value: "" });
   const elapsedFmt = formatTime(elapsedS);
   const totalFmt = `${TOTAL_S}s`;
+  // 2026-06-03 — The rAF narrative clock can reach the REVEAL phase before
+  // the orchestrator's `done` event fires (real builds occasionally run
+  // past the 60s clock). `isReady` is the single source of truth for "the
+  // workspace is actually built and its dashboard URL is live" — it gates
+  // the REVEAL copy and flips the CTAs from a finalizing state to real
+  // clickable anchors. Without it the operator saw a finished-looking
+  // screen with a dead look-alike button and no cue it was still wiring up.
+  const isReady = Boolean(revealLinks?.open);
 
   return (
     <div
@@ -625,10 +633,18 @@ export function BuildStageV2({ active, input, eventSource, revealLinks }: BuildS
               <PhasePanel index={5} active={phaseIndex === 5}>
                 <PhaseHead phase={5} stageMark={stageMark} />
                 <div className="sb-phase-body">
-                  <div className="sb-reveal">
-                    <div className="sb-reveal-banner">
-                      <span className="sb-reveal-tag">Live · {Math.round(elapsedS)}s build</span>
-                      <h3 className="sb-reveal-name">{displayName} is ready to hand over.</h3>
+                  <div className="sb-reveal" data-ready={isReady ? "yes" : "no"}>
+                    <div className={`sb-reveal-banner${isReady ? "" : " is-pending"}`}>
+                      <span className="sb-reveal-tag">
+                        {isReady
+                          ? `Live · ${Math.round(elapsedS)}s build`
+                          : `Finalizing · ${Math.round(elapsedS)}s`}
+                      </span>
+                      <h3 className="sb-reveal-name">
+                        {isReady
+                          ? `${displayName} is ready to hand over.`
+                          : `Putting the finishing touches on ${displayName}…`}
+                      </h3>
                     </div>
                     <div className="sb-reveal-stats">
                       <Stat k="Modules" v="4" small="/ 4 live" />
@@ -637,15 +653,16 @@ export function BuildStageV2({ active, input, eventSource, revealLinks }: BuildS
                       <Stat k="Archetype" v={archetypeLabel} small="" smallValue />
                     </div>
                     <div className="sb-reveal-ctas">
-                      {/* 2026-05-24 — Wired to real URLs from the orchestrator
-                          `done` payload (dashboardUrl + publicHomeUrl). When
-                          revealLinks is absent (animation still running, or
-                          the parent hasn't received `done` yet) the CTAs
-                          render as disabled-looking spans so the visual moment
-                          still lands. */}
-                      {revealLinks?.open ? (
+                      {/* 2026-06-03 — The rAF clock can reach REVEAL before the
+                          orchestrator's `done` event arrives. Until it does
+                          (isReady === false) the primary CTA renders as an
+                          explicit finalizing state — spinner + shimmer — so the
+                          operator reads it as still-working, not broken. The
+                          instant `done` lands and revealLinks is set, it flips
+                          to a real, clickable anchor. */}
+                      {isReady ? (
                         <a
-                          href={revealLinks.open}
+                          href={revealLinks!.open}
                           className="sb-btn sb-btn-primary"
                         >
                           Open workspace
@@ -655,15 +672,17 @@ export function BuildStageV2({ active, input, eventSource, revealLinks }: BuildS
                           </svg>
                         </a>
                       ) : (
-                        <span className="sb-btn sb-btn-primary" aria-busy="true">
-                          Open workspace
-                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round">
-                            <line x1={5} y1={12} x2={19} y2={12} />
-                            <polyline points="12 5 19 12 12 19" />
-                          </svg>
+                        <span
+                          className="sb-btn sb-btn-primary is-pending"
+                          role="status"
+                          aria-live="polite"
+                          aria-busy="true"
+                        >
+                          <span className="sb-btn-spinner" aria-hidden="true" />
+                          Finalizing workspace…
                         </span>
                       )}
-                      {revealLinks?.share ? (
+                      {isReady && revealLinks?.share ? (
                         <a
                           href={revealLinks.share}
                           target="_blank"
@@ -673,11 +692,20 @@ export function BuildStageV2({ active, input, eventSource, revealLinks }: BuildS
                           Share with client
                         </a>
                       ) : (
-                        <span className="sb-btn sb-btn-ghost" aria-busy="true">
+                        <span
+                          className={`sb-btn sb-btn-ghost${isReady ? " is-disabled" : " is-pending"}`}
+                          aria-busy={!isReady}
+                          aria-disabled="true"
+                        >
                           Share with client
                         </span>
                       )}
                     </div>
+                    {!isReady && (
+                      <p className="sb-reveal-hint" role="status" aria-live="polite">
+                        Wiring the last modules together — this goes live the moment your workspace is ready.
+                      </p>
+                    )}
                   </div>
                 </div>
               </PhasePanel>
@@ -1863,6 +1891,63 @@ function StageStyles() {
         border: 1px solid var(--sb-border);
       }
 
+      /* 2026-06-03 — Pending CTA state. The build clock can reach REVEAL
+         before the orchestrator's `done` fires; rather than a dead
+         look-alike button, the primary CTA shows an explicit finalizing
+         state (spinner + shimmer sweep) and flips to a real <a> the moment
+         revealLinks arrives. */
+      .sb-btn.is-pending { cursor: progress; pointer-events: none; }
+      .sb-btn-ghost.is-pending { opacity: 0.55; }
+      .sb-btn-ghost.is-disabled { opacity: 0.4; cursor: default; pointer-events: none; }
+      .sb-btn-primary.is-pending {
+        position: relative;
+        overflow: hidden;
+        background: color-mix(in oklab, var(--sb-accent) 60%, var(--sb-surface));
+        border-color: color-mix(in oklab, var(--sb-accent) 38%, var(--sb-border));
+        color: color-mix(in oklab, var(--sb-accent-ink) 88%, transparent);
+        box-shadow: none;
+      }
+      .sb-btn-primary.is-pending::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(90deg, transparent, color-mix(in oklab, var(--sb-accent-ink) 24%, transparent), transparent);
+        transform: translateX(-100%);
+        animation: sb-btn-shimmer 1.5s ease-in-out infinite;
+      }
+      .sb-btn-spinner {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+        border-radius: 50%;
+        border: 2px solid color-mix(in oklab, var(--sb-accent-ink) 32%, transparent);
+        border-top-color: var(--sb-accent-ink);
+        animation: sb-spin 0.7s linear infinite;
+      }
+      @keyframes sb-spin { to { transform: rotate(360deg); } }
+      @keyframes sb-btn-shimmer {
+        0% { transform: translateX(-100%); }
+        55%, 100% { transform: translateX(100%); }
+      }
+      .sb-reveal-hint {
+        margin: 2px 0 0;
+        font-family: 'Geist Mono', ui-monospace, monospace;
+        font-size: 11px;
+        letter-spacing: 0.01em;
+        color: var(--sb-ink-3);
+      }
+      /* Pending banner pulses an amber dot instead of the live green. */
+      .sb-reveal-banner.is-pending {
+        border-color: color-mix(in oklab, oklch(0.74 0.16 75) 30%, var(--sb-border));
+      }
+      .sb-reveal-banner.is-pending .sb-reveal-tag { color: oklch(0.62 0.13 75); }
+      .sb-reveal-banner.is-pending .sb-reveal-tag::before {
+        background: oklch(0.74 0.16 75);
+        box-shadow: 0 0 0 3px color-mix(in oklab, oklch(0.74 0.16 75) 22%, transparent);
+        animation: sb-pulse-dot 1.2s ease-in-out infinite;
+      }
+      @keyframes sb-pulse-dot { 50% { opacity: 0.4; } }
+
       /* RIGHT — phase narration panel */
       .sb-side {
         position: relative;
@@ -2062,6 +2147,9 @@ function StageStyles() {
         .sb-struct-card, .sb-lead { animation: none; opacity: 1; transform: none; }
         .sb-act-head .dot, .sb-reveal-tag::before { animation: none; }
         .sb-scan .caret { animation: none; }
+        .sb-btn-spinner,
+        .sb-btn-primary.is-pending::after,
+        .sb-reveal-banner.is-pending .sb-reveal-tag::before { animation: none; }
       }
       /* Reduced motion (JS-controlled layer) */
       .sb-stage[data-reduced="yes"] .sb-phase { transition: none; }
@@ -2076,6 +2164,11 @@ function StageStyles() {
         animation: none;
       }
       .sb-stage[data-reduced="yes"] .sb-scan .caret { animation: none; }
+      .sb-stage[data-reduced="yes"] .sb-btn-spinner,
+      .sb-stage[data-reduced="yes"] .sb-btn-primary.is-pending::after,
+      .sb-stage[data-reduced="yes"] .sb-reveal-banner.is-pending .sb-reveal-tag::before {
+        animation: none;
+      }
       .sb-stage[data-reduced="yes"] .sb-tick.is-active { opacity: 1; }
       .sb-stage[data-reduced="yes"] .sb-tick.is-active .bar .fill {
         transition: none;

--- a/packages/crm/src/app/(dashboard)/clients/new/build-animation/build-stage-v2.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/build-animation/build-stage-v2.tsx
@@ -1892,10 +1892,10 @@ function StageStyles() {
       }
 
       /* 2026-06-03 — Pending CTA state. The build clock can reach REVEAL
-         before the orchestrator's `done` fires; rather than a dead
+         before the orchestrator done event fires; rather than a dead
          look-alike button, the primary CTA shows an explicit finalizing
-         state (spinner + shimmer sweep) and flips to a real <a> the moment
-         revealLinks arrives. */
+         state (spinner + shimmer sweep) and flips to a real anchor the
+         moment revealLinks arrives. */
       .sb-btn.is-pending { cursor: progress; pointer-events: none; }
       .sb-btn-ghost.is-pending { opacity: 0.55; }
       .sb-btn-ghost.is-disabled { opacity: 0.4; cursor: default; pointer-events: none; }

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -28,6 +28,15 @@ import { loadLandingPayload } from "@/lib/landing/r1-save";
 import { rewriteR1Hrefs } from "@/lib/landing/r1-rewrite-hrefs";
 import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getPublicChatbotEmbed } from "@/lib/agents/public-embed";
+import {
+  LANDING_TEMPLATES,
+  isLandingTemplateId,
+} from "@/components/landing-templates/registry";
+import { r1PayloadToTemplateData } from "@/lib/landing/r1-payload-to-template";
+import {
+  archetypeToSfTheme,
+  buildTemplateCtas,
+} from "@/lib/landing/template-adapters";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -102,7 +111,29 @@ export default async function WorkspaceLandingPage({ params }: PageProps) {
     notFound();
   }
 
-  const { orgId } = data;
+  const { orgId, landingTemplate } = data;
+
+  // bisect 4/4: chatbot embed — shared by both render paths.
+  const chatbotEmbed = await getPublicChatbotEmbed(orgId);
+
+  // Health-templates pilot: when the workspace has opted into a premium
+  // full-page template (persisted at organizations.theme.landingTemplate),
+  // render it as an alternative renderer of the same r1 content. The template
+  // builds its own workspace-scoped CTAs (book/intake/tel:), so it does NOT
+  // need the r1 href-rewrite. Workspaces without a registered template fall
+  // through to the existing landing-r1 path below, unchanged.
+  if (isLandingTemplateId(landingTemplate)) {
+    const Tpl = LANDING_TEMPLATES[landingTemplate];
+    const templateData = r1PayloadToTemplateData(data.payload);
+    const ctas = buildTemplateCtas(slug, orgId, templateData.phone);
+    const theme = archetypeToSfTheme(data.payload.hero.archetype ?? data.archetype);
+    return (
+      <>
+        <Tpl data={templateData} ctas={ctas} theme={theme} />
+        {chatbotEmbed && <ChatbotEmbedScript embedUrl={chatbotEmbed.embedUrl} />}
+      </>
+    );
+  }
 
   // bisect 3/4: rewrite generic CTA hrefs to workspace-scoped URLs.
   const workspaceUrls = buildWorkspaceUrls(
@@ -115,9 +146,6 @@ export default async function WorkspaceLandingPage({ params }: PageProps) {
     intake: workspaceUrls.intake,
     home: workspaceUrls.home,
   });
-
-  // bisect 4/4: chatbot embed.
-  const chatbotEmbed = await getPublicChatbotEmbed(orgId);
 
   return (
     <>

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { Navbar } from "@/components/landing-r1/chrome/navbar";
 import { ChatbotEmbedScript } from "@/components/landing/chatbot-script";
 
 import { loadLandingPayload } from "@/lib/landing/r1-save";
+import { getWorkspaceTemplateContext } from "@/lib/landing/public-workspace";
 import { rewriteR1Hrefs } from "@/lib/landing/r1-rewrite-hrefs";
 import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getPublicChatbotEmbed } from "@/lib/agents/public-embed";
@@ -32,11 +33,15 @@ import {
   LANDING_TEMPLATES,
   isLandingTemplateId,
 } from "@/components/landing-templates/registry";
-import { r1PayloadToTemplateData } from "@/lib/landing/r1-payload-to-template";
+import {
+  r1PayloadToTemplateData,
+  submittedSoulToTemplateData,
+} from "@/lib/landing/r1-payload-to-template";
 import {
   archetypeToSfTheme,
   buildTemplateCtas,
 } from "@/lib/landing/template-adapters";
+import { ARCHETYPES, type AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
@@ -47,7 +52,26 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const data = await loadLandingPayload(slug);
 
   if (!data) {
-    return { title: "Page not found" };
+    // No r1 payload — fall back to the raw soul so soul-only workspaces still
+    // get a basic, indexable title/description instead of "Page not found".
+    const ctx = await getWorkspaceTemplateContext(slug);
+    const soul = ctx ? submittedSoulToTemplateData(ctx.soul) : null;
+    if (!soul || soul.business_name === "Our Practice") {
+      // No org, or a soul with no real business_name → nothing meaningful.
+      return { title: "Page not found" };
+    }
+    const description = soul.soul_description ?? soul.tagline;
+    return {
+      title: soul.business_name,
+      ...(description ? { description } : {}),
+      openGraph: {
+        title: soul.business_name,
+        ...(description ? { description } : {}),
+        type: "website",
+      },
+      robots: { index: true, follow: true },
+      alternates: { canonical: `/w/${slug}` },
+    };
   }
 
   const { seo, payload } = data;
@@ -105,43 +129,73 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function WorkspaceLandingPage({ params }: PageProps) {
   const { slug } = await params;
-  const data = await loadLandingPayload(slug);
 
-  if (!data) {
+  // Resolve the workspace by slug first. This succeeds for ANY existing
+  // workspace (soul-only ones included), so a workspace with a soul but no r1
+  // landing payload can still render a registered template below. notFound()
+  // only when the slug doesn't map to a workspace at all.
+  const ctx = await getWorkspaceTemplateContext(slug);
+  if (!ctx) {
     notFound();
   }
 
-  const { orgId, landingTemplate } = data;
+  // r1 landing payload — preferred content source when present, may be null.
+  const r1 = await loadLandingPayload(slug);
 
-  // bisect 4/4: chatbot embed — shared by both render paths.
-  const chatbotEmbed = await getPublicChatbotEmbed(orgId);
+  // Template id: r1's persisted value wins, else the org theme's. Either may be
+  // undefined / unregistered → falls through to the landing-r1 path.
+  const landingTemplate = r1?.landingTemplate ?? ctx.theme?.landingTemplate;
+
+  // Chatbot embed — shared by both render paths.
+  const chatbotEmbed = await getPublicChatbotEmbed(ctx.orgId);
 
   // Health-templates pilot: when the workspace has opted into a premium
   // full-page template (persisted at organizations.theme.landingTemplate),
-  // render it as an alternative renderer of the same r1 content. The template
-  // builds its own workspace-scoped CTAs (book/intake/tel:), so it does NOT
-  // need the r1 href-rewrite. Workspaces without a registered template fall
-  // through to the existing landing-r1 path below, unchanged.
+  // render it as an alternative renderer. Content comes from the r1 payload
+  // when present, otherwise from the raw organizations.soul jsonb so soul-only
+  // workspaces still render. The template builds its own workspace-scoped CTAs
+  // (book/intake/tel:), so it does NOT need the r1 href-rewrite. Workspaces
+  // without a registered template fall through to the landing-r1 path, which
+  // requires an r1 payload.
   if (isLandingTemplateId(landingTemplate)) {
     const Tpl = LANDING_TEMPLATES[landingTemplate];
-    const templateData = r1PayloadToTemplateData(data.payload);
-    const ctas = buildTemplateCtas(slug, orgId, templateData.phone);
-    const theme = archetypeToSfTheme(data.payload.hero.archetype ?? data.archetype);
+    const templateData = r1
+      ? r1PayloadToTemplateData(r1.payload)
+      : submittedSoulToTemplateData(ctx.soul);
+    // Re-skin via the archetype palette ONLY when one is explicitly set (on
+    // the r1 payload or the org theme). Otherwise pass undefined so the
+    // template renders in its own signature default palette — the designed look.
+    const explicitArchetype = r1?.archetype ?? ctx.theme?.aestheticArchetype;
+    const sfTheme =
+      explicitArchetype && explicitArchetype in ARCHETYPES
+        ? archetypeToSfTheme(explicitArchetype as AestheticArchetypeId)
+        : undefined;
     return (
       <>
-        <Tpl data={templateData} ctas={ctas} theme={theme} />
+        <Tpl
+          data={templateData}
+          ctas={buildTemplateCtas(slug, ctx.orgId, templateData.phone)}
+          theme={sfTheme}
+        />
         {chatbotEmbed && <ChatbotEmbedScript embedUrl={chatbotEmbed.embedUrl} />}
       </>
     );
+  }
+
+  // Non-template workspaces render the existing landing-r1 sections — which
+  // require an r1 payload. A soul-only workspace with no registered template
+  // has nothing to render here → notFound().
+  if (!r1) {
+    notFound();
   }
 
   // bisect 3/4: rewrite generic CTA hrefs to workspace-scoped URLs.
   const workspaceUrls = buildWorkspaceUrls(
     slug,
     process.env.WORKSPACE_BASE_DOMAIN ?? "app.seldonframe.com",
-    orgId,
+    ctx.orgId,
   );
-  const payload = rewriteR1Hrefs(data.payload, {
+  const payload = rewriteR1Hrefs(r1.payload, {
     book: workspaceUrls.book,
     intake: workspaceUrls.intake,
     home: workspaceUrls.home,

--- a/packages/crm/src/components/landing-templates/_contract/types.ts
+++ b/packages/crm/src/components/landing-templates/_contract/types.ts
@@ -1,4 +1,4 @@
-// SeldonFrame Â· shared data contract (matches EXAMPLE_SOULS.ts Â§3).
+// SeldonFrame · shared data contract (matches EXAMPLE_SOULS.ts §3).
 // Treat every field except `business_name` as possibly missing.
 
 export type Soul = {
@@ -34,7 +34,7 @@ export type CTAs = {
   intakeUrl?: string;
 };
 
-// The archetype theme â€” injected per business. Every template reads exactly
+// The archetype theme — injected per business. Every template reads exactly
 // these tokens; the values are surfaced to CSS as --sf-* custom properties.
 export type SfTheme = {
   primary?: string;

--- a/packages/crm/src/components/landing-templates/_contract/types.ts
+++ b/packages/crm/src/components/landing-templates/_contract/types.ts
@@ -1,0 +1,50 @@
+// SeldonFrame Â· shared data contract (matches EXAMPLE_SOULS.ts Â§3).
+// Treat every field except `business_name` as possibly missing.
+
+export type Soul = {
+  business_name: string;
+  tagline?: string;
+  soul_description?: string;
+  phone?: string;
+  email?: string;
+  address?: string;
+  service_area?: string[];
+  hours?: { day: string; open: string; close: string }[];
+  review_rating?: number;
+  review_count?: number;
+  trust_signals?: string[];
+  certifications?: string[];
+  emergency_service?: boolean;
+  same_day?: boolean;
+  offerings?: {
+    name: string;
+    description?: string;
+    price?: number;
+    currency?: string;
+    duration_minutes?: number;
+  }[];
+  faqs?: { q: string; a: string }[];
+  testimonials?: { name: string; text: string }[];
+  photos?: { url: string; alt?: string; role?: "hero" | "service" | "about" | "gallery" }[];
+};
+
+export type CTAs = {
+  bookUrl: string;
+  callHref?: string;
+  intakeUrl?: string;
+};
+
+// The archetype theme â€” injected per business. Every template reads exactly
+// these tokens; the values are surfaced to CSS as --sf-* custom properties.
+export type SfTheme = {
+  primary?: string;
+  secondary?: string;
+  bg?: string;
+  text?: string;
+  border?: string;
+  fontHeadline?: string;
+  fontBody?: string;
+};
+
+// Standard entry signature shared by ALL five templates (drop-in interchangeable).
+export type TemplateProps = { data: Soul; ctas: CTAs; theme?: SfTheme };

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/CinematicSanctuary.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/CinematicSanctuary.tsx
@@ -1,0 +1,34 @@
+import type { TemplateProps } from "../_contract/types";
+import { sfThemeVars } from "./theme";
+import { Styles } from "./Styles";
+import { Nav, Faq } from "./interactive";
+import { Hero, TrustStrip, Intro, Services, About, Gallery, Testimonials, CtaBand, Footer, MobileBar } from "./sections";
+
+/**
+ * Template 3 — "Cinematic Sanctuary"
+ * Shared entry signature: ({ data, ctas, theme }) => JSX
+ * Server component; only Nav + Faq opt into the client. Theme via --sf-* vars.
+ * Adds a Gallery section (well-suited to spas/sanctuaries). Restrained micro-
+ * motion is reduced-motion safe. Bottom-right left clear for the chat bubble.
+ */
+export function CinematicSanctuary({ data, ctas, theme }: TemplateProps) {
+  return (
+    <div className="sf3-root" style={sfThemeVars(theme)}>
+      <Styles />
+      <Nav data={data} ctas={ctas} />
+      <main>
+        <Hero data={data} ctas={ctas} />
+        <TrustStrip data={data} />
+        <Intro data={data} />
+        <Services data={data} ctas={ctas} />
+        <About data={data} ctas={ctas} />
+        <Gallery data={data} />
+        <Testimonials data={data} />
+        <Faq data={data} />
+        <CtaBand data={data} ctas={ctas} />
+      </main>
+      <Footer data={data} ctas={ctas} />
+      <MobileBar data={data} ctas={ctas} />
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/Styles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SF3_CSS } from "./css";
 
 // Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/Styles.tsx
@@ -1,0 +1,6 @@
+import { SF3_CSS } from "./css";
+
+// Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).
+export function Styles() {
+  return <style jsx global>{SF3_CSS}</style>;
+}

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/WHEN_TO_USE.md
@@ -1,0 +1,37 @@
+# Template 3 — Cinematic Sanctuary
+
+**When to use (for the archetype classifier):** premium, calm, **experience-led**
+wellness where atmosphere sells — **day spas, holistic wellness, osteopathy,
+acupuncture, float/sauna studios, retreats, meditation**. Reach for it when the
+soul is unhurried and sensory, photography is cinematic, and price-per-ritual is
+high. Includes a **Gallery** section well-suited to a beautiful physical space.
+
+**Emotional register:** minimal, luxurious, slow. Letter-spaced serif (Marcellus),
+large cinematic imagery, lots of negative space, numbered treatment vignettes, a
+single large pull-quote, restrained micro-motion. The page should feel like exhaling.
+
+## Files (identical package shape to all 5)
+`CinematicSanctuary.tsx` (entry) · `types.ts` · `theme.ts` · `css.ts` ·
+`Styles.tsx` · `icons.tsx` · `ui.tsx` (client) · `interactive.tsx` (`Nav`, `Faq`,
+client) · `sections.tsx` (`Hero, TrustStrip, Intro, Services, About, Gallery,
+Testimonials, CtaBand, Footer, MobileBar`) · `fixture.ts`.
+
+```tsx
+import CinematicSanctuary from "./CinematicSanctuary";
+import { stillwaterSanctuary, exampleCTAs } from "./fixture";
+export default () => <CinematicSanctuary data={stillwaterSanctuary} ctas={exampleCTAs} />;
+```
+
+## Shared invariants (byte-identical across all 5)
+Entry signature `({ data, ctas, theme })` · `types.ts` · the `--sf-*` variable
+names + `sfThemeVars()` output shape · `SmartImage → ThemedPlaceholder` fallback ·
+global `<style jsx>` · `"use client"` only on `Nav`/`Faq`/`SmartImage`.
+
+## Template-specific notes
+Adds a **Gallery** (`role: "gallery"` photos; first tile spans 2×2, the rest fall
+back to themed placeholders). Cinematic hero with copy lower-left (asymmetric,
+never centered). Numbered alternating vignettes. Single large testimonial quote.
+**Micro-motion** is gated on `@media (prefers-reduced-motion: no-preference)` so
+print/reduced-motion show the end state. Ships a dark "Noir" palette in the
+preview to demonstrate the same skeleton re-skinning to dark via `--sf-*`.
+Container queries on `.sf3-root`. Bottom-right kept clear for the chat bubble.

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/css.ts
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/css.ts
@@ -1,0 +1,207 @@
+/* SF3 global stylesheet — single source of truth shared by <Styles/>.
+   Mobile-first; container queries on .sf3-root. Every value resolves from --sf-* vars. */
+export const SF3_CSS = `
+.sf3-root{
+  --sf-primary-d: color-mix(in oklab, var(--sf-primary) 80%, #000);
+  --sf-tint: color-mix(in oklab, var(--sf-primary) 8%, var(--sf-bg));
+  --sf-card: color-mix(in oklab, var(--sf-text) 5%, var(--sf-bg));
+  --sf-ink-55: color-mix(in oklab, var(--sf-text) 52%, var(--sf-bg));
+  --sf-line: color-mix(in oklab, var(--sf-text) 16%, var(--sf-bg));
+  --wrap: 1280px;
+  container: sf3 / inline-size;
+  background: var(--sf-bg); color: var(--sf-text);
+  font-family: var(--sf-font-body); font-size: 16px; line-height: 1.7;
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+}
+.sf3-root *{ box-sizing:border-box; }
+.sf3-root img{ display:block; max-width:100%; }
+.sf3-wrap{ width:100%; max-width:var(--wrap); margin-inline:auto; padding-inline:26px; }
+
+/* type — letter-spaced serif */
+.sf3-h2{ font-family:var(--sf-font-headline); font-weight:400; letter-spacing:.04em; line-height:1.16; font-size:clamp(28px,5.6cqw,46px); margin:0; }
+.sf3-eyebrow{ font-weight:600; text-transform:uppercase; letter-spacing:.34em; font-size:11px; color:var(--sf-primary); margin:0 0 22px; }
+.sf3-muted{ color:var(--sf-ink-55); }
+
+/* buttons — quiet, underlined / outlined */
+.sf3-btn{ display:inline-flex; align-items:center; gap:10px; font-family:var(--sf-font-body); font-weight:600;
+  font-size:12px; letter-spacing:.2em; text-transform:uppercase; line-height:1; padding:16px 30px; border-radius:0;
+  border:1px solid transparent; cursor:pointer; text-decoration:none; white-space:nowrap; transition:background .3s, color .3s, border-color .3s, opacity .3s; }
+.sf3-btn svg{ font-size:14px; }
+.sf3-btn:focus-visible{ outline:2px solid var(--sf-primary); outline-offset:3px; }
+.sf3-btn-solid{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf3-btn-solid:hover{ background:var(--sf-primary); }
+.sf3-btn-line{ background:transparent; color:var(--sf-text); border-color:var(--sf-line); }
+.sf3-btn-line:hover{ border-color:var(--sf-text); }
+.sf3-btn-onimg{ background:transparent; color:#fff; border-color:rgba(255,255,255,.5); }
+.sf3-btn-onimg:hover{ background:#fff; color:var(--sf-secondary); border-color:#fff; }
+.sf3-btn-onimg-solid{ background:#fff; color:var(--sf-secondary); }
+.sf3-btn-block{ width:100%; justify-content:center; }
+.sf3-link{ display:inline-flex; align-items:center; gap:9px; font-weight:600; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--sf-primary); text-decoration:none; }
+.sf3-link:hover{ gap:14px; }
+
+/* nav */
+.sf3-nav{ position:sticky; top:0; z-index:40; background:color-mix(in oklab,var(--sf-bg) 85%,transparent); backdrop-filter:blur(12px); }
+.sf3-nav-in{ display:flex; align-items:center; justify-content:space-between; gap:16px; height:84px; }
+.sf3-brand{ display:inline-flex; align-items:center; gap:12px; min-width:0; flex-shrink:1; text-decoration:none; color:var(--sf-text); }
+.sf3-brand-mark{ flex:none; font-size:22px; color:var(--sf-primary); }
+.sf3-brand-name{ font-family:var(--sf-font-headline); font-weight:400; font-size:20px; letter-spacing:.15em; text-transform:uppercase; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sf3-nav-links{ display:none; gap:32px; }
+.sf3-nav-links a{ color:var(--sf-text); text-decoration:none; font-size:11px; font-weight:600; letter-spacing:.2em; text-transform:uppercase; opacity:.78; }
+.sf3-nav-links a:hover{ opacity:1; color:var(--sf-primary); }
+.sf3-nav-cta{ display:flex; align-items:center; gap:18px; }
+.sf3-link-call{ display:none; color:var(--sf-text); text-decoration:none; font-size:11px; font-weight:600; letter-spacing:.16em; text-transform:uppercase; }
+.sf3-link-call:hover{ color:var(--sf-primary); }
+.sf3-nav .sf3-btn{ display:none; }
+.sf3-burger{ display:inline-grid; place-items:center; width:44px; height:44px; border:1px solid var(--sf-line); color:var(--sf-text); font-size:22px; cursor:pointer; background:transparent; }
+
+.sf3-sheet{ position:fixed; inset:0; z-index:60; background:var(--sf-bg); transform:translateY(-100%); transition:transform .4s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; visibility:hidden; }
+.sf3-sheet.is-open{ transform:translateY(0); visibility:visible; }
+.sf3-sheet-top{ display:flex; align-items:center; justify-content:space-between; height:84px; }
+.sf3-sheet-links{ display:flex; flex-direction:column; padding:20px 26px; }
+.sf3-sheet-links a{ font-family:var(--sf-font-headline); font-weight:400; font-size:30px; letter-spacing:.08em; color:var(--sf-text); text-decoration:none; padding:16px 0; border-bottom:1px solid var(--sf-line); }
+.sf3-sheet-foot{ margin-top:auto; padding:26px; display:flex; flex-direction:column; gap:12px; }
+
+/* hero — cinematic, asymmetric (text lower-left), big negative space */
+.sf3-hero{ position:relative; }
+.sf3-hero-media{ position:relative; height:clamp(520px,82cqh,860px); }
+.sf3-hero-media .sf3-img,.sf3-hero-media .sf3-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf3-hero-scrim{ position:absolute; inset:0; background:linear-gradient(180deg, color-mix(in oklab,var(--sf-secondary) 28%,transparent) 0%, transparent 34%, color-mix(in oklab,var(--sf-secondary) 64%,transparent) 100%); }
+.sf3-hero-in{ position:absolute; left:0; right:0; bottom:0; padding:0 26px 56px; }
+.sf3-hero-eyebrow{ color:rgba(255,255,255,.86); font-weight:600; text-transform:uppercase; letter-spacing:.34em; font-size:11px; margin:0 0 22px; }
+.sf3-hero-h1{ font-family:var(--sf-font-headline); font-weight:400; color:#fff; letter-spacing:.06em; line-height:1.1; font-size:clamp(38px,8.4cqw,86px); margin:0 0 26px; max-width:15ch; }
+.sf3-hero-sub{ color:rgba(255,255,255,.86); font-size:clamp(15px,2.2cqw,18px); max-width:46ch; margin:0 0 32px; }
+.sf3-hero-actions{ display:flex; flex-wrap:wrap; gap:16px; align-items:center; }
+.sf3-hero-meta{ display:flex; gap:8px; align-items:center; color:#fff; font-size:12px; letter-spacing:.12em; text-transform:uppercase; }
+.sf3-hero-meta svg{ color:#fff; }
+
+/* micro-motion (restrained, reduced-motion safe) */
+@media (prefers-reduced-motion: no-preference){
+  .sf3-reveal{ opacity:0; transform:translateY(20px); animation:sf3up 1.1s cubic-bezier(.2,.7,.2,1) .12s both; }
+  .sf3-reveal-2{ animation-delay:.26s; }
+  .sf3-reveal-3{ animation-delay:.4s; }
+  @keyframes sf3up{ to{ opacity:1; transform:none; } }
+}
+
+/* trust */
+.sf3-trust{ border-bottom:1px solid var(--sf-line); }
+.sf3-trust-in{ display:flex; flex-wrap:wrap; justify-content:center; gap:14px 44px; padding-block:26px; }
+.sf3-trust-item{ display:inline-flex; align-items:center; gap:10px; font-size:11px; font-weight:600; letter-spacing:.18em; text-transform:uppercase; color:var(--sf-ink-55); }
+.sf3-trust-item svg{ color:var(--sf-primary); font-size:15px; }
+.sf3-trust-item b{ font-family:var(--sf-font-headline); font-weight:400; font-size:17px; letter-spacing:.04em; color:var(--sf-primary); }
+
+/* sections */
+.sf3-sec{ padding-block:104px; }
+.sf3-intro{ max-width:30ch; }
+.sf3-intro .sf3-h2{ font-size:clamp(26px,4.6cqw,40px); }
+
+/* numbered vignettes */
+.sf3-vig{ display:grid; grid-template-columns:1fr; gap:30px; align-items:center; padding-block:54px; border-top:1px solid var(--sf-line); }
+.sf3-vig-media{ position:relative; aspect-ratio:3/2; overflow:hidden; }
+.sf3-vig-media .sf3-img,.sf3-vig-media .sf3-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; transition:transform 1.2s cubic-bezier(.2,.7,.2,1); }
+.sf3-vig:hover .sf3-vig-media .sf3-img{ transform:scale(1.04); }
+.sf3-vig-body{ display:flex; flex-direction:column; gap:16px; }
+.sf3-vig-num{ font-family:var(--sf-font-headline); font-size:14px; letter-spacing:.3em; color:var(--sf-primary); }
+.sf3-vig-name{ font-family:var(--sf-font-headline); font-weight:400; letter-spacing:.03em; line-height:1.1; font-size:clamp(26px,3.8cqw,40px); margin:0; }
+.sf3-vig-desc{ margin:0; color:var(--sf-ink-55); font-size:16px; max-width:42ch; }
+.sf3-vig-meta{ display:flex; align-items:center; gap:24px; padding-top:8px; }
+.sf3-vig-price{ font-family:var(--sf-font-headline); font-size:22px; letter-spacing:.04em; }
+.sf3-vig-dur{ display:inline-flex; align-items:center; gap:8px; white-space:nowrap; color:var(--sf-ink-55); font-size:12px; letter-spacing:.14em; text-transform:uppercase; }
+.sf3-vig-dur svg{ color:var(--sf-primary); }
+.sf3-vig-body .sf3-link{ margin-top:4px; }
+
+/* about */
+.sf3-about{ display:grid; grid-template-columns:1fr; gap:40px; align-items:center; }
+.sf3-about-media{ position:relative; aspect-ratio:4/5; overflow:hidden; }
+.sf3-about-media .sf3-img,.sf3-about-media .sf3-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf3-about-text{ margin:0 0 20px; font-size:18px; color:var(--sf-text); max-width:50ch; line-height:1.8; }
+.sf3-creds{ list-style:none; padding:22px 0 24px; margin:0; display:flex; flex-direction:column; gap:12px; border-top:1px solid var(--sf-line); }
+.sf3-creds li{ display:flex; align-items:center; gap:12px; font-size:14px; letter-spacing:.04em; }
+.sf3-creds svg{ color:var(--sf-primary); }
+
+/* gallery */
+.sf3-gallery{ display:grid; grid-template-columns:repeat(2,1fr); gap:12px; }
+.sf3-gal{ position:relative; overflow:hidden; }
+.sf3-gal .sf3-img,.sf3-gal .sf3-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; transition:transform 1.2s cubic-bezier(.2,.7,.2,1); }
+.sf3-gal:hover .sf3-img{ transform:scale(1.05); }
+.sf3-gal-1{ aspect-ratio:1; } .sf3-gal-2{ aspect-ratio:1; } .sf3-gal-3{ aspect-ratio:1; } .sf3-gal-4{ aspect-ratio:1; }
+
+/* testimonial — single large quote */
+.sf3-quote{ text-align:center; max-width:30ch; margin-inline:auto; }
+.sf3-quote-mark{ font-family:var(--sf-font-headline); font-size:64px; line-height:0.5; color:var(--sf-primary); display:block; margin-bottom:24px; }
+.sf3-quote blockquote{ margin:0 0 24px; font-family:var(--sf-font-headline); font-weight:400; letter-spacing:.02em; line-height:1.4; font-size:clamp(24px,4cqw,38px); }
+.sf3-quote figcaption{ font-size:11px; letter-spacing:.24em; text-transform:uppercase; color:var(--sf-ink-55); }
+
+/* faq */
+.sf3-faq-in{ display:grid; grid-template-columns:1fr; gap:36px; }
+.sf3-faq-list{ border-top:1px solid var(--sf-line); }
+.sf3-faq-item{ border-bottom:1px solid var(--sf-line); }
+.sf3-faq-q{ width:100%; display:flex; align-items:center; justify-content:space-between; gap:18px; background:none; border:0; cursor:pointer; text-align:left; padding:28px 2px; font-family:var(--sf-font-headline); font-weight:400; letter-spacing:.03em; font-size:clamp(19px,2.4cqw,24px); color:var(--sf-text); }
+.sf3-faq-chev{ flex:none; font-size:20px; color:var(--sf-primary); transition:transform .35s; }
+.sf3-faq-item.is-open .sf3-faq-chev{ transform:rotate(180deg); }
+.sf3-faq-a{ display:grid; grid-template-rows:0fr; transition:grid-template-rows .35s ease; }
+.sf3-faq-item.is-open .sf3-faq-a{ grid-template-rows:1fr; }
+.sf3-faq-a > p{ overflow:hidden; margin:0; color:var(--sf-ink-55); font-size:16px; max-width:60ch; padding-bottom:0; transition:padding-bottom .35s; }
+.sf3-faq-item.is-open .sf3-faq-a > p{ padding-bottom:28px; }
+
+/* cta */
+.sf3-cta{ position:relative; overflow:hidden; }
+.sf3-cta-media{ position:absolute; inset:0; }
+.sf3-cta-media .sf3-img,.sf3-cta-media .sf3-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf3-cta-scrim{ position:absolute; inset:0; background:color-mix(in oklab,var(--sf-secondary) 58%,transparent); }
+.sf3-cta-in{ position:relative; text-align:center; padding-block:130px; }
+.sf3-cta-eyebrow{ color:rgba(255,255,255,.8); font-weight:600; text-transform:uppercase; letter-spacing:.34em; font-size:11px; margin:0 0 22px; }
+.sf3-cta-h{ font-family:var(--sf-font-headline); font-weight:400; color:#fff; letter-spacing:.06em; line-height:1.1; font-size:clamp(32px,6.4cqw,62px); margin:0 auto 30px; max-width:18ch; }
+.sf3-cta-actions{ display:flex; flex-wrap:wrap; gap:16px; justify-content:center; }
+
+/* footer */
+.sf3-foot{ background:var(--sf-secondary); color:var(--sf-bg); padding-top:80px; }
+.sf3-foot-in{ display:grid; grid-template-columns:1fr; gap:44px; padding-bottom:54px; }
+.sf3-foot-brand .sf3-brand-name{ color:var(--sf-bg); }
+.sf3-foot-brand .sf3-brand-mark{ color:var(--sf-primary); }
+.sf3-foot-tag{ color:color-mix(in oklab,var(--sf-bg) 64%,var(--sf-secondary)); margin:18px 0 24px; max-width:34ch; letter-spacing:.02em; }
+.sf3-foot-cols{ display:grid; grid-template-columns:1fr 1fr; gap:34px 24px; }
+.sf3-foot-col h3{ font-size:10px; letter-spacing:.22em; text-transform:uppercase; color:var(--sf-primary); margin:0 0 16px; }
+.sf3-foot-col ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:11px; }
+.sf3-foot-col li,.sf3-foot-col a{ color:color-mix(in oklab,var(--sf-bg) 76%,var(--sf-secondary)); font-size:13.5px; letter-spacing:.03em; text-decoration:none; }
+.sf3-foot-col a:hover{ color:#fff; }
+.sf3-foot-legal{ display:flex; flex-wrap:wrap; gap:8px 20px; justify-content:space-between; border-top:1px solid color-mix(in oklab,var(--sf-bg) 16%,var(--sf-secondary)); padding-block:24px; font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-bg) 52%,var(--sf-secondary)); }
+
+/* mobile bar */
+.sf3-mbar{ position:sticky; bottom:0; z-index:50; display:flex; gap:10px; padding:12px 16px calc(12px + env(safe-area-inset-bottom)); background:color-mix(in oklab,var(--sf-bg) 94%,transparent); backdrop-filter:blur(10px); border-top:1px solid var(--sf-line); }
+.sf3-mbar-call{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:15px 22px; border:1px solid var(--sf-line); color:var(--sf-text); text-decoration:none; font-weight:600; font-size:11px; letter-spacing:.16em; text-transform:uppercase; }
+.sf3-mbar-book{ flex:1; display:inline-flex; align-items:center; justify-content:center; padding:15px 22px; background:var(--sf-secondary); color:var(--sf-bg); text-decoration:none; font-weight:600; font-size:11px; letter-spacing:.16em; text-transform:uppercase; }
+
+/* placeholder + image */
+.sf3-img{ width:100%; height:100%; object-fit:cover; }
+.sf3-ph{ position:relative; width:100%; height:100%; min-height:160px; overflow:hidden;
+  background: repeating-linear-gradient(135deg, color-mix(in oklab,var(--sf-primary) 12%,var(--sf-card)) 0 16px, color-mix(in oklab,var(--sf-primary) 5%,var(--sf-card)) 16px 32px), var(--sf-card);
+  display:grid; place-items:center; }
+.sf3-ph::after{ content:""; position:absolute; inset:0; background:radial-gradient(120% 90% at 32% 22%, transparent 44%, color-mix(in oklab,var(--sf-secondary) 12%,transparent)); }
+.sf3-ph-tag{ position:relative; z-index:1; font-family:ui-monospace,Menlo,monospace; font-size:10px; letter-spacing:.14em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-secondary) 62%,var(--sf-bg)); background:color-mix(in oklab,var(--sf-bg) 82%,transparent); padding:6px 12px; border:1px solid var(--sf-line); }
+
+@media (prefers-reduced-motion: reduce){ .sf3-root *{ transition:none !important; } }
+
+/* container queries */
+@container sf3 (min-width:760px){
+  .sf3-wrap{ padding-inline:44px; }
+  .sf3-nav-links{ display:flex; }
+  .sf3-link-call{ display:inline-flex; }
+  .sf3-nav .sf3-btn{ display:inline-flex; }
+  .sf3-burger{ display:none; }
+  .sf3-mbar{ display:none; }
+  .sf3-hero-in{ padding:0 44px 80px; }
+  .sf3-vig{ grid-template-columns:1fr 1fr; gap:56px; padding-block:64px; }
+  .sf3-vig:nth-child(even) .sf3-vig-media{ order:2; }
+  .sf3-vig-media{ aspect-ratio:4/3; }
+  .sf3-about{ grid-template-columns:1fr 1fr; gap:64px; }
+  .sf3-gallery{ grid-template-columns:repeat(4,1fr); grid-auto-rows:1fr; }
+  .sf3-gal-1{ grid-column:span 2; grid-row:span 2; aspect-ratio:auto; }
+  .sf3-faq-in{ grid-template-columns:.8fr 1.2fr; gap:64px; }
+  .sf3-foot-in{ grid-template-columns:1.2fr 2fr; gap:64px; }
+  .sf3-foot-cols{ grid-template-columns:repeat(4,1fr); }
+}
+@container sf3 (min-width:1080px){
+  .sf3-hero-in{ max-width:var(--wrap); margin-inline:auto; left:0; right:0; }
+  .sf3-intro{ padding-left:0; }
+}
+`;

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/fixture.ts
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/fixture.ts
@@ -1,0 +1,55 @@
+import type { CTAs, Soul } from "../_contract/types";
+
+// Realistic holistic-sanctuary / osteopathy fixture. The About portrait, the
+// 4th treatment photo, and two gallery slots are intentionally omitted to
+// exercise the themed placeholder fallback.
+export const stillwaterSanctuary: Soul = {
+  business_name: "Stillwater",
+  tagline: "A sanctuary for deep rest and renewal",
+  soul_description:
+    "An unhurried space for holistic care — osteopathy, craniosacral therapy, and restorative bodywork. We treat the whole person, gently and without rush, so your body can find its own way back to ease.",
+  phone: "(512) 555-0733",
+  email: "rest@stillwatersanctuary.com",
+  address: "905 W 10th St, Austin, TX 78703",
+  service_area: ["Austin", "Clarksville", "Tarrytown"],
+  hours: [
+    { day: "Tue–Fri", open: "9am", close: "7pm" },
+    { day: "Sat", open: "9am", close: "4pm" },
+    { day: "Sun–Mon", open: "Closed", close: "" },
+  ],
+  review_rating: 5.0,
+  review_count: 142,
+  trust_signals: ["By appointment", "Members & drop-in", "Gift cards available"],
+  certifications: ["Registered Osteopath", "Certified Craniosacral Therapist"],
+  offerings: [
+    { name: "Osteopathy Session", description: "Whole-body assessment and gentle hands-on treatment.", price: 140, currency: "USD", duration_minutes: 60 },
+    { name: "Craniosacral Therapy", description: "Subtle, deeply calming work for the nervous system.", price: 120, currency: "USD", duration_minutes: 60 },
+    { name: "Deep Rest Massage", description: "Ninety unhurried minutes to fully let go.", price: 160, currency: "USD", duration_minutes: 90 },
+    { name: "Infrared Sauna & Cold", description: "A restorative heat-and-cold contrast ritual.", price: 60, currency: "USD", duration_minutes: 45 },
+  ],
+  faqs: [
+    { q: "What should I expect on a first visit?", a: "A calm, unhurried consultation, then a tailored treatment. Wear comfortable clothing and arrive a few minutes early to settle in." },
+    { q: "Is osteopathy covered by insurance?", a: "Many extended-health plans reimburse osteopathy. We provide detailed receipts for you to submit." },
+    { q: "How often should I come?", a: "It depends on your goals — many guests begin weekly and ease into a monthly maintenance rhythm." },
+    { q: "Do you offer gift cards?", a: "Yes. Digital gift cards are available for any service or amount — a quiet, generous gesture." },
+  ],
+  testimonials: [
+    { name: "Eleanor V.", text: "I left feeling lighter than I have in years. The space alone is a kind of medicine — I exhaled the moment I walked in." },
+    { name: "Daniel R.", text: "The most attentive, unrushed care I've experienced. I've never felt so genuinely looked after." },
+  ],
+  photos: [
+    { url: "https://images.unsplash.com/photo-1583416750470-965b2707b355?auto=format&fit=crop&w=1700&q=74", role: "hero", alt: "Sauna sanctuary" },
+    { url: "https://images.unsplash.com/photo-1519823551278-64ac92734fb1?auto=format&fit=crop&w=1100&q=72", role: "service", alt: "Osteopathy" },
+    { url: "https://images.unsplash.com/photo-1544161515-4ab6ce6db874?auto=format&fit=crop&w=1100&q=72", role: "service", alt: "Craniosacral therapy" },
+    { url: "https://images.unsplash.com/photo-1540555700478-4be289fbecef?auto=format&fit=crop&w=1100&q=72", role: "service", alt: "Deep rest massage" },
+    { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=1200&q=72", role: "gallery", alt: "Calm interior" },
+    { url: "https://images.unsplash.com/photo-1532926381893-7542290edf1d?auto=format&fit=crop&w=1100&q=72", role: "gallery", alt: "Treatment room" },
+    // service[3], gallery[2], gallery[3], role:"about" omitted → themed placeholder fallback
+  ],
+};
+
+export const exampleCTAs: CTAs = {
+  bookUrl: "/book",
+  callHref: "tel:+15125550733",
+  intakeUrl: "/intake",
+};

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/icons.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/icons.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react";
+
+// Inline SVG only — no external icon libraries.
+type P = SVGProps<SVGSVGElement>;
+const base = (p: P) => ({ width: "1em" as const, height: "1em" as const, viewBox: "0 0 24 24", "aria-hidden": true, ...p });
+
+export const Icon = {
+  star: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M12 2.5l2.9 6 6.6.9-4.8 4.6 1.2 6.5L12 18.9 6.1 22l1.2-6.5L2.5 9.4l6.6-.9z" /></svg>),
+  phone: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" d="M5 4h3l1.5 4.5L7.5 10a12 12 0 0 0 6 6l1.5-2 4.5 1.5V19a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2z" /></svg>),
+  arrow: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M13 6l6 6-6 6" /></svg>),
+  chevron: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" strokeLinejoin="round" d="M6 9l6 6 6-6" /></svg>),
+  menu: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" d="M4 7h16M4 12h16M4 17h16" /></svg>),
+  close: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" d="M6 6l12 12M18 6L6 18" /></svg>),
+  check: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>),
+  clock: (p: P) => (<svg {...base(p)}><circle cx={12} cy={12} r={9} fill="none" stroke="currentColor" strokeWidth={1.6} /><path fill="none" stroke="currentColor" strokeWidth={1.6} strokeLinecap="round" d="M12 7v5l3 2" /></svg>),
+  // organic leaf mark for the sanctuary wordmark
+  leaf: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.4} d="M5 19c0-8 5-13 14-14-1 9-6 14-14 14zM9 15c2-3 4-5 7-6" /></svg>),
+};

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/interactive.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+
+// ── Sticky nav with mobile sheet ───────────────────────────────────────────
+export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [open, setOpen] = useState(false);
+  const links: [string, string][] = [
+    ["Sanctuary", "#about"],
+    ["Rituals", "#services"],
+    ["Gallery", "#gallery"],
+    ["Contact", "#contact"],
+  ];
+  return (
+    <header className="sf3-nav" id="top">
+      <div className="sf3-wrap sf3-nav-in">
+        <a className="sf3-brand" href="#top" aria-label={data.business_name}>
+          <Icon.leaf className="sf3-brand-mark" /><span className="sf3-brand-name">{data.business_name}</span>
+        </a>
+        <nav className="sf3-nav-links" aria-label="Primary">{links.map(([l, h]) => (<a key={l} href={h}>{l}</a>))}</nav>
+        <div className="sf3-nav-cta">
+          {ctas.callHref && data.phone && <a className="sf3-link-call" href={ctas.callHref}>{data.phone}</a>}
+          <a className="sf3-btn sf3-btn-solid" href={ctas.bookUrl}>Reserve</a>
+          <button className="sf3-burger" aria-label="Menu" aria-expanded={open} onClick={() => setOpen(true)}><Icon.menu /></button>
+        </div>
+      </div>
+      <div className={"sf3-sheet" + (open ? " is-open" : "")} role="dialog" aria-modal="true" aria-hidden={!open}>
+        <div className="sf3-sheet-top sf3-wrap">
+          <span className="sf3-brand"><Icon.leaf className="sf3-brand-mark" /><span className="sf3-brand-name">{data.business_name}</span></span>
+          <button className="sf3-burger" aria-label="Close menu" onClick={() => setOpen(false)}><Icon.close /></button>
+        </div>
+        <nav className="sf3-sheet-links" aria-label="Mobile">{links.map(([l, h]) => (<a key={l} href={h} onClick={() => setOpen(false)}>{l}</a>))}</nav>
+        <div className="sf3-sheet-foot">
+          <a className="sf3-btn sf3-btn-solid sf3-btn-block" href={ctas.bookUrl} onClick={() => setOpen(false)}>Reserve</a>
+          {ctas.callHref && data.phone && <a className="sf3-btn sf3-btn-line sf3-btn-block" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ── FAQ accordion ──────────────────────────────────────────────────────────
+export function Faq({ data }: { data: Soul }) {
+  const faqs = data.faqs || [];
+  const [open, setOpen] = useState(0);
+  if (!faqs.length) return null;
+  return (
+    <section className="sf3-sec sf3-wrap" id="faq">
+      <div className="sf3-faq-in">
+        <div><p className="sf3-eyebrow">Good to know</p><h2 className="sf3-h2">Questions</h2></div>
+        <div className="sf3-faq-list">
+          {faqs.map((f, i) => {
+            const isOpen = open === i;
+            return (
+              <div className={"sf3-faq-item" + (isOpen ? " is-open" : "")} key={i}>
+                <button className="sf3-faq-q" aria-expanded={isOpen} onClick={() => setOpen(isOpen ? -1 : i)}>
+                  <span>{f.q}</span><Icon.chevron className="sf3-faq-chev" />
+                </button>
+                <div className="sf3-faq-a" role="region"><p>{f.a}</p></div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/sections.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/sections.tsx
@@ -1,0 +1,215 @@
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { SmartImage } from "./ui";
+import { sfDur, sfMoney, sfPhoto } from "./theme";
+
+// ── Hero (cinematic, asymmetric — copy lower-left, never centered) ─────────
+export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const eyebrow = data.service_area && data.service_area.length ? data.service_area[0] : data.certifications && data.certifications[0];
+  return (
+    <section className="sf3-hero">
+      <div className="sf3-hero-media">
+        <SmartImage photo={sfPhoto(data, "hero")} role="cinematic image" label="cinematic image" />
+        <div className="sf3-hero-scrim" aria-hidden="true" />
+      </div>
+      <div className="sf3-hero-in">
+        <div className="sf3-wrap" style={{ padding: 0 }}>
+          {eyebrow && <p className="sf3-hero-eyebrow sf3-reveal">{eyebrow}</p>}
+          <h1 className="sf3-hero-h1 sf3-reveal sf3-reveal-2">{data.tagline || data.business_name}</h1>
+          {data.soul_description && <p className="sf3-hero-sub sf3-reveal sf3-reveal-3">{data.soul_description}</p>}
+          <div className="sf3-hero-actions sf3-reveal sf3-reveal-3">
+            <a className="sf3-btn sf3-btn-onimg-solid" href={ctas.bookUrl}>Reserve a Visit</a>
+            {data.review_rating != null && (
+              <span className="sf3-hero-meta"><Icon.star /> {data.review_rating.toFixed(1)}{data.review_count != null && ` · ${data.review_count} reviews`}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Trust strip ────────────────────────────────────────────────────────────
+export function TrustStrip({ data }: { data: Soul }) {
+  const items: { b: string | null; sub: string }[] = [];
+  if (data.review_rating != null) items.push({ b: data.review_rating.toFixed(1), sub: data.review_count ? data.review_count + " reviews" : "rated" });
+  (data.certifications || []).forEach((s) => items.push({ b: null, sub: s }));
+  (data.trust_signals || []).slice(0, 2).forEach((s) => items.push({ b: null, sub: s }));
+  if (!items.length) return null;
+  return (
+    <section className="sf3-trust" aria-label="Credentials">
+      <div className="sf3-wrap sf3-trust-in">
+        {items.map((it, i) => (
+          <span className="sf3-trust-item" key={i}>{it.b ? <b>{it.b}</b> : <Icon.leaf />}{it.sub}</span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Intro (negative-space statement) ───────────────────────────────────────
+export function Intro({ data }: { data: Soul }) {
+  if (!data.soul_description) return null;
+  return (
+    <section className="sf3-sec sf3-wrap">
+      <div className="sf3-intro">
+        <p className="sf3-eyebrow">The Sanctuary</p>
+        <h2 className="sf3-h2">A space designed for the simple, restorative act of slowing down.</h2>
+      </div>
+    </section>
+  );
+}
+
+// ── Services (numbered vignettes, alternating) ─────────────────────────────
+export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const list = data.offerings || [];
+  if (!list.length) return null;
+  return (
+    <section className="sf3-sec sf3-wrap" id="services">
+      <div className="sf3-intro" style={{ marginBottom: 8 }}>
+        <p className="sf3-eyebrow">Rituals</p><h2 className="sf3-h2">Treatments</h2>
+      </div>
+      <div>
+        {list.map((o, i) => (
+          <article className="sf3-vig" key={o.name}>
+            <div className="sf3-vig-media"><SmartImage photo={sfPhoto(data, "service", i)} role="treatment" label={o.name} /></div>
+            <div className="sf3-vig-body">
+              <span className="sf3-vig-num">{String(i + 1).padStart(2, "0")} —</span>
+              <h3 className="sf3-vig-name">{o.name}</h3>
+              {o.description && <p className="sf3-vig-desc">{o.description}</p>}
+              {(sfMoney(o.price, o.currency) || sfDur(o.duration_minutes)) && (
+                <div className="sf3-vig-meta">
+                  {sfMoney(o.price, o.currency) && <span className="sf3-vig-price">{sfMoney(o.price, o.currency)}</span>}
+                  {sfDur(o.duration_minutes) && <span className="sf3-vig-dur"><Icon.clock /> {sfDur(o.duration_minutes)}</span>}
+                </div>
+              )}
+              <a className="sf3-link" href={ctas.bookUrl}>Reserve <Icon.arrow /></a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── About ──────────────────────────────────────────────────────────────────
+export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  if (!data.soul_description && !(data.certifications || []).length) return null;
+  return (
+    <section className="sf3-sec sf3-wrap" id="about">
+      <div className="sf3-about">
+        <div className="sf3-about-media"><SmartImage photo={sfPhoto(data, "about")} role="practitioner portrait" label="practitioner portrait" /></div>
+        <div>
+          <p className="sf3-eyebrow">Our Philosophy</p>
+          <h2 className="sf3-h2" style={{ marginBottom: 24 }}>Care that meets you where you are</h2>
+          {data.soul_description && <p className="sf3-about-text">{data.soul_description}</p>}
+          {(data.certifications || []).length > 0 && (
+            <ul className="sf3-creds">{data.certifications!.map((c) => (<li key={c}><Icon.check /> {c}</li>))}</ul>
+          )}
+          <a className="sf3-link" href={ctas.intakeUrl || ctas.bookUrl}>Our story <Icon.arrow /></a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Gallery (added section for this archetype) ─────────────────────────────
+export function Gallery({ data }: { data: Soul }) {
+  const gal = (data.photos || []).filter((p) => p && p.role === "gallery");
+  const slots = [0, 1, 2, 3];
+  return (
+    <section className="sf3-sec sf3-wrap" id="gallery">
+      <div className="sf3-intro" style={{ marginBottom: 32 }}>
+        <p className="sf3-eyebrow">The Space</p><h2 className="sf3-h2">A glimpse inside</h2>
+      </div>
+      <div className="sf3-gallery">
+        {slots.map((n) => (
+          <div className={"sf3-gal sf3-gal-" + (n + 1)} key={n}>
+            <SmartImage photo={gal[n]} role="gallery" label={"gallery 0" + (n + 1)} decorative={n !== 0} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Testimonial (single cinematic quote) ───────────────────────────────────
+export function Testimonials({ data }: { data: Soul }) {
+  const t = data.testimonials || [];
+  if (!t.length) return null;
+  const lead = t[0];
+  return (
+    <section className="sf3-sec sf3-wrap" id="reviews">
+      <figure className="sf3-quote">
+        <span className="sf3-quote-mark">{"\u201C"}</span>
+        <blockquote>{lead.text}</blockquote>
+        <figcaption>{"\u2014 " + lead.name}</figcaption>
+      </figure>
+    </section>
+  );
+}
+
+// ── CTA band ───────────────────────────────────────────────────────────────
+export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <section className="sf3-cta" id="contact">
+      <div className="sf3-cta-media"><SmartImage photo={sfPhoto(data, "gallery", 1)} role="texture" label="texture" decorative /></div>
+      <div className="sf3-cta-scrim" aria-hidden="true" />
+      <div className="sf3-wrap sf3-cta-in">
+        <p className="sf3-cta-eyebrow">Your ritual awaits</p>
+        <h2 className="sf3-cta-h">Return to yourself</h2>
+        <div className="sf3-cta-actions">
+          <a className="sf3-btn sf3-btn-onimg-solid" href={ctas.bookUrl}>Reserve a Visit</a>
+          {ctas.callHref && data.phone && <a className="sf3-btn sf3-btn-onimg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Footer ─────────────────────────────────────────────────────────────────
+export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const cols: [string, string[], "text" | "link"][] = [];
+  const contact: string[] = [];
+  if (data.address) contact.push(data.address);
+  if (data.phone) contact.push(data.phone);
+  if (data.email) contact.push(data.email);
+  if (contact.length) cols.push(["Contact", contact, "text"]);
+  if (data.service_area && data.service_area.length) cols.push(["Service Area", data.service_area, "text"]);
+  if (data.hours && data.hours.length)
+    cols.push(["Hours", data.hours.map((h) => (h.close ? `${h.day} \u00B7 ${h.open}\u2013${h.close}` : `${h.day} \u00B7 ${h.open}`)), "text"]);
+  cols.push(["Follow", ["Instagram", "Journal"], "link"]);
+  return (
+    <footer className="sf3-foot">
+      <div className="sf3-wrap sf3-foot-in">
+        <div className="sf3-foot-brand">
+          <span className="sf3-brand"><Icon.leaf className="sf3-brand-mark" /><span className="sf3-brand-name">{data.business_name}</span></span>
+          {data.tagline && <p className="sf3-foot-tag">{data.tagline}</p>}
+          <a className="sf3-btn sf3-btn-line" style={{ color: "var(--sf-bg)", borderColor: "color-mix(in oklab,var(--sf-bg) 40%,transparent)" }} href={ctas.bookUrl}>Reserve</a>
+        </div>
+        <div className="sf3-foot-cols">
+          {cols.map(([h, items, kind]) => (
+            <div className="sf3-foot-col" key={h}>
+              <h3>{h}</h3>
+              <ul>{items.map((x, i) => (<li key={i}>{kind === "link" ? <a href={ctas.bookUrl}>{x}</a> : x}</li>))}</ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="sf3-wrap sf3-foot-legal">
+        <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name}</span>
+        <span>Privacy · Accessibility</span>
+      </div>
+    </footer>
+  );
+}
+
+// ── Sticky mobile bar ──────────────────────────────────────────────────────
+export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <div className="sf3-mbar" aria-label="Quick actions">
+      {ctas.callHref && data.phone && <a className="sf3-mbar-call" href={ctas.callHref}><Icon.phone /> Call</a>}
+      <a className="sf3-mbar-book" href={ctas.bookUrl}>Reserve</a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/theme.ts
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/theme.ts
@@ -1,0 +1,42 @@
+import type { CSSProperties } from "react";
+import type { SfTheme, Soul } from "../_contract/types";
+
+// Tasteful default palette + font pairing for "Cinematic Sanctuary".
+export const SF3_DEFAULT_THEME: Required<SfTheme> = {
+  primary: "#9a8460", // bronze / sand
+  secondary: "#1f1b16", // warm near-black
+  bg: "#ece6db", // warm ivory
+  text: "#2a261f",
+  border: "#ddd5c6",
+  fontHeadline: "'Marcellus', Georgia, serif",
+  fontBody: "'Mulish', system-ui, sans-serif",
+};
+
+export function sfThemeVars(theme?: SfTheme): CSSProperties {
+  const t = { ...SF3_DEFAULT_THEME, ...(theme || {}) };
+  return {
+    ["--sf-primary" as string]: t.primary,
+    ["--sf-secondary" as string]: t.secondary,
+    ["--sf-bg" as string]: t.bg,
+    ["--sf-text" as string]: t.text,
+    ["--sf-border" as string]: t.border,
+    ["--sf-font-headline" as string]: t.fontHeadline,
+    ["--sf-font-body" as string]: t.fontBody,
+  } as CSSProperties;
+}
+
+export function sfMoney(price?: number, currency?: string): string | null {
+  if (price == null) return null;
+  const sym: Record<string, string> = { USD: "$", EUR: "€", GBP: "£" };
+  return (sym[currency || "USD"] || "$") + price;
+}
+export function sfDur(min?: number): string | null {
+  if (!min) return null;
+  if (min < 60) return min + " min";
+  const h = Math.floor(min / 60), m = min % 60;
+  return m ? `${h} hr ${m} min` : `${h} hr`;
+}
+export type Photo = NonNullable<Soul["photos"]>[number];
+export function sfPhoto(data: Soul, role: Photo["role"], idx = 0): Photo | null {
+  return (data.photos || []).filter((p) => p && p.role === role)[idx] || null;
+}

--- a/packages/crm/src/components/landing-templates/cinematic-sanctuary/ui.tsx
+++ b/packages/crm/src/components/landing-templates/cinematic-sanctuary/ui.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { Photo } from "./theme";
+
+export function ThemedPlaceholder({
+  role = "image", label, decorative = false, className = "", style,
+}: { role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  return (
+    <div className={"sf3-ph " + className} data-role={role} style={style} role="img" aria-label={label || role + " placeholder"}>
+      {!decorative && <span className="sf3-ph-tag">{label || role}</span>}
+    </div>
+  );
+}
+
+export function SmartImage({
+  photo, role, label, decorative, className = "", style,
+}: { photo?: Photo | null; role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  const [failed, setFailed] = useState(false);
+  if (!photo || !photo.url || failed) {
+    return <ThemedPlaceholder role={role} label={label} decorative={decorative} className={className} style={style} />;
+  }
+  return (
+    <img className={"sf3-img " + className} style={style} src={photo.url} alt={photo.alt || label || ""} loading="lazy" decoding="async" onError={() => setFailed(true)} />
+  );
+}

--- a/packages/crm/src/components/landing-templates/clinical-luxe/ClinicalLuxe.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/ClinicalLuxe.tsx
@@ -5,17 +5,14 @@ import { Nav, Faq } from "./interactive";
 import { Hero, TrustStrip, Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar } from "./sections";
 
 /**
- * Template 5 — "Earthy Modern Clinical"
- * Entry component. Shared signature across all five templates:
- *   ({ data, ctas, theme }) => JSX
- *
- * - Server component (no "use client"); only Nav + Faq opt into the client.
- * - Theme is applied as --sf-* CSS variables on the root; nothing is hardcoded.
- * - Bottom-right is left clear for the platform's injected AI chat bubble.
+ * Template 1 — "Clinical Luxe"
+ * Shared entry signature: ({ data, ctas, theme }) => JSX
+ * Server component; only Nav + Faq opt into the client. Theme applied as
+ * --sf-* CSS variables on the root. Bottom-right left clear for the chat bubble.
  */
-export function EarthyModernClinical({ data, ctas, theme }: TemplateProps) {
+export function ClinicalLuxe({ data, ctas, theme }: TemplateProps) {
   return (
-    <div className="sf5-root" style={sfThemeVars(theme)}>
+    <div className="sf1-root" style={sfThemeVars(theme)}>
       <Styles />
       <Nav data={data} ctas={ctas} />
       <main>

--- a/packages/crm/src/components/landing-templates/clinical-luxe/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/Styles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SF1_CSS } from "./css";
 
 // Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the

--- a/packages/crm/src/components/landing-templates/clinical-luxe/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/Styles.tsx
@@ -1,0 +1,7 @@
+import { SF1_CSS } from "./css";
+
+// Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the
+// SeldonFrame build). CSS lives in ./css.ts as the single source of truth.
+export function Styles() {
+  return <style jsx global>{SF1_CSS}</style>;
+}

--- a/packages/crm/src/components/landing-templates/clinical-luxe/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/WHEN_TO_USE.md
@@ -1,0 +1,36 @@
+# Template 1 — Clinical Luxe
+
+**When to use (for the archetype classifier):** premium, expertise-forward medical
+aesthetics where trust and refinement close the booking — **dermatology, med-spa,
+cosmetic & premium dental, plastic surgery, aesthetic clinics**. Reach for it when
+the soul reads upscale (board certifications, "patient-centered", financing) and
+photography is clinical/editorial. Services often carry duration but **no price**
+(consult-based) — the layout handles price-absent gracefully.
+
+**Emotional register:** refined, reassuring, editorial-medical. Full-bleed clinic
+photography, gold-on-charcoal, high-contrast serif display (Cormorant), generous
+whitespace, treatments as elegant alternating rows.
+
+## Files (identical package shape to all 5)
+`ClinicalLuxe.tsx` (entry) · `types.ts` · `theme.ts` · `css.ts` · `Styles.tsx` ·
+`icons.tsx` · `ui.tsx` (`SmartImage`/`ThemedPlaceholder`, client) ·
+`interactive.tsx` (`Nav`, `Faq`, client) · `sections.tsx` (`Hero, TrustStrip,
+Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar`) · `fixture.ts`.
+
+```tsx
+import ClinicalLuxe from "./ClinicalLuxe";
+import { lumenDermatology, exampleCTAs } from "./fixture";
+export default () => <ClinicalLuxe data={lumenDermatology} ctas={exampleCTAs} />;
+```
+
+## Shared invariants (byte-identical across all 5)
+Entry signature `({ data, ctas, theme })` · `types.ts` (`Soul/CTAs/SfTheme/
+TemplateProps`) · the `--sf-*` variable names + `sfThemeVars()` output shape ·
+`SmartImage → ThemedPlaceholder` fallback · global `<style jsx>` · `"use client"`
+only on `Nav`/`Faq`/`SmartImage`.
+
+## Template-specific composition
+Full-bleed hero (left-anchored, never centered) · centered credential trust strip ·
+numbered alternating treatment rows · split About · charcoal stats band · serif
+testimonials · FAQ accordion · full-bleed CTA · charcoal footer · sticky mobile bar.
+Container queries on `.sf1-root` drive reflow. Bottom-right kept clear for the chat bubble.

--- a/packages/crm/src/components/landing-templates/clinical-luxe/css.ts
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/css.ts
@@ -1,0 +1,231 @@
+/* SF1 global stylesheet — single source of truth shared by <Styles/>.
+   Mobile-first; container queries on .sf1-root. Every value resolves from --sf-* vars. */
+export const SF1_CSS = `
+.sf1-root{
+  --sf-primary-d: color-mix(in oklab, var(--sf-primary) 80%, #000);
+  --sf-primary-12: color-mix(in oklab, var(--sf-primary) 14%, var(--sf-bg));
+  --sf-card: color-mix(in oklab, var(--sf-secondary) 4%, var(--sf-bg));
+  --sf-card-2: color-mix(in oklab, var(--sf-secondary) 8%, var(--sf-bg));
+  --sf-ink-60: color-mix(in oklab, var(--sf-text) 58%, var(--sf-bg));
+  --sf-line: color-mix(in oklab, var(--sf-text) 16%, var(--sf-bg));
+  --wrap: 1240px;
+  container: sf1 / inline-size;
+  background: var(--sf-bg); color: var(--sf-text);
+  font-family: var(--sf-font-body); font-size: 16px; line-height: 1.6;
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+}
+.sf1-root *{ box-sizing: border-box; }
+.sf1-root img{ display:block; max-width:100%; }
+.sf1-wrap{ width:100%; max-width:var(--wrap); margin-inline:auto; padding-inline:22px; }
+
+/* type — editorial serif display */
+.sf1-h2{ font-family:var(--sf-font-headline); font-weight:500; letter-spacing:-.01em;
+  line-height:1.05; font-size:clamp(32px,7cqw,54px); margin:0; }
+.sf1-eyebrow{ font-family:var(--sf-font-body); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11.5px; color:var(--sf-primary); margin:0 0 18px; }
+.sf1-muted{ color:var(--sf-ink-60); }
+
+/* buttons — rectangular, refined */
+.sf1-btn{ display:inline-flex; align-items:center; gap:9px; font-family:var(--sf-font-body);
+  font-weight:700; font-size:12px; letter-spacing:.14em; text-transform:uppercase; line-height:1;
+  padding:15px 26px; border-radius:3px; border:1.5px solid transparent; cursor:pointer;
+  text-decoration:none; white-space:nowrap; transition:background .25s, color .25s, border-color .25s, transform .2s; }
+.sf1-btn svg{ font-size:15px; }
+.sf1-btn:hover{ transform:translateY(-1px); }
+.sf1-btn:focus-visible{ outline:2px solid var(--sf-primary); outline-offset:3px; }
+.sf1-btn-primary{ background:var(--sf-primary); color:#fff; }
+.sf1-btn-primary:hover{ background:var(--sf-primary-d); }
+.sf1-btn-dark{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf1-btn-outline{ background:transparent; color:var(--sf-text); border-color:var(--sf-line); }
+.sf1-btn-outline:hover{ border-color:var(--sf-text); }
+.sf1-btn-onimg{ background:transparent; color:#fff; border-color:rgba(255,255,255,.55); }
+.sf1-btn-onimg:hover{ background:rgba(255,255,255,.12); border-color:#fff; }
+.sf1-btn-gold-onimg{ background:var(--sf-primary); color:#fff; }
+.sf1-btn-block{ width:100%; justify-content:center; }
+
+/* nav */
+.sf1-nav{ position:sticky; top:0; z-index:40; background:color-mix(in oklab,var(--sf-bg) 88%,transparent);
+  backdrop-filter:blur(12px); border-bottom:1px solid var(--sf-line); }
+.sf1-nav-in{ display:flex; align-items:center; justify-content:space-between; gap:18px; height:78px; }
+.sf1-brand{ display:inline-flex; align-items:center; gap:11px; min-width:0; flex-shrink:1; text-decoration:none; color:var(--sf-text); }
+.sf1-brand-mark{ flex:none; font-size:26px; color:var(--sf-primary); }
+.sf1-brand-name{ font-family:var(--sf-font-headline); font-weight:600; font-size:23px; letter-spacing:.02em;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sf1-nav-links{ display:none; gap:34px; }
+.sf1-nav-links a{ color:var(--sf-text); text-decoration:none; font-size:12px; font-weight:700;
+  letter-spacing:.16em; text-transform:uppercase; opacity:.82; }
+.sf1-nav-links a:hover{ opacity:1; color:var(--sf-primary); }
+.sf1-nav-cta{ display:flex; align-items:center; gap:16px; }
+.sf1-link-call{ display:none; align-items:center; gap:7px; white-space:nowrap; color:var(--sf-text);
+  text-decoration:none; font-weight:700; font-size:13px; letter-spacing:.04em; }
+.sf1-link-call:hover{ color:var(--sf-primary); }
+.sf1-nav .sf1-btn{ display:none; }
+.sf1-burger{ display:inline-grid; place-items:center; width:44px; height:44px; border-radius:4px;
+  background:transparent; border:1.5px solid var(--sf-line); color:var(--sf-text); font-size:22px; cursor:pointer; }
+
+.sf1-sheet{ position:fixed; inset:0; z-index:60; background:var(--sf-bg); transform:translateY(-100%);
+  transition:transform .35s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; visibility:hidden; }
+.sf1-sheet.is-open{ transform:translateY(0); visibility:visible; }
+.sf1-sheet-top{ display:flex; align-items:center; justify-content:space-between; height:78px; }
+.sf1-sheet-links{ display:flex; flex-direction:column; padding:14px 24px; }
+.sf1-sheet-links a{ font-family:var(--sf-font-headline); font-weight:500; font-size:32px; color:var(--sf-text);
+  text-decoration:none; padding:14px 0; border-bottom:1px solid var(--sf-line); }
+.sf1-sheet-foot{ margin-top:auto; padding:24px; display:flex; flex-direction:column; gap:12px; }
+
+/* hero — full-bleed image, left-anchored copy */
+.sf1-hero{ position:relative; min-height:62cqh; display:flex; }
+.sf1-hero-media{ position:absolute; inset:0; }
+.sf1-hero-media .sf1-img,.sf1-hero-media .sf1-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf1-hero-scrim{ position:absolute; inset:0;
+  background:linear-gradient(100deg, color-mix(in oklab,var(--sf-secondary) 82%,transparent) 0%, color-mix(in oklab,var(--sf-secondary) 55%,transparent) 42%, color-mix(in oklab,var(--sf-secondary) 12%,transparent) 78%); }
+.sf1-hero-in{ position:relative; z-index:1; align-self:center; padding:64px 22px; width:100%; }
+.sf1-hero-eyebrow{ color:color-mix(in oklab,var(--sf-primary) 70%,#fff); font-weight:700; text-transform:uppercase;
+  letter-spacing:.24em; font-size:12px; margin:0 0 20px; }
+.sf1-hero-h1{ font-family:var(--sf-font-headline); font-weight:500; color:#fff; letter-spacing:-.01em;
+  line-height:1.04; font-size:clamp(42px,9cqw,80px); margin:0 0 22px; max-width:16ch; text-wrap:balance; }
+.sf1-hero-sub{ color:rgba(255,255,255,.9); font-size:clamp(16px,2.4cqw,20px); max-width:50ch; margin:0 0 32px; }
+.sf1-hero-actions{ display:flex; flex-wrap:wrap; gap:14px; }
+.sf1-hero-chips{ list-style:none; display:flex; flex-wrap:wrap; gap:14px 30px; margin:38px 0 0; padding:30px 0 0;
+  border-top:1px solid rgba(255,255,255,.25); }
+.sf1-hero-chips li{ display:inline-flex; align-items:center; gap:9px; color:#fff; font-size:13px; font-weight:600; letter-spacing:.02em; }
+.sf1-hero-chips b{ font-family:var(--sf-font-headline); font-size:20px; font-weight:600; }
+.sf1-hero-chips svg{ color:color-mix(in oklab,var(--sf-primary) 70%,#fff); font-size:17px; }
+.sf1-hero-stars{ color:color-mix(in oklab,var(--sf-primary) 70%,#fff); }
+
+/* trust strip */
+.sf1-trust{ border-bottom:1px solid var(--sf-line); }
+.sf1-trust-in{ display:flex; flex-wrap:wrap; justify-content:center; gap:14px 0; padding-block:24px; }
+.sf1-trust-item{ display:flex; align-items:center; gap:11px; padding:0 30px; font-size:12.5px; font-weight:700;
+  letter-spacing:.08em; text-transform:uppercase; color:var(--sf-ink-60); }
+.sf1-trust-item + .sf1-trust-item{ border-left:1px solid var(--sf-line); }
+.sf1-trust-item svg{ color:var(--sf-primary); font-size:16px; }
+.sf1-trust-lead{ font-family:var(--sf-font-headline); font-size:18px; font-weight:600; color:var(--sf-primary); letter-spacing:0; text-transform:none; }
+
+/* section heads */
+.sf1-sec{ padding-block:84px; }
+.sf1-sec-head{ display:flex; flex-direction:column; gap:14px; max-width:60ch; margin-bottom:18px; }
+
+/* services — editorial rows */
+.sf1-rows{ border-top:1px solid var(--sf-line); }
+.sf1-row{ display:grid; grid-template-columns:1fr; border-bottom:1px solid var(--sf-line); }
+.sf1-row-media{ position:relative; aspect-ratio:16/11; }
+.sf1-row-media .sf1-img,.sf1-row-media .sf1-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf1-row-body{ padding:34px 4px; display:flex; flex-direction:column; gap:14px; }
+.sf1-row-num{ font-family:var(--sf-font-headline); font-size:15px; color:var(--sf-primary); font-weight:600; letter-spacing:.1em; }
+.sf1-row-name{ font-family:var(--sf-font-headline); font-weight:500; font-size:clamp(26px,3.6cqw,38px); margin:0; line-height:1.08; }
+.sf1-row-desc{ margin:0; color:var(--sf-ink-60); font-size:16px; max-width:46ch; }
+.sf1-row-meta{ display:flex; align-items:center; gap:22px; margin-top:4px; }
+.sf1-row-meta .sf1-price{ font-family:var(--sf-font-headline); font-size:24px; font-weight:600; }
+.sf1-row-meta .sf1-dur{ display:inline-flex; align-items:center; gap:7px; color:var(--sf-ink-60); font-size:14px; font-weight:600; }
+.sf1-row-meta svg{ color:var(--sf-primary); font-size:16px; }
+.sf1-row-body .sf1-btn{ align-self:flex-start; margin-top:6px; }
+
+/* about */
+.sf1-about{ display:grid; grid-template-columns:1fr; gap:0; align-items:stretch; }
+.sf1-about-media{ position:relative; min-height:420px; }
+.sf1-about-media .sf1-img,.sf1-about-media .sf1-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf1-about-body{ background:var(--sf-card); padding:56px 22px; display:flex; flex-direction:column; gap:18px; justify-content:center; }
+.sf1-about-text{ margin:0; font-size:18px; color:var(--sf-text); max-width:48ch; line-height:1.7; }
+.sf1-creds{ list-style:none; padding:18px 0 0; margin:6px 0 0; display:flex; flex-direction:column; gap:11px; border-top:1px solid var(--sf-line); }
+.sf1-creds li{ display:flex; align-items:center; gap:10px; font-weight:600; font-size:15px; }
+.sf1-creds svg{ color:var(--sf-primary); }
+
+/* stats */
+.sf1-stats{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf1-stats-in{ display:flex; flex-wrap:wrap; gap:30px 64px; padding-block:54px; justify-content:center; }
+.sf1-stat{ text-align:center; }
+.sf1-stat-n{ display:block; font-family:var(--sf-font-headline); font-weight:500; font-size:clamp(40px,6cqw,58px); line-height:1; color:#fff; }
+.sf1-stat-l{ display:block; margin-top:8px; font-size:12px; letter-spacing:.16em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-bg) 64%,var(--sf-secondary)); }
+
+/* testimonials */
+.sf1-revs{ padding-block:84px; }
+.sf1-rev-grid{ display:grid; grid-template-columns:1fr; gap:34px; margin-top:40px; }
+.sf1-rev{ margin:0; display:flex; flex-direction:column; gap:18px; padding-right:10px; }
+.sf1-rev blockquote{ margin:0; font-family:var(--sf-font-headline); font-weight:500; font-size:clamp(21px,2.6cqw,26px); line-height:1.35; }
+.sf1-rev-stars{ color:var(--sf-primary); font-size:15px; }
+.sf1-rev figcaption{ font-size:12px; letter-spacing:.16em; text-transform:uppercase; color:var(--sf-ink-60); font-weight:700; }
+
+/* faq */
+.sf1-faq-in{ display:grid; grid-template-columns:1fr; gap:32px; }
+.sf1-faq-list{ border-top:1px solid var(--sf-line); }
+.sf1-faq-item{ border-bottom:1px solid var(--sf-line); }
+.sf1-faq-q{ width:100%; display:flex; align-items:center; justify-content:space-between; gap:18px; background:none;
+  border:0; cursor:pointer; text-align:left; padding:26px 2px; font-family:var(--sf-font-headline); font-weight:500;
+  font-size:clamp(19px,2.4cqw,23px); color:var(--sf-text); }
+.sf1-faq-chev{ flex:none; font-size:22px; color:var(--sf-primary); transition:transform .25s; }
+.sf1-faq-item.is-open .sf1-faq-chev{ transform:rotate(180deg); }
+.sf1-faq-a{ display:grid; grid-template-rows:0fr; transition:grid-template-rows .3s ease; }
+.sf1-faq-item.is-open .sf1-faq-a{ grid-template-rows:1fr; }
+.sf1-faq-a > p{ overflow:hidden; margin:0; color:var(--sf-ink-60); font-size:16px; padding-right:30px; padding-bottom:0; transition:padding-bottom .3s; }
+.sf1-faq-item.is-open .sf1-faq-a > p{ padding-bottom:26px; }
+
+/* cta band */
+.sf1-cta{ position:relative; overflow:hidden; }
+.sf1-cta-media{ position:absolute; inset:0; }
+.sf1-cta-media .sf1-img,.sf1-cta-media .sf1-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf1-cta-scrim{ position:absolute; inset:0; background:linear-gradient(90deg,color-mix(in oklab,var(--sf-secondary) 86%,transparent),color-mix(in oklab,var(--sf-secondary) 52%,transparent)); }
+.sf1-cta-in{ position:relative; padding-block:96px; text-align:left; }
+.sf1-cta-h{ font-family:var(--sf-font-headline); font-weight:500; color:#fff; line-height:1.05; font-size:clamp(34px,7cqw,60px); margin:0 0 16px; max-width:18ch; }
+.sf1-cta-sub{ color:rgba(255,255,255,.88); font-size:18px; margin:0 0 30px; max-width:44ch; }
+
+/* footer */
+.sf1-foot{ background:var(--sf-secondary); color:var(--sf-bg); padding-top:70px; }
+.sf1-foot-in{ display:grid; grid-template-columns:1fr; gap:42px; padding-bottom:52px; }
+.sf1-foot-brand .sf1-brand-name{ color:var(--sf-bg); }
+.sf1-foot-brand .sf1-brand-mark{ color:var(--sf-primary); }
+.sf1-foot-tag{ color:color-mix(in oklab,var(--sf-bg) 68%,var(--sf-secondary)); margin:16px 0 22px; max-width:36ch; }
+.sf1-foot-cols{ display:grid; grid-template-columns:1fr 1fr; gap:34px 24px; }
+.sf1-foot-col h3{ font-size:11px; letter-spacing:.18em; text-transform:uppercase; color:var(--sf-primary); margin:0 0 16px; }
+.sf1-foot-col ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; }
+.sf1-foot-col li,.sf1-foot-col a{ color:color-mix(in oklab,var(--sf-bg) 80%,var(--sf-secondary)); font-size:14px; text-decoration:none; }
+.sf1-foot-col a:hover{ color:#fff; }
+.sf1-foot-legal{ display:flex; flex-wrap:wrap; gap:8px 20px; justify-content:space-between;
+  border-top:1px solid color-mix(in oklab,var(--sf-bg) 16%,var(--sf-secondary)); padding-block:24px;
+  font-size:12px; letter-spacing:.04em; color:color-mix(in oklab,var(--sf-bg) 56%,var(--sf-secondary)); }
+
+/* sticky mobile bar */
+.sf1-mbar{ position:sticky; bottom:0; z-index:50; display:flex; gap:10px; padding:12px 16px calc(12px + env(safe-area-inset-bottom));
+  background:color-mix(in oklab,var(--sf-bg) 94%,transparent); backdrop-filter:blur(10px); border-top:1px solid var(--sf-line); }
+.sf1-mbar-call{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:15px 22px; border-radius:3px;
+  border:1.5px solid var(--sf-line); color:var(--sf-text); text-decoration:none; font-weight:700; font-size:12px; letter-spacing:.12em; text-transform:uppercase; }
+.sf1-mbar-book{ flex:1; display:inline-flex; align-items:center; justify-content:center; padding:15px 22px; border-radius:3px;
+  background:var(--sf-primary); color:#fff; text-decoration:none; font-weight:700; font-size:12px; letter-spacing:.12em; text-transform:uppercase; }
+
+/* placeholder + image */
+.sf1-img{ width:100%; height:100%; object-fit:cover; }
+.sf1-ph{ position:relative; width:100%; height:100%; min-height:160px; overflow:hidden;
+  background: repeating-linear-gradient(135deg, color-mix(in oklab,var(--sf-primary) 13%,var(--sf-card-2)) 0 13px, color-mix(in oklab,var(--sf-primary) 5%,var(--sf-card-2)) 13px 26px), var(--sf-card-2);
+  display:grid; place-items:center; }
+.sf1-ph::after{ content:""; position:absolute; inset:0; background:radial-gradient(120% 90% at 30% 18%, transparent 42%, color-mix(in oklab,var(--sf-secondary) 13%,transparent)); }
+.sf1-ph-tag{ position:relative; z-index:1; font-family:ui-monospace,Menlo,monospace; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase;
+  color:color-mix(in oklab,var(--sf-secondary) 66%,var(--sf-bg)); background:color-mix(in oklab,var(--sf-bg) 84%,transparent); padding:6px 11px; border-radius:2px; border:1px solid var(--sf-line); }
+
+@media (prefers-reduced-motion: reduce){ .sf1-root *{ transition:none !important; } }
+
+/* container queries */
+@container sf1 (min-width:760px){
+  .sf1-wrap{ padding-inline:40px; }
+  .sf1-nav-links{ display:flex; }
+  .sf1-nav .sf1-btn{ display:inline-flex; }
+  .sf1-burger{ display:none; }
+  .sf1-mbar{ display:none; }
+  .sf1-hero-in{ padding:96px 40px; }
+  .sf1-hero-actions{ gap:16px; }
+  .sf1-row{ grid-template-columns:1fr 1fr; align-items:center; gap:48px; }
+  .sf1-row-media{ aspect-ratio:4/3; }
+  .sf1-row:nth-child(even) .sf1-row-media{ order:2; }
+  .sf1-row-body{ padding:48px 0; }
+  .sf1-about{ grid-template-columns:1fr 1fr; }
+  .sf1-about-media{ min-height:560px; }
+  .sf1-about-body{ padding:72px 6cqw; }
+  .sf1-rev-grid{ grid-template-columns:repeat(2,1fr); gap:48px; }
+  .sf1-faq-in{ grid-template-columns:.7fr 1.3fr; gap:56px; }
+  .sf1-foot-in{ grid-template-columns:1.2fr 2fr; gap:64px; }
+  .sf1-foot-cols{ grid-template-columns:repeat(4,1fr); }
+  .sf1-cta-in{ padding-block:130px; }
+}
+@container sf1 (min-width:1080px){
+  .sf1-hero-in{ max-width:var(--wrap); margin-inline:auto; }
+  .sf1-rev-grid{ grid-template-columns:repeat(2,1fr); }
+}
+`;

--- a/packages/crm/src/components/landing-templates/clinical-luxe/fixture.ts
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/fixture.ts
@@ -1,0 +1,53 @@
+import type { CTAs, Soul } from "../_contract/types";
+
+// Realistic dermatology fixture. The About portrait, the 4th treatment photo,
+// and the CTA texture are intentionally omitted to exercise the themed
+// placeholder fallback. Note: derm `offerings` carry duration but no price.
+export const lumenDermatology: Soul = {
+  business_name: "Lumen Dermatology & Aesthetics",
+  tagline: "Expert skin care, a patient-centered approach",
+  soul_description:
+    "Board-certified dermatologists delivering medical, surgical, and cosmetic skin care. From preventative screenings to advanced rejuvenation, we provide personalized care you can trust.",
+  phone: "(512) 555-0610",
+  email: "concierge@lumenderm.com",
+  address: "3600 N Capital of Texas Hwy, Building B, Austin, TX 78746",
+  service_area: ["Austin", "West Lake Hills", "Lakeway"],
+  hours: [
+    { day: "Mon–Thu", open: "8am", close: "5pm" },
+    { day: "Fri", open: "8am", close: "3pm" },
+    { day: "Sat", open: "By appointment", close: "" },
+  ],
+  review_rating: 5.0,
+  review_count: 198,
+  trust_signals: ["Most PPO insurance accepted", "Financing available", "No referral needed"],
+  certifications: ["Board-Certified Dermatology", "Mohs Surgery Fellowship"],
+  offerings: [
+    { name: "Medical Dermatology", description: "Diagnosis and treatment for the full range of skin conditions.", duration_minutes: 30 },
+    { name: "Cosmetic Consultation", description: "A personalized rejuvenation plan, tailored to your goals.", duration_minutes: 45 },
+    { name: "Skin Cancer Screening", description: "A comprehensive, full-body dermatologic exam.", duration_minutes: 30 },
+    { name: "Laser & Microneedling", description: "Advanced resurfacing for tone, texture, and clarity.", duration_minutes: 60 },
+  ],
+  faqs: [
+    { q: "Do I need a referral?", a: "No referral is required. You can book directly and we'll coordinate with your physician as needed." },
+    { q: "Do you accept insurance?", a: "We accept most PPO plans for medical visits. Cosmetic services are self-pay, with financing available." },
+    { q: "How soon can I be seen?", a: "We hold same-week appointments for urgent skin concerns and screenings." },
+    { q: "What should I bring to my first visit?", a: "Your insurance card, a list of medications, and notes on any concerns you'd like us to review." },
+  ],
+  testimonials: [
+    { name: "Alicia M.", text: "The most thorough skin exam I've ever had. I finally feel in genuinely good hands." },
+    { name: "Thomas B.", text: "Professional, warm, and the results speak for themselves. A truly elevated experience." },
+  ],
+  photos: [
+    { url: "https://images.unsplash.com/photo-1570172619644-dfd03ed5d881?auto=format&fit=crop&w=1500&q=72", role: "hero", alt: "Serene treatment room" },
+    { url: "https://images.unsplash.com/photo-1512290923902-8a9f81dc236c?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Medical dermatology" },
+    { url: "https://images.unsplash.com/photo-1487412947147-5cebf100ffc2?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Cosmetic consultation" },
+    { url: "https://images.unsplash.com/photo-1598440947619-2c35fc9aa908?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Skin cancer screening" },
+    // service[3], role:"about" & role:"gallery" omitted → themed placeholder fallback
+  ],
+};
+
+export const exampleCTAs: CTAs = {
+  bookUrl: "/book",
+  callHref: "tel:+15125550610",
+  intakeUrl: "/intake",
+};

--- a/packages/crm/src/components/landing-templates/clinical-luxe/icons.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/icons.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from "react";
 
-// Inline SVG only — no external icon libraries (SeldonFrame house rule).
+// Inline SVG only — no external icon libraries.
 type P = SVGProps<SVGSVGElement>;
 const base = (p: P) => ({ width: "1em" as const, height: "1em" as const, viewBox: "0 0 24 24", "aria-hidden": true, ...p });
 
@@ -13,5 +13,6 @@ export const Icon = {
   close: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M6 6l12 12M18 6L6 18" /></svg>),
   check: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>),
   clock: (p: P) => (<svg {...base(p)}><circle cx={12} cy={12} r={9} fill="none" stroke="currentColor" strokeWidth={2} /><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M12 7v5l3 2" /></svg>),
-  mark: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M3 12c5 0 9-4 9-9 0 5 4 9 9 9-5 0-9 4-9 9 0-5-4-9-9-9z" /></svg>),
+  // refined diamond/petal mark for the luxe wordmark
+  mark: (p: P) => (<svg {...{ ...base(p), viewBox: "0 0 28 28" }}><path fill="none" stroke="currentColor" strokeWidth={1.4} d="M14 2c2.4 5 5.6 8.2 10.6 10.6C19.6 15 16.4 18.2 14 23.2 11.6 18.2 8.4 15 3.4 12.6 8.4 10.2 11.6 7 14 2z" /></svg>),
 };

--- a/packages/crm/src/components/landing-templates/clinical-luxe/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/interactive.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+
+// ── Sticky nav with mobile sheet ───────────────────────────────────────────
+export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [open, setOpen] = useState(false);
+  const links: [string, string][] = [
+    ["About", "#about"],
+    ["Treatments", "#services"],
+    ["Reviews", "#reviews"],
+    ["Contact", "#contact"],
+  ];
+  return (
+    <header className="sf1-nav" id="top">
+      <div className="sf1-wrap sf1-nav-in">
+        <a className="sf1-brand" href="#top" aria-label={data.business_name}>
+          <Icon.mark className="sf1-brand-mark" /><span className="sf1-brand-name">{data.business_name}</span>
+        </a>
+        <nav className="sf1-nav-links" aria-label="Primary">{links.map(([l, h]) => (<a key={l} href={h}>{l}</a>))}</nav>
+        <div className="sf1-nav-cta">
+          {ctas.callHref && data.phone && <a className="sf1-link-call" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+          <a className="sf1-btn sf1-btn-primary" href={ctas.bookUrl}>Book Now</a>
+          <button className="sf1-burger" aria-label="Menu" aria-expanded={open} onClick={() => setOpen(true)}><Icon.menu /></button>
+        </div>
+      </div>
+      <div className={"sf1-sheet" + (open ? " is-open" : "")} role="dialog" aria-modal="true" aria-hidden={!open}>
+        <div className="sf1-sheet-top sf1-wrap">
+          <span className="sf1-brand"><Icon.mark className="sf1-brand-mark" /><span className="sf1-brand-name">{data.business_name}</span></span>
+          <button className="sf1-burger" aria-label="Close menu" onClick={() => setOpen(false)}><Icon.close /></button>
+        </div>
+        <nav className="sf1-sheet-links" aria-label="Mobile">{links.map(([l, h]) => (<a key={l} href={h} onClick={() => setOpen(false)}>{l}</a>))}</nav>
+        <div className="sf1-sheet-foot">
+          <a className="sf1-btn sf1-btn-primary sf1-btn-block" href={ctas.bookUrl} onClick={() => setOpen(false)}>Book Now</a>
+          {ctas.callHref && data.phone && <a className="sf1-btn sf1-btn-outline sf1-btn-block" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ── FAQ accordion ──────────────────────────────────────────────────────────
+export function Faq({ data }: { data: Soul }) {
+  const faqs = data.faqs || [];
+  const [open, setOpen] = useState(0);
+  if (!faqs.length) return null;
+  return (
+    <section className="sf1-sec sf1-wrap" id="faq">
+      <div className="sf1-faq-in">
+        <div><p className="sf1-eyebrow">Good to know</p><h2 className="sf1-h2">Questions, answered</h2></div>
+        <div className="sf1-faq-list">
+          {faqs.map((f, i) => {
+            const isOpen = open === i;
+            return (
+              <div className={"sf1-faq-item" + (isOpen ? " is-open" : "")} key={i}>
+                <button className="sf1-faq-q" aria-expanded={isOpen} onClick={() => setOpen(isOpen ? -1 : i)}>
+                  <span>{f.q}</span><Icon.chevron className="sf1-faq-chev" />
+                </button>
+                <div className="sf1-faq-a" role="region"><p>{f.a}</p></div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/landing-templates/clinical-luxe/sections.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/sections.tsx
@@ -1,0 +1,216 @@
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { SmartImage } from "./ui";
+import { sfDur, sfMoney, sfPhoto } from "./theme";
+
+// ── Hero (full-bleed clinic photography, left-anchored copy — never centered) ─
+export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const hero = sfPhoto(data, "hero");
+  const eyebrow = data.service_area && data.service_area.length
+    ? data.service_area.slice(0, 3).join("  ·  ")
+    : data.certifications && data.certifications[0];
+  return (
+    <section className="sf1-hero">
+      <div className="sf1-hero-media">
+        <SmartImage photo={hero} role="clinic interior" label="clinic interior" />
+        <div className="sf1-hero-scrim" aria-hidden="true" />
+      </div>
+      <div className="sf1-hero-in sf1-wrap">
+        {eyebrow && <p className="sf1-hero-eyebrow">{eyebrow}</p>}
+        <h1 className="sf1-hero-h1">{data.tagline || data.business_name}</h1>
+        {data.soul_description && <p className="sf1-hero-sub">{data.soul_description}</p>}
+        <div className="sf1-hero-actions">
+          <a className="sf1-btn sf1-btn-gold-onimg" href={ctas.bookUrl}>Book an Appointment <Icon.arrow /></a>
+          {ctas.callHref && data.phone
+            ? <a className="sf1-btn sf1-btn-onimg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>
+            : <a className="sf1-btn sf1-btn-onimg" href="#services">View Treatments</a>}
+        </div>
+        {(data.review_rating != null || data.certifications) && (
+          <ul className="sf1-hero-chips">
+            {data.review_rating != null && (
+              <li><span className="sf1-hero-stars"><Icon.star /></span><b>{data.review_rating.toFixed(1)}</b>
+                {data.review_count != null && <span> / {data.review_count} reviews</span>}</li>
+            )}
+            {data.certifications && data.certifications[0] && <li><Icon.check /><span>{data.certifications[0]}</span></li>}
+            {data.trust_signals && data.trust_signals[0] && <li><Icon.check /><span>{data.trust_signals[0]}</span></li>}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// ── Trust strip ────────────────────────────────────────────────────────────
+export function TrustStrip({ data }: { data: Soul }) {
+  const items: { lead: string | null; sub: string }[] = [];
+  if (data.review_rating != null)
+    items.push({ lead: data.review_rating.toFixed(1) + "★", sub: data.review_count ? data.review_count + " reviews" : "rating" });
+  (data.trust_signals || []).forEach((s) => items.push({ lead: null, sub: s }));
+  (data.certifications || []).slice(0, 1).forEach((s) => items.push({ lead: null, sub: s }));
+  if (!items.length) return null;
+  return (
+    <section className="sf1-trust" aria-label="Credentials">
+      <div className="sf1-wrap sf1-trust-in">
+        {items.map((it, i) => (
+          <div className="sf1-trust-item" key={i}>
+            {it.lead ? <span className="sf1-trust-lead">{it.lead}</span> : <Icon.check />}
+            <span>{it.sub}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Services (editorial alternating rows; varied — not a 3-equal grid) ──────
+export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const list = data.offerings || [];
+  if (!list.length) return null;
+  return (
+    <section className="sf1-sec sf1-wrap" id="services">
+      <div className="sf1-sec-head">
+        <p className="sf1-eyebrow">Treatments</p>
+        <h2 className="sf1-h2">Considered care, expertly delivered</h2>
+      </div>
+      <div className="sf1-rows">
+        {list.map((o, i) => (
+          <article className="sf1-row" key={o.name}>
+            <div className="sf1-row-media"><SmartImage photo={sfPhoto(data, "service", i)} role="treatment" label={o.name} /></div>
+            <div className="sf1-row-body">
+              <span className="sf1-row-num">{String(i + 1).padStart(2, "0")}</span>
+              <h3 className="sf1-row-name">{o.name}</h3>
+              {o.description && <p className="sf1-row-desc">{o.description}</p>}
+              {(sfMoney(o.price, o.currency) || sfDur(o.duration_minutes)) && (
+                <div className="sf1-row-meta">
+                  {sfMoney(o.price, o.currency) && <span className="sf1-price">{sfMoney(o.price, o.currency)}</span>}
+                  {sfDur(o.duration_minutes) && <span className="sf1-dur"><Icon.clock /> {sfDur(o.duration_minutes)}</span>}
+                </div>
+              )}
+              <a className="sf1-btn sf1-btn-outline" href={ctas.bookUrl}>Book this treatment <Icon.arrow /></a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── About ──────────────────────────────────────────────────────────────────
+export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  if (!data.soul_description && !(data.certifications || []).length) return null;
+  return (
+    <section className="sf1-about" id="about">
+      <div className="sf1-about-media"><SmartImage photo={sfPhoto(data, "about")} role="practitioner portrait" label="practitioner portrait" /></div>
+      <div className="sf1-about-body">
+        <p className="sf1-eyebrow">Our Practice</p>
+        <h2 className="sf1-h2">Expertise you can feel at ease with</h2>
+        {data.soul_description && <p className="sf1-about-text">{data.soul_description}</p>}
+        {(data.certifications || []).length > 0 && (
+          <ul className="sf1-creds">{data.certifications!.map((c) => (<li key={c}><Icon.check /> {c}</li>))}</ul>
+        )}
+        <a className="sf1-btn sf1-btn-dark" href={ctas.intakeUrl || ctas.bookUrl}>Meet the team <Icon.arrow /></a>
+      </div>
+    </section>
+  );
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+export function Stats({ data }: { data: Soul }) {
+  const s: [string, string][] = [];
+  if (data.review_count != null) s.push([data.review_count.toLocaleString() + "+", "Patients seen"]);
+  if (data.review_rating != null) s.push([data.review_rating.toFixed(1), "Average rating"]);
+  if (data.service_area && data.service_area.length) s.push([String(data.service_area.length), "Communities served"]);
+  if (s.length < 2) return null;
+  return (
+    <section className="sf1-stats" aria-label="By the numbers">
+      <div className="sf1-wrap sf1-stats-in">
+        {s.map(([n, l], i) => (<div className="sf1-stat" key={i}><span className="sf1-stat-n">{n}</span><span className="sf1-stat-l">{l}</span></div>))}
+      </div>
+    </section>
+  );
+}
+
+// ── Testimonials ───────────────────────────────────────────────────────────
+export function Testimonials({ data }: { data: Soul }) {
+  const t = data.testimonials || [];
+  if (!t.length) return null;
+  return (
+    <section className="sf1-revs sf1-wrap" id="reviews">
+      <div className="sf1-sec-head"><p className="sf1-eyebrow">Patient Stories</p><h2 className="sf1-h2">In their words</h2></div>
+      <div className="sf1-rev-grid">
+        {t.slice(0, 4).map((r, i) => (
+          <figure className="sf1-rev" key={i}>
+            <span className="sf1-rev-stars"><Icon.star /><Icon.star /><Icon.star /><Icon.star /><Icon.star /></span>
+            <blockquote>{"\u201C" + r.text + "\u201D"}</blockquote>
+            <figcaption>{r.name}</figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── CTA band ───────────────────────────────────────────────────────────────
+export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <section className="sf1-cta" id="contact">
+      <div className="sf1-cta-media"><SmartImage photo={sfPhoto(data, "gallery")} role="texture" label="texture" decorative /></div>
+      <div className="sf1-cta-scrim" aria-hidden="true" />
+      <div className="sf1-wrap sf1-cta-in">
+        <h2 className="sf1-cta-h">Begin with a consultation</h2>
+        <p className="sf1-cta-sub">Personalized, board-certified care — book online in minutes.</p>
+        <div className="sf1-hero-actions">
+          <a className="sf1-btn sf1-btn-gold-onimg" href={ctas.bookUrl}>Book an Appointment <Icon.arrow /></a>
+          {ctas.callHref && data.phone && <a className="sf1-btn sf1-btn-onimg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Footer ─────────────────────────────────────────────────────────────────
+export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const cols: [string, string[], "text" | "link"][] = [];
+  const contact: string[] = [];
+  if (data.address) contact.push(data.address);
+  if (data.phone) contact.push(data.phone);
+  if (data.email) contact.push(data.email);
+  if (contact.length) cols.push(["Contact", contact, "text"]);
+  if (data.service_area && data.service_area.length) cols.push(["Service Area", data.service_area, "text"]);
+  if (data.hours && data.hours.length)
+    cols.push(["Hours", data.hours.map((h) => (h.close ? `${h.day}: ${h.open} \u2013 ${h.close}` : `${h.day}: ${h.open}`)), "text"]);
+  cols.push(["Follow", ["Instagram", "Facebook"], "link"]);
+  return (
+    <footer className="sf1-foot">
+      <div className="sf1-wrap sf1-foot-in">
+        <div className="sf1-foot-brand">
+          <span className="sf1-brand"><Icon.mark className="sf1-brand-mark" /><span className="sf1-brand-name">{data.business_name}</span></span>
+          {data.tagline && <p className="sf1-foot-tag">{data.tagline}</p>}
+          <a className="sf1-btn sf1-btn-primary" href={ctas.bookUrl}>Book Now</a>
+        </div>
+        <div className="sf1-foot-cols">
+          {cols.map(([h, items, kind]) => (
+            <div className="sf1-foot-col" key={h}>
+              <h3>{h}</h3>
+              <ul>{items.map((x, i) => (<li key={i}>{kind === "link" ? <a href={ctas.bookUrl}>{x}</a> : x}</li>))}</ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="sf1-wrap sf1-foot-legal">
+        <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name}</span>
+        <span>Privacy · Accessibility · Terms</span>
+      </div>
+    </footer>
+  );
+}
+
+// ── Sticky mobile bar ──────────────────────────────────────────────────────
+export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <div className="sf1-mbar" aria-label="Quick actions">
+      {ctas.callHref && data.phone && <a className="sf1-mbar-call" href={ctas.callHref}><Icon.phone /> Call</a>}
+      <a className="sf1-mbar-book" href={ctas.bookUrl}>Book Now</a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/clinical-luxe/theme.ts
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/theme.ts
@@ -1,22 +1,19 @@
 import type { CSSProperties } from "react";
 import type { SfTheme, Soul } from "../_contract/types";
 
-// Tasteful default palette + font pairing for "Earthy Modern Clinical".
-// Swapping these (or the injected theme) re-skins the entire template.
-export const SF5_DEFAULT_THEME: Required<SfTheme> = {
-  primary: "#b0552f", // clay / terracotta
-  secondary: "#2a1d15", // deep warm cocoa near-black
-  bg: "#ece5d8", // warm oat
-  text: "#2a1d15", // body ink
-  border: "#d6ccba", // warm hairline
-  fontHeadline: "'Outfit', system-ui, sans-serif",
-  fontBody: "'Hanken Grotesk', system-ui, sans-serif",
+// Tasteful default palette + font pairing for "Clinical Luxe".
+export const SF1_DEFAULT_THEME: Required<SfTheme> = {
+  primary: "#9c7c4d", // brass / gold
+  secondary: "#24211c", // warm charcoal
+  bg: "#f4f1ea", // warm ivory
+  text: "#2a2620",
+  border: "#e0dace",
+  fontHeadline: "'Cormorant Garamond', Georgia, serif",
+  fontBody: "'Mulish', system-ui, sans-serif",
 };
 
-// Resolve the theme into CSS custom properties applied on the root wrapper.
-// Tints/shades are derived downstream with color-mix(in oklab, …) — never hardcoded.
 export function sfThemeVars(theme?: SfTheme): CSSProperties {
-  const t = { ...SF5_DEFAULT_THEME, ...(theme || {}) };
+  const t = { ...SF1_DEFAULT_THEME, ...(theme || {}) };
   return {
     ["--sf-primary" as string]: t.primary,
     ["--sf-secondary" as string]: t.secondary,
@@ -28,23 +25,18 @@ export function sfThemeVars(theme?: SfTheme): CSSProperties {
   } as CSSProperties;
 }
 
-// ── data formatting helpers ────────────────────────────────────────────────
 export function sfMoney(price?: number, currency?: string): string | null {
   if (price == null) return null;
   const sym: Record<string, string> = { USD: "$", EUR: "€", GBP: "£" };
   return (sym[currency || "USD"] || "$") + price;
 }
-
 export function sfDur(min?: number): string | null {
   if (!min) return null;
   if (min < 60) return min + " min";
-  const h = Math.floor(min / 60);
-  const m = min % 60;
+  const h = Math.floor(min / 60), m = min % 60;
   return m ? `${h} hr ${m} min` : `${h} hr`;
 }
-
 export type Photo = NonNullable<Soul["photos"]>[number];
-
 export function sfPhoto(data: Soul, role: Photo["role"], idx = 0): Photo | null {
   const byRole = (data.photos || []).filter((p) => p && p.role === role);
   return byRole[idx] || null;

--- a/packages/crm/src/components/landing-templates/clinical-luxe/ui.tsx
+++ b/packages/crm/src/components/landing-templates/clinical-luxe/ui.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { Photo } from "./theme";
+
+// Themed color-field placeholder — the real fallback whenever a photo is
+// missing OR fails to load. Driven entirely by --sf-* vars (never a broken img).
+export function ThemedPlaceholder({
+  role = "image", label, decorative = false, className = "", style,
+}: { role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  return (
+    <div className={"sf1-ph " + className} data-role={role} style={style} role="img" aria-label={label || role + " placeholder"}>
+      {!decorative && <span className="sf1-ph-tag">{label || role}</span>}
+    </div>
+  );
+}
+
+export function SmartImage({
+  photo, role, label, decorative, className = "", style,
+}: { photo?: Photo | null; role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  const [failed, setFailed] = useState(false);
+  if (!photo || !photo.url || failed) {
+    return <ThemedPlaceholder role={role} label={label} decorative={decorative} className={className} style={style} />;
+  }
+  return (
+    <img className={"sf1-img " + className} style={style} src={photo.url} alt={photo.alt || label || ""} loading="lazy" decoding="async" onError={() => setFailed(true)} />
+  );
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/EarthyModernClinical.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/EarthyModernClinical.tsx
@@ -1,0 +1,35 @@
+import type { TemplateProps } from "../_contract/types";
+import { sfThemeVars } from "./theme";
+import { Styles } from "./Styles";
+import { Nav, Faq } from "./interactive";
+import { Hero, TrustStrip, Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar } from "./sections";
+
+/**
+ * Template 5 â€” "Earthy Modern Clinical"
+ * Entry component. Shared signature across all five templates:
+ *   ({ data, ctas, theme }) => JSX
+ *
+ * - Server component (no "use client"); only Nav + Faq opt into the client.
+ * - Theme is applied as --sf-* CSS variables on the root; nothing is hardcoded.
+ * - Bottom-right is left clear for the platform's injected AI chat bubble.
+ */
+export function EarthyModernClinical({ data, ctas, theme }: TemplateProps) {
+  return (
+    <div className="sf5-root" style={sfThemeVars(theme)}>
+      <Styles />
+      <Nav data={data} ctas={ctas} />
+      <main>
+        <Hero data={data} ctas={ctas} />
+        <TrustStrip data={data} />
+        <Services data={data} ctas={ctas} />
+        <About data={data} ctas={ctas} />
+        <Stats data={data} />
+        <Testimonials data={data} />
+        <Faq data={data} />
+        <CtaBand data={data} ctas={ctas} />
+      </main>
+      <Footer data={data} ctas={ctas} />
+      <MobileBar data={data} ctas={ctas} />
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/Styles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SF5_CSS } from "./css";
 
 // Global styles. styled-jsx MUST be `<style jsx global>` (scoped styled-jsx

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/Styles.tsx
@@ -1,0 +1,10 @@
+import { SF5_CSS } from "./css";
+
+// Global styles. styled-jsx MUST be `<style jsx global>` (scoped styled-jsx
+// breaks in the SeldonFrame build). The CSS lives in ./css.ts as the single
+// source of truth shared with the preview build.
+export function Styles() {
+  return (
+    <style jsx global>{SF5_CSS}</style>
+  );
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/WHEN_TO_USE.md
@@ -32,7 +32,7 @@ clinic, not a spa or a SaaS page.
 import EarthyModernClinical from "./EarthyModernClinical";
 import { austinFamilyChiropractic, exampleCTAs } from "./fixture";
 
-export default function Page() {
+export function Page() {
   return <EarthyModernClinical data={austinFamilyChiropractic} ctas={exampleCTAs} />;
   // theme is optional — omit for the tasteful default, or pass per-business --sf-* values.
 }

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/WHEN_TO_USE.md
@@ -1,0 +1,61 @@
+# Template 5 — Earthy Modern Clinical
+
+**When to use (for the archetype classifier):** the conversion workhorse for
+practitioner-led, body-care verticals where trust + clear pricing close the
+booking — **chiropractic, physiotherapy, sports recovery & rehab, wellness
+clinics**. Reach for it whenever the soul has priced `offerings`, real
+testimonials, and a "get out of pain / feel your best" promise; it is the safest
+default when a health business doesn't clearly fit templates 1–4.
+
+**Emotional register:** modern, credible, warm, confident — earthy clay + cream,
+bold geometric sans headlines, photography of hands-on care. Reads as a real
+clinic, not a spa or a SaaS page.
+
+---
+
+## Files (this is the per-template package; all 5 share this shape)
+
+| File | Role |
+|---|---|
+| `EarthyModernClinical.tsx` | **Entry** — `default ({ data, ctas, theme }) => JSX` |
+| `types.ts` | `Soul`, `CTAs`, `SfTheme`, `TemplateProps` (shared contract) |
+| `theme.ts` | `SF5_DEFAULT_THEME`, `sfThemeVars()`, data helpers (`sfMoney/sfDur/sfPhoto`) |
+| `css.ts` | `SF5_CSS` — the stylesheet string (single source of truth) |
+| `Styles.tsx` | emits `<style jsx global>{SF5_CSS}</style>` |
+| `icons.tsx` | inline-SVG icon set (no icon libraries) |
+| `ui.tsx` | `SmartImage` + `ThemedPlaceholder` (`"use client"` — onError fallback) |
+| `interactive.tsx` | `Nav`, `Faq` (`"use client"` — the only stateful sections) |
+| `sections.tsx` | `Hero, TrustStrip, Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar` (server) |
+| `fixture.ts` | realistic chiropractic soul for instant preview |
+
+```tsx
+import EarthyModernClinical from "./EarthyModernClinical";
+import { austinFamilyChiropractic, exampleCTAs } from "./fixture";
+
+export default function Page() {
+  return <EarthyModernClinical data={austinFamilyChiropractic} ctas={exampleCTAs} />;
+  // theme is optional — omit for the tasteful default, or pass per-business --sf-* values.
+}
+```
+
+## Section order (every template, data-driven; absent data hides gracefully)
+Sticky nav → split hero → trust strip → varied-size services → about panel →
+stats → testimonials → FAQ accordion → CTA band → footer → sticky mobile bar.
+
+## Guarantees honored
+- **Props-only content** — nothing about the business is hardcoded.
+- **Theme-only color/type** — every value resolves from `--sf-*`; tints via
+  `color-mix(in oklab, …)`. Swap the vars → the whole page re-skins.
+- **Graceful imagery** — `SmartImage` renders a real `<img>` and falls back to a
+  themed `ThemedPlaceholder` when a photo is missing or fails to load.
+- **House rules** — no Inter, asymmetric (never centered) hero, no 3-equal-card
+  grid, deep warm near-black (not `#000`), muted accents, SSR-safe (`"use
+  client"` only on `Nav`/`Faq`/`SmartImage`), responsive, reduced-motion aware.
+- **Bottom-right left clear** for the platform's injected AI chat bubble.
+
+## Responsiveness note
+Layout reflow is driven by **container queries** on `.sf5-root` (not viewport
+media queries), so the template adapts to whatever width it's mounted in —
+full-page, split-pane, or the preview's device toggle — while remaining
+mobile-first. Standard viewport media queries can be substituted 1:1 if the
+pipeline prefers them.

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/css.ts
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/css.ts
@@ -1,0 +1,251 @@
+/* SF5 global stylesheet â€” single source of truth, shared by <Styles/>.
+   Mobile-first; container queries on .sf5-root so the layout reflows by
+   available width (works for desktop, tablet, and embedded/preview contexts).
+   Every value resolves from --sf-* theme variables â€” no hardcoded brand color. */
+export const SF5_CSS = `
+.sf5-root{
+  /* tints derived from theme vars â€” never hardcoded */
+  --sf-primary-d: color-mix(in oklab, var(--sf-primary) 82%, #000);
+  --sf-primary-12: color-mix(in oklab, var(--sf-primary) 12%, var(--sf-bg));
+  --sf-card: color-mix(in oklab, var(--sf-secondary) 6%, var(--sf-bg));
+  --sf-card-2: color-mix(in oklab, var(--sf-secondary) 11%, var(--sf-bg));
+  --sf-ink-60: color-mix(in oklab, var(--sf-text) 62%, var(--sf-bg));
+  --sf-onp: color-mix(in oklab, var(--sf-bg) 92%, var(--sf-primary));
+  --sf-onp-60: color-mix(in oklab, var(--sf-bg) 70%, var(--sf-primary));
+  --wrap: 1200px;
+  container: sf5 / inline-size;
+  background: var(--sf-bg); color: var(--sf-text);
+  font-family: var(--sf-font-body);
+  font-size: 16px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+.sf5-root *{ box-sizing: border-box; }
+.sf5-root img{ display:block; max-width:100%; }
+.sf5-wrap{ width:100%; max-width:var(--wrap); margin-inline:auto; padding-inline:20px; }
+
+/* ---- type ---- */
+.sf5-h2{ font-family:var(--sf-font-headline); font-weight:700; letter-spacing:-.02em;
+  line-height:1.02; font-size:clamp(30px,8cqw,52px); margin:0; color:var(--sf-text); }
+.sf5-eyebrow{ font-family:var(--sf-font-body); font-weight:700; text-transform:uppercase;
+  letter-spacing:.14em; font-size:12px; color:var(--sf-primary); margin:0 0 14px; }
+.sf5-muted{ color:var(--sf-ink-60); }
+
+/* ---- buttons ---- */
+.sf5-btn{ --b:var(--sf-secondary); display:inline-flex; align-items:center; gap:9px;
+  font-family:var(--sf-font-body); font-weight:700; font-size:15px; line-height:1;
+  padding:13px 22px; border-radius:999px; border:1.5px solid transparent; cursor:pointer;
+  text-decoration:none; white-space:nowrap; transition:transform .15s ease, background .2s ease, color .2s ease, box-shadow .2s; }
+.sf5-btn svg{ font-size:18px; }
+.sf5-btn:hover{ transform:translateY(-1px); }
+.sf5-btn:focus-visible{ outline:3px solid var(--sf-primary); outline-offset:2px; }
+.sf5-btn-lg{ padding:16px 28px; font-size:16px; }
+.sf5-btn-block{ width:100%; justify-content:center; }
+.sf5-btn-primary{ background:var(--sf-primary); color:#fff; }
+.sf5-btn-primary:hover{ background:var(--sf-primary-d); }
+.sf5-btn-secondary{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf5-btn-outline{ background:transparent; color:var(--sf-text); border-color:color-mix(in oklab,var(--sf-text) 30%,transparent); }
+.sf5-btn-outline:hover{ border-color:var(--sf-text); }
+.sf5-btn-ghost{ background:transparent; color:var(--sf-text); border-color:var(--sf-border); }
+.sf5-btn-on-primary{ background:var(--sf-bg); color:var(--sf-secondary); }
+.sf5-btn-on-dark{ background:transparent; color:#fff; border-color:color-mix(in oklab,#fff 45%,transparent); }
+.sf5-btn-on-dark:hover{ border-color:#fff; }
+
+/* ---- nav ---- */
+.sf5-nav{ position:sticky; top:0; z-index:40; background:color-mix(in oklab,var(--sf-bg) 86%,transparent);
+  backdrop-filter:blur(10px); border-bottom:1px solid var(--sf-border); }
+.sf5-nav-in{ display:flex; align-items:center; justify-content:space-between; gap:16px; height:70px; }
+.sf5-brand{ display:inline-flex; align-items:center; gap:10px; min-width:0; flex-shrink:1; font-family:var(--sf-font-headline);
+  font-weight:700; font-size:19px; letter-spacing:-.01em; color:var(--sf-text); text-decoration:none; }
+.sf5-brand > span{ white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sf5-brand-mark{ flex:none; font-size:22px; color:var(--sf-primary); }
+.sf5-nav-links{ display:none; gap:30px; }
+.sf5-nav-links a{ color:var(--sf-text); text-decoration:none; font-weight:600; font-size:15px; opacity:.85; }
+.sf5-nav-links a:hover{ opacity:1; color:var(--sf-primary); }
+.sf5-nav-cta{ display:flex; align-items:center; gap:14px; }
+.sf5-link-call{ display:none; align-items:center; gap:7px; white-space:nowrap; color:var(--sf-text); text-decoration:none; font-weight:700; font-size:14px; }
+.sf5-link-call:hover{ color:var(--sf-primary); }
+.sf5-nav .sf5-btn-primary{ display:none; }
+.sf5-burger{ display:inline-grid; place-items:center; width:42px; height:42px; border-radius:12px;
+  background:transparent; border:1.5px solid var(--sf-border); color:var(--sf-text); font-size:22px; cursor:pointer; }
+
+/* mobile sheet */
+.sf5-sheet{ position:fixed; inset:0; z-index:60; background:var(--sf-bg); transform:translateY(-100%);
+  transition:transform .3s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; visibility:hidden; }
+.sf5-sheet.is-open{ transform:translateY(0); visibility:visible; }
+.sf5-sheet-top{ display:flex; align-items:center; justify-content:space-between; height:70px; }
+.sf5-sheet-links{ display:flex; flex-direction:column; gap:4px; padding:18px 24px; }
+.sf5-sheet-links a{ font-family:var(--sf-font-headline); font-weight:600; font-size:30px; color:var(--sf-text);
+  text-decoration:none; padding:12px 0; border-bottom:1px solid var(--sf-border); }
+.sf5-sheet-foot{ margin-top:auto; padding:24px; display:flex; flex-direction:column; gap:12px; }
+
+/* ---- hero (mobile-first: stacked) ---- */
+.sf5-hero{ position:relative; display:flex; flex-direction:column; }
+.sf5-hero-media{ position:relative; min-height:340px; }
+.sf5-hero-img,.sf5-hero-media .sf5-ph,.sf5-hero-media .sf5-img{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf5-hero-scrim{ position:absolute; inset:0; background:linear-gradient(180deg,color-mix(in oklab,var(--sf-secondary) 30%,transparent),color-mix(in oklab,var(--sf-secondary) 8%,transparent)); }
+.sf5-hero-body{ padding:34px 20px 40px; }
+.sf5-eyebrow{}
+.sf5-hero-h1{ font-family:var(--sf-font-headline); font-weight:700; letter-spacing:-.025em; line-height:1.0;
+  font-size:clamp(38px,12cqw,76px); margin:0 0 18px; color:var(--sf-text); text-wrap:balance; }
+.sf5-hero-sub{ font-size:clamp(16px,4cqw,19px); color:var(--sf-ink-60); max-width:46ch; margin:0 0 26px; }
+.sf5-hero-actions{ display:flex; flex-wrap:wrap; gap:12px; }
+.sf5-hero-chips{ list-style:none; display:flex; flex-wrap:wrap; gap:10px 22px; margin:28px 0 0; padding:0; }
+.sf5-hero-chips li{ display:inline-flex; align-items:center; gap:8px; font-weight:600; font-size:14px; }
+.sf5-hero-chips b{ font-weight:800; }
+.sf5-stars{ color:var(--sf-primary); display:inline-flex; }
+.sf5-chip-ic{ color:var(--sf-primary); font-size:16px; }
+
+/* ---- trust strip ---- */
+.sf5-trust{ border-top:1px solid var(--sf-border); border-bottom:1px solid var(--sf-border); background:var(--sf-card); }
+.sf5-trust-in{ display:flex; flex-wrap:wrap; gap:18px 40px; padding-block:22px; }
+.sf5-trust-item{ display:flex; align-items:center; gap:11px; }
+.sf5-trust-lead{ font-family:var(--sf-font-headline); font-weight:800; font-size:20px; color:var(--sf-primary); }
+.sf5-trust-ic{ color:var(--sf-primary); font-size:20px; }
+.sf5-trust-sub{ font-weight:600; font-size:14px; color:var(--sf-text); }
+
+/* ---- section heads ---- */
+.sf5-sec-head{ display:flex; flex-direction:column; gap:18px; align-items:flex-start; padding-top:64px; }
+
+/* ---- services ---- */
+.sf5-services{ padding-bottom:84px; }
+.sf5-svc-grid{ display:grid; gap:16px; margin-top:34px; grid-template-columns:1fr; }
+.sf5-svc{ background:var(--sf-card); border:1px solid var(--sf-border); border-radius:18px; overflow:hidden; display:flex; flex-direction:column; transition:transform .18s ease, box-shadow .25s ease; }
+.sf5-svc:hover{ transform:translateY(-3px); box-shadow:0 22px 44px -28px color-mix(in oklab,var(--sf-secondary) 60%,transparent); }
+.sf5-svc-media{ position:relative; aspect-ratio:16/10; }
+.sf5-svc-media .sf5-img,.sf5-svc-media .sf5-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf5-svc-body{ padding:22px; display:flex; flex-direction:column; gap:12px; flex:1; }
+.sf5-svc-name{ font-family:var(--sf-font-headline); font-weight:700; font-size:21px; margin:0; letter-spacing:-.01em; }
+.sf5-svc-desc{ margin:0; color:var(--sf-ink-60); font-size:15px; }
+.sf5-svc-meta{ display:flex; align-items:center; gap:16px; margin-top:auto; font-weight:600; font-size:14px; color:var(--sf-text); }
+.sf5-svc-meta span{ display:inline-flex; align-items:center; gap:6px; white-space:nowrap; }
+.sf5-svc-meta svg{ color:var(--sf-primary); font-size:16px; }
+.sf5-price{ font-family:var(--sf-font-headline); font-weight:800; font-size:18px; }
+.sf5-svc-book{ display:inline-flex; align-items:center; gap:7px; white-space:nowrap; font-weight:700; font-size:14px; color:var(--sf-primary); text-decoration:none; }
+.sf5-svc-book:hover{ gap:11px; }
+.sf5-svc--feature .sf5-btn{ align-self:flex-start; }
+
+/* ---- about ---- */
+.sf5-about{ display:grid; grid-template-columns:1fr; }
+.sf5-about-panel{ background:var(--sf-primary); color:var(--sf-bg); padding:48px 20px; display:flex; flex-direction:column; gap:26px; }
+.sf5-on-primary{ color:#fff; }
+.sf5-about-copy{ display:flex; flex-direction:column; gap:16px; max-width:54ch; }
+.sf5-about-role{ font-weight:800; text-transform:uppercase; letter-spacing:.12em; font-size:12px; color:var(--sf-onp); margin:0; }
+.sf5-about-text{ margin:0; font-size:17px; color:color-mix(in oklab,#fff 88%,var(--sf-primary)); }
+.sf5-creds{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:9px; }
+.sf5-creds li{ display:flex; align-items:center; gap:9px; font-weight:600; font-size:15px; color:#fff; }
+.sf5-creds svg{ color:var(--sf-bg); }
+.sf5-about-media{ position:relative; min-height:360px; }
+.sf5-about-media .sf5-img,.sf5-about-media .sf5-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+
+/* ---- stats ---- */
+.sf5-stats{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf5-stats-in{ display:flex; flex-wrap:wrap; gap:28px 56px; padding-block:46px; }
+.sf5-stat{ display:flex; flex-direction:column; gap:4px; }
+.sf5-stat-n{ font-family:var(--sf-font-headline); font-weight:800; font-size:clamp(34px,7cqw,52px); line-height:1; color:var(--sf-bg); }
+.sf5-stat-l{ font-size:14px; color:color-mix(in oklab,var(--sf-bg) 72%,var(--sf-secondary)); font-weight:600; }
+
+/* ---- testimonials ---- */
+.sf5-revs{ padding-block:72px; }
+.sf5-rev-grid{ display:grid; gap:16px; margin-top:32px; grid-template-columns:1fr; }
+.sf5-rev{ background:var(--sf-card-2); border-radius:16px; padding:28px; margin:0; display:flex; flex-direction:column; gap:16px; }
+.sf5-rev-stars{ font-size:15px; }
+.sf5-rev blockquote{ margin:0; font-family:var(--sf-font-headline); font-weight:500; font-size:19px; line-height:1.4; letter-spacing:-.01em; }
+.sf5-rev figcaption{ font-weight:700; font-size:14px; color:var(--sf-ink-60); }
+
+/* ---- faq ---- */
+.sf5-faq{ padding-bottom:84px; }
+.sf5-faq-in{ display:grid; grid-template-columns:1fr; gap:32px; }
+.sf5-faq-list{ border-top:1px solid var(--sf-border); }
+.sf5-faq-item{ border-bottom:1px solid var(--sf-border); }
+.sf5-faq-q{ width:100%; display:flex; align-items:center; justify-content:space-between; gap:18px;
+  background:none; border:0; cursor:pointer; text-align:left; padding:22px 4px;
+  font-family:var(--sf-font-headline); font-weight:600; font-size:19px; color:var(--sf-text); }
+.sf5-faq-chev{ flex:none; font-size:22px; color:var(--sf-primary); transition:transform .25s ease; }
+.sf5-faq-item.is-open .sf5-faq-chev{ transform:rotate(180deg); }
+.sf5-faq-a{ display:grid; grid-template-rows:0fr; transition:grid-template-rows .28s ease; }
+.sf5-faq-item.is-open .sf5-faq-a{ grid-template-rows:1fr; }
+.sf5-faq-a > p{ overflow:hidden; margin:0; color:var(--sf-ink-60); font-size:16px; padding-right:30px;
+  padding-bottom:0; transition:padding-bottom .28s ease; }
+.sf5-faq-item.is-open .sf5-faq-a > p{ padding-bottom:22px; }
+
+/* ---- cta band ---- */
+.sf5-cta{ position:relative; overflow:hidden; }
+.sf5-cta-media{ position:absolute; inset:0; }
+.sf5-cta-media .sf5-img,.sf5-cta-media .sf5-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf5-cta-scrim{ position:absolute; inset:0; background:linear-gradient(90deg,color-mix(in oklab,var(--sf-secondary) 88%,transparent),color-mix(in oklab,var(--sf-secondary) 55%,transparent)); }
+.sf5-cta-in{ position:relative; padding-block:84px; }
+.sf5-cta-h{ font-family:var(--sf-font-headline); font-weight:700; letter-spacing:-.02em; line-height:1.0;
+  font-size:clamp(34px,9cqw,60px); margin:0 0 14px; color:#fff; }
+.sf5-cta-sub{ color:color-mix(in oklab,#fff 86%,var(--sf-secondary)); font-size:18px; margin:0 0 28px; max-width:42ch; }
+
+/* ---- footer ---- */
+.sf5-foot{ background:var(--sf-secondary); color:var(--sf-bg); padding-top:64px; }
+.sf5-foot-in{ display:grid; grid-template-columns:1fr; gap:40px; padding-bottom:48px; }
+.sf5-brand--foot{ color:var(--sf-primary); }
+.sf5-foot-tag{ color:color-mix(in oklab,var(--sf-bg) 72%,var(--sf-secondary)); margin:14px 0 22px; max-width:34ch; }
+.sf5-foot-cols{ display:grid; grid-template-columns:1fr 1fr; gap:32px 24px; }
+.sf5-foot-col h3{ font-family:var(--sf-font-headline); font-size:13px; text-transform:uppercase; letter-spacing:.1em;
+  color:var(--sf-primary); margin:0 0 14px; }
+.sf5-foot-col ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:9px; }
+.sf5-foot-col li,.sf5-foot-col a{ color:color-mix(in oklab,var(--sf-bg) 82%,var(--sf-secondary)); font-size:14px; text-decoration:none; }
+.sf5-foot-col a:hover{ color:#fff; }
+.sf5-foot-legal{ display:flex; flex-wrap:wrap; gap:8px 20px; justify-content:space-between;
+  border-top:1px solid color-mix(in oklab,var(--sf-bg) 18%,var(--sf-secondary)); padding-block:22px;
+  font-size:13px; color:color-mix(in oklab,var(--sf-bg) 62%,var(--sf-secondary)); }
+
+/* ---- sticky mobile bar ---- */
+.sf5-mbar{ position:sticky; bottom:0; z-index:50; display:flex; gap:10px; padding:12px 16px calc(12px + env(safe-area-inset-bottom));
+  background:color-mix(in oklab,var(--sf-bg) 92%,transparent); backdrop-filter:blur(10px);
+  border-top:1px solid var(--sf-border); }
+.sf5-mbar-call{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:14px 20px;
+  border-radius:999px; border:1.5px solid var(--sf-border); color:var(--sf-text); text-decoration:none; font-weight:700; }
+.sf5-mbar-book{ flex:1; display:inline-flex; align-items:center; justify-content:center; padding:14px 20px;
+  border-radius:999px; background:var(--sf-primary); color:#fff; text-decoration:none; font-weight:700; }
+
+/* ---- placeholder + image ---- */
+.sf5-img{ width:100%; height:100%; object-fit:cover; }
+.sf5-ph{ position:relative; width:100%; height:100%; min-height:160px; overflow:hidden;
+  background:
+    repeating-linear-gradient(135deg, color-mix(in oklab,var(--sf-primary) 16%,var(--sf-card)) 0 14px, color-mix(in oklab,var(--sf-primary) 7%,var(--sf-card)) 14px 28px),
+    var(--sf-card-2);
+  display:grid; place-items:center; }
+.sf5-ph::after{ content:""; position:absolute; inset:0;
+  background:radial-gradient(120% 90% at 30% 20%, transparent 40%, color-mix(in oklab,var(--sf-secondary) 14%,transparent)); }
+.sf5-ph-tag{ position:relative; z-index:1; font-family:ui-monospace,'SFMono-Regular',Menlo,monospace;
+  font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-secondary) 70%,var(--sf-bg));
+  background:color-mix(in oklab,var(--sf-bg) 86%,transparent); padding:6px 11px; border-radius:999px; border:1px solid var(--sf-border); }
+
+@media (prefers-reduced-motion: reduce){ .sf5-root *{ transition:none !important; } }
+
+/* ===================== container queries (tablet â‰¥ 720) =================== */
+@container sf5 (min-width:720px){
+  .sf5-wrap{ padding-inline:32px; }
+  .sf5-nav-links{ display:flex; }
+  .sf5-nav .sf5-btn-primary{ display:inline-flex; }
+  .sf5-burger{ display:none; }
+  .sf5-mbar{ display:none; }
+  .sf5-hero{ display:grid; grid-template-columns:1.05fr .95fr; align-items:stretch; min-height:78cqh; }
+  .sf5-hero-media{ order:2; min-height:520px; }
+  .sf5-hero-body{ order:1; align-self:center; padding:64px 48px 64px max(32px,calc((100cqw - var(--wrap))/2 + 32px)); }
+  .sf5-hero-scrim{ background:linear-gradient(90deg,transparent 30%,color-mix(in oklab,var(--sf-secondary) 12%,transparent)); }
+  .sf5-sec-head{ flex-direction:row; align-items:flex-end; justify-content:space-between; }
+  .sf5-svc-grid{ grid-template-columns:1fr 1fr; }
+  .sf5-svc--feature{ grid-column:1 / -1; flex-direction:row; }
+  .sf5-svc--feature .sf5-svc-media{ flex:1.1; aspect-ratio:auto; min-height:300px; }
+  .sf5-svc--feature .sf5-svc-body{ flex:1; padding:34px; }
+  .sf5-about{ grid-template-columns:1.15fr .85fr; }
+  .sf5-about-panel{ padding:72px 8cqw 72px max(48px,calc((100cqw - var(--wrap))/2 + 8px)); justify-content:center; }
+  .sf5-about-media{ min-height:560px; }
+  .sf5-rev-grid{ grid-template-columns:repeat(3,1fr); }
+  .sf5-faq-in{ grid-template-columns:.7fr 1.3fr; gap:48px; }
+  .sf5-foot-in{ grid-template-columns:1.2fr 2fr; gap:64px; }
+  .sf5-foot-cols{ grid-template-columns:repeat(4,1fr); }
+  .sf5-cta-in{ padding-block:110px; }
+}
+@container sf5 (min-width:1040px){
+  .sf5-link-call{ display:inline-flex; }
+  .sf5-hero-h1{ font-size:clamp(56px,6.2cqw,82px); }
+  .sf5-svc-grid{ grid-template-columns:repeat(3,1fr); }
+  .sf5-svc--feature .sf5-svc-body{ padding:44px; max-width:560px; }
+}
+`;

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/css.ts
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/css.ts
@@ -1,10 +1,10 @@
-/* SF5 global stylesheet â€” single source of truth, shared by <Styles/>.
+/* SF5 global stylesheet — single source of truth, shared by <Styles/>.
    Mobile-first; container queries on .sf5-root so the layout reflows by
    available width (works for desktop, tablet, and embedded/preview contexts).
-   Every value resolves from --sf-* theme variables â€” no hardcoded brand color. */
+   Every value resolves from --sf-* theme variables — no hardcoded brand color. */
 export const SF5_CSS = `
 .sf5-root{
-  /* tints derived from theme vars â€” never hardcoded */
+  /* tints derived from theme vars — never hardcoded */
   --sf-primary-d: color-mix(in oklab, var(--sf-primary) 82%, #000);
   --sf-primary-12: color-mix(in oklab, var(--sf-primary) 12%, var(--sf-bg));
   --sf-card: color-mix(in oklab, var(--sf-secondary) 6%, var(--sf-bg));
@@ -217,7 +217,7 @@ export const SF5_CSS = `
 
 @media (prefers-reduced-motion: reduce){ .sf5-root *{ transition:none !important; } }
 
-/* ===================== container queries (tablet â‰¥ 720) =================== */
+/* ===================== container queries (tablet ≥ 720) =================== */
 @container sf5 (min-width:720px){
   .sf5-wrap{ padding-inline:32px; }
   .sf5-nav-links{ display:flex; }

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/fixture.ts
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/fixture.ts
@@ -1,0 +1,56 @@
+import type { CTAs, Soul } from "../_contract/types";
+
+// Realistic health fixture for instant preview. Matches the data the
+// SeldonFrame pipeline injects at build time â€” design against the shape, never
+// hardcode these values into the template. The About portrait and CTA texture
+// photos are intentionally omitted to exercise the themed-placeholder fallback.
+export const austinFamilyChiropractic: Soul = {
+  business_name: "Austin Family Chiropractic",
+  tagline: "Gentle, expert chiropractic care for the whole family",
+  soul_description:
+    "A family-focused clinic serving every age â€” from infants to seniors. Dr. Sarah Mitchell and her team specialize in spinal adjustments, corrective care, and whole-body wellness to relieve pain and restore mobility.",
+  phone: "(512) 555-0182",
+  email: "hello@austinfamilychiro.com",
+  address: "3204 Bee Caves Rd, Suite 102, Austin, TX 78746",
+  service_area: ["Austin", "West Lake Hills", "Bee Cave", "Rollingwood"],
+  hours: [
+    { day: "Monâ€“Fri", open: "8am", close: "6pm" },
+    { day: "Sat", open: "9am", close: "2pm" },
+    { day: "Sun", open: "Closed", close: "" },
+  ],
+  review_rating: 4.9,
+  review_count: 287,
+  trust_signals: ["Licensed Doctors of Chiropractic", "Most insurance accepted", "Same-week appointments"],
+  certifications: ["Doctor of Chiropractic (DC)", "Webster Technique Certified"],
+  same_day: true,
+  offerings: [
+    { name: "Spinal Adjustment", description: "Restore motion and relieve nerve pressure", price: 65, currency: "USD", duration_minutes: 30 },
+    { name: "Corrective Care Program", description: "A structured plan to fix the root cause", price: 120, currency: "USD", duration_minutes: 45 },
+    { name: "Prenatal Chiropractic", description: "Gentle, Webster-certified care through pregnancy", price: 85, currency: "USD", duration_minutes: 40 },
+    { name: "Pediatric Chiropractic", description: "Low-force adjustments for kids and infants", price: 55, currency: "USD", duration_minutes: 25 },
+  ],
+  faqs: [
+    { q: "Do you accept insurance?", a: "We accept most major plans including BCBS, Aetna, Cigna, and United. We verify your benefits before your first visit." },
+    { q: "Is chiropractic safe for children?", a: "Yes â€” pediatric adjustments use very gentle, low-force techniques appropriate for each age." },
+    { q: "What happens on my first visit?", a: "A full exam and consultation, then a personalized care plan with a clear timeline and cost estimate." },
+    { q: "Do I need a referral?", a: "No referral needed â€” you can book directly online or by phone, and we coordinate with your physician as required." },
+  ],
+  testimonials: [
+    { name: "Jennifer K.", text: "Dr. Mitchell's prenatal adjustments made an enormous difference in my comfort. I brought my newborn in too!" },
+    { name: "Marcus T.", text: "After 8 weeks my chronic back pain is virtually gone. They customize every single treatment." },
+    { name: "The Rivera Family", text: "Our whole family comes here â€” kids included. So welcoming, every single visit." },
+  ],
+  photos: [
+    { url: "https://images.unsplash.com/photo-1519823551278-64ac92734fb1?auto=format&fit=crop&w=1300&q=72", role: "hero", alt: "Gentle hands-on chiropractic care" },
+    { url: "https://images.unsplash.com/photo-1544161515-4ab6ce6db874?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Spinal adjustment" },
+    { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Corrective care session" },
+    { url: "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Prenatal movement care" },
+    // service[3] (pediatric), role:"about" & role:"gallery" omitted â†’ themed placeholder fallback
+  ],
+};
+
+export const exampleCTAs: CTAs = {
+  bookUrl: "/book",
+  callHref: "tel:+15125550182",
+  intakeUrl: "/intake",
+};

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/fixture.ts
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/fixture.ts
@@ -1,20 +1,20 @@
 import type { CTAs, Soul } from "../_contract/types";
 
 // Realistic health fixture for instant preview. Matches the data the
-// SeldonFrame pipeline injects at build time â€” design against the shape, never
+// SeldonFrame pipeline injects at build time — design against the shape, never
 // hardcode these values into the template. The About portrait and CTA texture
 // photos are intentionally omitted to exercise the themed-placeholder fallback.
 export const austinFamilyChiropractic: Soul = {
   business_name: "Austin Family Chiropractic",
   tagline: "Gentle, expert chiropractic care for the whole family",
   soul_description:
-    "A family-focused clinic serving every age â€” from infants to seniors. Dr. Sarah Mitchell and her team specialize in spinal adjustments, corrective care, and whole-body wellness to relieve pain and restore mobility.",
+    "A family-focused clinic serving every age — from infants to seniors. Dr. Sarah Mitchell and her team specialize in spinal adjustments, corrective care, and whole-body wellness to relieve pain and restore mobility.",
   phone: "(512) 555-0182",
   email: "hello@austinfamilychiro.com",
   address: "3204 Bee Caves Rd, Suite 102, Austin, TX 78746",
   service_area: ["Austin", "West Lake Hills", "Bee Cave", "Rollingwood"],
   hours: [
-    { day: "Monâ€“Fri", open: "8am", close: "6pm" },
+    { day: "Mon–Fri", open: "8am", close: "6pm" },
     { day: "Sat", open: "9am", close: "2pm" },
     { day: "Sun", open: "Closed", close: "" },
   ],
@@ -31,21 +31,21 @@ export const austinFamilyChiropractic: Soul = {
   ],
   faqs: [
     { q: "Do you accept insurance?", a: "We accept most major plans including BCBS, Aetna, Cigna, and United. We verify your benefits before your first visit." },
-    { q: "Is chiropractic safe for children?", a: "Yes â€” pediatric adjustments use very gentle, low-force techniques appropriate for each age." },
+    { q: "Is chiropractic safe for children?", a: "Yes — pediatric adjustments use very gentle, low-force techniques appropriate for each age." },
     { q: "What happens on my first visit?", a: "A full exam and consultation, then a personalized care plan with a clear timeline and cost estimate." },
-    { q: "Do I need a referral?", a: "No referral needed â€” you can book directly online or by phone, and we coordinate with your physician as required." },
+    { q: "Do I need a referral?", a: "No referral needed — you can book directly online or by phone, and we coordinate with your physician as required." },
   ],
   testimonials: [
     { name: "Jennifer K.", text: "Dr. Mitchell's prenatal adjustments made an enormous difference in my comfort. I brought my newborn in too!" },
     { name: "Marcus T.", text: "After 8 weeks my chronic back pain is virtually gone. They customize every single treatment." },
-    { name: "The Rivera Family", text: "Our whole family comes here â€” kids included. So welcoming, every single visit." },
+    { name: "The Rivera Family", text: "Our whole family comes here — kids included. So welcoming, every single visit." },
   ],
   photos: [
     { url: "https://images.unsplash.com/photo-1519823551278-64ac92734fb1?auto=format&fit=crop&w=1300&q=72", role: "hero", alt: "Gentle hands-on chiropractic care" },
     { url: "https://images.unsplash.com/photo-1544161515-4ab6ce6db874?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Spinal adjustment" },
     { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Corrective care session" },
     { url: "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=900&q=72", role: "service", alt: "Prenatal movement care" },
-    // service[3] (pediatric), role:"about" & role:"gallery" omitted â†’ themed placeholder fallback
+    // service[3] (pediatric), role:"about" & role:"gallery" omitted → themed placeholder fallback
   ],
 };
 

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/icons.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/icons.tsx
@@ -1,0 +1,17 @@
+import type { SVGProps } from "react";
+
+// Inline SVG only â€” no external icon libraries (SeldonFrame house rule).
+type P = SVGProps<SVGSVGElement>;
+const base = (p: P) => ({ width: "1em" as const, height: "1em" as const, viewBox: "0 0 24 24", "aria-hidden": true, ...p });
+
+export const Icon = {
+  star: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M12 2.5l2.9 6 6.6.9-4.8 4.6 1.2 6.5L12 18.9 6.1 22l1.2-6.5L2.5 9.4l6.6-.9z" /></svg>),
+  phone: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" d="M5 4h3l1.5 4.5L7.5 10a12 12 0 0 0 6 6l1.5-2 4.5 1.5V19a2 2 0 0 1-2 2A16 16 0 0 1 3 6a2 2 0 0 1 2-2z" /></svg>),
+  arrow: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M13 6l6 6-6 6" /></svg>),
+  chevron: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" d="M6 9l6 6 6-6" /></svg>),
+  menu: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M4 7h16M4 12h16M4 17h16" /></svg>),
+  close: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M6 6l12 12M18 6L6 18" /></svg>),
+  check: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>),
+  clock: (p: P) => (<svg {...base(p)}><circle cx={12} cy={12} r={9} fill="none" stroke="currentColor" strokeWidth={2} /><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M12 7v5l3 2" /></svg>),
+  mark: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M3 12c5 0 9-4 9-9 0 5 4 9 9 9-5 0-9 4-9 9 0-5-4-9-9-9z" /></svg>),
+};

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/interactive.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { CTAs, Soul } from "../_contract/types";
 import { Icon } from "./icons";
 
-// â”€â”€ Sticky nav with mobile sheet â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Sticky nav with mobile sheet ───────────────────────────────────────────
 export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
   const [open, setOpen] = useState(false);
   const links: [string, string][] = [
@@ -50,7 +50,7 @@ export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
   );
 }
 
-// â”€â”€ FAQ accordion â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── FAQ accordion ──────────────────────────────────────────────────────────
 export function Faq({ data }: { data: Soul }) {
   const faqs = data.faqs || [];
   const [open, setOpen] = useState(0);

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/interactive.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+
+// â”€â”€ Sticky nav with mobile sheet â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [open, setOpen] = useState(false);
+  const links: [string, string][] = [
+    ["About", "#about"],
+    ["Services", "#services"],
+    ["Reviews", "#reviews"],
+    ["Contact", "#contact"],
+  ];
+  return (
+    <header className="sf5-nav" id="top">
+      <div className="sf5-wrap sf5-nav-in">
+        <a className="sf5-brand" href="#top" aria-label={data.business_name}>
+          <Icon.mark className="sf5-brand-mark" />
+          <span>{data.business_name}</span>
+        </a>
+        <nav className="sf5-nav-links" aria-label="Primary">
+          {links.map(([l, h]) => (<a key={l} href={h}>{l}</a>))}
+        </nav>
+        <div className="sf5-nav-cta">
+          {ctas.callHref && data.phone && (
+            <a className="sf5-link-call" href={ctas.callHref}><Icon.phone /> <span>{data.phone}</span></a>
+          )}
+          <a className="sf5-btn sf5-btn-primary" href={ctas.bookUrl}>Book a Session</a>
+          <button className="sf5-burger" aria-label="Menu" aria-expanded={open} onClick={() => setOpen(true)}><Icon.menu /></button>
+        </div>
+      </div>
+      <div className={"sf5-sheet" + (open ? " is-open" : "")} role="dialog" aria-modal="true" aria-hidden={!open}>
+        <div className="sf5-sheet-top sf5-wrap">
+          <span className="sf5-brand"><Icon.mark className="sf5-brand-mark" />{data.business_name}</span>
+          <button className="sf5-burger" aria-label="Close menu" onClick={() => setOpen(false)}><Icon.close /></button>
+        </div>
+        <nav className="sf5-sheet-links" aria-label="Mobile">
+          {links.map(([l, h]) => (<a key={l} href={h} onClick={() => setOpen(false)}>{l}</a>))}
+        </nav>
+        <div className="sf5-sheet-foot">
+          <a className="sf5-btn sf5-btn-primary sf5-btn-block" href={ctas.bookUrl} onClick={() => setOpen(false)}>Book a Session</a>
+          {ctas.callHref && data.phone && (
+            <a className="sf5-btn sf5-btn-ghost sf5-btn-block" href={ctas.callHref}><Icon.phone /> {data.phone}</a>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// â”€â”€ FAQ accordion â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Faq({ data }: { data: Soul }) {
+  const faqs = data.faqs || [];
+  const [open, setOpen] = useState(0);
+  if (!faqs.length) return null;
+  return (
+    <section className="sf5-faq" id="faq">
+      <div className="sf5-wrap sf5-faq-in">
+        <div className="sf5-faq-aside">
+          <p className="sf5-eyebrow">Good to know</p>
+          <h2 className="sf5-h2">Questions,<br />answered</h2>
+        </div>
+        <div className="sf5-faq-list">
+          {faqs.map((f, i) => {
+            const isOpen = open === i;
+            return (
+              <div className={"sf5-faq-item" + (isOpen ? " is-open" : "")} key={i}>
+                <button className="sf5-faq-q" aria-expanded={isOpen} onClick={() => setOpen(isOpen ? -1 : i)}>
+                  <span>{f.q}</span><Icon.chevron className="sf5-faq-chev" />
+                </button>
+                <div className="sf5-faq-a" role="region"><p>{f.a}</p></div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/sections.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/sections.tsx
@@ -1,0 +1,246 @@
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { SmartImage } from "./ui";
+import { sfDur, sfMoney, sfPhoto } from "./theme";
+
+// â”€â”€ Hero (split / asymmetric â€” never centered) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const hero = sfPhoto(data, "hero");
+  const eyebrow = data.service_area && data.service_area.length
+    ? "Now welcoming patients Â· " + data.service_area[0]
+    : data.certifications && data.certifications[0];
+  return (
+    <section className="sf5-hero">
+      <div className="sf5-hero-media">
+        <SmartImage photo={hero} role="hero portrait" label="hero portrait" className="sf5-hero-img" />
+        <div className="sf5-hero-scrim" aria-hidden="true" />
+      </div>
+      <div className="sf5-hero-body">
+        {eyebrow && <p className="sf5-eyebrow">{eyebrow}</p>}
+        <h1 className="sf5-hero-h1">{data.tagline || data.business_name}</h1>
+        {data.soul_description && <p className="sf5-hero-sub">{data.soul_description}</p>}
+        <div className="sf5-hero-actions">
+          <a className="sf5-btn sf5-btn-primary sf5-btn-lg" href={ctas.bookUrl}>Book a Session <Icon.arrow /></a>
+          {ctas.callHref && data.phone
+            ? <a className="sf5-btn sf5-btn-outline sf5-btn-lg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>
+            : <a className="sf5-btn sf5-btn-outline sf5-btn-lg" href="#services">View Services</a>}
+        </div>
+        {(data.review_rating != null || data.certifications) && (
+          <ul className="sf5-hero-chips">
+            {data.review_rating != null && (
+              <li><span className="sf5-stars"><Icon.star /></span><b>{data.review_rating.toFixed(1)}</b>
+                {data.review_count != null && <span className="sf5-muted">Â· {data.review_count} reviews</span>}</li>
+            )}
+            {data.certifications && data.certifications[0] && (
+              <li><Icon.check className="sf5-chip-ic" /><span>{data.certifications[0]}</span></li>
+            )}
+            {data.same_day && <li><Icon.check className="sf5-chip-ic" /><span>Same-week appointments</span></li>}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ Trust strip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function TrustStrip({ data }: { data: Soul }) {
+  const items: { lead: string | null; sub: string }[] = [];
+  if (data.review_rating != null)
+    items.push({ lead: data.review_rating.toFixed(1) + "â˜…", sub: data.review_count ? data.review_count + " patient reviews" : "Patient rating" });
+  (data.trust_signals || []).forEach((s) => items.push({ lead: null, sub: s }));
+  if (!items.length) return null;
+  return (
+    <section className="sf5-trust" aria-label="Why patients trust us">
+      <div className="sf5-wrap sf5-trust-in">
+        {items.map((it, i) => (
+          <div className="sf5-trust-item" key={i}>
+            {it.lead ? <span className="sf5-trust-lead">{it.lead}</span> : <Icon.check className="sf5-trust-ic" />}
+            <span className="sf5-trust-sub">{it.sub}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ Services (varied card sizes â€” first card spans full width) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const list = data.offerings || [];
+  if (!list.length) return null;
+  const [feat, ...rest] = list;
+  return (
+    <section className="sf5-services" id="services">
+      <div className="sf5-wrap">
+        <div className="sf5-sec-head">
+          <div>
+            <p className="sf5-eyebrow">Services</p>
+            <h2 className="sf5-h2">Paths to<br />Pain-Free Living</h2>
+          </div>
+          <a className="sf5-btn sf5-btn-secondary" href="#services">Explore all services <Icon.arrow /></a>
+        </div>
+        <div className="sf5-svc-grid">
+          <article className="sf5-svc sf5-svc--feature">
+            <div className="sf5-svc-media"><SmartImage photo={sfPhoto(data, "service", 0)} role="service" label={feat.name} /></div>
+            <div className="sf5-svc-body">
+              <div className="sf5-svc-top">
+                <h3 className="sf5-svc-name">{feat.name}</h3>
+                {feat.description && <p className="sf5-svc-desc">{feat.description}</p>}
+              </div>
+              <div className="sf5-svc-meta">
+                {sfDur(feat.duration_minutes) && <span><Icon.clock /> {sfDur(feat.duration_minutes)}</span>}
+                {sfMoney(feat.price, feat.currency) && <span className="sf5-price">{sfMoney(feat.price, feat.currency)}</span>}
+              </div>
+              <a className="sf5-btn sf5-btn-primary" href={ctas.bookUrl}>Book now</a>
+            </div>
+          </article>
+          {rest.map((o, i) => (
+            <article className="sf5-svc sf5-svc--sm" key={o.name}>
+              <div className="sf5-svc-media"><SmartImage photo={sfPhoto(data, "service", i + 1)} role="service" label={o.name} /></div>
+              <div className="sf5-svc-body">
+                <h3 className="sf5-svc-name">{o.name}</h3>
+                {o.description && <p className="sf5-svc-desc">{o.description}</p>}
+                <div className="sf5-svc-meta">
+                  {sfDur(o.duration_minutes) && <span><Icon.clock /> {sfDur(o.duration_minutes)}</span>}
+                  {sfMoney(o.price, o.currency) && <span className="sf5-price">{sfMoney(o.price, o.currency)}</span>}
+                </div>
+                <a className="sf5-svc-book" href={ctas.bookUrl}>Book now <Icon.arrow /></a>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ About (color panel + portrait) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  if (!data.soul_description && !(data.certifications || []).length) return null;
+  const portrait = sfPhoto(data, "about");
+  const lead = (data.certifications && data.certifications[0]) || "Lead Specialist";
+  return (
+    <section className="sf5-about" id="about">
+      <div className="sf5-about-panel">
+        <h2 className="sf5-h2 sf5-on-primary">Your Partner<br />in Health</h2>
+        <div className="sf5-about-copy">
+          <p className="sf5-about-role">{lead}</p>
+          <p className="sf5-about-text">{data.soul_description}</p>
+          {(data.certifications || []).length > 0 && (
+            <ul className="sf5-creds">
+              {data.certifications!.map((c) => (<li key={c}><Icon.check /> {c}</li>))}
+            </ul>
+          )}
+          <a className="sf5-btn sf5-btn-on-primary" href={ctas.intakeUrl || ctas.bookUrl}>Read my story</a>
+        </div>
+      </div>
+      <div className="sf5-about-media">
+        <SmartImage photo={portrait} role="practitioner portrait" label="practitioner portrait" />
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ Stats (optional proof) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Stats({ data }: { data: Soul }) {
+  const stats: [string, string][] = [];
+  if (data.review_count != null) stats.push([data.review_count.toLocaleString() + "+", "Patients cared for"]);
+  if (data.review_rating != null) stats.push([data.review_rating.toFixed(1), "Average rating"]);
+  if (data.service_area && data.service_area.length) stats.push([String(data.service_area.length), "Communities served"]);
+  if (stats.length < 2) return null;
+  return (
+    <section className="sf5-stats" aria-label="By the numbers">
+      <div className="sf5-wrap sf5-stats-in">
+        {stats.map(([n, l], i) => (
+          <div className="sf5-stat" key={i}><span className="sf5-stat-n">{n}</span><span className="sf5-stat-l">{l}</span></div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ Testimonials â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Testimonials({ data }: { data: Soul }) {
+  const t = data.testimonials || [];
+  if (!t.length) return null;
+  return (
+    <section className="sf5-revs" id="reviews">
+      <div className="sf5-wrap">
+        <h2 className="sf5-h2">What Our<br />Patients Say</h2>
+        <div className="sf5-rev-grid">
+          {t.slice(0, 4).map((r, i) => (
+            <figure className="sf5-rev" key={i}>
+              <span className="sf5-stars sf5-rev-stars"><Icon.star /><Icon.star /><Icon.star /><Icon.star /><Icon.star /></span>
+              <blockquote>{"\u201C" + r.text + "\u201D"}</blockquote>
+              <figcaption>{"\u2014 " + r.name}</figcaption>
+            </figure>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ CTA band (over warm texture) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <section className="sf5-cta" id="contact">
+      <div className="sf5-cta-media"><SmartImage photo={sfPhoto(data, "gallery")} role="texture" label="warm texture" decorative /></div>
+      <div className="sf5-cta-scrim" aria-hidden="true" />
+      <div className="sf5-wrap sf5-cta-in">
+        <h2 className="sf5-cta-h">Ready to<br />Feel Your Best?</h2>
+        <p className="sf5-cta-sub">Your journey to a healthier, more comfortable life starts here.</p>
+        <div className="sf5-hero-actions">
+          <a className="sf5-btn sf5-btn-primary sf5-btn-lg" href={ctas.bookUrl}>Book a Session <Icon.arrow /></a>
+          {ctas.callHref && data.phone && <a className="sf5-btn sf5-btn-on-dark sf5-btn-lg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// â”€â”€ Footer â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const cols: [string, string[], "text" | "link"][] = [];
+  const contact: string[] = [];
+  if (data.address) contact.push(data.address);
+  if (data.phone) contact.push(data.phone);
+  if (data.email) contact.push(data.email);
+  if (contact.length) cols.push(["Contact", contact, "text"]);
+  if (data.service_area && data.service_area.length) cols.push(["Service area", data.service_area, "text"]);
+  if (data.hours && data.hours.length)
+    cols.push(["Hours", data.hours.map((h) => (h.close ? `${h.day}: ${h.open} \u2013 ${h.close}` : `${h.day}: ${h.open}`)), "text"]);
+  cols.push(["Follow", ["Instagram", "Facebook"], "link"]);
+  return (
+    <footer className="sf5-foot">
+      <div className="sf5-wrap sf5-foot-in">
+        <div className="sf5-foot-brand">
+          <span className="sf5-brand sf5-brand--foot"><Icon.mark className="sf5-brand-mark" />{data.business_name}</span>
+          {data.tagline && <p className="sf5-foot-tag">{data.tagline}</p>}
+          <a className="sf5-btn sf5-btn-primary" href={ctas.bookUrl}>Book a Session</a>
+        </div>
+        <div className="sf5-foot-cols">
+          {cols.map(([h, items, kind]) => (
+            <div className="sf5-foot-col" key={h}>
+              <h3>{h}</h3>
+              <ul>{items.map((x, i) => (<li key={i}>{kind === "link" ? <a href={ctas.bookUrl}>{x}</a> : x}</li>))}</ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="sf5-wrap sf5-foot-legal">
+        <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name + ". All rights reserved."}</span>
+        <span>Privacy Â· Accessibility Â· Terms</span>
+      </div>
+    </footer>
+  );
+}
+
+// â”€â”€ Sticky mobile action bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <div className="sf5-mbar" aria-label="Quick actions">
+      {ctas.callHref && data.phone && <a className="sf5-mbar-call" href={ctas.callHref}><Icon.phone /> Call</a>}
+      <a className="sf5-mbar-book" href={ctas.bookUrl}>Book a Session</a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/sections.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/sections.tsx
@@ -3,11 +3,11 @@ import { Icon } from "./icons";
 import { SmartImage } from "./ui";
 import { sfDur, sfMoney, sfPhoto } from "./theme";
 
-// â”€â”€ Hero (split / asymmetric â€” never centered) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Hero (split / asymmetric — never centered) ─────────────────────────────
 export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
   const hero = sfPhoto(data, "hero");
   const eyebrow = data.service_area && data.service_area.length
-    ? "Now welcoming patients Â· " + data.service_area[0]
+    ? "Now welcoming patients · " + data.service_area[0]
     : data.certifications && data.certifications[0];
   return (
     <section className="sf5-hero">
@@ -29,7 +29,7 @@ export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
           <ul className="sf5-hero-chips">
             {data.review_rating != null && (
               <li><span className="sf5-stars"><Icon.star /></span><b>{data.review_rating.toFixed(1)}</b>
-                {data.review_count != null && <span className="sf5-muted">Â· {data.review_count} reviews</span>}</li>
+                {data.review_count != null && <span className="sf5-muted">· {data.review_count} reviews</span>}</li>
             )}
             {data.certifications && data.certifications[0] && (
               <li><Icon.check className="sf5-chip-ic" /><span>{data.certifications[0]}</span></li>
@@ -42,11 +42,11 @@ export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
   );
 }
 
-// â”€â”€ Trust strip â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Trust strip ────────────────────────────────────────────────────────────
 export function TrustStrip({ data }: { data: Soul }) {
   const items: { lead: string | null; sub: string }[] = [];
   if (data.review_rating != null)
-    items.push({ lead: data.review_rating.toFixed(1) + "â˜…", sub: data.review_count ? data.review_count + " patient reviews" : "Patient rating" });
+    items.push({ lead: data.review_rating.toFixed(1) + "★", sub: data.review_count ? data.review_count + " patient reviews" : "Patient rating" });
   (data.trust_signals || []).forEach((s) => items.push({ lead: null, sub: s }));
   if (!items.length) return null;
   return (
@@ -63,7 +63,7 @@ export function TrustStrip({ data }: { data: Soul }) {
   );
 }
 
-// â”€â”€ Services (varied card sizes â€” first card spans full width) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Services (varied card sizes — first card spans full width) ─────────────
 export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
   const list = data.offerings || [];
   if (!list.length) return null;
@@ -113,7 +113,7 @@ export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
   );
 }
 
-// â”€â”€ About (color panel + portrait) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── About (color panel + portrait) ─────────────────────────────────────────
 export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
   if (!data.soul_description && !(data.certifications || []).length) return null;
   const portrait = sfPhoto(data, "about");
@@ -140,7 +140,7 @@ export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
   );
 }
 
-// â”€â”€ Stats (optional proof) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Stats (optional proof) ─────────────────────────────────────────────────
 export function Stats({ data }: { data: Soul }) {
   const stats: [string, string][] = [];
   if (data.review_count != null) stats.push([data.review_count.toLocaleString() + "+", "Patients cared for"]);
@@ -158,7 +158,7 @@ export function Stats({ data }: { data: Soul }) {
   );
 }
 
-// â”€â”€ Testimonials â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Testimonials ───────────────────────────────────────────────────────────
 export function Testimonials({ data }: { data: Soul }) {
   const t = data.testimonials || [];
   if (!t.length) return null;
@@ -180,7 +180,7 @@ export function Testimonials({ data }: { data: Soul }) {
   );
 }
 
-// â”€â”€ CTA band (over warm texture) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── CTA band (over warm texture) ───────────────────────────────────────────
 export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
   return (
     <section className="sf5-cta" id="contact">
@@ -198,7 +198,7 @@ export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
   );
 }
 
-// â”€â”€ Footer â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Footer ─────────────────────────────────────────────────────────────────
 export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
   const cols: [string, string[], "text" | "link"][] = [];
   const contact: string[] = [];
@@ -229,13 +229,13 @@ export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
       </div>
       <div className="sf5-wrap sf5-foot-legal">
         <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name + ". All rights reserved."}</span>
-        <span>Privacy Â· Accessibility Â· Terms</span>
+        <span>Privacy · Accessibility · Terms</span>
       </div>
     </footer>
   );
 }
 
-// â”€â”€ Sticky mobile action bar â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+// ── Sticky mobile action bar ───────────────────────────────────────────────
 export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
   return (
     <div className="sf5-mbar" aria-label="Quick actions">

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/theme.ts
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/theme.ts
@@ -1,0 +1,51 @@
+import type { CSSProperties } from "react";
+import type { SfTheme, Soul } from "../_contract/types";
+
+// Tasteful default palette + font pairing for "Earthy Modern Clinical".
+// Swapping these (or the injected theme) re-skins the entire template.
+export const SF5_DEFAULT_THEME: Required<SfTheme> = {
+  primary: "#b0552f", // clay / terracotta
+  secondary: "#2a1d15", // deep warm cocoa near-black
+  bg: "#ece5d8", // warm oat
+  text: "#2a1d15", // body ink
+  border: "#d6ccba", // warm hairline
+  fontHeadline: "'Outfit', system-ui, sans-serif",
+  fontBody: "'Hanken Grotesk', system-ui, sans-serif",
+};
+
+// Resolve the theme into CSS custom properties applied on the root wrapper.
+// Tints/shades are derived downstream with color-mix(in oklab, â€¦) â€” never hardcoded.
+export function sfThemeVars(theme?: SfTheme): CSSProperties {
+  const t = { ...SF5_DEFAULT_THEME, ...(theme || {}) };
+  return {
+    ["--sf-primary" as string]: t.primary,
+    ["--sf-secondary" as string]: t.secondary,
+    ["--sf-bg" as string]: t.bg,
+    ["--sf-text" as string]: t.text,
+    ["--sf-border" as string]: t.border,
+    ["--sf-font-headline" as string]: t.fontHeadline,
+    ["--sf-font-body" as string]: t.fontBody,
+  } as CSSProperties;
+}
+
+// â”€â”€ data formatting helpers â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+export function sfMoney(price?: number, currency?: string): string | null {
+  if (price == null) return null;
+  const sym: Record<string, string> = { USD: "$", EUR: "â‚¬", GBP: "Â£" };
+  return (sym[currency || "USD"] || "$") + price;
+}
+
+export function sfDur(min?: number): string | null {
+  if (!min) return null;
+  if (min < 60) return min + " min";
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  return m ? `${h} hr ${m} min` : `${h} hr`;
+}
+
+export type Photo = NonNullable<Soul["photos"]>[number];
+
+export function sfPhoto(data: Soul, role: Photo["role"], idx = 0): Photo | null {
+  const byRole = (data.photos || []).filter((p) => p && p.role === role);
+  return byRole[idx] || null;
+}

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/ui.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/ui.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { CSSProperties } from "react";
 import type { Photo } from "./theme";
 
-// Themed color-field placeholder â€” the real fallback whenever a photo is
+// Themed color-field placeholder — the real fallback whenever a photo is
 // missing OR fails to load. Driven entirely by --sf-* vars, so it always
 // looks intentional (never a broken <img>). Decorative backgrounds hide the tag.
 export function ThemedPlaceholder({

--- a/packages/crm/src/components/landing-templates/earthy-modern-clinical/ui.tsx
+++ b/packages/crm/src/components/landing-templates/earthy-modern-clinical/ui.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { Photo } from "./theme";
+
+// Themed color-field placeholder â€” the real fallback whenever a photo is
+// missing OR fails to load. Driven entirely by --sf-* vars, so it always
+// looks intentional (never a broken <img>). Decorative backgrounds hide the tag.
+export function ThemedPlaceholder({
+  role = "image",
+  label,
+  decorative = false,
+  className = "",
+  style,
+}: {
+  role?: string;
+  label?: string;
+  decorative?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div className={"sf5-ph " + className} data-role={role} style={style} role="img" aria-label={label || role + " placeholder"}>
+      {!decorative && <span className="sf5-ph-tag">{label || role}</span>}
+    </div>
+  );
+}
+
+// Real <img> with graceful fallback to the themed placeholder on error.
+export function SmartImage({
+  photo,
+  role,
+  label,
+  decorative,
+  className = "",
+  style,
+}: {
+  photo?: Photo | null;
+  role?: string;
+  label?: string;
+  decorative?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}) {
+  const [failed, setFailed] = useState(false);
+  if (!photo || !photo.url || failed) {
+    return <ThemedPlaceholder role={role} label={label} decorative={decorative} className={className} style={style} />;
+  }
+  return (
+    <img
+      className={"sf5-img " + className}
+      style={style}
+      src={photo.url}
+      alt={photo.alt || label || ""}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/EditorialBodywork.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/EditorialBodywork.tsx
@@ -5,17 +5,15 @@ import { Nav, Faq } from "./interactive";
 import { Hero, TrustStrip, Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar } from "./sections";
 
 /**
- * Template 5 — "Earthy Modern Clinical"
- * Entry component. Shared signature across all five templates:
- *   ({ data, ctas, theme }) => JSX
- *
- * - Server component (no "use client"); only Nav + Faq opt into the client.
- * - Theme is applied as --sf-* CSS variables on the root; nothing is hardcoded.
- * - Bottom-right is left clear for the platform's injected AI chat bubble.
+ * Template 4 — "Editorial Bodywork"
+ * Shared entry signature: ({ data, ctas, theme }) => JSX
+ * Server component; only Nav + Faq opt into the client. Theme via --sf-* vars.
+ * Split-screen hero with an italic-accent headline (back half of `tagline`).
+ * Bottom-right left clear for the platform's injected AI chat bubble.
  */
-export function EarthyModernClinical({ data, ctas, theme }: TemplateProps) {
+export function EditorialBodywork({ data, ctas, theme }: TemplateProps) {
   return (
-    <div className="sf5-root" style={sfThemeVars(theme)}>
+    <div className="sf4-root" style={sfThemeVars(theme)}>
       <Styles />
       <Nav data={data} ctas={ctas} />
       <main>

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/Styles.tsx
@@ -1,0 +1,6 @@
+import { SF4_CSS } from "./css";
+
+// Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).
+export function Styles() {
+  return <style jsx global>{SF4_CSS}</style>;
+}

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/Styles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SF4_CSS } from "./css";
 
 // Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/WHEN_TO_USE.md
@@ -1,0 +1,37 @@
+# Template 4 — Editorial Bodywork
+
+**When to use (for the archetype classifier):** warm, tactile, **touch-based**
+services where the booking is per-treatment and price/duration matter —
+**massage therapy, bodywork, sports & deep-tissue recovery, reflexology,
+craniosacral, facial/skin bars**. Reach for it when the soul has several priced
+`offerings` and the brand is grounded and sensory rather than clinical.
+
+**Emotional register:** warm, tactile, grounded, conversion-clear. Split-screen
+hero with an italic-accent headline ("Find *your* quiet"), warm-brown palette,
+serif with expressive italics (Spectral), numbered priced treatment rows each
+with their own Book button.
+
+## Files (identical package shape to all 5)
+`EditorialBodywork.tsx` (entry) · `types.ts` · `theme.ts` (+ `sfAccent`) ·
+`css.ts` · `Styles.tsx` · `icons.tsx` · `ui.tsx` (client) · `interactive.tsx`
+(`Nav`, `Faq`, client) · `sections.tsx` (`Hero, TrustStrip, Services, About,
+Stats, Testimonials, CtaBand, Footer, MobileBar`) · `fixture.ts`.
+
+```tsx
+import EditorialBodywork from "./EditorialBodywork";
+import { palmerBodywork, exampleCTAs } from "./fixture";
+export default () => <EditorialBodywork data={palmerBodywork} ctas={exampleCTAs} />;
+```
+
+## Shared invariants (byte-identical across all 5)
+Entry signature `({ data, ctas, theme })` · `types.ts` · the `--sf-*` variable
+names + `sfThemeVars()` output shape · `SmartImage → ThemedPlaceholder` fallback ·
+global `<style jsx>` · `"use client"` only on `Nav`/`Faq`/`SmartImage`.
+
+## Template-specific notes
+Split-screen hero takes **two `role: "hero"` photos** (left has the copy overlay,
+right is a detail). `sfAccent()` italicises the back half of the `tagline` for the
+editorial accent (works for any copy; degrades to plain for single words). Numbered
+treatment rows lead with price + duration + a per-row **Book** for a conversion-clear
+menu. Ships a dark "Espresso" palette in the preview. Container queries on
+`.sf4-root`. Bottom-right kept clear for the chat bubble.

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/css.ts
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/css.ts
@@ -1,0 +1,207 @@
+/* SF4 global stylesheet — single source of truth shared by <Styles/>.
+   Mobile-first; container queries on .sf4-root. Every value resolves from --sf-* vars. */
+export const SF4_CSS = `
+.sf4-root{
+  --sf-primary-d: color-mix(in oklab, var(--sf-primary) 80%, #000);
+  --sf-tint: color-mix(in oklab, var(--sf-primary) 10%, var(--sf-bg));
+  --sf-card: color-mix(in oklab, var(--sf-secondary) 5%, var(--sf-bg));
+  --sf-card-2: color-mix(in oklab, var(--sf-secondary) 9%, var(--sf-bg));
+  --sf-ink-60: color-mix(in oklab, var(--sf-text) 55%, var(--sf-bg));
+  --sf-line: color-mix(in oklab, var(--sf-text) 15%, var(--sf-bg));
+  --wrap: 1220px;
+  container: sf4 / inline-size;
+  background: var(--sf-bg); color: var(--sf-text);
+  font-family: var(--sf-font-body); font-size: 16px; line-height: 1.62;
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+}
+.sf4-root *{ box-sizing:border-box; }
+.sf4-root img{ display:block; max-width:100%; }
+.sf4-wrap{ width:100%; max-width:var(--wrap); margin-inline:auto; padding-inline:24px; }
+
+.sf4-h2{ font-family:var(--sf-font-headline); font-weight:500; letter-spacing:-.01em; line-height:1.08; font-size:clamp(30px,6cqw,50px); margin:0; }
+.sf4-h2 em{ font-style:italic; font-weight:500; }
+.sf4-eyebrow{ font-weight:700; text-transform:uppercase; letter-spacing:.18em; font-size:11px; color:var(--sf-primary); margin:0 0 16px; }
+.sf4-muted{ color:var(--sf-ink-60); }
+
+/* buttons */
+.sf4-btn{ display:inline-flex; align-items:center; gap:9px; font-family:var(--sf-font-body); font-weight:700;
+  font-size:13.5px; letter-spacing:.02em; line-height:1; padding:14px 24px; border-radius:6px; border:1.5px solid transparent;
+  cursor:pointer; text-decoration:none; white-space:nowrap; transition:background .22s, color .22s, border-color .22s, transform .16s; }
+.sf4-btn svg{ font-size:17px; }
+.sf4-btn:hover{ transform:translateY(-1px); }
+.sf4-btn:focus-visible{ outline:2px solid var(--sf-primary); outline-offset:3px; }
+.sf4-btn-primary{ background:var(--sf-primary); color:#fff; }
+.sf4-btn-primary:hover{ background:var(--sf-primary-d); }
+.sf4-btn-dark{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf4-btn-outline{ background:transparent; color:var(--sf-text); border-color:var(--sf-line); }
+.sf4-btn-outline:hover{ border-color:var(--sf-text); }
+.sf4-btn-onimg{ background:transparent; color:#fff; border-color:rgba(255,255,255,.55); }
+.sf4-btn-onimg:hover{ background:#fff; color:var(--sf-secondary); border-color:#fff; }
+.sf4-btn-onimg-solid{ background:#fff; color:var(--sf-secondary); }
+.sf4-btn-block{ width:100%; justify-content:center; }
+.sf4-btn-sm{ padding:11px 18px; font-size:12.5px; }
+
+/* nav */
+.sf4-nav{ position:sticky; top:0; z-index:40; background:color-mix(in oklab,var(--sf-bg) 88%,transparent); backdrop-filter:blur(12px); border-bottom:1px solid var(--sf-line); }
+.sf4-nav-in{ display:flex; align-items:center; justify-content:space-between; gap:16px; height:72px; }
+.sf4-brand{ display:inline-flex; align-items:center; gap:10px; min-width:0; flex-shrink:1; text-decoration:none; color:var(--sf-text); }
+.sf4-brand-mark{ flex:none; font-size:22px; color:var(--sf-primary); }
+.sf4-brand-name{ font-family:var(--sf-font-headline); font-weight:500; font-size:23px; letter-spacing:.01em; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sf4-nav-links{ display:none; gap:32px; }
+.sf4-nav-links a{ color:var(--sf-text); text-decoration:none; font-size:14px; font-weight:600; opacity:.82; }
+.sf4-nav-links a:hover{ opacity:1; color:var(--sf-primary); }
+.sf4-nav-cta{ display:flex; align-items:center; gap:14px; }
+.sf4-link-call{ display:none; align-items:center; gap:7px; white-space:nowrap; color:var(--sf-text); text-decoration:none; font-weight:700; font-size:13.5px; }
+.sf4-link-call:hover{ color:var(--sf-primary); }
+.sf4-nav .sf4-btn{ display:none; }
+.sf4-burger{ display:inline-grid; place-items:center; width:44px; height:44px; border-radius:8px; background:transparent; border:1.5px solid var(--sf-line); color:var(--sf-text); font-size:22px; cursor:pointer; }
+
+.sf4-sheet{ position:fixed; inset:0; z-index:60; background:var(--sf-bg); transform:translateY(-100%); transition:transform .32s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; visibility:hidden; }
+.sf4-sheet.is-open{ transform:translateY(0); visibility:visible; }
+.sf4-sheet-top{ display:flex; align-items:center; justify-content:space-between; height:72px; }
+.sf4-sheet-links{ display:flex; flex-direction:column; padding:16px 24px; }
+.sf4-sheet-links a{ font-family:var(--sf-font-headline); font-weight:500; font-size:30px; color:var(--sf-text); text-decoration:none; padding:13px 0; border-bottom:1px solid var(--sf-line); }
+.sf4-sheet-foot{ margin-top:auto; padding:24px; display:flex; flex-direction:column; gap:12px; }
+
+/* hero — split-screen */
+.sf4-hero{ display:grid; grid-template-columns:1fr; }
+.sf4-hero-left{ position:relative; min-height:440px; display:flex; }
+.sf4-hero-left .sf4-img,.sf4-hero-left .sf4-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf4-hero-scrim{ position:absolute; inset:0; background:linear-gradient(180deg, color-mix(in oklab,var(--sf-secondary) 50%,transparent), color-mix(in oklab,var(--sf-secondary) 72%,transparent)); }
+.sf4-hero-in{ position:relative; z-index:1; align-self:center; padding:56px 24px; width:100%; }
+.sf4-hero-eyebrow{ color:rgba(255,255,255,.82); font-weight:700; text-transform:uppercase; letter-spacing:.18em; font-size:11px; margin:0 0 20px; }
+.sf4-hero-h1{ font-family:var(--sf-font-headline); font-weight:500; color:#fff; line-height:1.04; font-size:clamp(44px,9cqw,82px); margin:0 0 22px; }
+.sf4-hero-h1 em{ font-style:italic; font-weight:500; }
+.sf4-hero-sub{ color:rgba(255,255,255,.88); font-size:clamp(15px,2.4cqw,18px); max-width:38ch; margin:0 0 30px; }
+.sf4-hero-actions{ display:flex; flex-wrap:wrap; gap:14px; }
+.sf4-hero-right{ position:relative; min-height:300px; }
+.sf4-hero-right .sf4-img,.sf4-hero-right .sf4-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+
+/* trust */
+.sf4-trust{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf4-trust-in{ display:flex; flex-wrap:wrap; justify-content:center; gap:14px 0; padding-block:20px; }
+.sf4-trust-item{ display:inline-flex; align-items:center; gap:10px; padding:0 26px; font-size:13px; font-weight:600; color:color-mix(in oklab,var(--sf-bg) 84%,var(--sf-secondary)); }
+.sf4-trust-item + .sf4-trust-item{ border-left:1px solid color-mix(in oklab,var(--sf-bg) 20%,var(--sf-secondary)); }
+.sf4-trust-item svg{ color:var(--sf-primary); font-size:15px; }
+.sf4-trust-item b{ font-family:var(--sf-font-headline); font-weight:500; font-size:17px; color:var(--sf-bg); }
+
+/* sections */
+.sf4-sec{ padding-block:84px; }
+.sf4-sec-head{ display:flex; flex-direction:column; gap:14px; max-width:54ch; margin-bottom:40px; }
+
+/* treatments — numbered rows, price+duration+book each */
+.sf4-treat{ border-top:1px solid var(--sf-line); }
+.sf4-row{ display:grid; grid-template-columns:1fr; gap:18px; align-items:center; padding:26px 0; border-bottom:1px solid var(--sf-line); }
+.sf4-row-lead{ display:flex; align-items:center; gap:20px; }
+.sf4-row-thumb{ position:relative; width:84px; height:84px; flex:none; border-radius:10px; overflow:hidden; }
+.sf4-row-thumb .sf4-img,.sf4-row-thumb .sf4-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf4-row-num{ font-family:var(--sf-font-headline); font-style:italic; font-size:18px; color:var(--sf-primary); flex:none; width:34px; }
+.sf4-row-info{ min-width:0; }
+.sf4-row-name{ font-family:var(--sf-font-headline); font-weight:500; font-size:24px; margin:0 0 4px; letter-spacing:-.01em; }
+.sf4-row-desc{ margin:0; color:var(--sf-ink-60); font-size:15px; }
+.sf4-row-end{ display:flex; align-items:center; justify-content:space-between; gap:18px; padding-left:54px; }
+.sf4-row-meta{ display:flex; flex-direction:column; gap:2px; }
+.sf4-row-price{ font-family:var(--sf-font-headline); font-weight:500; font-size:22px; }
+.sf4-row-dur{ display:inline-flex; align-items:center; gap:6px; white-space:nowrap; color:var(--sf-ink-60); font-size:13px; font-weight:600; }
+.sf4-row-dur svg{ color:var(--sf-primary); font-size:14px; }
+
+/* about — split editorial */
+.sf4-about{ display:grid; grid-template-columns:1fr; gap:34px; align-items:center; }
+.sf4-about-media{ position:relative; aspect-ratio:4/5; overflow:hidden; border-radius:12px; }
+.sf4-about-media .sf4-img,.sf4-about-media .sf4-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf4-about-text{ margin:0 0 20px; font-size:18px; color:var(--sf-text); max-width:48ch; line-height:1.72; }
+.sf4-about-text em{ font-family:var(--sf-font-headline); font-style:italic; font-size:1.05em; }
+.sf4-creds{ list-style:none; padding:20px 0 22px; margin:0; display:flex; flex-wrap:wrap; gap:10px; border-top:1px solid var(--sf-line); }
+.sf4-creds li{ display:inline-flex; align-items:center; gap:8px; background:var(--sf-tint); border-radius:999px; padding:9px 15px; font-weight:600; font-size:13px; }
+.sf4-creds svg{ color:var(--sf-primary); }
+
+/* stats */
+.sf4-stats{ background:var(--sf-card-2); }
+.sf4-stats-in{ display:flex; flex-wrap:wrap; gap:28px 56px; justify-content:center; padding-block:50px; }
+.sf4-stat{ text-align:center; }
+.sf4-stat-n{ display:block; font-family:var(--sf-font-headline); font-weight:500; font-size:clamp(36px,6cqw,52px); line-height:1; color:var(--sf-primary); }
+.sf4-stat-l{ display:block; margin-top:6px; font-size:13px; font-weight:600; color:var(--sf-ink-60); }
+
+/* testimonials */
+.sf4-rev-grid{ display:grid; grid-template-columns:1fr; gap:20px; }
+.sf4-rev{ background:var(--sf-card); border:1px solid var(--sf-line); border-radius:14px; padding:30px; margin:0; display:flex; flex-direction:column; gap:16px; }
+.sf4-rev-stars{ color:var(--sf-primary); font-size:14px; }
+.sf4-rev blockquote{ margin:0; font-family:var(--sf-font-headline); font-weight:500; font-size:20px; line-height:1.45; }
+.sf4-rev figcaption{ font-weight:700; font-size:14px; color:var(--sf-ink-60); }
+
+/* faq */
+.sf4-faq-in{ display:grid; grid-template-columns:1fr; gap:30px; }
+.sf4-faq-list{ border-top:1px solid var(--sf-line); }
+.sf4-faq-item{ border-bottom:1px solid var(--sf-line); }
+.sf4-faq-q{ width:100%; display:flex; align-items:center; justify-content:space-between; gap:18px; background:none; border:0; cursor:pointer; text-align:left; padding:24px 2px; font-family:var(--sf-font-headline); font-weight:500; font-size:20px; color:var(--sf-text); }
+.sf4-faq-chev{ flex:none; font-size:21px; color:var(--sf-primary); transition:transform .25s; }
+.sf4-faq-item.is-open .sf4-faq-chev{ transform:rotate(180deg); }
+.sf4-faq-a{ display:grid; grid-template-rows:0fr; transition:grid-template-rows .28s; }
+.sf4-faq-item.is-open .sf4-faq-a{ grid-template-rows:1fr; }
+.sf4-faq-a > p{ overflow:hidden; margin:0; color:var(--sf-ink-60); font-size:16px; max-width:60ch; padding-bottom:0; transition:padding-bottom .28s; }
+.sf4-faq-item.is-open .sf4-faq-a > p{ padding-bottom:24px; }
+
+/* cta */
+.sf4-cta{ position:relative; overflow:hidden; }
+.sf4-cta-media{ position:absolute; inset:0; }
+.sf4-cta-media .sf4-img,.sf4-cta-media .sf4-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf4-cta-scrim{ position:absolute; inset:0; background:linear-gradient(90deg,color-mix(in oklab,var(--sf-secondary) 84%,transparent),color-mix(in oklab,var(--sf-secondary) 56%,transparent)); }
+.sf4-cta-in{ position:relative; padding-block:104px; }
+.sf4-cta-h{ font-family:var(--sf-font-headline); font-weight:500; color:#fff; line-height:1.06; font-size:clamp(34px,7cqw,58px); margin:0 0 14px; max-width:18ch; }
+.sf4-cta-h em{ font-style:italic; }
+.sf4-cta-sub{ color:rgba(255,255,255,.86); font-size:18px; margin:0 0 28px; max-width:42ch; }
+
+/* footer */
+.sf4-foot{ background:var(--sf-secondary); color:var(--sf-bg); padding-top:66px; }
+.sf4-foot-in{ display:grid; grid-template-columns:1fr; gap:40px; padding-bottom:48px; }
+.sf4-foot-brand .sf4-brand-name{ color:var(--sf-bg); }
+.sf4-foot-brand .sf4-brand-mark{ color:var(--sf-primary); }
+.sf4-foot-tag{ color:color-mix(in oklab,var(--sf-bg) 66%,var(--sf-secondary)); margin:16px 0 22px; max-width:34ch; }
+.sf4-foot-cols{ display:grid; grid-template-columns:1fr 1fr; gap:32px 24px; }
+.sf4-foot-col h3{ font-size:11px; letter-spacing:.16em; text-transform:uppercase; color:var(--sf-primary); margin:0 0 14px; }
+.sf4-foot-col ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; }
+.sf4-foot-col li,.sf4-foot-col a{ color:color-mix(in oklab,var(--sf-bg) 78%,var(--sf-secondary)); font-size:14px; text-decoration:none; }
+.sf4-foot-col a:hover{ color:#fff; }
+.sf4-foot-legal{ display:flex; flex-wrap:wrap; gap:8px 20px; justify-content:space-between; border-top:1px solid color-mix(in oklab,var(--sf-bg) 16%,var(--sf-secondary)); padding-block:22px; font-size:12.5px; color:color-mix(in oklab,var(--sf-bg) 56%,var(--sf-secondary)); }
+
+/* mobile bar */
+.sf4-mbar{ position:sticky; bottom:0; z-index:50; display:flex; gap:10px; padding:12px 16px calc(12px + env(safe-area-inset-bottom)); background:color-mix(in oklab,var(--sf-bg) 93%,transparent); backdrop-filter:blur(10px); border-top:1px solid var(--sf-line); }
+.sf4-mbar-call{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:14px 20px; border-radius:8px; border:1.5px solid var(--sf-line); color:var(--sf-text); text-decoration:none; font-weight:700; }
+.sf4-mbar-book{ flex:1; display:inline-flex; align-items:center; justify-content:center; padding:14px 20px; border-radius:8px; background:var(--sf-primary); color:#fff; text-decoration:none; font-weight:700; }
+
+/* placeholder + image */
+.sf4-img{ width:100%; height:100%; object-fit:cover; }
+.sf4-ph{ position:relative; width:100%; height:100%; min-height:120px; overflow:hidden;
+  background: repeating-linear-gradient(135deg, color-mix(in oklab,var(--sf-primary) 14%,var(--sf-card)) 0 14px, color-mix(in oklab,var(--sf-primary) 6%,var(--sf-card)) 14px 28px), var(--sf-card-2);
+  display:grid; place-items:center; }
+.sf4-ph::after{ content:""; position:absolute; inset:0; background:radial-gradient(120% 90% at 30% 20%, transparent 42%, color-mix(in oklab,var(--sf-secondary) 14%,transparent)); }
+.sf4-ph-tag{ position:relative; z-index:1; font-family:ui-monospace,Menlo,monospace; font-size:10px; letter-spacing:.08em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-secondary) 64%,var(--sf-bg)); background:color-mix(in oklab,var(--sf-bg) 84%,transparent); padding:5px 10px; border-radius:4px; border:1px solid var(--sf-line); text-align:center; }
+
+@media (prefers-reduced-motion: reduce){ .sf4-root *{ transition:none !important; } }
+
+/* container queries */
+@container sf4 (min-width:760px){
+  .sf4-wrap{ padding-inline:40px; }
+  .sf4-nav-links{ display:flex; }
+  .sf4-link-call{ display:inline-flex; }
+  .sf4-nav .sf4-btn{ display:inline-flex; }
+  .sf4-burger{ display:none; }
+  .sf4-mbar{ display:none; }
+  .sf4-hero{ grid-template-columns:1.1fr .9fr; }
+  .sf4-hero-left{ min-height:78cqh; }
+  .sf4-hero-in{ padding:80px max(40px,calc((100cqw - var(--wrap))/2 + 40px)) 80px; }
+  .sf4-hero-right{ min-height:auto; }
+  .sf4-row{ grid-template-columns:1.5fr 1fr; gap:30px; }
+  .sf4-row-end{ justify-content:flex-end; padding-left:0; }
+  .sf4-about{ grid-template-columns:.85fr 1.15fr; gap:56px; }
+  .sf4-about-media{ aspect-ratio:4/5; }
+  .sf4-rev-grid{ grid-template-columns:repeat(2,1fr); gap:24px; }
+  .sf4-faq-in{ grid-template-columns:.8fr 1.2fr; gap:52px; }
+  .sf4-foot-in{ grid-template-columns:1.2fr 2fr; gap:60px; }
+  .sf4-foot-cols{ grid-template-columns:repeat(4,1fr); }
+  .sf4-cta-in{ padding-block:130px; }
+}
+@container sf4 (min-width:1040px){
+  .sf4-rev-grid{ grid-template-columns:repeat(2,1fr); }
+}
+`;

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/fixture.ts
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/fixture.ts
@@ -1,0 +1,55 @@
+import type { CTAs, Soul } from "../_contract/types";
+
+// Realistic massage / bodywork fixture. The 4th treatment thumbnail and the
+// About portrait are intentionally omitted to exercise the themed placeholder
+// fallback. The hero is split-screen (two `role: "hero"` photos).
+export const palmerBodywork: Soul = {
+  business_name: "Palmer Bodywork",
+  tagline: "Find your quiet",
+  soul_description:
+    "Therapeutic bodywork tailored to you. Every session is built around what your body needs — relief, recovery, and longevity, in unhurried hands.",
+  phone: "(512) 555-0455",
+  email: "book@palmerbodywork.com",
+  address: "2407 Manor Rd, Austin, TX 78722",
+  service_area: ["Austin", "East Austin", "Mueller", "Cherrywood"],
+  hours: [
+    { day: "Mon–Fri", open: "10am", close: "8pm" },
+    { day: "Sat", open: "10am", close: "5pm" },
+    { day: "Sun", open: "Closed", close: "" },
+  ],
+  review_rating: 4.9,
+  review_count: 412,
+  trust_signals: ["Licensed Massage Therapists", "Gift certificates available", "FSA/HSA receipts provided"],
+  certifications: ["Licensed Massage Therapist", "Certified in Myofascial Release"],
+  offerings: [
+    { name: "Swedish Relaxation", description: "Flowing strokes to ease tension and quiet the mind.", price: 95, currency: "USD", duration_minutes: 60 },
+    { name: "Deep Tissue", description: "Targeted pressure to release chronic, stubborn knots.", price: 135, currency: "USD", duration_minutes: 90 },
+    { name: "Hot Stone Therapy", description: "Heated basalt stones for deep, grounding warmth.", price: 145, currency: "USD", duration_minutes: 90 },
+    { name: "Prenatal Massage", description: "Safe, supportive care for every trimester.", price: 110, currency: "USD", duration_minutes: 60 },
+  ],
+  faqs: [
+    { q: "How do I choose the right massage?", a: "Book an initial session and your therapist will assess and recommend the best approach — most clients get a tailored blend." },
+    { q: "Do you offer gift certificates?", a: "Yes — available online or in-studio, a perfect gift for any occasion." },
+    { q: "Can I use my FSA/HSA?", a: "Often, yes. We provide detailed receipts you can submit for reimbursement." },
+    { q: "What should I expect on my first visit?", a: "A short intake about your goals and any tension areas, then an unhurried, fully tailored session." },
+  ],
+  testimonials: [
+    { name: "Rebecca O.", text: "The best massage I've had in Austin — they knew exactly which knots needed attention." },
+    { name: "Chris A.", text: "Monthly sports massage has become a non-negotiable part of my marathon training." },
+  ],
+  photos: [
+    { url: "https://images.unsplash.com/photo-1519823551278-64ac92734fb1?auto=format&fit=crop&w=1300&q=72", role: "hero", alt: "Therapeutic bodywork" },
+    { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=1100&q=72", role: "hero", alt: "Aromatherapy detail" },
+    { url: "https://images.unsplash.com/photo-1544161515-4ab6ce6db874?auto=format&fit=crop&w=400&q=72", role: "service", alt: "Swedish relaxation" },
+    { url: "https://images.unsplash.com/photo-1600334129128-685c5582fd35?auto=format&fit=crop&w=400&q=72", role: "service", alt: "Deep tissue" },
+    { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=400&q=72", role: "service", alt: "Hot stone therapy" },
+    { url: "https://images.unsplash.com/photo-1556760544-74068565f05c?auto=format&fit=crop&w=1400&q=72", role: "gallery", alt: "Studio detail" },
+    // service[3] (Prenatal) & role:"about" omitted → themed placeholder fallback
+  ],
+};
+
+export const exampleCTAs: CTAs = {
+  bookUrl: "/book",
+  callHref: "tel:+15125550455",
+  intakeUrl: "/intake",
+};

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/icons.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/icons.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from "react";
 
-// Inline SVG only — no external icon libraries (SeldonFrame house rule).
+// Inline SVG only — no external icon libraries.
 type P = SVGProps<SVGSVGElement>;
 const base = (p: P) => ({ width: "1em" as const, height: "1em" as const, viewBox: "0 0 24 24", "aria-hidden": true, ...p });
 
@@ -13,5 +13,5 @@ export const Icon = {
   close: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M6 6l12 12M18 6L6 18" /></svg>),
   check: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>),
   clock: (p: P) => (<svg {...base(p)}><circle cx={12} cy={12} r={9} fill="none" stroke="currentColor" strokeWidth={2} /><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M12 7v5l3 2" /></svg>),
-  mark: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M3 12c5 0 9-4 9-9 0 5 4 9 9 9-5 0-9 4-9 9 0-5-4-9-9-9z" /></svg>),
+  mark: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={1.6} d="M4 12c4-1 7-4 8-8 1 4 4 7 8 8-4 1-7 4-8 8-1-4-4-7-8-8z" /></svg>),
 };

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/interactive.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+
+// ── Sticky nav with mobile sheet ───────────────────────────────────────────
+export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [open, setOpen] = useState(false);
+  const links: [string, string][] = [
+    ["About", "#about"],
+    ["Treatments", "#services"],
+    ["Reviews", "#reviews"],
+    ["Contact", "#contact"],
+  ];
+  return (
+    <header className="sf4-nav" id="top">
+      <div className="sf4-wrap sf4-nav-in">
+        <a className="sf4-brand" href="#top" aria-label={data.business_name}>
+          <Icon.mark className="sf4-brand-mark" /><span className="sf4-brand-name">{data.business_name}</span>
+        </a>
+        <nav className="sf4-nav-links" aria-label="Primary">{links.map(([l, h]) => (<a key={l} href={h}>{l}</a>))}</nav>
+        <div className="sf4-nav-cta">
+          {ctas.callHref && data.phone && <a className="sf4-link-call" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+          <a className="sf4-btn sf4-btn-primary" href={ctas.bookUrl}>Book a Session</a>
+          <button className="sf4-burger" aria-label="Menu" aria-expanded={open} onClick={() => setOpen(true)}><Icon.menu /></button>
+        </div>
+      </div>
+      <div className={"sf4-sheet" + (open ? " is-open" : "")} role="dialog" aria-modal="true" aria-hidden={!open}>
+        <div className="sf4-sheet-top sf4-wrap">
+          <span className="sf4-brand"><Icon.mark className="sf4-brand-mark" /><span className="sf4-brand-name">{data.business_name}</span></span>
+          <button className="sf4-burger" aria-label="Close menu" onClick={() => setOpen(false)}><Icon.close /></button>
+        </div>
+        <nav className="sf4-sheet-links" aria-label="Mobile">{links.map(([l, h]) => (<a key={l} href={h} onClick={() => setOpen(false)}>{l}</a>))}</nav>
+        <div className="sf4-sheet-foot">
+          <a className="sf4-btn sf4-btn-primary sf4-btn-block" href={ctas.bookUrl} onClick={() => setOpen(false)}>Book a Session</a>
+          {ctas.callHref && data.phone && <a className="sf4-btn sf4-btn-outline sf4-btn-block" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ── FAQ accordion ──────────────────────────────────────────────────────────
+export function Faq({ data }: { data: Soul }) {
+  const faqs = data.faqs || [];
+  const [open, setOpen] = useState(0);
+  if (!faqs.length) return null;
+  return (
+    <section className="sf4-sec sf4-wrap" id="faq">
+      <div className="sf4-faq-in">
+        <div><p className="sf4-eyebrow">Good to know</p><h2 className="sf4-h2">Before you <em>book</em></h2></div>
+        <div className="sf4-faq-list">
+          {faqs.map((f, i) => {
+            const isOpen = open === i;
+            return (
+              <div className={"sf4-faq-item" + (isOpen ? " is-open" : "")} key={i}>
+                <button className="sf4-faq-q" aria-expanded={isOpen} onClick={() => setOpen(isOpen ? -1 : i)}>
+                  <span>{f.q}</span><Icon.chevron className="sf4-faq-chev" />
+                </button>
+                <div className="sf4-faq-a" role="region"><p>{f.a}</p></div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/sections.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/sections.tsx
@@ -1,0 +1,199 @@
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { SmartImage } from "./ui";
+import { sfDur, sfMoney, sfPhoto, sfAccent } from "./theme";
+
+// ── Hero (split-screen, italic-accent headline — never centered) ───────────
+export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [a, b] = sfAccent(data.tagline || data.business_name);
+  const eyebrow = data.service_area && data.service_area.length ? data.service_area[0] : data.certifications && data.certifications[0];
+  return (
+    <section className="sf4-hero">
+      <div className="sf4-hero-left">
+        <SmartImage photo={sfPhoto(data, "hero", 0)} role="bodywork image" label="bodywork image" />
+        <div className="sf4-hero-scrim" aria-hidden="true" />
+        <div className="sf4-hero-in">
+          {eyebrow && <p className="sf4-hero-eyebrow">{eyebrow}</p>}
+          <h1 className="sf4-hero-h1">{a}{b && <em>{b}</em>}</h1>
+          {data.soul_description && <p className="sf4-hero-sub">{data.soul_description}</p>}
+          <div className="sf4-hero-actions">
+            <a className="sf4-btn sf4-btn-onimg-solid" href={ctas.bookUrl}>Book a Session <Icon.arrow /></a>
+            <a className="sf4-btn sf4-btn-onimg" href="#services">View Treatments</a>
+          </div>
+        </div>
+      </div>
+      <div className="sf4-hero-right"><SmartImage photo={sfPhoto(data, "hero", 1)} role="detail image" label="detail image" /></div>
+    </section>
+  );
+}
+
+// ── Trust strip ────────────────────────────────────────────────────────────
+export function TrustStrip({ data }: { data: Soul }) {
+  const items: { b: string | null; sub: string }[] = [];
+  if (data.review_rating != null) items.push({ b: data.review_rating.toFixed(1) + "★", sub: data.review_count ? data.review_count + " reviews" : "rated" });
+  (data.trust_signals || []).forEach((s) => items.push({ b: null, sub: s }));
+  if (!items.length) return null;
+  return (
+    <section className="sf4-trust" aria-label="Credentials">
+      <div className="sf4-wrap sf4-trust-in">
+        {items.map((it, i) => (
+          <div className="sf4-trust-item" key={i}>{it.b ? <b>{it.b}</b> : <Icon.check />}{it.sub}</div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Services (numbered priced rows, per-row Book — conversion-clear) ────────
+export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const list = data.offerings || [];
+  if (!list.length) return null;
+  return (
+    <section className="sf4-sec sf4-wrap" id="services">
+      <div className="sf4-sec-head"><p className="sf4-eyebrow">Treatments</p><h2 className="sf4-h2">Bodywork, <em>tailored</em> to you</h2></div>
+      <div className="sf4-treat">
+        {list.map((o, i) => (
+          <article className="sf4-row" key={o.name}>
+            <div className="sf4-row-lead">
+              <span className="sf4-row-num">{String(i + 1).padStart(2, "0")}</span>
+              <div className="sf4-row-thumb"><SmartImage photo={sfPhoto(data, "service", i)} role="treatment" label={o.name} /></div>
+              <div className="sf4-row-info">
+                <h3 className="sf4-row-name">{o.name}</h3>
+                {o.description && <p className="sf4-row-desc">{o.description}</p>}
+              </div>
+            </div>
+            <div className="sf4-row-end">
+              <div className="sf4-row-meta">
+                {sfMoney(o.price, o.currency) && <span className="sf4-row-price">{sfMoney(o.price, o.currency)}</span>}
+                {sfDur(o.duration_minutes) && <span className="sf4-row-dur"><Icon.clock /> {sfDur(o.duration_minutes)}</span>}
+              </div>
+              <a className="sf4-btn sf4-btn-outline sf4-btn-sm" href={ctas.bookUrl}>Book</a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── About (split editorial) ────────────────────────────────────────────────
+export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  if (!data.soul_description && !(data.certifications || []).length) return null;
+  return (
+    <section className="sf4-sec sf4-wrap" id="about">
+      <div className="sf4-about">
+        <div className="sf4-about-media"><SmartImage photo={sfPhoto(data, "about")} role="therapist portrait" label="therapist portrait" /></div>
+        <div>
+          <p className="sf4-eyebrow">The Practice</p>
+          <h2 className="sf4-h2" style={{ marginBottom: 22 }}>Hands that <em>listen</em></h2>
+          {data.soul_description && <p className="sf4-about-text">{data.soul_description}</p>}
+          {(data.certifications || []).length > 0 && (
+            <ul className="sf4-creds">{data.certifications!.map((c) => (<li key={c}><Icon.check /> {c}</li>))}</ul>
+          )}
+          <a className="sf4-btn sf4-btn-dark" href={ctas.intakeUrl || ctas.bookUrl}>About the studio <Icon.arrow /></a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+export function Stats({ data }: { data: Soul }) {
+  const s: [string, string][] = [];
+  if (data.review_count != null) s.push([data.review_count.toLocaleString() + "+", "Sessions given"]);
+  if (data.review_rating != null) s.push([data.review_rating.toFixed(1), "Average rating"]);
+  if (data.offerings && data.offerings.length) s.push([String(data.offerings.length), "Modalities"]);
+  if (s.length < 2) return null;
+  return (
+    <section className="sf4-stats" aria-label="By the numbers">
+      <div className="sf4-wrap sf4-stats-in">
+        {s.map(([n, l], i) => (<div className="sf4-stat" key={i}><span className="sf4-stat-n">{n}</span><span className="sf4-stat-l">{l}</span></div>))}
+      </div>
+    </section>
+  );
+}
+
+// ── Testimonials ───────────────────────────────────────────────────────────
+export function Testimonials({ data }: { data: Soul }) {
+  const t = data.testimonials || [];
+  if (!t.length) return null;
+  return (
+    <section className="sf4-sec sf4-wrap" id="reviews">
+      <div className="sf4-sec-head"><p className="sf4-eyebrow">Reviews</p><h2 className="sf4-h2">Felt, not just <em>heard</em></h2></div>
+      <div className="sf4-rev-grid">
+        {t.slice(0, 4).map((r, i) => (
+          <figure className="sf4-rev" key={i}>
+            <span className="sf4-rev-stars"><Icon.star /><Icon.star /><Icon.star /><Icon.star /><Icon.star /></span>
+            <blockquote>{"\u201C" + r.text + "\u201D"}</blockquote>
+            <figcaption>{"\u2014 " + r.name}</figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── CTA band ───────────────────────────────────────────────────────────────
+export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <section className="sf4-cta" id="contact">
+      <div className="sf4-cta-media"><SmartImage photo={sfPhoto(data, "gallery")} role="texture" label="texture" decorative /></div>
+      <div className="sf4-cta-scrim" aria-hidden="true" />
+      <div className="sf4-wrap sf4-cta-in">
+        <h2 className="sf4-cta-h">Find <em>your</em> quiet</h2>
+        <p className="sf4-cta-sub">Relief, recovery, and longevity — book a session that's built around your body.</p>
+        <div className="sf4-hero-actions">
+          <a className="sf4-btn sf4-btn-onimg-solid" href={ctas.bookUrl}>Book a Session <Icon.arrow /></a>
+          {ctas.callHref && data.phone && <a className="sf4-btn sf4-btn-onimg" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Footer ─────────────────────────────────────────────────────────────────
+export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const cols: [string, string[], "text" | "link"][] = [];
+  const contact: string[] = [];
+  if (data.address) contact.push(data.address);
+  if (data.phone) contact.push(data.phone);
+  if (data.email) contact.push(data.email);
+  if (contact.length) cols.push(["Contact", contact, "text"]);
+  if (data.service_area && data.service_area.length) cols.push(["Service Area", data.service_area, "text"]);
+  if (data.hours && data.hours.length)
+    cols.push(["Hours", data.hours.map((h) => (h.close ? `${h.day}: ${h.open} \u2013 ${h.close}` : `${h.day}: ${h.open}`)), "text"]);
+  cols.push(["Follow", ["Instagram", "Facebook"], "link"]);
+  return (
+    <footer className="sf4-foot">
+      <div className="sf4-wrap sf4-foot-in">
+        <div className="sf4-foot-brand">
+          <span className="sf4-brand"><Icon.mark className="sf4-brand-mark" /><span className="sf4-brand-name">{data.business_name}</span></span>
+          {data.tagline && <p className="sf4-foot-tag">{data.tagline}</p>}
+          <a className="sf4-btn sf4-btn-primary" href={ctas.bookUrl}>Book a Session</a>
+        </div>
+        <div className="sf4-foot-cols">
+          {cols.map(([h, items, kind]) => (
+            <div className="sf4-foot-col" key={h}>
+              <h3>{h}</h3>
+              <ul>{items.map((x, i) => (<li key={i}>{kind === "link" ? <a href={ctas.bookUrl}>{x}</a> : x}</li>))}</ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="sf4-wrap sf4-foot-legal">
+        <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name}</span>
+        <span>Privacy · Accessibility · Terms</span>
+      </div>
+    </footer>
+  );
+}
+
+// ── Sticky mobile bar ──────────────────────────────────────────────────────
+export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <div className="sf4-mbar" aria-label="Quick actions">
+      {ctas.callHref && data.phone && <a className="sf4-mbar-call" href={ctas.callHref}><Icon.phone /> Call</a>}
+      <a className="sf4-mbar-book" href={ctas.bookUrl}>Book a Session</a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/theme.ts
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/theme.ts
@@ -1,22 +1,19 @@
 import type { CSSProperties } from "react";
 import type { SfTheme, Soul } from "../_contract/types";
 
-// Tasteful default palette + font pairing for "Earthy Modern Clinical".
-// Swapping these (or the injected theme) re-skins the entire template.
-export const SF5_DEFAULT_THEME: Required<SfTheme> = {
-  primary: "#b0552f", // clay / terracotta
-  secondary: "#2a1d15", // deep warm cocoa near-black
-  bg: "#ece5d8", // warm oat
-  text: "#2a1d15", // body ink
-  border: "#d6ccba", // warm hairline
-  fontHeadline: "'Outfit', system-ui, sans-serif",
+// Tasteful default palette + font pairing for "Editorial Bodywork".
+export const SF4_DEFAULT_THEME: Required<SfTheme> = {
+  primary: "#7c5440", // warm brown
+  secondary: "#241813", // deep espresso
+  bg: "#ece3d6", // warm cream
+  text: "#2a1d14",
+  border: "#ddd0bf",
+  fontHeadline: "'Spectral', Georgia, serif",
   fontBody: "'Hanken Grotesk', system-ui, sans-serif",
 };
 
-// Resolve the theme into CSS custom properties applied on the root wrapper.
-// Tints/shades are derived downstream with color-mix(in oklab, …) — never hardcoded.
 export function sfThemeVars(theme?: SfTheme): CSSProperties {
-  const t = { ...SF5_DEFAULT_THEME, ...(theme || {}) };
+  const t = { ...SF4_DEFAULT_THEME, ...(theme || {}) };
   return {
     ["--sf-primary" as string]: t.primary,
     ["--sf-secondary" as string]: t.secondary,
@@ -28,24 +25,25 @@ export function sfThemeVars(theme?: SfTheme): CSSProperties {
   } as CSSProperties;
 }
 
-// ── data formatting helpers ────────────────────────────────────────────────
 export function sfMoney(price?: number, currency?: string): string | null {
   if (price == null) return null;
   const sym: Record<string, string> = { USD: "$", EUR: "€", GBP: "£" };
   return (sym[currency || "USD"] || "$") + price;
 }
-
 export function sfDur(min?: number): string | null {
   if (!min) return null;
   if (min < 60) return min + " min";
-  const h = Math.floor(min / 60);
-  const m = min % 60;
+  const h = Math.floor(min / 60), m = min % 60;
   return m ? `${h} hr ${m} min` : `${h} hr`;
 }
-
 export type Photo = NonNullable<Soul["photos"]>[number];
-
 export function sfPhoto(data: Soul, role: Photo["role"], idx = 0): Photo | null {
-  const byRole = (data.photos || []).filter((p) => p && p.role === role);
-  return byRole[idx] || null;
+  return (data.photos || []).filter((p) => p && p.role === role)[idx] || null;
+}
+// Editorial italic accent: split a phrase, italicising the back half.
+export function sfAccent(text?: string): [string, string | null] {
+  const w = (text || "").trim().split(/\s+/);
+  if (w.length < 2) return [text || "", null];
+  const mid = Math.ceil(w.length / 2);
+  return [w.slice(0, mid).join(" ") + " ", w.slice(mid).join(" ")];
 }

--- a/packages/crm/src/components/landing-templates/editorial-bodywork/ui.tsx
+++ b/packages/crm/src/components/landing-templates/editorial-bodywork/ui.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { Photo } from "./theme";
+
+export function ThemedPlaceholder({
+  role = "image", label, decorative = false, className = "", style,
+}: { role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  return (
+    <div className={"sf4-ph " + className} data-role={role} style={style} role="img" aria-label={label || role + " placeholder"}>
+      {!decorative && <span className="sf4-ph-tag">{label || role}</span>}
+    </div>
+  );
+}
+
+export function SmartImage({
+  photo, role, label, decorative, className = "", style,
+}: { photo?: Photo | null; role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  const [failed, setFailed] = useState(false);
+  if (!photo || !photo.url || failed) {
+    return <ThemedPlaceholder role={role} label={label} decorative={decorative} className={className} style={style} />;
+  }
+  return (
+    <img className={"sf4-img " + className} style={style} src={photo.url} alt={photo.alt || label || ""} loading="lazy" decoding="async" onError={() => setFailed(true)} />
+  );
+}

--- a/packages/crm/src/components/landing-templates/registry.ts
+++ b/packages/crm/src/components/landing-templates/registry.ts
@@ -1,0 +1,45 @@
+// landing-templates/registry.ts
+//
+// Registry of premium Claude Design full-page health/wellness landing
+// templates. Each template is a self-contained package under
+// `landing-templates/<id>/` exporting a component with the shared
+// `({ data, ctas, theme }) => JSX` signature (see `_contract/types.ts`).
+//
+// Adding a template = (1) drop the package under `<id>/`, (2) add the
+// entry below, (3) map the relevant verticals in TEMPLATE_BY_VERTICAL.
+// The `/w/[slug]` route reads this map to dispatch; nothing else changes.
+
+import type { ComponentType } from "react";
+import type { TemplateProps } from "./_contract/types";
+import { EarthyModernClinical } from "./earthy-modern-clinical/EarthyModernClinical";
+
+export const LANDING_TEMPLATES = {
+  "earthy-modern-clinical": EarthyModernClinical,
+  // T1 Clinical Luxe · T2 Warm Wellness · T3 Cinematic Sanctuary ·
+  // T4 Editorial Bodywork land here as Claude Design delivers them.
+} as const satisfies Record<string, ComponentType<TemplateProps>>;
+
+export type LandingTemplateId = keyof typeof LANDING_TEMPLATES;
+
+/** Runtime guard for persisted ids (theme.landingTemplate is untyped JSON). */
+export function isLandingTemplateId(value: unknown): value is LandingTemplateId {
+  return typeof value === "string" && value in LANDING_TEMPLATES;
+}
+
+/**
+ * Vertical → template. Keys are lowercased soul `industry` / CRM-personality
+ * vertical strings. Seeded with the verticals T5 (Earthy Modern Clinical)
+ * covers; extended as T1–T4 arrive. `pickLandingTemplate` falls back to the
+ * archetype default, then to T5 as the safe health default.
+ */
+export const TEMPLATE_BY_VERTICAL: Record<string, LandingTemplateId> = {
+  chiropractic: "earthy-modern-clinical",
+  chiropractor: "earthy-modern-clinical",
+  physiotherapy: "earthy-modern-clinical",
+  physical_therapy: "earthy-modern-clinical",
+  "physical-therapy": "earthy-modern-clinical",
+  "sports-medicine": "earthy-modern-clinical",
+  sports_medicine: "earthy-modern-clinical",
+  rehab: "earthy-modern-clinical",
+  wellness: "earthy-modern-clinical",
+};

--- a/packages/crm/src/components/landing-templates/registry.ts
+++ b/packages/crm/src/components/landing-templates/registry.ts
@@ -1,7 +1,7 @@
 // landing-templates/registry.ts
 //
-// Registry of premium Claude Design full-page health/wellness landing
-// templates. Each template is a self-contained package under
+// Registry of the five premium Claude Design full-page health/wellness
+// landing templates. Each is a self-contained package under
 // `landing-templates/<id>/` exporting a component with the shared
 // `({ data, ctas, theme }) => JSX` signature (see `_contract/types.ts`).
 //
@@ -11,12 +11,18 @@
 
 import type { ComponentType } from "react";
 import type { TemplateProps } from "./_contract/types";
+import { ClinicalLuxe } from "./clinical-luxe/ClinicalLuxe";
+import { WarmWellness } from "./warm-wellness/WarmWellness";
+import { CinematicSanctuary } from "./cinematic-sanctuary/CinematicSanctuary";
+import { EditorialBodywork } from "./editorial-bodywork/EditorialBodywork";
 import { EarthyModernClinical } from "./earthy-modern-clinical/EarthyModernClinical";
 
 export const LANDING_TEMPLATES = {
-  "earthy-modern-clinical": EarthyModernClinical,
-  // T1 Clinical Luxe · T2 Warm Wellness · T3 Cinematic Sanctuary ·
-  // T4 Editorial Bodywork land here as Claude Design delivers them.
+  "clinical-luxe": ClinicalLuxe, // T1 — derm / med-spa / cosmetic
+  "warm-wellness": WarmWellness, // T2 — prenatal / women's health / coaching
+  "cinematic-sanctuary": CinematicSanctuary, // T3 — spa / holistic / osteopathy
+  "editorial-bodywork": EditorialBodywork, // T4 — massage / bodywork / recovery
+  "earthy-modern-clinical": EarthyModernClinical, // T5 — chiro / physio (workhorse)
 } as const satisfies Record<string, ComponentType<TemplateProps>>;
 
 export type LandingTemplateId = keyof typeof LANDING_TEMPLATES;
@@ -26,18 +32,59 @@ export function isLandingTemplateId(value: unknown): value is LandingTemplateId 
   return typeof value === "string" && value in LANDING_TEMPLATES;
 }
 
+/** The safe default when a health business doesn't clearly fit a niche. */
+export const DEFAULT_HEALTH_TEMPLATE: LandingTemplateId = "earthy-modern-clinical";
+
 /**
  * Vertical → template. Keys are lowercased soul `industry` / CRM-personality
- * vertical strings. Seeded with the verticals T5 (Earthy Modern Clinical)
- * covers; extended as T1–T4 arrive. `pickLandingTemplate` falls back to the
- * archetype default, then to T5 as the safe health default.
+ * vertical strings. `pickLandingTemplate` (creation pipeline, Phase 2) reads
+ * this first, then falls back to the archetype default, then to
+ * DEFAULT_HEALTH_TEMPLATE.
  */
 export const TEMPLATE_BY_VERTICAL: Record<string, LandingTemplateId> = {
+  // T1 — Clinical Luxe
+  dermatology: "clinical-luxe",
+  derm: "clinical-luxe",
+  "med-spa": "clinical-luxe",
+  medspa: "clinical-luxe",
+  "medical-spa": "clinical-luxe",
+  cosmetic: "clinical-luxe",
+  aesthetics: "clinical-luxe",
+  aesthetic: "clinical-luxe",
+  dermatologist: "clinical-luxe",
+  skincare: "clinical-luxe",
+  // T2 — Warm Wellness
+  prenatal: "warm-wellness",
+  postnatal: "warm-wellness",
+  "womens-health": "warm-wellness",
+  "women's-health": "warm-wellness",
+  maternity: "warm-wellness",
+  pilates: "warm-wellness",
+  yoga: "warm-wellness",
+  fitness: "warm-wellness",
+  coaching: "warm-wellness",
+  // T3 — Cinematic Sanctuary
+  spa: "cinematic-sanctuary",
+  holistic: "cinematic-sanctuary",
+  osteopathy: "cinematic-sanctuary",
+  osteopath: "cinematic-sanctuary",
+  osteopathic: "cinematic-sanctuary",
+  acupuncture: "cinematic-sanctuary",
+  "functional-medicine": "cinematic-sanctuary",
+  sanctuary: "cinematic-sanctuary",
+  retreat: "cinematic-sanctuary",
+  // T4 — Editorial Bodywork
+  massage: "editorial-bodywork",
+  "massage-therapy": "editorial-bodywork",
+  bodywork: "editorial-bodywork",
+  recovery: "editorial-bodywork",
+  // T5 — Earthy Modern Clinical (workhorse)
   chiropractic: "earthy-modern-clinical",
   chiropractor: "earthy-modern-clinical",
   physiotherapy: "earthy-modern-clinical",
   physical_therapy: "earthy-modern-clinical",
   "physical-therapy": "earthy-modern-clinical",
+  physio: "earthy-modern-clinical",
   "sports-medicine": "earthy-modern-clinical",
   sports_medicine: "earthy-modern-clinical",
   rehab: "earthy-modern-clinical",

--- a/packages/crm/src/components/landing-templates/warm-wellness/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/Styles.tsx
@@ -1,0 +1,6 @@
+import { SF2_CSS } from "./css";
+
+// Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).
+export function Styles() {
+  return <style jsx global>{SF2_CSS}</style>;
+}

--- a/packages/crm/src/components/landing-templates/warm-wellness/Styles.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/Styles.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { SF2_CSS } from "./css";
 
 // Global styles. styled-jsx MUST be `<style jsx global>` (scoped breaks in the build).

--- a/packages/crm/src/components/landing-templates/warm-wellness/WHEN_TO_USE.md
+++ b/packages/crm/src/components/landing-templates/warm-wellness/WHEN_TO_USE.md
@@ -1,0 +1,34 @@
+# Template 2 — Warm Wellness
+
+**When to use (for the archetype classifier):** friendly, **solo-practitioner /
+personal-brand** wellness where the relationship is the product — **prenatal &
+postnatal fitness, women's health, pilates & yoga studios, health coaching,
+nutrition, lactation/doula**. Reach for it when the soul is one named person, the
+voice is warm and first-person, and there's a promo/offer (e.g. "first class free").
+
+**Emotional register:** bright, airy, human, feminine. Dusty-rose, soft rounded
+forms, lifestyle photography, a "Hi, I'm …" about block, a promo pill in the nav.
+Feels like a trusted friend who's also an expert.
+
+## Files (identical package shape to all 5)
+`WarmWellness.tsx` (entry) · `types.ts` · `theme.ts` (+ `sfPromo`, `sfFirstName`) ·
+`css.ts` · `Styles.tsx` · `icons.tsx` · `ui.tsx` (client) · `interactive.tsx`
+(`Nav`, `Faq`, client) · `sections.tsx` (`Hero, TrustStrip, Services, About,
+Stats, Testimonials, CtaBand, Footer, MobileBar`) · `fixture.ts`.
+
+```tsx
+import WarmWellness from "./WarmWellness";
+import { georgiaHart, exampleCTAs } from "./fixture";
+export default () => <WarmWellness data={georgiaHart} ctas={exampleCTAs} />;
+```
+
+## Shared invariants (byte-identical across all 5)
+Entry signature `({ data, ctas, theme })` · `types.ts` · the `--sf-*` variable
+names + `sfThemeVars()` output shape · `SmartImage → ThemedPlaceholder` fallback ·
+global `<style jsx>` · `"use client"` only on `Nav`/`Faq`/`SmartImage`.
+
+## Template-specific niceties
+Promo pill derived from `trust_signals` (matches free/off/%/trial/first — hides
+otherwise) · split airy hero with floating rating badge · varied rounded cards
+(first spans wide) · "Hi, I'm {firstName}" about (first word of `business_name`) ·
+rounded rose CTA card. Container queries on `.sf2-root`. Bottom-right kept clear.

--- a/packages/crm/src/components/landing-templates/warm-wellness/WarmWellness.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/WarmWellness.tsx
@@ -5,17 +5,14 @@ import { Nav, Faq } from "./interactive";
 import { Hero, TrustStrip, Services, About, Stats, Testimonials, CtaBand, Footer, MobileBar } from "./sections";
 
 /**
- * Template 5 — "Earthy Modern Clinical"
- * Entry component. Shared signature across all five templates:
- *   ({ data, ctas, theme }) => JSX
- *
- * - Server component (no "use client"); only Nav + Faq opt into the client.
- * - Theme is applied as --sf-* CSS variables on the root; nothing is hardcoded.
- * - Bottom-right is left clear for the platform's injected AI chat bubble.
+ * Template 2 — "Warm Wellness"
+ * Shared entry signature: ({ data, ctas, theme }) => JSX
+ * Server component; only Nav + Faq opt into the client. Theme via --sf-* vars.
+ * Bottom-right left clear for the platform's injected AI chat bubble.
  */
-export function EarthyModernClinical({ data, ctas, theme }: TemplateProps) {
+export function WarmWellness({ data, ctas, theme }: TemplateProps) {
   return (
-    <div className="sf5-root" style={sfThemeVars(theme)}>
+    <div className="sf2-root" style={sfThemeVars(theme)}>
       <Styles />
       <Nav data={data} ctas={ctas} />
       <main>

--- a/packages/crm/src/components/landing-templates/warm-wellness/css.ts
+++ b/packages/crm/src/components/landing-templates/warm-wellness/css.ts
@@ -1,0 +1,214 @@
+/* SF2 global stylesheet — single source of truth shared by <Styles/>.
+   Mobile-first; container queries on .sf2-root. Every value resolves from --sf-* vars. */
+export const SF2_CSS = `
+.sf2-root{
+  --sf-primary-d: color-mix(in oklab, var(--sf-primary) 78%, #000);
+  --sf-primary-soft: color-mix(in oklab, var(--sf-primary) 16%, var(--sf-bg));
+  --sf-primary-tint: color-mix(in oklab, var(--sf-primary) 9%, var(--sf-bg));
+  --sf-card: color-mix(in oklab, var(--sf-secondary) 4%, var(--sf-bg));
+  --sf-ink-60: color-mix(in oklab, var(--sf-text) 56%, var(--sf-bg));
+  --sf-line: color-mix(in oklab, var(--sf-text) 13%, var(--sf-bg));
+  --wrap: 1180px;
+  container: sf2 / inline-size;
+  background: var(--sf-bg); color: var(--sf-text);
+  font-family: var(--sf-font-body); font-size: 16px; line-height: 1.6;
+  -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+}
+.sf2-root *{ box-sizing:border-box; }
+.sf2-root img{ display:block; max-width:100%; }
+.sf2-wrap{ width:100%; max-width:var(--wrap); margin-inline:auto; padding-inline:22px; }
+
+.sf2-h2{ font-family:var(--sf-font-headline); font-weight:600; letter-spacing:-.01em; line-height:1.08; font-size:clamp(30px,6.6cqw,50px); margin:0; }
+.sf2-eyebrow{ font-weight:800; text-transform:uppercase; letter-spacing:.16em; font-size:11.5px; color:var(--sf-primary); margin:0 0 16px; }
+.sf2-muted{ color:var(--sf-ink-60); }
+
+/* buttons — soft pills */
+.sf2-btn{ display:inline-flex; align-items:center; gap:9px; font-family:var(--sf-font-body); font-weight:800;
+  font-size:14.5px; line-height:1; padding:14px 24px; border-radius:999px; border:2px solid transparent; cursor:pointer;
+  text-decoration:none; white-space:nowrap; transition:transform .16s, background .2s, color .2s, box-shadow .25s; }
+.sf2-btn svg{ font-size:18px; }
+.sf2-btn:hover{ transform:translateY(-2px); }
+.sf2-btn:focus-visible{ outline:3px solid var(--sf-primary); outline-offset:2px; }
+.sf2-btn-primary{ background:var(--sf-primary); color:#fff; box-shadow:0 12px 24px -12px color-mix(in oklab,var(--sf-primary) 70%,transparent); }
+.sf2-btn-primary:hover{ background:var(--sf-primary-d); }
+.sf2-btn-dark{ background:var(--sf-secondary); color:var(--sf-bg); }
+.sf2-btn-soft{ background:var(--sf-primary-soft); color:var(--sf-primary-d); }
+.sf2-btn-soft:hover{ background:color-mix(in oklab,var(--sf-primary) 24%,var(--sf-bg)); }
+.sf2-btn-ghost{ background:transparent; color:var(--sf-text); border-color:var(--sf-line); }
+.sf2-btn-block{ width:100%; justify-content:center; }
+
+/* nav */
+.sf2-nav{ position:sticky; top:0; z-index:40; background:color-mix(in oklab,var(--sf-bg) 85%,transparent); backdrop-filter:blur(12px); }
+.sf2-nav-in{ display:flex; align-items:center; justify-content:space-between; gap:14px; height:76px; }
+.sf2-brand{ display:inline-flex; align-items:center; gap:11px; min-width:0; flex-shrink:1; text-decoration:none; color:var(--sf-text); }
+.sf2-brand-mark{ flex:none; width:40px; height:40px; border-radius:50%; background:var(--sf-primary-soft); color:var(--sf-primary-d);
+  display:grid; place-items:center; font-family:var(--sf-font-headline); font-weight:700; font-size:19px; }
+.sf2-brand-name{ font-family:var(--sf-font-headline); font-weight:600; font-size:21px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sf2-nav-mid{ display:none; align-items:center; gap:28px; }
+.sf2-nav-mid a{ color:var(--sf-text); text-decoration:none; font-weight:700; font-size:14.5px; opacity:.82; }
+.sf2-nav-mid a:hover{ opacity:1; color:var(--sf-primary); }
+.sf2-promo{ display:none; align-items:center; gap:7px; background:var(--sf-primary-soft); color:var(--sf-primary-d);
+  font-weight:800; font-size:12px; letter-spacing:.04em; padding:9px 15px; border-radius:999px; text-transform:uppercase; }
+.sf2-nav-cta{ display:flex; align-items:center; gap:12px; }
+.sf2-nav .sf2-btn-primary{ display:none; }
+.sf2-burger{ display:inline-grid; place-items:center; width:44px; height:44px; border-radius:50%; background:var(--sf-card); border:1.5px solid var(--sf-line); color:var(--sf-text); font-size:22px; cursor:pointer; }
+
+.sf2-sheet{ position:fixed; inset:0; z-index:60; background:var(--sf-bg); transform:translateY(-100%); transition:transform .32s cubic-bezier(.4,0,.2,1); display:flex; flex-direction:column; visibility:hidden; }
+.sf2-sheet.is-open{ transform:translateY(0); visibility:visible; }
+.sf2-sheet-top{ display:flex; align-items:center; justify-content:space-between; height:76px; }
+.sf2-sheet-links{ display:flex; flex-direction:column; padding:14px 24px; }
+.sf2-sheet-links a{ font-family:var(--sf-font-headline); font-weight:600; font-size:30px; color:var(--sf-text); text-decoration:none; padding:13px 0; border-bottom:1px solid var(--sf-line); }
+.sf2-sheet-foot{ margin-top:auto; padding:24px; display:flex; flex-direction:column; gap:12px; }
+
+/* hero — split, soft */
+.sf2-hero{ display:grid; grid-template-columns:1fr; gap:0; align-items:center; }
+.sf2-hero-body{ padding:40px 22px 24px; }
+.sf2-hero-h1{ font-family:var(--sf-font-headline); font-weight:600; line-height:1.05; letter-spacing:-.015em; font-size:clamp(38px,10cqw,68px); margin:0 0 20px; text-wrap:balance; }
+.sf2-hero-sub{ color:var(--sf-ink-60); font-size:clamp(16px,3cqw,19px); max-width:44ch; margin:0 0 28px; }
+.sf2-hero-actions{ display:flex; flex-wrap:wrap; gap:12px; align-items:center; }
+.sf2-hero-note{ font-weight:800; font-size:13px; color:var(--sf-primary); display:inline-flex; align-items:center; gap:7px; }
+.sf2-hero-chips{ list-style:none; display:flex; flex-wrap:wrap; gap:10px 12px; margin:30px 0 0; padding:0; }
+.sf2-hero-chips li{ display:inline-flex; align-items:center; gap:8px; background:var(--sf-card); border:1px solid var(--sf-line); border-radius:999px; padding:9px 16px; font-weight:700; font-size:13.5px; }
+.sf2-hero-chips svg{ color:var(--sf-primary); font-size:16px; }
+.sf2-hero-chips b{ font-weight:800; }
+.sf2-hero-media{ position:relative; padding:0 22px 36px; }
+.sf2-hero-photo{ position:relative; border-radius:28px; overflow:hidden; aspect-ratio:4/5; box-shadow:0 30px 60px -34px color-mix(in oklab,var(--sf-secondary) 60%,transparent); }
+.sf2-hero-photo .sf2-img,.sf2-hero-photo .sf2-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf2-hero-badge{ position:absolute; left:18px; bottom:18px; background:color-mix(in oklab,var(--sf-bg) 92%,transparent); backdrop-filter:blur(6px);
+  border-radius:18px; padding:13px 17px; display:flex; align-items:center; gap:11px; box-shadow:0 14px 30px -16px color-mix(in oklab,var(--sf-secondary) 60%,transparent); }
+.sf2-hero-badge .sf2-stars{ color:var(--sf-primary); font-size:13px; }
+.sf2-hero-badge b{ font-family:var(--sf-font-headline); font-size:17px; }
+.sf2-hero-badge small{ display:block; font-size:11.5px; color:var(--sf-ink-60); }
+
+/* trust */
+.sf2-trust{ background:var(--sf-primary-tint); }
+.sf2-trust-in{ display:flex; flex-wrap:wrap; justify-content:center; gap:12px 14px; padding-block:24px; }
+.sf2-trust-item{ display:inline-flex; align-items:center; gap:9px; font-weight:700; font-size:13.5px; color:var(--sf-text); }
+.sf2-trust-item svg{ color:var(--sf-primary); font-size:17px; }
+.sf2-trust-item .sf2-lead{ font-family:var(--sf-font-headline); font-weight:700; color:var(--sf-primary); font-size:17px; }
+.sf2-trust-dot{ width:4px; height:4px; border-radius:50%; background:var(--sf-line); }
+
+/* sections */
+.sf2-sec{ padding-block:80px; }
+.sf2-sec-head{ display:flex; flex-direction:column; gap:14px; max-width:54ch; margin-bottom:36px; }
+
+/* services — rounded varied cards */
+.sf2-svc-grid{ display:grid; grid-template-columns:1fr; gap:18px; }
+.sf2-svc{ background:var(--sf-card); border:1px solid var(--sf-line); border-radius:24px; overflow:hidden; display:flex; flex-direction:column; transition:transform .18s, box-shadow .25s; }
+.sf2-svc:hover{ transform:translateY(-4px); box-shadow:0 26px 50px -30px color-mix(in oklab,var(--sf-secondary) 55%,transparent); }
+.sf2-svc-media{ position:relative; aspect-ratio:5/4; }
+.sf2-svc-media .sf2-img,.sf2-svc-media .sf2-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf2-svc-body{ padding:24px; display:flex; flex-direction:column; gap:11px; flex:1; }
+.sf2-svc-name{ font-family:var(--sf-font-headline); font-weight:600; font-size:23px; margin:0; }
+.sf2-svc-desc{ margin:0; color:var(--sf-ink-60); font-size:15px; }
+.sf2-svc-meta{ display:flex; align-items:center; gap:14px; margin-top:auto; padding-top:6px; }
+.sf2-svc-meta .sf2-price{ font-family:var(--sf-font-headline); font-weight:700; font-size:20px; }
+.sf2-svc-meta .sf2-dur{ display:inline-flex; align-items:center; gap:6px; white-space:nowrap; color:var(--sf-ink-60); font-weight:700; font-size:13.5px; }
+.sf2-svc-meta .sf2-price{ white-space:nowrap; }
+.sf2-svc-meta svg{ color:var(--sf-primary); font-size:15px; }
+.sf2-svc .sf2-btn{ margin-top:4px; }
+.sf2-svc--wide .sf2-btn{ align-self:flex-start; }
+
+/* about — Hi, I'm … */
+.sf2-about{ display:grid; grid-template-columns:1fr; gap:30px; align-items:center; }
+.sf2-about-media{ position:relative; border-radius:28px; overflow:hidden; aspect-ratio:4/5; box-shadow:0 30px 60px -34px color-mix(in oklab,var(--sf-secondary) 55%,transparent); }
+.sf2-about-media .sf2-img,.sf2-about-media .sf2-ph{ position:absolute; inset:0; width:100%; height:100%; object-fit:cover; }
+.sf2-about-hi{ font-family:var(--sf-font-headline); font-weight:600; font-size:clamp(30px,5.4cqw,46px); margin:0 0 16px; line-height:1.1; }
+.sf2-about-text{ margin:0 0 18px; font-size:17px; color:var(--sf-text); max-width:50ch; }
+.sf2-creds{ list-style:none; padding:0; margin:0 0 22px; display:flex; flex-wrap:wrap; gap:10px; }
+.sf2-creds li{ display:inline-flex; align-items:center; gap:8px; background:var(--sf-primary-tint); border-radius:999px; padding:9px 15px; font-weight:700; font-size:13px; }
+.sf2-creds svg{ color:var(--sf-primary); }
+
+/* stats */
+.sf2-stats-in{ display:grid; grid-template-columns:repeat(2,1fr); gap:18px; }
+.sf2-stat{ background:var(--sf-primary-tint); border-radius:22px; padding:28px 24px; text-align:center; }
+.sf2-stat-n{ display:block; font-family:var(--sf-font-headline); font-weight:700; font-size:clamp(34px,6cqw,48px); line-height:1; color:var(--sf-primary); }
+.sf2-stat-l{ display:block; margin-top:8px; font-size:13px; font-weight:700; color:var(--sf-ink-60); }
+
+/* testimonials */
+.sf2-rev-grid{ display:grid; grid-template-columns:1fr; gap:18px; }
+.sf2-rev{ background:var(--sf-card); border:1px solid var(--sf-line); border-radius:24px; padding:28px; margin:0; display:flex; flex-direction:column; gap:15px; }
+.sf2-rev-stars{ color:var(--sf-primary); font-size:14px; }
+.sf2-rev blockquote{ margin:0; font-size:17px; line-height:1.55; }
+.sf2-rev figcaption{ display:flex; align-items:center; gap:11px; font-weight:800; font-size:14px; }
+.sf2-rev-av{ width:38px; height:38px; border-radius:50%; background:var(--sf-primary-soft); color:var(--sf-primary-d); display:grid; place-items:center; font-family:var(--sf-font-headline); font-weight:700; }
+
+/* faq */
+.sf2-faq-in{ display:grid; grid-template-columns:1fr; gap:30px; }
+.sf2-faq-list{ display:flex; flex-direction:column; gap:12px; }
+.sf2-faq-item{ background:var(--sf-card); border:1px solid var(--sf-line); border-radius:18px; overflow:hidden; }
+.sf2-faq-item.is-open{ border-color:color-mix(in oklab,var(--sf-primary) 40%,var(--sf-line)); }
+.sf2-faq-q{ width:100%; display:flex; align-items:center; justify-content:space-between; gap:16px; background:none; border:0; cursor:pointer; text-align:left; padding:20px 22px; font-family:var(--sf-font-headline); font-weight:600; font-size:18.5px; color:var(--sf-text); }
+.sf2-faq-chev{ flex:none; font-size:21px; color:var(--sf-primary); transition:transform .25s; }
+.sf2-faq-item.is-open .sf2-faq-chev{ transform:rotate(180deg); }
+.sf2-faq-a{ display:grid; grid-template-rows:0fr; transition:grid-template-rows .28s; }
+.sf2-faq-item.is-open .sf2-faq-a{ grid-template-rows:1fr; }
+.sf2-faq-a > p{ overflow:hidden; margin:0; color:var(--sf-ink-60); font-size:15.5px; padding:0 22px; transition:padding .28s; }
+.sf2-faq-item.is-open .sf2-faq-a > p{ padding:0 22px 22px; }
+
+/* cta */
+.sf2-cta{ padding-block:30px; }
+.sf2-cta-card{ position:relative; overflow:hidden; border-radius:34px; padding:60px 28px; background:var(--sf-primary); color:#fff; text-align:center; }
+.sf2-cta-card::after{ content:""; position:absolute; right:-60px; top:-60px; width:240px; height:240px; border-radius:50%; background:color-mix(in oklab,#fff 14%,transparent); }
+.sf2-cta-card::before{ content:""; position:absolute; left:-50px; bottom:-70px; width:200px; height:200px; border-radius:50%; background:color-mix(in oklab,#fff 10%,transparent); }
+.sf2-cta-h{ position:relative; font-family:var(--sf-font-headline); font-weight:600; line-height:1.06; font-size:clamp(30px,6cqw,50px); margin:0 0 14px; }
+.sf2-cta-sub{ position:relative; color:rgba(255,255,255,.9); font-size:18px; margin:0 auto 26px; max-width:42ch; }
+.sf2-cta-actions{ position:relative; display:flex; flex-wrap:wrap; gap:12px; justify-content:center; }
+.sf2-btn-onrose{ background:#fff; color:var(--sf-primary-d); }
+.sf2-btn-onrose-out{ background:transparent; color:#fff; border-color:rgba(255,255,255,.6); }
+
+/* footer */
+.sf2-foot{ background:var(--sf-secondary); color:var(--sf-bg); padding-top:64px; }
+.sf2-foot-in{ display:grid; grid-template-columns:1fr; gap:40px; padding-bottom:46px; }
+.sf2-foot-brand .sf2-brand-name{ color:var(--sf-bg); }
+.sf2-foot-tag{ color:color-mix(in oklab,var(--sf-bg) 70%,var(--sf-secondary)); margin:16px 0 22px; max-width:34ch; }
+.sf2-foot-cols{ display:grid; grid-template-columns:1fr 1fr; gap:32px 24px; }
+.sf2-foot-col h3{ font-size:11px; letter-spacing:.14em; text-transform:uppercase; color:var(--sf-primary); margin:0 0 14px; }
+.sf2-foot-col ul{ list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:10px; }
+.sf2-foot-col li,.sf2-foot-col a{ color:color-mix(in oklab,var(--sf-bg) 80%,var(--sf-secondary)); font-size:14px; text-decoration:none; }
+.sf2-foot-col a:hover{ color:#fff; }
+.sf2-foot-legal{ display:flex; flex-wrap:wrap; gap:8px 20px; justify-content:space-between; border-top:1px solid color-mix(in oklab,var(--sf-bg) 16%,var(--sf-secondary)); padding-block:22px; font-size:12.5px; color:color-mix(in oklab,var(--sf-bg) 58%,var(--sf-secondary)); }
+
+/* mobile bar */
+.sf2-mbar{ position:sticky; bottom:0; z-index:50; display:flex; gap:10px; padding:12px 16px calc(12px + env(safe-area-inset-bottom)); background:color-mix(in oklab,var(--sf-bg) 93%,transparent); backdrop-filter:blur(10px); border-top:1px solid var(--sf-line); }
+.sf2-mbar-call{ display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:14px 20px; border-radius:999px; border:2px solid var(--sf-line); color:var(--sf-text); text-decoration:none; font-weight:800; }
+.sf2-mbar-book{ flex:1; display:inline-flex; align-items:center; justify-content:center; padding:14px 20px; border-radius:999px; background:var(--sf-primary); color:#fff; text-decoration:none; font-weight:800; }
+
+/* placeholder + image */
+.sf2-img{ width:100%; height:100%; object-fit:cover; }
+.sf2-ph{ position:relative; width:100%; height:100%; min-height:160px; overflow:hidden;
+  background: repeating-linear-gradient(135deg, color-mix(in oklab,var(--sf-primary) 15%,var(--sf-card)) 0 14px, color-mix(in oklab,var(--sf-primary) 6%,var(--sf-card)) 14px 28px), var(--sf-card);
+  display:grid; place-items:center; }
+.sf2-ph::after{ content:""; position:absolute; inset:0; background:radial-gradient(120% 90% at 32% 20%, transparent 44%, color-mix(in oklab,var(--sf-secondary) 11%,transparent)); }
+.sf2-ph-tag{ position:relative; z-index:1; font-family:ui-monospace,Menlo,monospace; font-size:10.5px; letter-spacing:.08em; text-transform:uppercase; color:color-mix(in oklab,var(--sf-secondary) 62%,var(--sf-bg)); background:color-mix(in oklab,var(--sf-bg) 84%,transparent); padding:6px 11px; border-radius:999px; border:1px solid var(--sf-line); }
+
+@media (prefers-reduced-motion: reduce){ .sf2-root *{ transition:none !important; } }
+
+/* container queries */
+@container sf2 (min-width:720px){
+  .sf2-wrap{ padding-inline:36px; }
+  .sf2-nav-mid{ display:flex; }
+  .sf2-promo{ display:inline-flex; }
+  .sf2-nav .sf2-btn-primary{ display:inline-flex; }
+  .sf2-burger{ display:none; }
+  .sf2-mbar{ display:none; }
+  .sf2-hero{ grid-template-columns:1.02fr .98fr; gap:24px; }
+  .sf2-hero-body{ padding:72px 16px 72px max(36px,calc((100cqw - var(--wrap))/2 + 36px)); }
+  .sf2-hero-media{ padding:48px max(36px,calc((100cqw - var(--wrap))/2 + 36px)) 48px 0; }
+  .sf2-svc-grid{ grid-template-columns:1fr 1fr; }
+  .sf2-svc--wide{ grid-column:1 / -1; flex-direction:row; }
+  .sf2-svc--wide .sf2-svc-media{ flex:1; aspect-ratio:auto; min-height:280px; }
+  .sf2-svc--wide .sf2-svc-body{ flex:1.1; padding:34px; }
+  .sf2-about{ grid-template-columns:.9fr 1.1fr; gap:48px; }
+  .sf2-stats-in{ grid-template-columns:repeat(4,1fr); }
+  .sf2-rev-grid{ grid-template-columns:repeat(3,1fr); }
+  .sf2-faq-in{ grid-template-columns:.8fr 1.2fr; gap:48px; }
+  .sf2-foot-in{ grid-template-columns:1.2fr 2fr; gap:60px; }
+  .sf2-foot-cols{ grid-template-columns:repeat(4,1fr); }
+  .sf2-cta-card{ padding:84px 40px; }
+}
+@container sf2 (min-width:1040px){
+  .sf2-hero-h1{ font-size:clamp(48px,5.4cqw,68px); }
+  .sf2-svc-grid{ grid-template-columns:repeat(3,1fr); }
+}
+`;

--- a/packages/crm/src/components/landing-templates/warm-wellness/fixture.ts
+++ b/packages/crm/src/components/landing-templates/warm-wellness/fixture.ts
@@ -1,0 +1,56 @@
+import type { CTAs, Soul } from "../_contract/types";
+
+// Realistic women's-wellness / prenatal personal-brand fixture. The About
+// portrait and the last two class photos are intentionally omitted to exercise
+// the themed placeholder fallback. `trust_signals` includes "First class free",
+// which surfaces as the nav promo pill + hero note (graceful — hides if absent).
+export const georgiaHart: Soul = {
+  business_name: "Georgia Hart",
+  tagline: "Fitness for every stage of motherhood",
+  soul_description:
+    "Pre & postnatal pilates and strength coaching for women — gentle, expert movement to help you feel strong, supported, and like yourself again. Small groups and 1:1 in the heart of Austin.",
+  phone: "(512) 555-0294",
+  email: "hello@movewithgeorgia.com",
+  address: "1100 S Lamar Blvd, Studio 4, Austin, TX 78704",
+  service_area: ["Austin", "South Congress", "Zilker", "Travis Heights"],
+  hours: [
+    { day: "Mon–Fri", open: "6am", close: "7pm" },
+    { day: "Sat", open: "8am", close: "1pm" },
+    { day: "Sun", open: "Closed", close: "" },
+  ],
+  review_rating: 4.9,
+  review_count: 164,
+  trust_signals: ["First class free", "Small-group & 1:1", "Mums welcome with babies"],
+  certifications: ["Pre & Postnatal Certified", "STOTT Pilates Certified"],
+  offerings: [
+    { name: "Prenatal Pilates", description: "Safe, supportive movement for every trimester.", price: 28, currency: "USD", duration_minutes: 50 },
+    { name: "Postnatal Recovery", description: "Rebuild core and pelvic-floor strength, gently.", price: 32, currency: "USD", duration_minutes: 50 },
+    { name: "Strength for Mums", description: "Build real, functional strength for everyday life.", price: 30, currency: "USD", duration_minutes: 45 },
+    { name: "1:1 Personal Coaching", description: "A program built entirely around you and your goals.", price: 75, currency: "USD", duration_minutes: 60 },
+    { name: "Mum & Baby Class", description: "Move together — no childcare needed.", price: 24, currency: "USD", duration_minutes: 45 },
+  ],
+  faqs: [
+    { q: "Is it safe during pregnancy?", a: "Absolutely. Every class is led by a certified pre/postnatal coach and tailored to your trimester and comfort." },
+    { q: "When can I start postnatally?", a: "Most mums begin around 6 weeks (12 after a C-section) with clearance. We start gently and build from there." },
+    { q: "Do I need any experience?", a: "None at all. Classes are beginner-friendly and every movement has options for your level." },
+    { q: "Can I bring my baby?", a: "Yes — our Mum & Baby classes are designed for exactly that. Come as you are." },
+  ],
+  testimonials: [
+    { name: "Hannah W.", text: "Georgia helped me feel strong and confident again after my second baby. I genuinely look forward to every class." },
+    { name: "Priya S.", text: "The prenatal classes were the best thing I did for my pregnancy. So knowledgeable and so kind." },
+    { name: "Mia L.", text: "Finally a space that gets it. Bringing my little one along made it actually possible to show up." },
+  ],
+  photos: [
+    { url: "https://images.unsplash.com/photo-1518611012118-696072aa579a?auto=format&fit=crop&w=1100&q=72", role: "hero", alt: "Pilates class" },
+    { url: "https://images.unsplash.com/photo-1599447421416-3414500d18a5?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Prenatal pilates" },
+    { url: "https://images.unsplash.com/photo-1559599101-f09722fb4948?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Postnatal recovery" },
+    { url: "https://images.unsplash.com/photo-1518310383802-640c2de311b2?auto=format&fit=crop&w=1000&q=72", role: "service", alt: "Strength class" },
+    // service[3], service[4], role:"about" omitted → themed placeholder fallback
+  ],
+};
+
+export const exampleCTAs: CTAs = {
+  bookUrl: "/book",
+  callHref: "tel:+15125550294",
+  intakeUrl: "/intake",
+};

--- a/packages/crm/src/components/landing-templates/warm-wellness/icons.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/icons.tsx
@@ -1,6 +1,6 @@
 import type { SVGProps } from "react";
 
-// Inline SVG only — no external icon libraries (SeldonFrame house rule).
+// Inline SVG only — no external icon libraries.
 type P = SVGProps<SVGSVGElement>;
 const base = (p: P) => ({ width: "1em" as const, height: "1em" as const, viewBox: "0 0 24 24", "aria-hidden": true, ...p });
 
@@ -13,5 +13,5 @@ export const Icon = {
   close: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M6 6l12 12M18 6L6 18" /></svg>),
   check: (p: P) => (<svg {...base(p)}><path fill="none" stroke="currentColor" strokeWidth={2.2} strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>),
   clock: (p: P) => (<svg {...base(p)}><circle cx={12} cy={12} r={9} fill="none" stroke="currentColor" strokeWidth={2} /><path fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" d="M12 7v5l3 2" /></svg>),
-  mark: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M3 12c5 0 9-4 9-9 0 5 4 9 9 9-5 0-9 4-9 9 0-5-4-9-9-9z" /></svg>),
+  heart: (p: P) => (<svg {...base(p)}><path fill="currentColor" d="M12 21s-7-4.5-9.5-9C1 9 2.5 5.5 6 5.5c2 0 3.2 1.2 4 2.4.8-1.2 2-2.4 4-2.4 3.5 0 5 3.5 3.5 6.5C19 16.5 12 21 12 21z" /></svg>),
 };

--- a/packages/crm/src/components/landing-templates/warm-wellness/interactive.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/interactive.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { sfPromo, sfFirstName } from "./theme";
+
+// ── Sticky nav with promo pill + mobile sheet ──────────────────────────────
+export function Nav({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const [open, setOpen] = useState(false);
+  const promo = sfPromo(data);
+  const mono = sfFirstName(data.business_name).slice(0, 1);
+  const links: [string, string][] = [
+    ["Meet Me", "#about"],
+    ["Classes", "#services"],
+    ["Reviews", "#reviews"],
+    ["Contact", "#contact"],
+  ];
+  return (
+    <header className="sf2-nav" id="top">
+      <div className="sf2-wrap sf2-nav-in">
+        <a className="sf2-brand" href="#top" aria-label={data.business_name}>
+          <span className="sf2-brand-mark">{mono}</span>
+          <span className="sf2-brand-name">{data.business_name}</span>
+        </a>
+        <nav className="sf2-nav-mid" aria-label="Primary">{links.map(([l, h]) => (<a key={l} href={h}>{l}</a>))}</nav>
+        <div className="sf2-nav-cta">
+          {promo && <span className="sf2-promo"><Icon.heart /> {promo}</span>}
+          <a className="sf2-btn sf2-btn-primary" href={ctas.bookUrl}>Book a Class</a>
+          <button className="sf2-burger" aria-label="Menu" aria-expanded={open} onClick={() => setOpen(true)}><Icon.menu /></button>
+        </div>
+      </div>
+      <div className={"sf2-sheet" + (open ? " is-open" : "")} role="dialog" aria-modal="true" aria-hidden={!open}>
+        <div className="sf2-sheet-top sf2-wrap">
+          <span className="sf2-brand"><span className="sf2-brand-mark">{mono}</span><span className="sf2-brand-name">{data.business_name}</span></span>
+          <button className="sf2-burger" aria-label="Close menu" onClick={() => setOpen(false)}><Icon.close /></button>
+        </div>
+        <nav className="sf2-sheet-links" aria-label="Mobile">{links.map(([l, h]) => (<a key={l} href={h} onClick={() => setOpen(false)}>{l}</a>))}</nav>
+        <div className="sf2-sheet-foot">
+          <a className="sf2-btn sf2-btn-primary sf2-btn-block" href={ctas.bookUrl} onClick={() => setOpen(false)}>Book a Class</a>
+          {ctas.callHref && data.phone && <a className="sf2-btn sf2-btn-ghost sf2-btn-block" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ── FAQ accordion ──────────────────────────────────────────────────────────
+export function Faq({ data }: { data: Soul }) {
+  const faqs = data.faqs || [];
+  const [open, setOpen] = useState(0);
+  if (!faqs.length) return null;
+  return (
+    <section className="sf2-sec sf2-wrap" id="faq">
+      <div className="sf2-faq-in">
+        <div><p className="sf2-eyebrow">Good to know</p><h2 className="sf2-h2">Your questions, answered</h2></div>
+        <div className="sf2-faq-list">
+          {faqs.map((f, i) => {
+            const isOpen = open === i;
+            return (
+              <div className={"sf2-faq-item" + (isOpen ? " is-open" : "")} key={i}>
+                <button className="sf2-faq-q" aria-expanded={isOpen} onClick={() => setOpen(isOpen ? -1 : i)}>
+                  <span>{f.q}</span><Icon.chevron className="sf2-faq-chev" />
+                </button>
+                <div className="sf2-faq-a" role="region"><p>{f.a}</p></div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/landing-templates/warm-wellness/sections.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/sections.tsx
@@ -1,0 +1,228 @@
+import type { CTAs, Soul } from "../_contract/types";
+import { Icon } from "./icons";
+import { SmartImage } from "./ui";
+import { sfDur, sfMoney, sfPhoto, sfPromo, sfFirstName } from "./theme";
+
+// ── Hero (split, airy — never centered) ────────────────────────────────────
+export function Hero({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const promo = sfPromo(data);
+  const eyebrow = data.service_area && data.service_area.length
+    ? (data.certifications && data.certifications[0] ? data.certifications[0] + " · " + data.service_area[0] : data.service_area[0])
+    : data.certifications && data.certifications[0];
+  return (
+    <section className="sf2-hero">
+      <div className="sf2-hero-body">
+        {eyebrow && <p className="sf2-eyebrow">{eyebrow}</p>}
+        <h1 className="sf2-hero-h1">{data.tagline || data.business_name}</h1>
+        {data.soul_description && <p className="sf2-hero-sub">{data.soul_description}</p>}
+        <div className="sf2-hero-actions">
+          <a className="sf2-btn sf2-btn-primary" href={ctas.bookUrl}>Book a Class <Icon.arrow /></a>
+          {promo
+            ? <span className="sf2-hero-note"><Icon.heart /> {promo}</span>
+            : (ctas.callHref && data.phone && <a className="sf2-btn sf2-btn-soft" href={ctas.callHref}><Icon.phone /> {data.phone}</a>)}
+        </div>
+        {(data.trust_signals || data.certifications) && (
+          <ul className="sf2-hero-chips">
+            {(data.trust_signals || []).slice(0, 3).map((s, i) => (<li key={i}><Icon.check /> {s}</li>))}
+          </ul>
+        )}
+      </div>
+      <div className="sf2-hero-media">
+        <div className="sf2-hero-photo">
+          <SmartImage photo={sfPhoto(data, "hero")} role="lifestyle photo" label="lifestyle photo" />
+          {data.review_rating != null && (
+            <div className="sf2-hero-badge">
+              <span className="sf2-stars"><Icon.star /><Icon.star /><Icon.star /><Icon.star /><Icon.star /></span>
+              <div><b>{data.review_rating.toFixed(1)}</b>{data.review_count != null && <small>{data.review_count} happy clients</small>}</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Trust strip ────────────────────────────────────────────────────────────
+import { Fragment } from "react";
+export function TrustStrip({ data }: { data: Soul }) {
+  const items: { lead: string | null; sub: string }[] = [];
+  if (data.review_rating != null)
+    items.push({ lead: data.review_rating.toFixed(1) + "★", sub: data.review_count ? data.review_count + " reviews" : "rated" });
+  (data.certifications || []).forEach((s) => items.push({ lead: null, sub: s }));
+  (data.trust_signals || []).slice(0, 2).forEach((s) => items.push({ lead: null, sub: s }));
+  if (!items.length) return null;
+  return (
+    <section className="sf2-trust" aria-label="Credentials">
+      <div className="sf2-wrap sf2-trust-in">
+        {items.map((it, i) => (
+          <Fragment key={i}>
+            {i > 0 && <span className="sf2-trust-dot" />}
+            <span className="sf2-trust-item">{it.lead ? <span className="sf2-lead">{it.lead}</span> : <Icon.check />}{it.sub}</span>
+          </Fragment>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── Services (varied rounded cards; first card wide) ───────────────────────
+export function Services({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const list = data.offerings || [];
+  if (!list.length) return null;
+  const [feat, ...rest] = list;
+  return (
+    <section className="sf2-sec sf2-wrap" id="services">
+      <div className="sf2-sec-head"><p className="sf2-eyebrow">Classes & Coaching</p><h2 className="sf2-h2">Find the class that fits your stage</h2></div>
+      <div className="sf2-svc-grid">
+        <article className="sf2-svc sf2-svc--wide">
+          <div className="sf2-svc-media"><SmartImage photo={sfPhoto(data, "service", 0)} role="class" label={feat.name} /></div>
+          <div className="sf2-svc-body">
+            <h3 className="sf2-svc-name">{feat.name}</h3>
+            {feat.description && <p className="sf2-svc-desc">{feat.description}</p>}
+            <div className="sf2-svc-meta">
+              {sfMoney(feat.price, feat.currency) && <span className="sf2-price">{sfMoney(feat.price, feat.currency)}</span>}
+              {sfDur(feat.duration_minutes) && <span className="sf2-dur"><Icon.clock /> {sfDur(feat.duration_minutes)}</span>}
+            </div>
+            <a className="sf2-btn sf2-btn-primary" href={ctas.bookUrl}>Book this class <Icon.arrow /></a>
+          </div>
+        </article>
+        {rest.map((o, i) => (
+          <article className="sf2-svc" key={o.name}>
+            <div className="sf2-svc-media"><SmartImage photo={sfPhoto(data, "service", i + 1)} role="class" label={o.name} /></div>
+            <div className="sf2-svc-body">
+              <h3 className="sf2-svc-name">{o.name}</h3>
+              {o.description && <p className="sf2-svc-desc">{o.description}</p>}
+              <div className="sf2-svc-meta">
+                {sfMoney(o.price, o.currency) && <span className="sf2-price">{sfMoney(o.price, o.currency)}</span>}
+                {sfDur(o.duration_minutes) && <span className="sf2-dur"><Icon.clock /> {sfDur(o.duration_minutes)}</span>}
+              </div>
+              <a className="sf2-btn sf2-btn-soft" href={ctas.bookUrl}>Book <Icon.arrow /></a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── About ("Hi, I'm …" personal block) ─────────────────────────────────────
+export function About({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  if (!data.soul_description && !(data.certifications || []).length) return null;
+  const first = sfFirstName(data.business_name);
+  return (
+    <section className="sf2-sec sf2-wrap" id="about">
+      <div className="sf2-about">
+        <div className="sf2-about-media"><SmartImage photo={sfPhoto(data, "about")} role="portrait" label={first + " — portrait"} /></div>
+        <div>
+          <p className="sf2-eyebrow">Meet your coach</p>
+          <h2 className="sf2-about-hi">Hi, I'm {first} 👋</h2>
+          {data.soul_description && <p className="sf2-about-text">{data.soul_description}</p>}
+          {(data.certifications || []).length > 0 && (
+            <ul className="sf2-creds">{data.certifications!.map((c) => (<li key={c}><Icon.check /> {c}</li>))}</ul>
+          )}
+          <a className="sf2-btn sf2-btn-dark" href={ctas.intakeUrl || ctas.bookUrl}>My story <Icon.arrow /></a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Stats ──────────────────────────────────────────────────────────────────
+export function Stats({ data }: { data: Soul }) {
+  const s: [string, string][] = [];
+  if (data.review_count != null) s.push([data.review_count.toLocaleString() + "+", "Women coached"]);
+  if (data.review_rating != null) s.push([data.review_rating.toFixed(1) + "★", "Average rating"]);
+  if (data.offerings && data.offerings.length) s.push([String(data.offerings.length), "Class formats"]);
+  if (data.service_area && data.service_area.length) s.push([String(data.service_area.length), "Neighborhoods"]);
+  if (s.length < 2) return null;
+  return (
+    <section className="sf2-sec sf2-wrap" aria-label="By the numbers">
+      <div className="sf2-stats-in">
+        {s.map(([n, l], i) => (<div className="sf2-stat" key={i}><span className="sf2-stat-n">{n}</span><span className="sf2-stat-l">{l}</span></div>))}
+      </div>
+    </section>
+  );
+}
+
+// ── Testimonials ───────────────────────────────────────────────────────────
+export function Testimonials({ data }: { data: Soul }) {
+  const t = data.testimonials || [];
+  if (!t.length) return null;
+  return (
+    <section className="sf2-sec sf2-wrap" id="reviews">
+      <div className="sf2-sec-head"><p className="sf2-eyebrow">Happy clients</p><h2 className="sf2-h2">Loved by mums like you</h2></div>
+      <div className="sf2-rev-grid">
+        {t.slice(0, 3).map((r, i) => (
+          <figure className="sf2-rev" key={i}>
+            <span className="sf2-rev-stars"><Icon.star /><Icon.star /><Icon.star /><Icon.star /><Icon.star /></span>
+            <blockquote>{"\u201C" + r.text + "\u201D"}</blockquote>
+            <figcaption><span className="sf2-rev-av">{(r.name || "?").slice(0, 1)}</span>{r.name}</figcaption>
+          </figure>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ── CTA card ───────────────────────────────────────────────────────────────
+export function CtaBand({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <section className="sf2-cta sf2-wrap" id="contact">
+      <div className="sf2-cta-card">
+        <h2 className="sf2-cta-h">Ready to feel strong again?</h2>
+        <p className="sf2-cta-sub">Your first class is on me. Let's move together — at every stage.</p>
+        <div className="sf2-cta-actions">
+          <a className="sf2-btn sf2-btn-onrose" href={ctas.bookUrl}>Book a Class <Icon.arrow /></a>
+          {ctas.callHref && data.phone && <a className="sf2-btn sf2-btn-onrose-out" href={ctas.callHref}><Icon.phone /> {data.phone}</a>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ── Footer ─────────────────────────────────────────────────────────────────
+export function Footer({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  const cols: [string, string[], "text" | "link"][] = [];
+  const contact: string[] = [];
+  if (data.address) contact.push(data.address);
+  if (data.phone) contact.push(data.phone);
+  if (data.email) contact.push(data.email);
+  if (contact.length) cols.push(["Contact", contact, "text"]);
+  if (data.service_area && data.service_area.length) cols.push(["Where I Teach", data.service_area, "text"]);
+  if (data.hours && data.hours.length)
+    cols.push(["Hours", data.hours.map((h) => (h.close ? `${h.day}: ${h.open} \u2013 ${h.close}` : `${h.day}: ${h.open}`)), "text"]);
+  cols.push(["Follow", ["Instagram", "TikTok"], "link"]);
+  return (
+    <footer className="sf2-foot">
+      <div className="sf2-wrap sf2-foot-in">
+        <div className="sf2-foot-brand">
+          <span className="sf2-brand"><span className="sf2-brand-mark">{sfFirstName(data.business_name).slice(0, 1)}</span><span className="sf2-brand-name">{data.business_name}</span></span>
+          {data.tagline && <p className="sf2-foot-tag">{data.tagline}</p>}
+          <a className="sf2-btn sf2-btn-primary" href={ctas.bookUrl}>Book a Class</a>
+        </div>
+        <div className="sf2-foot-cols">
+          {cols.map(([h, items, kind]) => (
+            <div className="sf2-foot-col" key={h}>
+              <h3>{h}</h3>
+              <ul>{items.map((x, i) => (<li key={i}>{kind === "link" ? <a href={ctas.bookUrl}>{x}</a> : x}</li>))}</ul>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="sf2-wrap sf2-foot-legal">
+        <span>{"\u00A9 " + new Date().getFullYear() + " " + data.business_name}</span>
+        <span>Privacy · Accessibility · Terms</span>
+      </div>
+    </footer>
+  );
+}
+
+// ── Sticky mobile bar ──────────────────────────────────────────────────────
+export function MobileBar({ data, ctas }: { data: Soul; ctas: CTAs }) {
+  return (
+    <div className="sf2-mbar" aria-label="Quick actions">
+      {ctas.callHref && data.phone && <a className="sf2-mbar-call" href={ctas.callHref}><Icon.phone /> Call</a>}
+      <a className="sf2-mbar-book" href={ctas.bookUrl}>Book a Class</a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing-templates/warm-wellness/theme.ts
+++ b/packages/crm/src/components/landing-templates/warm-wellness/theme.ts
@@ -1,0 +1,49 @@
+import type { CSSProperties } from "react";
+import type { SfTheme, Soul } from "../_contract/types";
+
+// Tasteful default palette + font pairing for "Warm Wellness".
+export const SF2_DEFAULT_THEME: Required<SfTheme> = {
+  primary: "#c2868a", // dusty rose
+  secondary: "#2e2933", // deep warm plum-ink
+  bg: "#faf5f2",
+  text: "#2e2933",
+  border: "#ecdfdb",
+  fontHeadline: "'Lora', Georgia, serif",
+  fontBody: "'Nunito Sans', system-ui, sans-serif",
+};
+
+export function sfThemeVars(theme?: SfTheme): CSSProperties {
+  const t = { ...SF2_DEFAULT_THEME, ...(theme || {}) };
+  return {
+    ["--sf-primary" as string]: t.primary,
+    ["--sf-secondary" as string]: t.secondary,
+    ["--sf-bg" as string]: t.bg,
+    ["--sf-text" as string]: t.text,
+    ["--sf-border" as string]: t.border,
+    ["--sf-font-headline" as string]: t.fontHeadline,
+    ["--sf-font-body" as string]: t.fontBody,
+  } as CSSProperties;
+}
+
+export function sfMoney(price?: number, currency?: string): string | null {
+  if (price == null) return null;
+  const sym: Record<string, string> = { USD: "$", EUR: "€", GBP: "£" };
+  return (sym[currency || "USD"] || "$") + price;
+}
+export function sfDur(min?: number): string | null {
+  if (!min) return null;
+  if (min < 60) return min + " min";
+  const h = Math.floor(min / 60), m = min % 60;
+  return m ? `${h} hr ${m} min` : `${h} hr`;
+}
+export type Photo = NonNullable<Soul["photos"]>[number];
+export function sfPhoto(data: Soul, role: Photo["role"], idx = 0): Photo | null {
+  return (data.photos || []).filter((p) => p && p.role === role)[idx] || null;
+}
+// Surface a promotional offer if the soul advertises one (graceful — hides otherwise).
+export function sfPromo(data: Soul): string | null {
+  return (data.trust_signals || []).find((s) => /free|%|\boff\b|trial|first/i.test(s)) || null;
+}
+export function sfFirstName(name?: string): string {
+  return (name || "").split(/\s+/)[0];
+}

--- a/packages/crm/src/components/landing-templates/warm-wellness/ui.tsx
+++ b/packages/crm/src/components/landing-templates/warm-wellness/ui.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import type { CSSProperties } from "react";
+import type { Photo } from "./theme";
+
+export function ThemedPlaceholder({
+  role = "image", label, decorative = false, className = "", style,
+}: { role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  return (
+    <div className={"sf2-ph " + className} data-role={role} style={style} role="img" aria-label={label || role + " placeholder"}>
+      {!decorative && <span className="sf2-ph-tag">{label || role}</span>}
+    </div>
+  );
+}
+
+export function SmartImage({
+  photo, role, label, decorative, className = "", style,
+}: { photo?: Photo | null; role?: string; label?: string; decorative?: boolean; className?: string; style?: CSSProperties }) {
+  const [failed, setFailed] = useState(false);
+  if (!photo || !photo.url || failed) {
+    return <ThemedPlaceholder role={role} label={label} decorative={decorative} className={className} style={style} />;
+  }
+  return (
+    <img className={"sf2-img " + className} style={style} src={photo.url} alt={photo.alt || label || ""} loading="lazy" decoding="async" onError={() => setFailed(true)} />
+  );
+}

--- a/packages/crm/src/lib/landing/public-workspace.ts
+++ b/packages/crm/src/lib/landing/public-workspace.ts
@@ -1,0 +1,58 @@
+// packages/crm/src/lib/landing/public-workspace.ts
+//
+// Public, slug-keyed lookup of the bits of a workspace the /w/[slug] route
+// needs to render a registered landing template DIRECTLY from the workspace's
+// raw `organizations.soul` jsonb — used when no r1 landing payload exists yet.
+//
+// This is the soul-first counterpart to r1-save.ts's loadLandingPayload():
+//   • loadLandingPayload → the r1 landing_pages row (preferred when present).
+//   • getWorkspaceTemplateContext → the org's id + raw soul + theme, so the
+//     route can fall back to submittedSoulToTemplateData(soul) and still pick a
+//     template via theme.landingTemplate / theme.aestheticArchetype.
+//
+// No auth — these are public marketing pages. Returns null when the slug
+// doesn't resolve to a workspace (the route turns that into notFound()).
+
+import { db } from "@/db";
+import { organizations } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+/**
+ * Resolve a workspace slug → the org id, its raw `soul` jsonb (untyped on
+ * purpose — the caller maps it defensively via submittedSoulToTemplateData),
+ * and the slice of `theme` that drives template selection.
+ *
+ * @returns `{ orgId, soul, theme }` or null when no organization has that slug.
+ */
+export async function getWorkspaceTemplateContext(slug: string): Promise<{
+  orgId: string;
+  soul: unknown;
+  theme: { landingTemplate?: string; aestheticArchetype?: string } | null;
+} | null> {
+  const [row] = await db
+    .select({
+      id: organizations.id,
+      soul: organizations.soul,
+      theme: organizations.theme,
+    })
+    .from(organizations)
+    .where(eq(organizations.slug, slug))
+    .limit(1);
+
+  if (!row) return null;
+
+  // theme is jsonb (OrgTheme); landingTemplate / aestheticArchetype are
+  // optional. Normalize to plain optional strings for the route's use.
+  const theme = row.theme
+    ? {
+        ...(typeof row.theme.landingTemplate === "string"
+          ? { landingTemplate: row.theme.landingTemplate }
+          : {}),
+        ...(typeof row.theme.aestheticArchetype === "string"
+          ? { aestheticArchetype: row.theme.aestheticArchetype }
+          : {}),
+      }
+    : null;
+
+  return { orgId: row.id, soul: row.soul, theme };
+}

--- a/packages/crm/src/lib/landing/r1-payload-to-template.ts
+++ b/packages/crm/src/lib/landing/r1-payload-to-template.ts
@@ -1,0 +1,201 @@
+// lib/landing/r1-payload-to-template.ts
+//
+// Maps the R1 landing payload (the extracted, cleaned hero/services/
+// testimonials/faq/footer that `/w/[slug]` already loads) onto the shared
+// landing-template `Soul` contract. This makes the premium full-page
+// templates (e.g. earthy-modern-clinical) *alternative renderers* of the
+// same r1 content — no separate data source, no second extraction.
+//
+// House rules:
+//   • Never throw on missing data. Every r1 sub-section is treated as
+//     possibly absent / partially filled. Absent fields are OMITTED so the
+//     template renders its themed placeholders rather than empty strings.
+//   • The r1 service shape (`R1Service`) only carries { id, name, description }
+//     and the payload carries no per-service photos — so offerings get name +
+//     description, and price/duration/service-photos are picked up ONLY if a
+//     future enriched payload happens to include them (tolerant, never
+//     required). Hero is the one image the r1 payload reliably provides.
+
+import type {
+  R1LandingPayload,
+  R1Service,
+  R1Testimonial,
+  R1FaqItem,
+} from "./r1-payload-prompt";
+import type { Soul } from "@/components/landing-templates/_contract/types";
+
+type Photo = NonNullable<Soul["photos"]>[number];
+type Offering = NonNullable<Soul["offerings"]>[number];
+
+/** Trim a string; return undefined for empty/whitespace-only/missing. */
+function clean(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const t = v.trim();
+  return t.length ? t : undefined;
+}
+
+/** Keep a finite number; drop NaN / Infinity / non-numbers. */
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+/**
+ * Join an r1 footer address ({ line1, city, state, zip }) into the single
+ * string the template expects. Omits blank parts; returns undefined when
+ * nothing usable is present. Format: "line1, city, state zip".
+ */
+function joinAddress(
+  address: R1LandingPayload["footer"]["address"],
+): string | undefined {
+  if (!address) return undefined;
+  const line1 = clean(address.line1);
+  const city = clean(address.city);
+  const state = clean(address.state);
+  const zip = clean(address.zip);
+  const cityState = [city, state].filter(Boolean).join(", ");
+  const cityStateZip = [cityState, zip].filter(Boolean).join(" ").trim();
+  const out = [line1, cityStateZip].filter(Boolean).join(", ").trim();
+  return out.length ? out : undefined;
+}
+
+/**
+ * Map an r1 service entry → template offering. The base r1 shape has only
+ * name + description; price / currency / duration are read defensively in
+ * case an enriched payload provides them, but are never required.
+ */
+function toOffering(svc: R1Service): Offering | null {
+  const name = clean(svc?.name);
+  if (!name) return null; // name is the only required offering field
+  const loose = svc as Partial<Offering> & R1Service;
+  const offering: Offering = { name };
+  const description = clean(svc.description);
+  if (description) offering.description = description;
+  const price = num(loose.price);
+  if (price != null) offering.price = price;
+  const currency = clean(loose.currency);
+  if (currency) offering.currency = currency;
+  const duration = num(loose.duration_minutes);
+  if (duration != null) offering.duration_minutes = duration;
+  return offering;
+}
+
+/** Map an r1 testimonial → template testimonial ({ name, text }). */
+function toTestimonial(t: R1Testimonial): { name: string; text: string } | null {
+  const text = clean(t?.quote);
+  const name = clean(t?.name);
+  if (!text || !name) return null;
+  return { name, text };
+}
+
+/** Map an r1 faq item → template faq ({ q, a }). */
+function toFaq(item: R1FaqItem): { q: string; a: string } | null {
+  const q = clean(item?.question);
+  const a = clean(item?.answer);
+  if (!q || !a) return null;
+  return { q, a };
+}
+
+/**
+ * Convert an R1 landing payload into the shared template `Soul`.
+ *
+ * Defensive by design: any sub-section may be missing or partial. Absent
+ * fields are omitted (the templates render graceful, themed placeholders).
+ * The only invariant is `business_name` (always produced — falls back from
+ * hero → footer → "Our Practice").
+ */
+export function r1PayloadToTemplateData(payload: R1LandingPayload): Soul {
+  // Tolerate a malformed/partial payload object without throwing.
+  const hero = payload?.hero ?? ({} as R1LandingPayload["hero"]);
+  const services = payload?.services ?? ({} as R1LandingPayload["services"]);
+  const testimonialsSec =
+    payload?.testimonials ?? ({} as R1LandingPayload["testimonials"]);
+  const faqSec = payload?.faq ?? ({} as R1LandingPayload["faq"]);
+  const footer = payload?.footer ?? ({} as R1LandingPayload["footer"]);
+
+  // ── identity ──────────────────────────────────────────────────────────────
+  const business_name =
+    clean(hero.businessName) ?? clean(footer.businessName) ?? "Our Practice";
+
+  const soul: Soul = { business_name };
+
+  const tagline = clean(hero.tagline) ?? clean(footer.tagline);
+  if (tagline) soul.tagline = tagline;
+
+  const soul_description = clean(hero.subhead);
+  if (soul_description) soul.soul_description = soul_description;
+
+  // ── reviews (hero first, testimonials summary as fallback) ─────────────────
+  const reviewSummary = testimonialsSec.reviewSummary;
+  const review_rating = num(hero.reviewRating) ?? num(reviewSummary?.rating);
+  if (review_rating != null) soul.review_rating = review_rating;
+  const review_count = num(hero.reviewCount) ?? num(reviewSummary?.count);
+  if (review_count != null) soul.review_count = review_count;
+
+  if (hero.emergencyService === true) soul.emergency_service = true;
+
+  // ── contact / location (footer) ────────────────────────────────────────────
+  const phone = clean(footer.phone);
+  if (phone) soul.phone = phone;
+  const email = clean(footer.email);
+  if (email) soul.email = email;
+  const address = joinAddress(footer.address);
+  if (address) soul.address = address;
+
+  const service_area = (footer.serviceAreas ?? [])
+    .map(clean)
+    .filter((s): s is string => Boolean(s));
+  if (service_area.length) soul.service_area = service_area;
+
+  // ── trust signals / certifications (footer) ────────────────────────────────
+  const trust_signals = (footer.trustBadges ?? [])
+    .map((b) => clean(b?.label))
+    .filter((s): s is string => Boolean(s));
+  if (trust_signals.length) soul.trust_signals = trust_signals;
+
+  const license = clean(footer.license);
+  if (license) soul.certifications = [license];
+
+  // ── offerings (services) ────────────────────────────────────────────────────
+  const offerings = (services.services ?? [])
+    .map(toOffering)
+    .filter((o): o is Offering => o != null);
+  if (offerings.length) soul.offerings = offerings;
+
+  // ── testimonials ────────────────────────────────────────────────────────────
+  const testimonials = (testimonialsSec.testimonials ?? [])
+    .map(toTestimonial)
+    .filter((t): t is { name: string; text: string } => t != null);
+  if (testimonials.length) soul.testimonials = testimonials;
+
+  // ── faqs ────────────────────────────────────────────────────────────────────
+  const faqs = (faqSec.items ?? [])
+    .map(toFaq)
+    .filter((f): f is { q: string; a: string } => f != null);
+  if (faqs.length) soul.faqs = faqs;
+
+  // ── photos ──────────────────────────────────────────────────────────────────
+  // Hero is the one image r1 reliably provides. Per-service images are mapped
+  // in source order ONLY when an (enriched) service entry carries an `image`
+  // url — preserving order so sfPhoto(data, "service", i) lines up with the
+  // i-th offering. Absent → omitted → template placeholder.
+  const photos: Photo[] = [];
+  const heroUrl = clean(hero.heroImage?.src);
+  if (heroUrl) {
+    const heroPhoto: Photo = { url: heroUrl, role: "hero" };
+    const heroAlt = clean(hero.heroImage?.alt);
+    if (heroAlt) heroPhoto.alt = heroAlt;
+    photos.push(heroPhoto);
+  }
+  for (const svc of services.services ?? []) {
+    const loose = svc as R1Service & { image?: unknown; imageUrl?: unknown };
+    const url = clean(loose.image) ?? clean(loose.imageUrl);
+    if (!url) continue;
+    const photo: Photo = { url, role: "service" };
+    const alt = clean(svc.name);
+    if (alt) photo.alt = alt;
+    photos.push(photo);
+  }
+  if (photos.length) soul.photos = photos;
+
+  return soul;
+}

--- a/packages/crm/src/lib/landing/r1-payload-to-template.ts
+++ b/packages/crm/src/lib/landing/r1-payload-to-template.ts
@@ -199,3 +199,182 @@ export function r1PayloadToTemplateData(payload: R1LandingPayload): Soul {
 
   return soul;
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Flat submitted-soul → template Soul
+// ────────────────────────────────────────────────────────────────────────────
+//
+// Some workspaces have a raw `organizations.soul` jsonb (a FLAT business
+// profile captured at submission time) but no r1 landing payload yet. The
+// /w/[slug] route falls back to this mapper so those workspaces still render a
+// registered template. The flat soul is untyped JSON, so every access is
+// defensive and the function NEVER throws.
+//
+// Shape we expect (all keys optional except the produced business_name):
+//   business_name, tagline, soul_description, phone, email, address (strings),
+//   offerings (array of STRINGS or { name, ... } objects),
+//   faqs ({ q, a }[]), testimonials ({ name, text }[]).
+// Richer fields (review_rating/count, service_area, trust_signals,
+// certifications, emergency_service/same_day, photos) are passed through ONLY
+// when present and well-typed — otherwise omitted so the template renders its
+// themed placeholders.
+
+/** Narrow an unknown to a plain (non-array, non-null) object. */
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Keep only the finite-number entries of an unknown; undefined otherwise. */
+function strArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.map(clean).filter((s): s is string => Boolean(s));
+  return out.length ? out : undefined;
+}
+
+/**
+ * Map one flat-soul offering entry → template offering.
+ *   • string            → { name: <string> }
+ *   • { name: string }  → passthrough (description/price/currency/duration
+ *                          read defensively, never required)
+ *   • anything else     → dropped (null)
+ */
+function flatOffering(item: unknown): Offering | null {
+  if (typeof item === "string") {
+    const name = clean(item);
+    return name ? { name } : null;
+  }
+  if (!isRecord(item)) return null;
+  const name = clean(item.name);
+  if (!name) return null;
+  const offering: Offering = { name };
+  const description = clean(item.description);
+  if (description) offering.description = description;
+  const price = num(item.price);
+  if (price != null) offering.price = price;
+  const currency = clean(item.currency);
+  if (currency) offering.currency = currency;
+  const duration = num(item.duration_minutes);
+  if (duration != null) offering.duration_minutes = duration;
+  return offering;
+}
+
+/** Map a flat-soul faq entry → { q, a }; null unless both are non-empty. */
+function flatFaq(item: unknown): { q: string; a: string } | null {
+  if (!isRecord(item)) return null;
+  const q = clean(item.q);
+  const a = clean(item.a);
+  if (!q || !a) return null;
+  return { q, a };
+}
+
+/**
+ * Map a flat-soul testimonial entry → { name, text }. `text` is required;
+ * `name` falls back to "Anonymous" so a well-formed quote without an attributed
+ * author still renders (the contract types `name` as required).
+ */
+function flatTestimonial(item: unknown): { name: string; text: string } | null {
+  if (!isRecord(item)) return null;
+  const text = clean(item.text);
+  if (!text) return null;
+  const name = clean(item.name) ?? "Anonymous";
+  return { name, text };
+}
+
+/** Map a flat-soul photo entry → template photo; null unless `url` is present. */
+function flatPhoto(item: unknown): Photo | null {
+  if (!isRecord(item)) return null;
+  const url = clean(item.url);
+  if (!url) return null;
+  const photo: Photo = { url };
+  const alt = clean(item.alt);
+  if (alt) photo.alt = alt;
+  const role = item.role;
+  if (
+    role === "hero" ||
+    role === "service" ||
+    role === "about" ||
+    role === "gallery"
+  ) {
+    photo.role = role;
+  }
+  return photo;
+}
+
+/**
+ * Convert a raw, FLAT `organizations.soul` jsonb into the shared template
+ * `Soul`. Used by /w/[slug] when a workspace has a soul but no r1 landing
+ * payload. Defensive by design: any field may be missing or the wrong type;
+ * such fields are omitted. The only invariant is `business_name` (falls back to
+ * "Our Practice"). Never throws.
+ */
+export function submittedSoulToTemplateData(raw: unknown): Soul {
+  const src: Record<string, unknown> = isRecord(raw) ? raw : {};
+
+  // ── identity ────────────────────────────────────────────────────────────
+  const business_name = clean(src.business_name) ?? "Our Practice";
+  const soul: Soul = { business_name };
+
+  const tagline = clean(src.tagline);
+  if (tagline) soul.tagline = tagline;
+  const soul_description = clean(src.soul_description);
+  if (soul_description) soul.soul_description = soul_description;
+
+  // ── contact / location ──────────────────────────────────────────────────
+  const phone = clean(src.phone);
+  if (phone) soul.phone = phone;
+  const email = clean(src.email);
+  if (email) soul.email = email;
+  const address = clean(src.address);
+  if (address) soul.address = address;
+
+  const service_area = strArray(src.service_area);
+  if (service_area) soul.service_area = service_area;
+
+  // ── reviews / trust ───────────────────────────────────────────────────────
+  const review_rating = num(src.review_rating);
+  if (review_rating != null) soul.review_rating = review_rating;
+  const review_count = num(src.review_count);
+  if (review_count != null) soul.review_count = review_count;
+
+  const trust_signals = strArray(src.trust_signals);
+  if (trust_signals) soul.trust_signals = trust_signals;
+  const certifications = strArray(src.certifications);
+  if (certifications) soul.certifications = certifications;
+
+  if (src.emergency_service === true) soul.emergency_service = true;
+  if (src.same_day === true) soul.same_day = true;
+
+  // ── offerings (array of strings or { name, … } objects) ───────────────────
+  if (Array.isArray(src.offerings)) {
+    const offerings = src.offerings
+      .map(flatOffering)
+      .filter((o): o is Offering => o != null);
+    if (offerings.length) soul.offerings = offerings;
+  }
+
+  // ── faqs ──────────────────────────────────────────────────────────────────
+  if (Array.isArray(src.faqs)) {
+    const faqs = src.faqs
+      .map(flatFaq)
+      .filter((f): f is { q: string; a: string } => f != null);
+    if (faqs.length) soul.faqs = faqs;
+  }
+
+  // ── testimonials ──────────────────────────────────────────────────────────
+  if (Array.isArray(src.testimonials)) {
+    const testimonials = src.testimonials
+      .map(flatTestimonial)
+      .filter((t): t is { name: string; text: string } => t != null);
+    if (testimonials.length) soul.testimonials = testimonials;
+  }
+
+  // ── photos (only when present + well-typed) ───────────────────────────────
+  if (Array.isArray(src.photos)) {
+    const photos = src.photos
+      .map(flatPhoto)
+      .filter((p): p is Photo => p != null);
+    if (photos.length) soul.photos = photos;
+  }
+
+  return soul;
+}

--- a/packages/crm/src/lib/landing/r1-save.ts
+++ b/packages/crm/src/lib/landing/r1-save.ts
@@ -101,6 +101,10 @@ export async function loadLandingPayload(workspaceSlug: string): Promise<{
   payload: R1LandingPayload;
   archetype: AestheticArchetypeId;
   orgId: string;
+  /** Health-templates pilot: id persisted at organizations.theme.landingTemplate
+   *  (undefined for every workspace that hasn't opted into a premium template).
+   *  Additive — existing callers ignore it and the landing-r1 path is unchanged. */
+  landingTemplate: string | undefined;
   seo: { title: string; description: string; ogImage: string | null };
 } | null> {
   // Join landing_pages → organizations to resolve workspace slug → orgId.
@@ -109,12 +113,18 @@ export async function loadLandingPayload(workspaceSlug: string): Promise<{
   const { organizations } = await import("@/db/schema");
 
   const [orgRow] = await db
-    .select({ id: organizations.id })
+    .select({ id: organizations.id, theme: organizations.theme })
     .from(organizations)
     .where(eq(organizations.slug, workspaceSlug))
     .limit(1);
 
   if (!orgRow) return null;
+
+  // theme is jsonb typed as OrgTheme; landingTemplate is an optional string.
+  const landingTemplate =
+    typeof orgRow.theme?.landingTemplate === "string"
+      ? orgRow.theme.landingTemplate
+      : undefined;
 
   const [row] = await db
     .select({
@@ -146,6 +156,7 @@ export async function loadLandingPayload(workspaceSlug: string): Promise<{
     payload,
     archetype,
     orgId: orgRow.id,
+    landingTemplate,
     seo: {
       title: (seoRaw["title"] as string | undefined) ?? payload.footer.businessName,
       description:

--- a/packages/crm/src/lib/landing/template-adapters.ts
+++ b/packages/crm/src/lib/landing/template-adapters.ts
@@ -1,0 +1,59 @@
+// lib/landing/template-adapters.ts
+//
+// Adapters that bridge SeldonFrame's internal data shapes onto the shared
+// landing-template contract (`components/landing-templates/_contract/types`).
+//
+// - archetypeToSfTheme: archetype palette/fonts → the template's flat
+//   --sf-* theme tokens. The template hardcodes nothing; swapping the
+//   archetype re-skins the whole page.
+// - buildTemplateCtas: workspace-scoped booking / intake / call hrefs.
+//
+// The soul/payload → template `Soul` mapper lives in r1-payload-to-template
+// (added when the /w dispatch is wired) — it normalizes the r1 landing
+// payload (the extracted, cleaned content) into the template data shape.
+
+import { ARCHETYPES, type AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
+import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
+import type { CTAs, SfTheme } from "@/components/landing-templates/_contract/types";
+
+/**
+ * Map an aesthetic archetype to the template's flat SfTheme tokens.
+ * Falls back to editorial-warm for unknown ids. Font families are quoted
+ * with system-ui fallbacks; the actual webfonts are loaded by the host
+ * theme layer (apply-theme.ts googleFontUrl helper).
+ */
+export function archetypeToSfTheme(archetypeId: AestheticArchetypeId): SfTheme {
+  const a = ARCHETYPES[archetypeId] ?? ARCHETYPES["editorial-warm"];
+  return {
+    primary: a.palette.primary,
+    secondary: a.palette.secondary,
+    bg: a.palette.background,
+    text: a.palette.text,
+    border: a.palette.border,
+    fontHeadline: `"${a.fonts.headline}", system-ui, sans-serif`,
+    fontBody: `"${a.fonts.body}", system-ui, sans-serif`,
+  };
+}
+
+/**
+ * Build the workspace-scoped CTAs the template links to. `phone` (from the
+ * landing content) becomes a tel: href; book/intake come from the workspace
+ * URL helper so they resolve to the live booking + intake surfaces.
+ */
+export function buildTemplateCtas(
+  slug: string,
+  orgId: string,
+  phone?: string | null,
+): CTAs {
+  const urls = buildWorkspaceUrls(
+    slug,
+    process.env.WORKSPACE_BASE_DOMAIN ?? "app.seldonframe.com",
+    orgId,
+  );
+  const digits = phone ? phone.replace(/[^\d+]/g, "") : "";
+  return {
+    bookUrl: urls.book,
+    intakeUrl: urls.intake,
+    callHref: digits ? `tel:${digits}` : undefined,
+  };
+}

--- a/packages/crm/src/lib/theme/types.ts
+++ b/packages/crm/src/lib/theme/types.ts
@@ -53,6 +53,13 @@ export interface OrgTheme {
    *  archetype-curated Unsplash fallback. Optional for backward compat:
    *  workspaces created pre-1.54 lazy-reclassify on first hero persist. */
   aestheticArchetype?: AestheticArchetypeId;
+  /** Health-vertical templates pilot — id of the premium full-page landing
+   *  template to render at /w/[slug] (see components/landing-templates/
+   *  registry.ts). When set + registered, the /w route renders that template
+   *  instead of the landing-r1 sections. Stored as a plain string (decoupled
+   *  from the registry's union); validated at read time via isLandingTemplateId.
+   *  Absent on every existing workspace → unchanged landing-r1 behavior. */
+  landingTemplate?: string;
 }
 
 // v1.38.5 — flipped default mode from "dark" to "light".

--- a/packages/crm/tests/unit/r1-payload-to-template.spec.ts
+++ b/packages/crm/tests/unit/r1-payload-to-template.spec.ts
@@ -1,0 +1,211 @@
+// Tests for r1PayloadToTemplateData — maps the R1 landing payload onto the
+// shared landing-template `Soul` contract.
+//
+// Repo convention: node:test + tsx (see scripts/run-unit-tests.js). There is
+// no vitest in this monorepo; unit tests live at tests/unit/**/*.spec.ts and
+// run via `pnpm test:unit`.
+//
+// Coverage:
+//   1. Representative full payload → all major Soul fields populated, incl.
+//      a hero photo with role "hero".
+//   2. Minimal payload (optional sections empty/missing) → no throw, absent
+//      fields omitted, business_name still produced.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { r1PayloadToTemplateData } from "../../src/lib/landing/r1-payload-to-template";
+import type { R1LandingPayload } from "../../src/lib/landing/r1-payload-prompt";
+
+// ── Representative fixture (mirrors a real generated r1 payload) ──────────────
+const fullPayload: R1LandingPayload = {
+  hero: {
+    archetype: "clinical-trust",
+    businessName: "Austin Family Chiropractic",
+    tagline: "Gentle, expert chiropractic care for the whole family",
+    subhead:
+      "A family-focused clinic serving every age — from infants to seniors — with spinal adjustments, corrective care, and whole-body wellness.",
+    primaryCTA: { label: "Book a consultation", href: "/book" },
+    secondaryCTA: { label: "Book online", href: "/book" },
+    trustBadges: [{ label: "Licensed Doctors of Chiropractic" }],
+    reviewRating: 4.9,
+    reviewCount: 287,
+    emergencyService: false,
+    heroImage: {
+      src: "https://images.example.com/hero.jpg",
+      alt: "Gentle hands-on chiropractic care",
+    },
+  },
+  services: {
+    archetype: "clinical-trust",
+    eyebrow: "Our services",
+    heading: "Care for every body",
+    intro: "We treat the root cause, not just the symptoms.",
+    services: [
+      { id: "s1", name: "Spinal Adjustment", description: "Restore motion and relieve nerve pressure." },
+      { id: "s2", name: "Corrective Care Program", description: "A structured plan to fix the root cause." },
+      { id: "s3", name: "Prenatal Chiropractic", description: "Gentle, Webster-certified care through pregnancy." },
+    ],
+    cta: { label: "Call (512) 555-0182", href: "tel:+15125550182" },
+  },
+  testimonials: {
+    archetype: "clinical-trust",
+    eyebrow: "Patient reviews",
+    heading: "287 reviews. 4.9 stars.",
+    testimonials: [
+      { id: "t1", quote: "Dr. Mitchell's prenatal adjustments changed everything.", name: "Jennifer K.", city: "Austin", rating: 5 },
+      { id: "t2", quote: "After 8 weeks my chronic back pain is virtually gone.", name: "Marcus T.", rating: 5 },
+    ],
+    reviewSummary: { rating: 4.9, count: 287, sources: "Google · Yelp" },
+  },
+  faq: {
+    archetype: "clinical-trust",
+    eyebrow: "Quick answers",
+    heading: "Frequently asked questions",
+    items: [
+      { id: "f1", question: "Do you accept insurance?", answer: "We accept most major plans." },
+      { id: "f2", question: "Is chiropractic safe for children?", answer: "Yes — we use gentle, low-force techniques." },
+      { id: "f3", question: "Do I need a referral?", answer: "No referral needed — book directly." },
+    ],
+  },
+  footer: {
+    archetype: "clinical-trust",
+    businessName: "Austin Family Chiropractic",
+    tagline: "Whole-family chiropractic care since 2009.",
+    phone: "(512) 555-0182",
+    email: "hello@austinfamilychiro.com",
+    address: { line1: "3204 Bee Caves Rd, Suite 102", city: "Austin", state: "TX", zip: "78746" },
+    serviceAreas: ["Austin", "West Lake Hills", "Bee Cave"],
+    license: "Doctor of Chiropractic (DC)",
+    trustBadges: [
+      { label: "Licensed Doctors of Chiropractic" },
+      { label: "Most insurance accepted" },
+    ],
+  },
+};
+
+describe("r1PayloadToTemplateData — representative payload", () => {
+  const soul = r1PayloadToTemplateData(fullPayload);
+
+  test("maps hero → business_name / tagline / soul_description", () => {
+    assert.equal(soul.business_name, "Austin Family Chiropractic");
+    assert.equal(soul.tagline, "Gentle, expert chiropractic care for the whole family");
+    assert.ok(soul.soul_description && soul.soul_description.startsWith("A family-focused clinic"));
+  });
+
+  test("maps hero review rating + count", () => {
+    assert.equal(soul.review_rating, 4.9);
+    assert.equal(soul.review_count, 287);
+  });
+
+  test("produces a hero photo with role 'hero'", () => {
+    assert.ok(Array.isArray(soul.photos));
+    const hero = soul.photos!.find((p) => p.role === "hero");
+    assert.ok(hero, "expected a photo with role 'hero'");
+    assert.equal(hero!.url, "https://images.example.com/hero.jpg");
+    assert.equal(hero!.alt, "Gentle hands-on chiropractic care");
+  });
+
+  test("maps services → offerings (≥1 with a name, order preserved)", () => {
+    assert.ok(Array.isArray(soul.offerings));
+    assert.equal(soul.offerings!.length, 3);
+    assert.equal(soul.offerings![0].name, "Spinal Adjustment");
+    assert.equal(soul.offerings![0].description, "Restore motion and relieve nerve pressure.");
+    // r1 service shape carries no price/duration → omitted, not zeroed.
+    assert.equal(soul.offerings![0].price, undefined);
+    assert.equal(soul.offerings![0].duration_minutes, undefined);
+  });
+
+  test("maps testimonials → { name, text }", () => {
+    assert.equal(soul.testimonials!.length, 2);
+    assert.equal(soul.testimonials![0].name, "Jennifer K.");
+    assert.equal(soul.testimonials![0].text, "Dr. Mitchell's prenatal adjustments changed everything.");
+  });
+
+  test("maps faq items → { q, a }", () => {
+    assert.equal(soul.faqs!.length, 3);
+    assert.equal(soul.faqs![0].q, "Do you accept insurance?");
+    assert.equal(soul.faqs![0].a, "We accept most major plans.");
+  });
+
+  test("maps footer → phone / email / joined address / service_area", () => {
+    assert.equal(soul.phone, "(512) 555-0182");
+    assert.equal(soul.email, "hello@austinfamilychiro.com");
+    assert.equal(soul.address, "3204 Bee Caves Rd, Suite 102, Austin, TX 78746");
+    assert.deepEqual(soul.service_area, ["Austin", "West Lake Hills", "Bee Cave"]);
+  });
+
+  test("maps footer trustBadges → trust_signals and license → certifications", () => {
+    assert.deepEqual(soul.trust_signals, [
+      "Licensed Doctors of Chiropractic",
+      "Most insurance accepted",
+    ]);
+    assert.deepEqual(soul.certifications, ["Doctor of Chiropractic (DC)"]);
+  });
+});
+
+describe("r1PayloadToTemplateData — minimal payload", () => {
+  // Only the five required top-level sections, each with the bare minimum.
+  // Optional sub-fields (reviews, photos, faqs, testimonials, address, etc.)
+  // are intentionally absent.
+  const minimal: R1LandingPayload = {
+    hero: {
+      archetype: "soft-residential",
+      businessName: "Cedar Park Wellness",
+      tagline: "Feel better, naturally",
+      subhead: "",
+      primaryCTA: { label: "Book", href: "/book" },
+      trustBadges: [],
+    },
+    services: {
+      archetype: "soft-residential",
+      heading: "What we do",
+      services: [],
+    },
+    testimonials: {
+      archetype: "soft-residential",
+      heading: "What our patients say",
+      testimonials: [],
+    },
+    faq: {
+      archetype: "soft-residential",
+      heading: "Frequently asked questions",
+      items: [],
+    },
+    footer: {
+      archetype: "soft-residential",
+      businessName: "Cedar Park Wellness",
+      phone: "",
+    },
+  };
+
+  test("does not throw on missing optional sections", () => {
+    assert.doesNotThrow(() => r1PayloadToTemplateData(minimal));
+  });
+
+  test("still produces business_name", () => {
+    const soul = r1PayloadToTemplateData(minimal);
+    assert.equal(soul.business_name, "Cedar Park Wellness");
+  });
+
+  test("omits absent fields rather than emitting empties", () => {
+    const soul = r1PayloadToTemplateData(minimal);
+    assert.equal(soul.soul_description, undefined); // hero.subhead was ""
+    assert.equal(soul.phone, undefined); // footer.phone was ""
+    assert.equal(soul.address, undefined);
+    assert.equal(soul.review_rating, undefined);
+    assert.equal(soul.review_count, undefined);
+    assert.equal(soul.offerings, undefined);
+    assert.equal(soul.testimonials, undefined);
+    assert.equal(soul.faqs, undefined);
+    assert.equal(soul.photos, undefined);
+    assert.equal(soul.service_area, undefined);
+    assert.equal(soul.trust_signals, undefined);
+    assert.equal(soul.certifications, undefined);
+  });
+
+  test("tagline still maps when present", () => {
+    const soul = r1PayloadToTemplateData(minimal);
+    assert.equal(soul.tagline, "Feel better, naturally");
+  });
+});

--- a/packages/crm/tests/unit/r1-payload-to-template.spec.ts
+++ b/packages/crm/tests/unit/r1-payload-to-template.spec.ts
@@ -14,7 +14,10 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { r1PayloadToTemplateData } from "../../src/lib/landing/r1-payload-to-template";
+import {
+  r1PayloadToTemplateData,
+  submittedSoulToTemplateData,
+} from "../../src/lib/landing/r1-payload-to-template";
 import type { R1LandingPayload } from "../../src/lib/landing/r1-payload-prompt";
 
 // ── Representative fixture (mirrors a real generated r1 payload) ──────────────
@@ -207,5 +210,108 @@ describe("r1PayloadToTemplateData — minimal payload", () => {
   test("tagline still maps when present", () => {
     const soul = r1PayloadToTemplateData(minimal);
     assert.equal(soul.tagline, "Feel better, naturally");
+  });
+});
+
+// ── submittedSoulToTemplateData — flat organizations.soul jsonb ───────────────
+// The soul-only fallback path used by /w/[slug] when a workspace has a raw soul
+// but no r1 landing payload. The flat soul carries string offerings, plus
+// faqs/testimonials in the template's own shape.
+describe("submittedSoulToTemplateData — flat soul with string offerings", () => {
+  const flat = {
+    business_name: "Riverside Physiotherapy",
+    tagline: "Move better, live stronger",
+    soul_description:
+      "A modern physio clinic focused on hands-on manual therapy and active rehab.",
+    phone: "(604) 555-0144",
+    email: "hello@riversidephysio.ca",
+    address: "120 Riverside Dr, Vancouver, BC",
+    offerings: [
+      "Manual Therapy",
+      "Sports Rehabilitation",
+      "  ", // whitespace-only → dropped
+      { name: "Dry Needling", description: "IMS for chronic tension." },
+      { description: "no name → dropped" },
+      42, // non-string / non-object → dropped
+    ],
+    faqs: [
+      { q: "Do you direct bill?", a: "Yes, to most major insurers." },
+      { q: "", a: "missing question → dropped" },
+    ],
+    testimonials: [
+      { name: "Sarah L.", text: "Back to running pain-free in six weeks." },
+      { text: "Great clinic." }, // no name → kept with fallback
+      { name: "No Text" }, // no text → dropped
+    ],
+  };
+
+  const soul = submittedSoulToTemplateData(flat);
+
+  test("maps identity + contact fields (trimmed, present only)", () => {
+    assert.equal(soul.business_name, "Riverside Physiotherapy");
+    assert.equal(soul.tagline, "Move better, live stronger");
+    assert.ok(soul.soul_description?.startsWith("A modern physio clinic"));
+    assert.equal(soul.phone, "(604) 555-0144");
+    assert.equal(soul.email, "hello@riversidephysio.ca");
+    assert.equal(soul.address, "120 Riverside Dr, Vancouver, BC");
+  });
+
+  test("string offerings become { name }, objects pass through, junk dropped", () => {
+    assert.ok(Array.isArray(soul.offerings));
+    assert.deepEqual(
+      soul.offerings!.map((o) => o.name),
+      ["Manual Therapy", "Sports Rehabilitation", "Dry Needling"],
+    );
+    // first two are name-only; the object offering keeps its description.
+    assert.equal(soul.offerings![0].description, undefined);
+    assert.equal(soul.offerings![2].description, "IMS for chronic tension.");
+  });
+
+  test("faqs keep only items with both q and a", () => {
+    assert.equal(soul.faqs!.length, 1);
+    assert.deepEqual(soul.faqs![0], {
+      q: "Do you direct bill?",
+      a: "Yes, to most major insurers.",
+    });
+  });
+
+  test("testimonials keep items with text; name falls back when absent", () => {
+    assert.equal(soul.testimonials!.length, 2);
+    assert.deepEqual(soul.testimonials![0], {
+      name: "Sarah L.",
+      text: "Back to running pain-free in six weeks.",
+    });
+    assert.equal(soul.testimonials![1].text, "Great clinic.");
+    assert.equal(soul.testimonials![1].name, "Anonymous");
+  });
+
+  test("omits rich fields the flat soul never provides", () => {
+    assert.equal(soul.photos, undefined);
+    assert.equal(soul.review_rating, undefined);
+    assert.equal(soul.review_count, undefined);
+    assert.equal(soul.hours, undefined);
+    assert.equal(soul.service_area, undefined);
+  });
+});
+
+describe("submittedSoulToTemplateData — empty / garbage input", () => {
+  test("returns { business_name: 'Our Practice' } without throwing", () => {
+    for (const garbage of [undefined, null, {}, [], 7, "nope", true]) {
+      assert.doesNotThrow(() => submittedSoulToTemplateData(garbage));
+      const soul = submittedSoulToTemplateData(garbage);
+      assert.deepEqual(soul, { business_name: "Our Practice" });
+    }
+  });
+
+  test("tolerates malformed sub-arrays without throwing or emitting them", () => {
+    const soul = submittedSoulToTemplateData({
+      offerings: "not-an-array",
+      faqs: [null, 3, "x"],
+      testimonials: [{}, { name: 5 }],
+    });
+    assert.equal(soul.business_name, "Our Practice");
+    assert.equal(soul.offerings, undefined);
+    assert.equal(soul.faqs, undefined);
+    assert.equal(soul.testimonials, undefined);
   });
 });


### PR DESCRIPTION
## Summary
- Add 5 premium health/wellness full-page landing templates — Clinical Luxe,
  Warm Wellness, Cinematic Sanctuary, Editorial Bodywork, Earthy Modern Clinical
  — under components/landing-templates/<id>/ with a shared ({ data, ctas, theme })
  API and a registry.
- Wire them into /w/[slug]: when theme.landingTemplate is set, render the chosen
  template from the r1 payload (themed via the archetype → --sf-*); otherwise fall
  back to the existing landing-r1 render, unchanged.
- Add TEMPLATE_BY_VERTICAL + DEFAULT_HEALTH_TEMPLATE (feeds the upcoming auto-pick).
- Fix /clients/new REVEAL CTA: show an explicit finalizing state (spinner +
  "Finalizing…") until the orchestrator's `done` fires, then flip to the real
  clickable Open workspace button.

## Notes
- Templates theme 100% via --sf-* vars; each Styles.tsx is "use client".
- Non-health flow + landing-r1 untouched.
- Verified locally with a full `next build` (✓ compiled, 224/224 pages, 0 styled-jsx errors).

## Follow-up (separate PR)
- Design picker on /clients/new + ready-page swap + creation-time pickLandingTemplate auto-pick.