### PR TITLE
feat: landing-design picker — auto-pick at creation + ready-page swap

### DIFF
--- a/packages/crm/src/lib/landing/apply-landing-template.ts
+++ b/packages/crm/src/lib/landing/apply-landing-template.ts
@@ -1,0 +1,56 @@
+// lib/landing/apply-landing-template.ts
+//
+// Auto-pick + persist a health/wellness landing template at workspace creation.
+// Called from the web create flows (run-create-from-url / -paste) right after
+// createFullWorkspace. Best-effort, idempotent, self-contained (reads + writes
+// organizations.theme itself).
+//
+// Behavior:
+//   - Classifies the health sub-vertical from the extracted facts.
+//   - Non-health → no-op (classifier returns null → /w/[slug] keeps landing-r1).
+//   - Health → writes theme.landingTemplate (+ landingTemplateChoice "auto") so
+//     /w/[slug] renders the premium template.
+//   - Respects an explicit operator choice: if landingTemplateChoice is already
+//     a concrete id (hand-picked), leaves it untouched.
+
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { organizations } from "@/db/schema";
+import { DEFAULT_ORG_THEME, type OrgTheme } from "@/lib/theme/types";
+import { classifyHealthTemplate } from "@/lib/landing/template-selection";
+
+export async function applyLandingTemplateForWorkspace(
+  orgId: string,
+  facts: {
+    businessName?: string | null;
+    businessDescription?: string | null;
+    services?: readonly string[] | null;
+  },
+): Promise<{ applied: boolean; template: string | null }> {
+  const template = classifyHealthTemplate(facts);
+  if (!template) return { applied: false, template: null };
+
+  const [org] = await db
+    .select({ theme: organizations.theme })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+  if (!org) return { applied: false, template: null };
+
+  const prev: OrgTheme = org.theme ?? DEFAULT_ORG_THEME;
+  // Respect an explicit, non-auto operator choice — only fill the unset/auto case.
+  if (prev.landingTemplateChoice && prev.landingTemplateChoice !== "auto") {
+    return { applied: false, template: prev.landingTemplate ?? null };
+  }
+
+  await db
+    .update(organizations)
+    .set({
+      theme: { ...prev, landingTemplate: template, landingTemplateChoice: "auto" },
+      updatedAt: new Date(),
+    })
+    .where(eq(organizations.id, orgId));
+
+  return { applied: true, template };
+}

--- a/packages/crm/src/lib/landing/template-selection.ts
+++ b/packages/crm/src/lib/landing/template-selection.ts
@@ -40,3 +40,48 @@ export function resolveHealthTemplate(
 ): LandingTemplateId {
   return pickLandingTemplate(vertical) ?? DEFAULT_HEALTH_TEMPLATE;
 }
+
+/**
+ * Classify the best-fit health/wellness template directly from extracted
+ * business facts (name + description + services). Keyword-based, deterministic,
+ * and intentionally conservative: returns null for anything that isn't clearly
+ * a health/wellness sub-vertical, so non-health workspaces keep landing-r1.
+ *
+ * Why not reuse the CRM personality? It's too coarse (hvac / dental / legal /
+ * coaching / agency / default) to tell chiro from massage from derm — the five
+ * templates need that distinction. The copy carries it; this reads the copy.
+ * Order matters: most-specific match wins.
+ */
+export function classifyHealthTemplate(input: {
+  businessName?: string | null;
+  businessDescription?: string | null;
+  services?: readonly string[] | null;
+}): LandingTemplateId | null {
+  const hay = [
+    input.businessName ?? "",
+    input.businessDescription ?? "",
+    ...(input.services ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  const has = (...kw: string[]) => kw.some((k) => hay.includes(k));
+
+  // T1 Clinical Luxe — derm / med-spa / cosmetic / aesthetics.
+  if (has("dermatolog", "med spa", "medspa", "med-spa", "aesthetic", "botox", "cosmetic", "skincare", "skin care", "laser clinic"))
+    return "clinical-luxe";
+  // T2 Warm Wellness — prenatal / women's health / pilates / yoga.
+  if (has("prenatal", "postnatal", "pre-natal", "post-natal", "pregnan", "women's health", "womens health", "pilates", "yoga", "doula", "midwif"))
+    return "warm-wellness";
+  // T4 Editorial Bodywork — massage / bodywork. (Before "spa" so a massage
+  // spa reads as bodywork.)
+  if (has("massage", "bodywork", "deep tissue", "myofascial"))
+    return "editorial-bodywork";
+  // T3 Cinematic Sanctuary — spa / holistic / osteopathy / acupuncture.
+  if (has("day spa", "sauna", "holistic", "osteopath", "acupunctur", "reiki", "naturopath", "wellness sanctuary", "wellness retreat"))
+    return "cinematic-sanctuary";
+  // T5 Earthy Modern Clinical — chiro / physio / sports med / rehab.
+  if (has("chiropract", "physiotherap", "physical therap", "physio", "sports medicine", "sports med", "rehabilitation", "rehab clinic", "orthopedic"))
+    return "earthy-modern-clinical";
+
+  return null;
+}

--- a/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
@@ -15,6 +15,7 @@ import type { CreateFullWorkspaceInput, CreateFullWorkspaceResult } from "@/lib/
 import type { LimitDecision } from "@/lib/billing/limits";
 import type { ExtractedBusinessFacts } from "./extraction-prompt";
 import { runR1LandingStep } from "@/lib/landing/r1-landing-step";
+import { applyLandingTemplateForWorkspace } from "@/lib/landing/apply-landing-template";
 
 export type RunPasteDeps = {
   enforceWorkspaceLimit: (args: { primaryOrgId: string | null; ownedWorkspaceCount: number }) => Promise<LimitDecision>;
@@ -201,6 +202,26 @@ export async function runCreateFromPaste(input: RunPasteInput): Promise<RunPaste
               }),
             );
           }
+        }
+
+        // 7d2. Auto-pick a premium health/wellness landing template (best-
+        //      effort, health-only) so /w/<slug> renders it instead of
+        //      landing-r1. Non-health businesses are left on landing-r1.
+        try {
+          const tplFacts = facts as CreateFullWorkspaceInput;
+          await applyLandingTemplateForWorkspace(result.workspace_id, {
+            businessName: tplFacts.business_name,
+            businessDescription: tplFacts.business_description,
+            services: tplFacts.services,
+          });
+        } catch (err) {
+          console.warn(
+            JSON.stringify({
+              event: "landing_template_autopick_failed",
+              workspace_id: result.workspace_id,
+              detail: err instanceof Error ? err.message : String(err),
+            }),
+          );
         }
 
         // 7e. Generate the R1 landing payload + persist.

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -39,6 +39,7 @@ import type { CreateFullWorkspaceInput, CreateFullWorkspaceResult } from "@/lib/
 import type { LimitDecision } from "@/lib/billing/limits";
 import type { ExtractedBusinessFacts } from "./extraction-prompt";
 import { runR1LandingStep } from "@/lib/landing/r1-landing-step";
+import { applyLandingTemplateForWorkspace } from "@/lib/landing/apply-landing-template";
 
 export type RunDeps = {
   enforceWorkspaceLimit: (args: { primaryOrgId: string | null; ownedWorkspaceCount: number }) => Promise<LimitDecision>;
@@ -314,6 +315,28 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
               }),
             );
           }
+        }
+
+        // 7c3. Auto-pick a premium health/wellness landing template so
+        //      /w/<slug> renders it instead of landing-r1. Best-effort +
+        //      health-only — the classifier returns null for non-health
+        //      businesses, which keep landing-r1 untouched. Runs before the
+        //      R1 step so theme.landingTemplate is set when /w first renders.
+        try {
+          const tplFacts = facts as CreateFullWorkspaceInput;
+          await applyLandingTemplateForWorkspace(result.workspace_id, {
+            businessName: tplFacts.business_name,
+            businessDescription: tplFacts.business_description,
+            services: tplFacts.services,
+          });
+        } catch (err) {
+          console.warn(
+            JSON.stringify({
+              event: "landing_template_autopick_failed",
+              workspace_id: result.workspace_id,
+              detail: err instanceof Error ? err.message : String(err),
+            }),
+          );
         }
 
         // 7d. Generate the R1 landing payload + persist.


### PR DESCRIPTION
## Summary
- Port the operator-dashboard design picker (DesignChip, ReadyDesignModule,
  shared DesignPicker, token-driven styles) into components/clients/design-picker/
  + 5 thumbnails in public/landing-thumbs/. Theme-token-driven (dark/light +
  operator accent), no --sf-*.
- Auto-pick at creation: new health/wellness workspaces (URL or paste) auto-render
  a premium template at /w/[slug] — classifyHealthTemplate reads the extracted copy
  (chiro→Earthy, massage→Editorial, derm→Clinical Luxe, prenatal→Warm Wellness,
  spa/osteo→Cinematic Sanctuary). Non-health → landing-r1 untouched.
- Ready-page swap: /clients/[slug]/ready shows the current design + Auto rationale;
  "Change design" persists via setLandingTemplateAction and re-renders /w/[slug].
- OrgTheme gains landingTemplateChoice.

## Notes
- Non-health flow + landing-r1 untouched. Verified: full next build (224/224 pages,
  0 errors) at every step.

## Follow-up (optional)
- Pre-build "Design · Auto ▾" chip in the /clients/new idle scene. Auto + the
  ready-page override already cover the operator need.