### PR TITLE
feat: pre-build landing-design chip on /clients/new

### DIFF
--- a/packages/crm/src/app/(dashboard)/clients/new/build-animation/idle-scene.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/build-animation/idle-scene.tsx
@@ -40,6 +40,10 @@
 import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 
+import { DesignChip } from "@/components/clients/design-picker/DesignChip";
+import { PickerStyles } from "@/components/clients/design-picker/Styles";
+import type { DesignId } from "@/components/clients/design-picker/types";
+
 // ── Typewriter placeholder examples (cycles while the input is idle) ─────────
 
 const URL_PLACEHOLDERS = [
@@ -95,6 +99,10 @@ export type IdleSceneProps = {
   // visitor on the right input when they passed ?biz= (no URL). Defaults
   // to "url" — the more common path.
   initialTab?: "url" | "biz";
+  // 2026-06-04 — pre-build landing-design pick. The Design chip lives in the
+  // input-box toolbar; "auto" is the default (pipeline picks by vertical).
+  landingTemplate: DesignId;
+  onLandingTemplateChange: (v: DesignId) => void;
 };
 
 type TabId = "url" | "biz";
@@ -178,6 +186,8 @@ export function IdleScene({
   bizInfoDisabled = false,
   errorOverlay,
   initialTab = "url",
+  landingTemplate,
+  onLandingTemplateChange,
 }: IdleSceneProps) {
   const [tab, setTab] = useState<TabId>(initialTab);
   const [urlFocused, setUrlFocused] = useState(false);
@@ -402,11 +412,17 @@ export function IdleScene({
               </div>
             )}
             <div className="sf-idle-form-foot">
-              <span className="sf-idle-hint">
-                <span className="sf-kbd">⌘</span>
-                <span className="sf-kbd">↵</span>
-                <small>to launch</small>
-              </span>
+              <div style={{ display: "flex", alignItems: "center", gap: "12px", flexWrap: "wrap", minWidth: 0 }}>
+                {/* 2026-06-04 — pre-build landing-design picker. Default "auto"
+                    (pipeline picks by vertical); operators can choose a premium
+                    health/wellness template before building. */}
+                <DesignChip value={landingTemplate} onChange={onLandingTemplateChange} />
+                <span className="sf-idle-hint">
+                  <span className="sf-kbd">⌘</span>
+                  <span className="sf-kbd">↵</span>
+                  <small>to launch</small>
+                </span>
+              </div>
               <button
                 type="submit"
                 className="sf-idle-submit"
@@ -541,6 +557,7 @@ export function IdleScene({
       </aside>
 
       <IdleStyles />
+      <PickerStyles />
     </section>
   );
 }

--- a/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
@@ -27,6 +27,7 @@ import { UpgradeModal } from "@/components/billing/upgrade-modal";
 import type { DetectVerticalInput } from "@/lib/workspace/detect-vertical";
 import { BuildAnimation } from "./build-animation";
 import { IdleScene } from "./build-animation/idle-scene";
+import type { DesignId } from "@/components/clients/design-picker/types";
 
 // ── BYOK copy ─────────────────────────────────────────────────────────────────
 const COPY = {
@@ -187,6 +188,10 @@ export function ClientsNewForm({
   const [revealLinks, setRevealLinks] = useState<
     { open: string; share?: string | null } | null
   >(null);
+  // 2026-06-04 — Operator's pre-build landing-design pick (the Design chip in
+  // the idle scene). "auto" → the pipeline auto-picks by vertical; a concrete
+  // template id is threaded to the create SSE as ?template= and overrides it.
+  const [landingTemplate, setLandingTemplate] = useState<DesignId>("auto");
   // Tracks which mode was last submitted so BYOK retry re-submits the right stream.
   const lastModeRef = useRef<"url" | "biz">(prefillBiz && !prefillUrl ? "biz" : "url");
   // Guard so the autoSubmit effect only fires once per mount even if
@@ -219,6 +224,7 @@ export function ClientsNewForm({
     setUpgradeInfo(null);
 
     const qs = new URLSearchParams({ url: targetUrl });
+    if (landingTemplate && landingTemplate !== "auto") qs.set("template", landingTemplate);
     const es = new EventSource(`/api/v1/web/workspaces/create-from-url?${qs.toString()}`);
     esRef.current = es;
     setLiveEventSource(es);
@@ -294,6 +300,7 @@ export function ClientsNewForm({
     setUpgradeInfo(null);
 
     const qs = new URLSearchParams({ text });
+    if (landingTemplate && landingTemplate !== "auto") qs.set("template", landingTemplate);
     const es = new EventSource(`/api/v1/web/workspaces/create-from-paste?${qs.toString()}`);
     esRef.current = es;
     setLiveEventSource(es);
@@ -559,6 +566,8 @@ export function ClientsNewForm({
             // the query-string defaults OR the localStorage seed
             // hydration in the mount effect above.
             initialTab={initialTab}
+            landingTemplate={landingTemplate}
+            onLandingTemplateChange={setLandingTemplate}
           />
         </div>
 

--- a/packages/crm/src/app/api/v1/web/workspaces/create-from-paste/route.ts
+++ b/packages/crm/src/app/api/v1/web/workspaces/create-from-paste/route.ts
@@ -39,7 +39,7 @@ export const dynamic = "force-dynamic";
 // GET: EventSource-compatible (browser EventSource only supports GET).
 //      Reads "text" as a query param.
 // POST: Programmatic callers — reads body.text as JSON.
-async function dispatchCreateFromPaste(text: unknown): Promise<Response> {
+async function dispatchCreateFromPaste(text: unknown, landingTemplate?: unknown): Promise<Response> {
   const session = await auth();
 
   const sessionUser = session?.user?.id
@@ -96,7 +96,7 @@ async function dispatchCreateFromPaste(text: unknown): Promise<Response> {
       seedDefaultOutboundTriggers,
       workspaceBaseDomain: process.env.WORKSPACE_BASE_DOMAIN ?? "app.seldonframe.com",
     },
-    body: { text },
+    body: { text, landingTemplate: typeof landingTemplate === "string" ? landingTemplate : undefined },
     sessionUser,
   });
 
@@ -108,11 +108,12 @@ export async function GET(request: NextRequest): Promise<Response> {
   // browser. The pasted text travels as a query param because EventSource
   // cannot POST a body.
   const text = request.nextUrl.searchParams.get("text");
-  return dispatchCreateFromPaste(text);
+  const template = request.nextUrl.searchParams.get("template");
+  return dispatchCreateFromPaste(text, template);
 }
 
 export async function POST(request: Request): Promise<Response> {
   // Programmatic JSON-body entry point.
-  const body = (await request.json().catch(() => ({}))) as { text?: unknown };
-  return dispatchCreateFromPaste(body.text);
+  const body = (await request.json().catch(() => ({}))) as { text?: unknown; template?: unknown };
+  return dispatchCreateFromPaste(body.text, body.template);
 }

--- a/packages/crm/src/app/api/v1/web/workspaces/create-from-url/route.ts
+++ b/packages/crm/src/app/api/v1/web/workspaces/create-from-url/route.ts
@@ -79,7 +79,7 @@ export const dynamic = "force-dynamic";
 // future programmatic callers (curl, future SDKs) that prefer JSON body
 // posting; both call the same runCreateFromUrl orchestrator with the same
 // RunDeps.
-async function dispatchCreateFromUrl(url: unknown): Promise<Response> {
+async function dispatchCreateFromUrl(url: unknown, landingTemplate?: unknown): Promise<Response> {
   const session = await auth();
 
   // The session callback in lib/auth/config.ts exposes `orgId` (NOT
@@ -144,7 +144,7 @@ async function dispatchCreateFromUrl(url: unknown): Promise<Response> {
       seedDefaultOutboundTriggers,
       workspaceBaseDomain: process.env.WORKSPACE_BASE_DOMAIN ?? "app.seldonframe.com",
     },
-    body: { url },
+    body: { url, landingTemplate: typeof landingTemplate === "string" ? landingTemplate : undefined },
     sessionUser,
   });
 
@@ -156,12 +156,15 @@ export async function GET(request: NextRequest): Promise<Response> {
   // browser. The URL travels as a query param because EventSource cannot
   // POST a body.
   const url = request.nextUrl.searchParams.get("url");
-  return dispatchCreateFromUrl(url);
+  // Operator's pre-build design pick from the /clients/new chip (omitted /
+  // "auto" → the pipeline auto-picks by vertical).
+  const template = request.nextUrl.searchParams.get("template");
+  return dispatchCreateFromUrl(url, template);
 }
 
 export async function POST(request: Request): Promise<Response> {
   // Programmatic JSON-body entry point — for future SDKs, server-side
   // callers, or non-browser clients that prefer POST + JSON.
-  const body = (await request.json().catch(() => ({}))) as { url?: unknown };
-  return dispatchCreateFromUrl(body.url);
+  const body = (await request.json().catch(() => ({}))) as { url?: unknown; template?: unknown };
+  return dispatchCreateFromUrl(body.url, body.template);
 }

--- a/packages/crm/src/lib/landing/apply-landing-template.ts
+++ b/packages/crm/src/lib/landing/apply-landing-template.ts
@@ -19,6 +19,7 @@ import { db } from "@/db";
 import { organizations } from "@/db/schema";
 import { DEFAULT_ORG_THEME, type OrgTheme } from "@/lib/theme/types";
 import { classifyHealthTemplate } from "@/lib/landing/template-selection";
+import { isLandingTemplateId } from "@/components/landing-templates/registry";
 
 export async function applyLandingTemplateForWorkspace(
   orgId: string,
@@ -27,8 +28,16 @@ export async function applyLandingTemplateForWorkspace(
     businessDescription?: string | null;
     services?: readonly string[] | null;
   },
+  /** Operator's explicit pre-build pick from the /clients/new design chip.
+   *  undefined / "auto" → classify from facts; a registered template id →
+   *  use it verbatim and record it as a hand-pick (choice = the id). */
+  templateOverride?: string | null,
 ): Promise<{ applied: boolean; template: string | null }> {
-  const template = classifyHealthTemplate(facts);
+  const override =
+    templateOverride && templateOverride !== "auto" && isLandingTemplateId(templateOverride)
+      ? templateOverride
+      : null;
+  const template = override ?? classifyHealthTemplate(facts);
   if (!template) return { applied: false, template: null };
 
   const [org] = await db
@@ -39,15 +48,20 @@ export async function applyLandingTemplateForWorkspace(
   if (!org) return { applied: false, template: null };
 
   const prev: OrgTheme = org.theme ?? DEFAULT_ORG_THEME;
-  // Respect an explicit, non-auto operator choice — only fill the unset/auto case.
-  if (prev.landingTemplateChoice && prev.landingTemplateChoice !== "auto") {
+  // Respect an existing explicit, non-auto operator choice — unless THIS call
+  // carries its own override (a fresh hand-pick always wins).
+  if (!override && prev.landingTemplateChoice && prev.landingTemplateChoice !== "auto") {
     return { applied: false, template: prev.landingTemplate ?? null };
   }
 
   await db
     .update(organizations)
     .set({
-      theme: { ...prev, landingTemplate: template, landingTemplateChoice: "auto" },
+      theme: {
+        ...prev,
+        landingTemplate: template,
+        landingTemplateChoice: override ?? "auto",
+      },
       updatedAt: new Date(),
     })
     .where(eq(organizations.id, orgId));

--- a/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
@@ -41,7 +41,7 @@ export type RunPasteDeps = {
 
 export type RunPasteInput = {
   deps: RunPasteDeps;
-  body: { text: unknown };
+  body: { text: unknown; landingTemplate?: string };
   sessionUser: { id: string; primaryOrgId: string | null } | null;
 };
 
@@ -209,11 +209,15 @@ export async function runCreateFromPaste(input: RunPasteInput): Promise<RunPaste
         //      landing-r1. Non-health businesses are left on landing-r1.
         try {
           const tplFacts = facts as CreateFullWorkspaceInput;
-          await applyLandingTemplateForWorkspace(result.workspace_id, {
-            businessName: tplFacts.business_name,
-            businessDescription: tplFacts.business_description,
-            services: tplFacts.services,
-          });
+          await applyLandingTemplateForWorkspace(
+            result.workspace_id,
+            {
+              businessName: tplFacts.business_name,
+              businessDescription: tplFacts.business_description,
+              services: tplFacts.services,
+            },
+            input.body.landingTemplate,
+          );
         } catch (err) {
           console.warn(
             JSON.stringify({

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -109,7 +109,7 @@ export type RunDeps = {
 
 export type RunInput = {
   deps: RunDeps;
-  body: { url: unknown };
+  body: { url: unknown; landingTemplate?: string };
   sessionUser: { id: string; primaryOrgId: string | null } | null;
 };
 
@@ -324,11 +324,15 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         //      R1 step so theme.landingTemplate is set when /w first renders.
         try {
           const tplFacts = facts as CreateFullWorkspaceInput;
-          await applyLandingTemplateForWorkspace(result.workspace_id, {
-            businessName: tplFacts.business_name,
-            businessDescription: tplFacts.business_description,
-            services: tplFacts.services,
-          });
+          await applyLandingTemplateForWorkspace(
+            result.workspace_id,
+            {
+              businessName: tplFacts.business_name,
+              businessDescription: tplFacts.business_description,
+              services: tplFacts.services,
+            },
+            input.body.landingTemplate,
+          );
         } catch (err) {
           console.warn(
             JSON.stringify({


### PR DESCRIPTION
## Summary
Adds a "Design · Auto ✨" chip to the /clients/new input toolbar so operators
can pick a premium health/wellness template before building — instead of only
auto-pick + the ready-page swap. Threads the choice end-to-end:
DesignChip → form state → &template= on the create SSE → route → run fn →
applyLandingTemplateForWorkspace(override). Default "auto", so the non-health
flow is unaffected (pipeline still auto-picks by vertical).

## Verify on preview
- [ ] /clients/new shows the Design chip, default "Auto"
- [ ] Leave Auto → build a chiro → /w renders earthy-modern-clinical
- [ ] Pick a specific design → build → /w renders THAT design (overrides auto)
- [ ] Dark mode + custom accent → chip chrome tracks the dashboard theme
- [ ] Non-health (HVAC) build unaffected
- Full next build green (224/224); runtime pick→build is the one thing to confirm live.