### PR TITLE
Client-onboarding intake + wiring agent

### DIFF
--- a/docs/superpowers/plans/2026-06-04-client-onboarding-intake.md
+++ b/docs/superpowers/plans/2026-06-04-client-onboarding-intake.md
@@ -1,0 +1,405 @@
+# Client-Onboarding Intake + Wiring Agent — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a client pays, email them a no-login multi-step intake; on submit, a wiring agent builds a staged change-plan across the workspace (Soul → website → booking → chatbot → CRM) that the agency reviews and applies with one click.
+
+**Architecture:** Reuse the existing in-house intake renderer (Typeform-style cards), the existing `form.submitted` event bus, and the existing `/p/[token]` tokenized-link pattern. Add one new field type (`file`), two tables (`onboarding_links`, `change_plans`), a deterministic answer→change-plan mapper, and a review-and-apply executor that calls the existing per-surface server actions. Parsing of hours/services is **deterministic** (best-effort) with the human review screen as the safety net — no LLM in the core path.
+
+**Tech Stack:** Next.js 16 (App Router, Turbopack), Drizzle + Neon Postgres, Vitest, `@vercel/blob`, React server actions.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-client-onboarding-intake-design.md`
+
+**Test commands:** unit `pnpm -C packages/crm test:unit` · build-verify `pnpm -C packages/crm build` (Turbopack — required; `tsc` alone misses styled-jsx/server-component errors).
+
+---
+
+## File Structure
+
+**New files**
+- `packages/crm/src/db/schema/onboarding.ts` — `onboarding_links` + `change_plans` tables.
+- `packages/crm/drizzle/00XX_onboarding_intake.sql` — migration for both tables (number = next in sequence).
+- `packages/crm/src/lib/onboarding/parse-hours.ts` — `parseHoursText()` (deterministic).
+- `packages/crm/src/lib/onboarding/parse-services.ts` — `parseServicesText()` (deterministic).
+- `packages/crm/src/lib/onboarding/change-plan.ts` — `ChangePlan` type + `buildChangePlan()` mapper.
+- `packages/crm/src/lib/onboarding/execute-change-plan.ts` — `applyChangePlan()` executor.
+- `packages/crm/src/lib/onboarding/onboarding-form-definition.ts` — the 7-chapter question set.
+- `packages/crm/src/lib/onboarding/links.ts` — token mint/load (mirrors `lib/proposals/load-by-token.ts`).
+- `packages/crm/src/lib/uploads/file-validation.ts` — `validateUploadField()` (accept + size).
+- `packages/crm/src/app/onboard/[token]/page.tsx` — public no-login intake render.
+- `packages/crm/src/app/(dashboard)/onboarding/[id]/page.tsx` — agency review screen.
+- `packages/crm/src/app/(dashboard)/onboarding/[id]/apply-action.ts` — `applyChangePlanAction` server action.
+- Test files mirror each lib file under `packages/crm/tests/unit/onboarding/`.
+
+**Modified files**
+- `packages/crm/src/lib/blueprint/types.ts` — add `file` to `IntakeQuestion` (`~:299-301`).
+- `packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts` — add `file` input branch (`renderQuestionInput`, `~:292`).
+- `packages/crm/src/app/api/v1/public/intake/route.ts` — blob-upload files before the JSON write (`~:77`, events `~:319`).
+- `packages/crm/src/app/api/webhooks/stripe/connect/route.ts` — mint + email onboarding link post-activation (`~:535`).
+- `packages/crm/src/lib/events/listeners.ts` — subscribe a handler to `form.submitted` gated on the onboarding form (`~:94`).
+
+---
+
+## Phase 1 — Schema foundations
+
+### Task 1: `onboarding_links` + `change_plans` tables
+
+**Files:**
+- Create: `packages/crm/src/db/schema/onboarding.ts`
+- Create: `packages/crm/drizzle/00XX_onboarding_intake.sql`
+- Modify: `packages/crm/src/db/schema/index.ts` (export the new schema — match the existing barrel pattern)
+
+- [ ] **Step 1: Write the schema**
+
+```ts
+// packages/crm/src/db/schema/onboarding.ts
+import { pgTable, uuid, text, timestamp, jsonb, index } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations";
+
+export const onboardingLinks = pgTable(
+  "onboarding_links",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    orgId: uuid("org_id").notNull().references(() => organizations.id, { onDelete: "cascade" }),
+    token: text("token").notNull(),
+    // pending → submitted → applied
+    status: text("status").notNull().default("pending"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }),
+  },
+  (t) => ({ tokenIdx: index("onboarding_links_token_idx").on(t.token) }),
+);
+
+export const changePlans = pgTable(
+  "change_plans",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    orgId: uuid("org_id").notNull().references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id"),
+    plan: jsonb("plan").notNull(),
+    // pending_review → applied → discarded
+    status: text("status").notNull().default("pending_review"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    appliedAt: timestamp("applied_at", { withTimezone: true }),
+  },
+  (t) => ({ orgIdx: index("change_plans_org_idx").on(t.orgId) }),
+);
+```
+
+- [ ] **Step 2: Write the SQL migration** (number it as the next file in `packages/crm/drizzle/`; confirm the highest existing number first)
+
+```sql
+CREATE TABLE IF NOT EXISTS "onboarding_links" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE cascade,
+  "token" text NOT NULL,
+  "status" text DEFAULT 'pending' NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "submitted_at" timestamptz
+);
+CREATE INDEX IF NOT EXISTS "onboarding_links_token_idx" ON "onboarding_links" ("token");
+
+CREATE TABLE IF NOT EXISTS "change_plans" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE cascade,
+  "submission_id" uuid,
+  "plan" jsonb NOT NULL,
+  "status" text DEFAULT 'pending_review' NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "applied_at" timestamptz
+);
+CREATE INDEX IF NOT EXISTS "change_plans_org_idx" ON "change_plans" ("org_id");
+```
+
+- [ ] **Step 3: Export + journal.** Add exports to the schema barrel and append the migration to `packages/crm/drizzle/meta/_journal.json` exactly as the migration pipeline expects (match the format of the last entry — the repo has a journal CI check, task #95).
+- [ ] **Step 4: Build-verify.** Run `pnpm -C packages/crm build`. Expected: compiles (Drizzle types resolve).
+- [ ] **Step 5: Commit.** `feat(onboarding): onboarding_links + change_plans tables`
+
+---
+
+## Phase 2 — The `file` field type (TDD)
+
+### Task 2: File-validation helper (pure, TDD)
+
+**Files:**
+- Create: `packages/crm/src/lib/uploads/file-validation.ts`
+- Test: `packages/crm/tests/unit/onboarding/file-validation.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { validateUploadField } from "@/lib/uploads/file-validation";
+
+describe("validateUploadField", () => {
+  const cfg = { accept: [".csv", ".xlsx"], maxSizeMb: 10 };
+  it("accepts an allowed type under the size cap", () => {
+    expect(validateUploadField({ name: "contacts.csv", sizeBytes: 1_000 }, cfg)).toEqual({ ok: true });
+  });
+  it("rejects a disallowed extension", () => {
+    expect(validateUploadField({ name: "evil.exe", sizeBytes: 10 }, cfg)).toEqual({
+      ok: false, reason: "type",
+    });
+  });
+  it("rejects a file over the size cap", () => {
+    expect(validateUploadField({ name: "big.csv", sizeBytes: 11 * 1024 * 1024 }, cfg)).toEqual({
+      ok: false, reason: "size",
+    });
+  });
+  it("matches accept case-insensitively", () => {
+    expect(validateUploadField({ name: "CONTACTS.CSV", sizeBytes: 1 }, cfg)).toEqual({ ok: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`validateUploadField` not defined). `pnpm -C packages/crm test:unit file-validation`
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/crm/src/lib/uploads/file-validation.ts
+export type UploadFieldConfig = { accept: string[]; maxSizeMb: number };
+export type UploadCandidate = { name: string; sizeBytes: number };
+export type UploadValidation = { ok: true } | { ok: false; reason: "type" | "size" };
+
+export function validateUploadField(file: UploadCandidate, cfg: UploadFieldConfig): UploadValidation {
+  const lower = file.name.toLowerCase();
+  const okType = cfg.accept.some((ext) => lower.endsWith(ext.toLowerCase()));
+  if (!okType) return { ok: false, reason: "type" };
+  if (file.sizeBytes > cfg.maxSizeMb * 1024 * 1024) return { ok: false, reason: "size" };
+  return { ok: true };
+}
+```
+
+- [ ] **Step 4: Run — expect PASS.** **Step 5: Commit** `feat(onboarding): file upload validation helper`.
+
+### Task 3: Add `file` to the `IntakeQuestion` type
+
+**Files:** Modify `packages/crm/src/lib/blueprint/types.ts` (`IntakeQuestion`, `~:299-301`)
+
+- [ ] **Step 1: Read** `types.ts` around the `IntakeQuestion` union to confirm the exact shape, then add `"file"` to the `type` union and an optional `file?: { accept: string[]; maxSizeMb: number; multiple: boolean }` config field. Do not remove existing fields.
+- [ ] **Step 2: Build-verify** `pnpm -C packages/crm build`. Expected: compiles; no renderer exhaustiveness break yet (renderer handled next task).
+- [ ] **Step 3: Commit** `feat(onboarding): file question type on IntakeQuestion`.
+
+### Task 4: Renderer input branch for `file`
+
+**Files:** Modify `packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts` (`renderQuestionInput`, `~:292`)
+
+- [ ] **Step 1: Read** the `renderQuestionInput` switch and an existing branch (e.g. `text`) to match markup/aria conventions.
+- [ ] **Step 2: Add** a `case "file":` branch rendering `<input type="file" accept="…" {multiple?}>` with the field key, required flag, and the same label/error markup the other branches use. Keep it vanilla (the renderer emits static HTML + the form's JS handler).
+- [ ] **Step 3: Wire** the form's submit JS to read selected files for `file` questions (the existing handler serializes inputs by key — extend it to collect `File` objects for upload in the next task).
+- [ ] **Step 4: Build-verify** `pnpm -C packages/crm build`.
+- [ ] **Step 5: Commit** `feat(onboarding): render file inputs in the intake card flow`.
+
+### Task 5: Blob-upload files on submit
+
+**Files:** Modify `packages/crm/src/app/api/v1/public/intake/route.ts` (`~:77`); reference `lib/uploads/user-image.ts` for the `@vercel/blob put` pattern.
+
+- [ ] **Step 1: Read** `public/intake/route.ts` (how it parses the body + writes `intake_submissions`) and `lib/uploads/user-image.ts`.
+- [ ] **Step 2: Branch on content type.** When the request is `multipart/form-data` (file questions present), for each uploaded file call `validateUploadField` (Task 2); on `ok`, `put()` to Blob; replace the field value in `data` with the returned URL (array of URLs when `multiple`). Reject with 400 + the reason on validation failure.
+- [ ] **Step 3: Keep the JSON path unchanged** for forms without files (back-compat).
+- [ ] **Step 4: Confirm** the existing `intake.submitted` / `form.submitted` emit still fires after the write (`~:319`).
+- [ ] **Step 5: Build-verify + commit** `feat(onboarding): store uploaded intake files in blob storage`.
+
+---
+
+## Phase 3 — Onboarding form + delivery
+
+### Task 6: The onboarding form definition
+
+**Files:** Create `packages/crm/src/lib/onboarding/onboarding-form-definition.ts`
+
+- [ ] **Step 1: Define** `ONBOARDING_QUESTIONS: IntakeQuestion[]` for the 7 chapters exactly as the spec's "intake — 7 chapters" section (keys: `business_name, tagline, phone, email, has_public_address, address, hours_text, services_text, primary_service, logo, brand_colors, photos, website_url, socials, google_reviews_url, testimonials, contacts_file, bookings_file, call_handling, lead_routing, has_domain, domain`). Use existing types; `logo/photos` = `file` (images), `contacts_file/bookings_file` = `file` (`.csv/.xlsx`). Set `showIf` for `address` (`has_public_address=Yes`) and `domain` (`has_domain=Yes`).
+- [ ] **Step 2: Add** `seedOnboardingForm(orgId)` that writes this question set as an intake form with slug `onboarding` (reuse the intake create path — `createFormAction` / `persistAndRender` from `lib/page-blocks/intake-structure.ts`), and returns the `formId`.
+- [ ] **Step 3:** No test (declarative config). **Build-verify + commit** `feat(onboarding): 7-chapter onboarding form definition`.
+
+### Task 7: Token mint/load + `/onboard/[token]` route
+
+**Files:** Create `packages/crm/src/lib/onboarding/links.ts`, `packages/crm/src/app/onboard/[token]/page.tsx`; reference `lib/proposals/load-by-token.ts`.
+
+- [ ] **Step 1: Write the failing test** for the token validator (mirror `load-by-token`):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { isValidOnboardingToken } from "@/lib/onboarding/links";
+describe("isValidOnboardingToken", () => {
+  it("accepts a 32+ char url-safe token", () => {
+    expect(isValidOnboardingToken("A".repeat(32))).toBe(true);
+  });
+  it("rejects short or unsafe tokens", () => {
+    expect(isValidOnboardingToken("short")).toBe(false);
+    expect(isValidOnboardingToken("bad/" + "x".repeat(40))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL. Step 3: Implement** `links.ts`: `mintOnboardingToken()` (crypto-random, base64url, ≥32 chars), `isValidOnboardingToken(t)` (`/^[A-Za-z0-9_-]{32,}$/`), `createOnboardingLink(orgId)` (insert row, return token), `loadOnboardingLinkByToken(token)` (regex-then-DB, like proposals).
+- [ ] **Step 4: Run — expect PASS.**
+- [ ] **Step 5: Build the public route** `app/onboard/[token]/page.tsx`: validate token → load link → render the workspace's `onboarding` form HTML (same render path as the public `/intake` page). No auth. On invalid/used token, render a friendly "this link is no longer active" panel.
+- [ ] **Step 6: Build-verify + commit** `feat(onboarding): tokenized /onboard/[token] route`.
+
+### Task 8: Generate + email the link on payment
+
+**Files:** Modify `packages/crm/src/app/api/webhooks/stripe/connect/route.ts` (`~:535`, the `checkout.session.completed` activation block)
+
+- [ ] **Step 1: Read** the activation block and the `notifyProspectOfActivation` call to match the email/util conventions.
+- [ ] **Step 2: After activation**, call `seedOnboardingForm(orgId)` (Task 6) + `createOnboardingLink(orgId)` (Task 7), build the `/onboard/[token]` URL, and send an agency-branded email to the client (reuse the existing proposal/activation email helper). Idempotency: skip if an `onboarding_links` row already exists for the org (guards webhook retries).
+- [ ] **Step 3: Build-verify + commit** `feat(onboarding): email the onboarding link on workspace activation`.
+
+---
+
+## Phase 4 — The wiring agent
+
+### Task 9: `parseHoursText` (pure, TDD)
+
+**Files:** Create `packages/crm/src/lib/onboarding/parse-hours.ts`; Test `packages/crm/tests/unit/onboarding/parse-hours.spec.ts`
+
+- [ ] **Step 1: Write the failing test** (use the booking `availability` shape from `lib/bookings/actions.ts:81` — `Record<"monday".."sunday", {enabled,start,end}>`, `"HH:MM"`):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseHoursText } from "@/lib/onboarding/parse-hours";
+
+describe("parseHoursText", () => {
+  it("parses a weekday range with a Saturday and a closed Sunday", () => {
+    const a = parseHoursText("Mon-Fri 9-5, Sat 10-2, closed Sun");
+    expect(a.monday).toEqual({ enabled: true, start: "09:00", end: "17:00" });
+    expect(a.friday).toEqual({ enabled: true, start: "09:00", end: "17:00" });
+    expect(a.saturday).toEqual({ enabled: true, start: "10:00", end: "14:00" });
+    expect(a.sunday.enabled).toBe(false);
+  });
+  it("defaults unmatched input to Mon-Fri 9-5, weekends off", () => {
+    const a = parseHoursText("we're flexible");
+    expect(a.monday.enabled).toBe(true);
+    expect(a.saturday.enabled).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL. Step 3: Implement** a deterministic parser: tokenize on commas; map day names/abbreviations + ranges (`Mon-Fri`) to day keys; parse `9-5`/`9am-5pm`/`09:00-17:00` to `"HH:MM"`; honor `closed <day>`; default any day not mentioned to the Mon-Fri-9-5/weekends-off baseline. Export `WeeklyAvailability` type matching the booking shape.
+- [ ] **Step 4: Run — expect PASS. Step 5: Commit** `feat(onboarding): deterministic hours parser`.
+
+### Task 10: `parseServicesText` (pure, TDD)
+
+**Files:** Create `packages/crm/src/lib/onboarding/parse-services.ts`; Test `…/parse-services.spec.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { parseServicesText } from "@/lib/onboarding/parse-services";
+
+describe("parseServicesText", () => {
+  it("parses name, price, and duration from common formats", () => {
+    const s = parseServicesText("60-min massage — $90\nDeep tissue (90 min) - $130\nConsult: free");
+    expect(s[0]).toEqual({ name: "massage", price: 90, durationMinutes: 60 });
+    expect(s[1]).toEqual({ name: "Deep tissue", price: 130, durationMinutes: 90 });
+    expect(s[2]).toEqual({ name: "Consult", price: 0, durationMinutes: 30 });
+  });
+  it("returns [] for empty input", () => {
+    expect(parseServicesText("")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL. Step 3: Implement** a per-line parser: extract `$NNN` (or "free"→0) as price; extract `NN min`/`NN-min` as duration (default 30); the remaining text (trimmed of separators `—|-|:`) is the name. Skip blank lines. Export `ParsedService = { name; price; durationMinutes }`.
+- [ ] **Step 4: Run — expect PASS. Step 5: Commit** `feat(onboarding): deterministic services parser`.
+
+### Task 11: `buildChangePlan` mapper (pure, TDD)
+
+**Files:** Create `packages/crm/src/lib/onboarding/change-plan.ts`; Test `…/change-plan.spec.ts`
+
+- [ ] **Step 1: Define the type**
+
+```ts
+export type ChangePlan = {
+  soul: Record<string, unknown>;                 // fields to merge (both casings handled at apply time)
+  theme?: { primaryColor?: string; accentColor?: string };
+  bookingDefault?: { availability: WeeklyAvailability; primaryServiceName?: string };
+  appointmentTypes: { title: string; durationMinutes: number; price: number }[];
+  contactsFileUrl?: string;
+  bookingsFileUrl?: string;                       // stored, not imported (stub)
+  callHandling: "ai_voice" | "human_then_text" | "none";
+  leadRouting: ("email" | "text")[];
+  domain?: string;
+  summaries: string[];                            // human-readable lines for the review screen
+};
+```
+
+- [ ] **Step 2: Write the failing test** — feed a representative submission `data` object (the onboarding keys) and assert the mapped `ChangePlan`: soul gets `business_name/tagline/phone`, `bookingDefault.availability` comes from `parseHoursText`, `appointmentTypes` from `parseServicesText`, `callHandling` maps the select value, `summaries` is non-empty. (Write concrete expected values.)
+- [ ] **Step 3: Run — expect FAIL. Step 4: Implement** `buildChangePlan(data)` composing `parseHoursText` + `parseServicesText` + direct field mapping. Pure function, no DB/IO.
+- [ ] **Step 5: Run — expect PASS. Step 6: Commit** `feat(onboarding): answer→change-plan mapper`.
+
+### Task 12: Persist the plan on submission
+
+**Files:** Modify `packages/crm/src/lib/events/listeners.ts` (`~:94`); reference the `form.submitted` payload + `$formId` matcher.
+
+- [ ] **Step 1: Read** the existing `form.submitted` listener/fan-out.
+- [ ] **Step 2: Add** a handler gated on the onboarding form (`formId` matches an `onboarding`-slug form): load the submission `data`, call `buildChangePlan(data)`, insert a `change_plans` row (`status: pending_review`), flip the `onboarding_links` row to `submitted`, and notify the agency (reuse the ops-notification email helper, task #91).
+- [ ] **Step 3: Build-verify + commit** `feat(onboarding): build + persist change plan on submission`.
+
+### Task 13: The executor
+
+**Files:** Create `packages/crm/src/lib/onboarding/execute-change-plan.ts`
+
+- [ ] **Step 1: Write the failing test** (mock the server actions; assert call order + inputs):
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+// vi.mock the imported server actions, then:
+import { applyChangePlan } from "@/lib/onboarding/execute-change-plan";
+
+it("applies surfaces in order: soul→booking→theme→chatbot→contacts", async () => {
+  const calls: string[] = [];
+  // arrange mocks to push their name into `calls`
+  await applyChangePlan(/* orgId */ "org-1", /* plan */ samplePlan);
+  expect(calls).toEqual(["soul", "seedLanding", "booking", "theme", "chatbot", "contacts"]);
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL. Step 3: Implement** `applyChangePlan(orgId, plan)` calling, in order: (1) write `organizations.soul` (both casings) + `applyPipelineStagesFromSoul` + `seedLandingFromSoul(orgId)`; (2) `updateBookingTypeAction` (default type hours/price/duration) + create extra appointment types; (3) `update_theme`; (4) `update_website_chatbot` (refresh from new soul); (5) parse `contactsFileUrl` → `bulkImportContactsAction({ rows })`. Domain/voice/SMS produce instruction strings only. Each surface wrapped in try/catch → collect per-surface result; never throw the whole apply on one surface failing.
+- [ ] **Step 4: Run — expect PASS. Step 5: Commit** `feat(onboarding): change-plan executor`.
+
+---
+
+## Phase 5 — Review UI
+
+### Task 14: Review screen + Apply action
+
+**Files:** Create `packages/crm/src/app/(dashboard)/onboarding/[id]/page.tsx` + `apply-action.ts`
+
+- [ ] **Step 1: Build the server action** `applyChangePlanAction(planId)`: auth via `getOrgId()`, load the plan (assert it belongs to the org + is `pending_review`), call `applyChangePlan`, set `status: applied` + `appliedAt`, flip `onboarding_links` to `applied`, notify the client. Returns the per-surface results.
+- [ ] **Step 2: Build the review page**: render `plan.summaries` grouped by surface (Website / Booking / Brand / Chatbot / Contacts / Domain & Phones), each with the before→after summary; a single **"Apply all"** primary button bound to the action; per-item skip checkboxes (omit skipped surfaces from the applied plan). Match the dashboard's existing card styling.
+- [ ] **Step 3: Build-verify** `pnpm -C packages/crm build`.
+- [ ] **Step 4: Commit** `feat(onboarding): agency review-and-apply screen`.
+
+---
+
+## Phase 6 — Verification
+
+### Task 15: Integration test
+
+**Files:** Test `packages/crm/tests/unit/onboarding/onboarding-flow.spec.ts` (or integration suite if one exists)
+
+- [ ] **Step 1: Write** a test that drives: build a fake onboarding submission `data` → `buildChangePlan` → insert plan → `applyChangePlan` against mocked server actions → assert each surface action was invoked with the mapped inputs and the plan flips to `applied`.
+- [ ] **Step 2: Run — expect PASS.**
+- [ ] **Step 3: Full suite** `pnpm -C packages/crm test:unit` — confirm no regressions (ignore the known pre-existing failures noted in the repo). **Step 4: Build-verify** `pnpm -C packages/crm build`. **Step 5: Commit** `test(onboarding): end-to-end change-plan flow`.
+
+### Task 16: Manual smoke test (SURFACE TO USER — do not auto-run)
+
+- [ ] On a Vercel preview deploy: create a test proposal → pay in Stripe test mode → confirm the onboarding email arrives → open `/onboard/[token]` → fill the form with a logo + a small contacts CSV → submit → confirm a `pending_review` plan appears on the review screen → click **Apply all** → verify the workspace landing (`/w/[slug]`), the booking hours/services, the chatbot copy, and the imported contacts all reflect the answers.
+- [ ] Report results back; fix any gaps as hotfix tasks.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** file type (T2-5), onboarding form + tokenized link + email delivery (T6-8), deterministic hours/services parsing (T9-10), mapper (T11), persist-on-submit (T12), executor with the 3 gotchas — soul re-render, separate chatbot refresh, booking-hours via server action (T13), review-then-apply UI (T14), tests (T15-16), both tables (T1). All spec sections map to a task.
+- **Type consistency:** `WeeklyAvailability` defined in `parse-hours.ts` and reused by `change-plan.ts` + the booking executor; `ParsedService` → `appointmentTypes`; `ChangePlan` is the single contract between mapper, persistence, executor, and UI.
+- **No placeholders:** parsers, validation, schema, and `ChangePlan` carry real code; integration tasks name the exact file + anchor + behavior + test.
+- **Booking-hours gotcha** is encoded as a task instruction (use `updateBookingTypeAction`, not the MCP tools).
+
+---
+
+## Execution Handoff
+
+Recommended: **subagent-driven-development** (fresh subagent per task, two-stage review). Phases 1-2 and 9-11 are mechanical/TDD (cheap model); Phases 3-5 (webhook, route, listener, UI) are integration (standard model). Task 16 is manual — surface to the user.

--- a/docs/superpowers/specs/2026-06-04-client-onboarding-intake-design.md
+++ b/docs/superpowers/specs/2026-06-04-client-onboarding-intake-design.md
@@ -1,0 +1,259 @@
+# Client-Onboarding Intake + Wiring Agent — Design
+
+**Date:** 2026-06-04
+**Status:** Approved design (mode: review-then-apply)
+**Author:** Max + Claude
+
+## Goal
+
+When an agency's client pays, send them a world-class, no-login multi-step
+intake form. When they submit, a **wiring agent** maps their answers and
+uploaded files into a **staged change-plan** across the new workspace
+(Soul → website → booking → chatbot → CRM). The agency reviews the plan and
+clicks **"Apply all."** One link turns "client paid" into a fully built
+front office, with a human QA gate before anything goes live.
+
+## Why review-then-apply (not fully automatic)
+
+The agency sells a paid setup ($1,500). They want to eyeball the client's
+site, booking, and imported data before the client sees it — and the review
+screen doubles as the "look what we built you" moment on the kickoff call.
+A fully-automatic mode can be added later as a per-agency toggle.
+
+## Background — what already exists (reuse, don't rebuild)
+
+- **Proposal → Stripe Connect payment → workspace activation** is built. The
+  post-payment hook is the Connect webhook
+  `app/api/webhooks/stripe/connect/route.ts` (`checkout.session.completed`,
+  ~line 535) — the clean insertion point for "generate + email the onboarding
+  link."
+- **Intake-form engine is in-house** (modeled after Formbricks, not embedded).
+  It already renders a **Typeform-style one-question-per-card** flow with a
+  progress bar, Back/Continue, auto-advance, `showIf` conditional logic, and
+  validation — `lib/blueprint/renderers/formbricks-stack-v1.ts`. The card UX is
+  free; we just author questions.
+- **Field types supported by the renderer:** `text, textarea, email, phone,
+  number, select, multi-select, rating, date`. **No `file` type** (the one gap).
+- **Submission fires events:** the public intake POST
+  (`app/api/v1/public/intake/route.ts`) emits `intake.submitted` and
+  `form.submitted` on the Seldon event bus; `lib/events/listeners.ts` already
+  fans `form.submitted` out to deployed agents (matcher on `$formId`). The
+  wiring agent subscribes here — **zero new event plumbing.**
+- **Tokenized public links** are an established pattern: `proposals.signedToken`
+  + `lib/proposals/load-by-token.ts` + the `/p/[token]` public route family.
+  We mirror it with `/onboard/[token]` (no client login).
+- **Soul is the source of truth** (`organizations.soul` JSONB, written in BOTH
+  camelCase and snake_case by `buildSeedSoul`). `submit_soul` cascades:
+  `applyPipelineStagesFromSoul` + `seedLandingFromSoul`.
+- **Every per-surface apply function already exists** (see "Apply surface").
+
+## Non-goals (YAGNI)
+
+- Fully-automatic apply (chosen: review-then-apply).
+- Bookings-CSV import execution — store the uploaded file and flag it
+  "import on request"; the importer is a separate sub-project. Contacts import
+  already works and IS in scope.
+- Real Google Meet/Zoom link generation (separate booking-location sub-project).
+- Auto Twilio number provisioning (agency does Twilio manually for now — the
+  agent only *generates the instructions*).
+- New "repeatable group" or "hours-grid" field types — avoided by capturing
+  hours and services as guided free-text that the agent parses (see below).
+
+## Architecture — the lifecycle
+
+```
+Client pays
+  └─ Stripe Connect webhook (checkout.session.completed, ~line 535)
+       ├─ generate signed onboarding token → /onboard/[token]
+       └─ email the link to the new client (agency-branded)
+
+Client opens /onboard/[token] (no login)
+  └─ fills the 7-chapter card flow (existing renderer)
+       └─ submit → blob-upload any files → store answers
+            └─ fires form.submitted (existing event bus)
+
+Wiring agent (subscribed to the onboarding formId)
+  └─ reads answers + file URLs
+       └─ builds a CHANGE PLAN (structured diff), status = pending_review
+            └─ notifies the agency
+
+Agency opens the review screen
+  └─ sees the plan → clicks "Apply all"
+       └─ executor runs server actions in order
+            └─ workspace marked ready → agency + client notified
+```
+
+## Components to build
+
+### 1. `file` question type (the one form gap)
+
+- Add `file` to `IntakeQuestion` (`lib/blueprint/types.ts`) with config
+  `{ accept: string[], maxSizeMb: number, multiple: boolean }`.
+- Add the input branch to the renderer's `renderQuestionInput` switch
+  (`formbricks-stack-v1.ts`).
+- On submit, upload each file to Vercel Blob (reuse `lib/uploads/user-image.ts`
+  + `@vercel/blob` `put`), and store the resulting URL(s) in the submission
+  `data` under the question key. The public intake POST stores only JSON today,
+  so add the upload step ahead of the JSON write.
+- Validation: enforce `accept` (images for logo/photos; `.csv/.xlsx` for data)
+  and `maxSizeMb`.
+
+### 2. The onboarding form definition
+
+- A canonical onboarding intake (the 7 chapters below), seeded as a copy per
+  activated workspace so branding/`showIf` can vary, with a stable slug
+  `onboarding` (and the formId recorded on the workspace so the agent can gate).
+
+### 3. Delivery — tokenized link + email
+
+- New table `onboarding_links { token (unique, indexed), orgId, status
+  (pending|submitted|applied), createdAt, submittedAt }`. Token shape mirrors
+  `proposals.signedToken` (`^[A-Za-z0-9_-]{32,}$`).
+- In the Connect webhook post-activation block: create the row, build the URL,
+  send an agency-branded email to the client.
+- Public route `app/onboard/[token]/page.tsx` — validate token (reuse the
+  `load-by-token` regex-then-DB pattern), render the workspace's onboarding form.
+  No auth.
+
+### 4. The wiring agent
+
+- A listener gated on the onboarding `formId` (reuse the existing
+  `form.submitted` fan-out, or a dedicated listener in `lib/events/listeners.ts`).
+- Reads answers + file URLs and produces a **change plan**: an ordered,
+  structured list of operations with human-readable summaries. LLM parsing turns
+  guided free-text into structure (hours-text → weekly availability;
+  services-text → appointment types; brand description → theme).
+- Persist: new table `change_plans { id, orgId, submissionId, plan jsonb,
+  status (pending_review|applied|discarded), createdAt, appliedAt }`.
+- **Review UI** (dashboard): renders the plan grouped by surface with the
+  before/after summary; a single **"Apply all"** button (and per-item skip).
+- **Executor** (on Apply) runs, in order:
+  1. **Soul:** write `organizations.soul` (both casings) + `applyPipelineStagesFromSoul` + `seedLandingFromSoul(orgId)` → re-renders `/w/[slug]`.
+  2. **Booking:** `updateBookingTypeAction` for hours/price/duration on the
+     default type; create extra appointment types from parsed services.
+  3. **Theme:** `update_theme` (mode/colors/font) from logo/brand answers.
+  4. **Chatbot:** `update_website_chatbot` to refresh FAQ/pricing/greeting from
+     the new Soul (Soul edits do NOT auto-update an existing chatbot).
+  5. **Contacts:** parse the uploaded CSV/XLSX → `bulkImportContactsAction({ rows })`.
+  6. **Domain / voice / SMS:** generate instructions only (DNS records from the
+     existing apex-A/CNAME logic; Twilio forwarding steps keyed to the client's
+     `call_handling` choice). Surfaced to the agency/client — not auto-applied.
+- Mark workspace ready; notify agency + client.
+
+## The intake — 7 chapters (few questions per card, plain copy)
+
+`*` = required. `file*` types are the new field. Hours/services are free-text
+parsed by the agent (no new field types).
+
+**0 — Welcome** (intro panel) — "Let's build your new front office. ~10 minutes.
+Upload what you have; skip what you don't and we'll handle it."
+
+**1 — Your business**
+- `business_name` text* (prefilled from the proposal)
+- `tagline` text* — "What you do, in one line"
+- `phone` phone* · `email` email*
+- `has_public_address` select* (Yes / No)
+- `address` text — showIf `has_public_address = Yes`
+- `hours_text` textarea* — "Your weekly hours (e.g. Mon–Fri 9–5, Sat 10–2,
+  closed Sun)" → agent parses to `availability`
+
+**2 — Services & prices**
+- `services_text` textarea* — "List your services with prices, one per line
+  (e.g. 60-min massage — $90)" → agent parses to appointment types
+- `primary_service` text* — "Which one is your big 'Book now' button?"
+
+**3 — Brand & photos**
+- `logo` file (image, optional)
+- `brand_colors` text — "Brand colors (or leave blank to use your logo's)"
+- `photos` file (image, multiple, optional) — else stock for the vertical
+- `website_url` text (optional) · `socials` textarea (optional)
+
+**4 — Get found & reviewed**
+- `google_reviews_url` text (optional) — "Your Google Business / reviews link"
+- `testimonials` textarea (optional) — "A few things clients always say (or
+  leave blank — we'll pull from Google)"
+
+**5 — Move your data** (optional)
+- `contacts_file` file (.csv/.xlsx, optional)
+- `bookings_file` file (.csv, optional) — stored, imported on request
+
+**6 — Phones & follow-up**
+- `call_handling` select* — (AI answers / I answer, AI texts missed calls / Not yet)
+- `lead_routing` multi-select* — (Email / Text)
+
+**7 — Your website domain**
+- `has_domain` select* (Yes / No)
+- `domain` text — showIf `has_domain = Yes`
+
+**Done** (closing panel) — "That's everything. We're building your front office
+now — you'll get an email the moment it's ready to review."
+
+## Answer → apply mapping
+
+| Answer(s) | Applied via |
+| --- | --- |
+| business_name, tagline, phone, email, address, "what you do" | Soul (both casings) → `seedLandingFromSoul()` |
+| hours_text (parsed) | `updateBookingTypeAction` (`availability`) — only path that sets hours |
+| services_text (parsed), primary_service | create appointment types (`updateBookingTypeAction`/create) + Soul offerings → landing |
+| logo, brand_colors | `update_theme` + store logo |
+| photos, website_url, socials | Soul → landing payload (hero/gallery/footer) |
+| google_reviews_url, testimonials | Soul (`google_place_url`, `testimonials`) → review automations + landing |
+| contacts_file | parse → `bulkImportContactsAction({ rows })` |
+| bookings_file | stored; flagged for import (sub-project) |
+| call_handling | generates Twilio steps (Voice/Messaging config + forward-on-no-answer); applies missed-call-text-back archetype if chosen |
+| lead_routing | notification settings |
+| has_domain, domain | stores domain + generates DNS steps (apex A / CNAME) |
+| (all of the above) | `update_website_chatbot` to refresh the chatbot persona |
+
+## Key technical gotchas (designed for)
+
+1. **Soul → landing is not automatic.** Plain soul writes don't re-render the
+   page; the executor must call `seedLandingFromSoul(orgId)` (what `submit_soul`
+   does internally).
+2. **Chatbot persona is separate from Soul.** Updating Soul does not refresh an
+   existing chatbot's FAQ/pricing/greeting — the executor calls
+   `update_website_chatbot` explicitly.
+3. **Booking hours can only be set via `updateBookingTypeAction`** (server
+   action) — the MCP `create_appointment_type`/`update_appointment_type` tools
+   cannot set `availability` (create hardcodes Mon–Fri 9–5; update ignores it).
+4. **Dual Soul casing** — write both camelCase and snake_case to match
+   `buildSeedSoul`, or landing/settings read mismatched data.
+5. **Free-text parsing** is the agent's job — hours and services come in as
+   prose; the agent produces the structured `availability` and appointment-type
+   rows, and surfaces them in the review plan so the agency can correct.
+
+## Data-model changes
+
+- `IntakeQuestion`: add `file` type + `{ accept, maxSizeMb, multiple }`.
+- `intake_submissions`: no schema change — file URLs live in `data` (jsonb).
+- New table `onboarding_links` (token, orgId, status, timestamps).
+- New table `change_plans` (id, orgId, submissionId, plan jsonb, status,
+  createdAt, appliedAt).
+
+## Testing strategy (TDD)
+
+- **Unit (pure, test-first):** the answer→change-plan mapper (hours-text →
+  availability; services-text → appointment types); `file` validation
+  (accept/size). These are deterministic and the core risk.
+- **Unit (mocked):** the executor calls the right server actions in the right
+  order with the mapped inputs.
+- **Integration:** submit onboarding form → `form.submitted` → a `change_plans`
+  row appears as `pending_review`; "Apply all" → executor invokes each surface;
+  status flips to `applied`.
+- **Manual (Vercel preview):** pay (test mode) → receive link → fill the form
+  with a logo + a contacts CSV → review screen shows the plan → Apply →
+  workspace landing/booking/chatbot/contacts reflect the answers.
+
+## Rollout
+
+- Fires only for agency-activated workspaces (gated by the proposal/activation
+  flow). Existing self-serve workspaces are unaffected.
+- Bookings-CSV import ships stubbed (file stored, flagged). Everything else is
+  fully applied.
+
+## Decomposition note
+
+This spec is one sub-project of a larger arc Max raised. Tracked separately:
+**(B)** bookings-CSV importer, **(C)** booking date-blocking + real Meet/Zoom
+location field, **(D)** turnkey live voice, **(E)** refresh the stale
+`/docs/agents/voice-sms` article. None block this spec.

--- a/packages/crm/drizzle/0056_onboarding_links_change_plans.sql
+++ b/packages/crm/drizzle/0056_onboarding_links_change_plans.sql
@@ -1,0 +1,34 @@
+-- packages/crm/drizzle/0056_onboarding_links_change_plans.sql
+-- 2026-06-04 — Client-onboarding intake (Task 1 of 16).
+-- Two tables:
+--   onboarding_links — tokenized intake links sent to clients post-payment.
+--                      Status flow: pending → submitted → applied.
+--   change_plans     — wiring-agent output: validated diff to apply to the
+--                      workspace (services, hours, branding, etc.).
+--                      Status flow: pending_review → applied | discarded.
+-- Spec: docs/superpowers/specs/2026-06-04-client-onboarding-intake-design.md
+
+CREATE TABLE IF NOT EXISTS "onboarding_links" (
+  "id"           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "org_id"       uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "token"        text NOT NULL,
+  "status"       text NOT NULL DEFAULT 'pending',
+  "created_at"   timestamptz NOT NULL DEFAULT now(),
+  "submitted_at" timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS "onboarding_links_token_idx"
+  ON "onboarding_links" ("token");
+
+CREATE TABLE IF NOT EXISTS "change_plans" (
+  "id"            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "org_id"        uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "submission_id" uuid,
+  "plan"          jsonb NOT NULL,
+  "status"        text NOT NULL DEFAULT 'pending_review',
+  "created_at"    timestamptz NOT NULL DEFAULT now(),
+  "applied_at"    timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS "change_plans_org_idx"
+  ON "change_plans" ("org_id");

--- a/packages/crm/drizzle/meta/_journal.json
+++ b/packages/crm/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780086069047,
       "tag": "0055_users_onboarding_completed_at",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1780604372645,
+      "tag": "0056_onboarding_links_change_plans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crm/src/app/(dashboard)/onboarding/[id]/apply-action.ts
+++ b/packages/crm/src/app/(dashboard)/onboarding/[id]/apply-action.ts
@@ -1,0 +1,114 @@
+// packages/crm/src/app/(dashboard)/onboarding/[id]/apply-action.ts
+//
+// 2026-06-04 — Onboarding T14. Server action: agency clicks "Apply all"
+// on the change-plan review screen. Validates org ownership + status,
+// runs the executor, flips both rows to "applied", and best-effort
+// notifies the client their workspace is ready.
+
+"use server";
+
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+import { db } from "@/db";
+import { changePlans, onboardingLinks } from "@/db/schema";
+import { getOrgId } from "@/lib/auth/helpers";
+import { applyChangePlan, type ApplyChangePlanResult } from "@/lib/onboarding/execute-change-plan";
+import type { ChangePlan as ChangePlanPayload } from "@/lib/onboarding/change-plan";
+
+// ── result type ────────────────────────────────────────────────────────────────
+
+export type ApplyChangePlanActionResult =
+  | { ok: true; surfaces: ApplyChangePlanResult }
+  | { ok: false; error: string };
+
+// ── action ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Apply a pending change plan to the workspace.
+ *
+ * Guards:
+ *   1. getOrgId() — must have an active workspace session.
+ *   2. Row must exist + belong to this org.
+ *   3. status must be "pending_review" — idempotency: already-applied
+ *      plans return an error so the UI can show "Already applied".
+ *
+ * On success:
+ *   - Runs applyChangePlan (6 surfaces, each isolated — never aborts on
+ *     one failure).
+ *   - Flips change_plans.status → "applied", change_plans.applied_at → now.
+ *   - Flips the org's onboarding_links row → "applied" (best-effort; the
+ *     link row is found by orgId so we don't require the caller to pass
+ *     the link id).
+ *   - Best-effort client notification (wrapped — cannot throw).
+ *   - Revalidates the review page so the UI reflects the new status.
+ */
+export async function applyChangePlanAction(
+  planId: string,
+): Promise<ApplyChangePlanActionResult> {
+  // ── 1. auth ──────────────────────────────────────────────────────────────────
+  const orgId = await getOrgId();
+  if (!orgId) return { ok: false, error: "unauthorized" };
+
+  // ── 2. load + guard ──────────────────────────────────────────────────────────
+  const [row] = await db
+    .select()
+    .from(changePlans)
+    .where(and(eq(changePlans.id, planId), eq(changePlans.orgId, orgId)))
+    .limit(1);
+
+  if (!row) return { ok: false, error: "not_found" };
+  if (row.status !== "pending_review") {
+    return { ok: false, error: `already_${row.status}` };
+  }
+
+  // ── 3. execute ───────────────────────────────────────────────────────────────
+  const surfaces = await applyChangePlan(orgId, row.plan as ChangePlanPayload);
+
+  // ── 4. flip change_plans → applied ───────────────────────────────────────────
+  await db
+    .update(changePlans)
+    .set({ status: "applied", appliedAt: new Date() })
+    .where(eq(changePlans.id, planId));
+
+  // ── 5. flip onboarding_links → applied (best-effort) ─────────────────────────
+  try {
+    await db
+      .update(onboardingLinks)
+      .set({ status: "applied" })
+      .where(and(eq(onboardingLinks.orgId, orgId), eq(onboardingLinks.status, "submitted")));
+  } catch (err) {
+    console.warn(
+      JSON.stringify({
+        event: "apply_change_plan_link_flip_failed",
+        planId,
+        orgId,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+
+  // ── 6. best-effort client notification ────────────────────────────────────────
+  // We don't have a direct "workspace is ready" email for the client-onboarding
+  // flow yet; log the intent so it's traceable and can be wired when the email
+  // template is available.
+  try {
+    console.log(
+      JSON.stringify({
+        event: "apply_change_plan_success",
+        planId,
+        orgId,
+        surfaces: Object.fromEntries(
+          Object.entries(surfaces).map(([k, v]) => [k, v.ok ? "ok" : v.error]),
+        ),
+      }),
+    );
+  } catch {
+    // never throws
+  }
+
+  // ── 7. revalidate ─────────────────────────────────────────────────────────────
+  revalidatePath(`/onboarding/${planId}`);
+
+  return { ok: true, surfaces };
+}

--- a/packages/crm/src/app/(dashboard)/onboarding/[id]/page.tsx
+++ b/packages/crm/src/app/(dashboard)/onboarding/[id]/page.tsx
@@ -1,0 +1,175 @@
+// packages/crm/src/app/(dashboard)/onboarding/[id]/page.tsx
+//
+// 2026-06-04 — Onboarding T14. Agency review-and-apply screen.
+// Shows the change plan's summaries grouped into friendly sections
+// and a single "Apply all" button. After apply the page re-renders
+// in an "Applied" state (via revalidatePath in the action).
+
+import { notFound, redirect } from "next/navigation";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { changePlans } from "@/db/schema";
+import { getOrgId } from "@/lib/auth/helpers";
+import type { ChangePlan as ChangePlanPayload } from "@/lib/onboarding/change-plan";
+import { applyChangePlanAction } from "./apply-action";
+
+export const dynamic = "force-dynamic";
+
+// ── section grouping ────────────────────────────────────────────────────────────
+//
+// Each summary line starts with a prefix like "Website:", "Booking:", etc.
+// We bucket them into friendly section headings for display.
+
+type Section = {
+  heading: string;
+  lines: string[];
+};
+
+const SECTION_PREFIXES: { prefix: string; heading: string }[] = [
+  { prefix: "Website", heading: "Website" },
+  { prefix: "Booking", heading: "Booking" },
+  { prefix: "Services", heading: "Services" },
+  { prefix: "Theme", heading: "Brand" },
+  { prefix: "Call handling", heading: "Chatbot & Phones" },
+  { prefix: "Domain", heading: "Domain & Phones" },
+  { prefix: "CRM", heading: "Contacts" },
+  { prefix: "Bookings", heading: "Bookings Import" },
+  { prefix: "Workspace", heading: "Workspace" },
+];
+
+function groupSummaries(summaries: string[]): Section[] {
+  const buckets = new Map<string, string[]>();
+
+  for (const line of summaries) {
+    let heading = "Other";
+    for (const { prefix, heading: h } of SECTION_PREFIXES) {
+      if (line.startsWith(prefix)) {
+        heading = h;
+        break;
+      }
+    }
+    const existing = buckets.get(heading) ?? [];
+    existing.push(line);
+    buckets.set(heading, existing);
+  }
+
+  return Array.from(buckets.entries()).map(([heading, lines]) => ({
+    heading,
+    lines,
+  }));
+}
+
+// ── page ────────────────────────────────────────────────────────────────────────
+
+export default async function OnboardingReviewPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const orgId = await getOrgId();
+  if (!orgId) redirect("/login");
+
+  const { id } = await params;
+
+  const [row] = await db
+    .select()
+    .from(changePlans)
+    .where(and(eq(changePlans.id, id), eq(changePlans.orgId, orgId)))
+    .limit(1);
+
+  if (!row) notFound();
+
+  const plan = row.plan as ChangePlanPayload;
+  const businessName =
+    typeof plan.soul?.["business_name"] === "string"
+      ? plan.soul["business_name"]
+      : typeof plan.soul?.["businessName"] === "string"
+        ? plan.soul["businessName"]
+        : "this client";
+
+  const sections = groupSummaries(plan.summaries ?? []);
+  const isApplied = row.status === "applied";
+
+  // Bind the action to this plan id so the form needs no hidden input.
+  // The form action type requires (FormData) => void | Promise<void>, so
+  // we wrap the bound action to discard the return value.
+  const boundApply = applyChangePlanAction.bind(null, id);
+  async function applyAction(_formData: FormData): Promise<void> {
+    "use server";
+    await boundApply();
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10 space-y-8">
+      {/* ── header ── */}
+      <header className="space-y-1">
+        <h1 className="text-3xl font-semibold tracking-tight">
+          Review {businessName}&apos;s setup
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {isApplied
+            ? "This change plan has been applied to the workspace."
+            : "Confirm the changes below then click Apply all to wire them into the workspace."}
+        </p>
+      </header>
+
+      {/* ── summaries ── */}
+      {sections.length > 0 ? (
+        <div className="space-y-6">
+          {sections.map((section) => (
+            <section
+              key={section.heading}
+              className="rounded-2xl border bg-card/40 p-5 space-y-3"
+            >
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+                {section.heading}
+              </h2>
+              <ul className="space-y-2">
+                {section.lines.map((line, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm">
+                    <span className="mt-0.5 flex-shrink-0 h-4 w-4 rounded-full bg-primary/10 text-primary flex items-center justify-center text-[10px] font-bold">
+                      {isApplied ? "✓" : "·"}
+                    </span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-2xl border bg-card/40 p-5 text-sm text-muted-foreground">
+          No changes recorded in this plan.
+        </div>
+      )}
+
+      {/* ── action ── */}
+      <div className="pt-2">
+        {isApplied ? (
+          <div className="inline-flex items-center gap-2 rounded-xl bg-emerald-500/10 border border-emerald-500/20 px-5 py-3 text-sm font-medium text-emerald-600 dark:text-emerald-400">
+            <span>Applied ✓</span>
+            {row.appliedAt && (
+              <span className="text-xs opacity-70">
+                {new Date(row.appliedAt).toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </span>
+            )}
+          </div>
+        ) : (
+          <form action={applyAction}>
+            <button
+              type="submit"
+              className="inline-flex items-center gap-2 rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-sm hover:bg-primary/90 active:scale-[0.98] transition-all"
+            >
+              Apply all
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/packages/crm/src/app/api/v1/public/intake/route.ts
+++ b/packages/crm/src/app/api/v1/public/intake/route.ts
@@ -248,8 +248,8 @@ export async function POST(request: Request) {
       // Config defaults: if field is not found or has no file config,
       // reject everything (safe default — unknown extensions blocked).
       const cfg = {
-        accept: (field as { accept?: string[] } | undefined)?.accept ?? [],
-        maxSizeMb: (field as { maxSizeMb?: number } | undefined)?.maxSizeMb ?? 0,
+        accept: field?.accept ?? [],
+        maxSizeMb: field?.maxSizeMb ?? 0,
       };
 
       const urls: string[] = [];

--- a/packages/crm/src/app/api/v1/public/intake/route.ts
+++ b/packages/crm/src/app/api/v1/public/intake/route.ts
@@ -1,3 +1,5 @@
+import { put } from "@vercel/blob";
+import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/db";
@@ -5,6 +7,7 @@ import { contacts, intakeForms, intakeSubmissions, organizations } from "@/db/sc
 import type { IntakeFormField } from "@/db/schema/intake-forms";
 import { enforceContactLimit } from "@/lib/billing/limits";
 import { emitSeldonEvent } from "@/lib/events/bus";
+import { validateUploadField } from "@/lib/uploads/file-validation";
 import {
   resolveWorkspaceSlugFromRequest,
   resolveWorkspaceSlugFromRequestWithCustomDomains,
@@ -75,11 +78,72 @@ function dedupSeen(key: string): boolean {
 }
 
 export async function POST(request: Request) {
+  // ------------------------------------------------------------------
+  // Parse the request body — supports both application/json (original)
+  // and multipart/form-data (when the form has file questions).
+  // Both paths produce the same common shape before any submission logic.
+  // ------------------------------------------------------------------
+  const contentType = request.headers.get("content-type") ?? "";
+  const isMultipart = contentType.includes("multipart/form-data");
+
   let body: SubmitBody;
-  try {
-    body = (await request.json()) as SubmitBody;
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  // pendingFileUploads is populated during multipart parsing and
+  // resolved (blob put) after the form row is loaded.
+  let pendingFileUploads: Array<{
+    questionId: string;
+    files: File[];
+    multi: boolean;
+  }> | null = null;
+
+  if (isMultipart) {
+    let fd: FormData;
+    try {
+      fd = await request.formData();
+    } catch {
+      return NextResponse.json({ error: "Invalid multipart body." }, { status: 400 });
+    }
+    const rawAnswers = fd.get("answers");
+    let parsedAnswers: Record<string, unknown> | null = null;
+    if (typeof rawAnswers === "string") {
+      try {
+        const parsed = JSON.parse(rawAnswers);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          parsedAnswers = parsed as Record<string, unknown>;
+        }
+      } catch {
+        // fall through — parsedAnswers stays null
+      }
+    }
+    body = {
+      orgSlug: fd.get("orgSlug") ?? undefined,
+      formSlug: fd.get("formSlug") ?? undefined,
+      answers: parsedAnswers ?? undefined,
+      workspace: fd.get("workspace") ?? undefined,
+      idempotencyKey: fd.get("idempotencyKey") ?? undefined,
+    };
+    // Collect file parts — we can't resolve which are "file" questions
+    // until we load the form below, so we store all "file:*" parts now.
+    const fileMap = new Map<string, File[]>();
+    for (const [key, value] of fd.entries()) {
+      if (key.startsWith("file:") && value instanceof File) {
+        const qid = key.slice(5); // strip "file:" prefix
+        if (!fileMap.has(qid)) fileMap.set(qid, []);
+        fileMap.get(qid)!.push(value);
+      }
+    }
+    if (fileMap.size > 0) {
+      pendingFileUploads = Array.from(fileMap.entries()).map(([questionId, files]) => ({
+        questionId,
+        files,
+        multi: files.length > 1,
+      }));
+    }
+  } else {
+    try {
+      body = (await request.json()) as SubmitBody;
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+    }
   }
 
   // 2026-05-18 (later) — idempotency check. Header takes precedence
@@ -166,6 +230,81 @@ export async function POST(request: Request) {
 
   if (!form || !form.isActive) {
     return NextResponse.json({ error: "Form not found." }, { status: 404 });
+  }
+
+  // ------------------------------------------------------------------
+  // Multipart file uploads: validate + push to Vercel Blob.
+  // We enrich `answers` in-place so the rest of the submission path
+  // (dedup, contact creation, event emits) sees the blob URLs as if
+  // they were regular string answers.
+  // ------------------------------------------------------------------
+  if (pendingFileUploads && pendingFileUploads.length > 0) {
+    const formFields = (Array.isArray(form.fields) ? form.fields : []) as IntakeFormField[];
+    // Build a map of questionId → field config for O(1) lookup.
+    const fieldMap = new Map<string, IntakeFormField>(formFields.map((f) => [f.key, f]));
+
+    for (const { questionId, files, multi } of pendingFileUploads) {
+      const field = fieldMap.get(questionId);
+      // Config defaults: if field is not found or has no file config,
+      // reject everything (safe default — unknown extensions blocked).
+      const cfg = {
+        accept: (field as { accept?: string[] } | undefined)?.accept ?? [],
+        maxSizeMb: (field as { maxSizeMb?: number } | undefined)?.maxSizeMb ?? 0,
+      };
+
+      const urls: string[] = [];
+      for (const file of files) {
+        // Validate extension + size.
+        const validation = validateUploadField(
+          { name: file.name, sizeBytes: file.size },
+          cfg,
+        );
+        if (!validation.ok) {
+          return NextResponse.json(
+            {
+              error:
+                validation.reason === "type"
+                  ? `File type not allowed for question "${questionId}".`
+                  : `File exceeds the ${cfg.maxSizeMb}MB size limit for question "${questionId}".`,
+              questionId,
+              reason: validation.reason,
+            },
+            { status: 400 },
+          );
+        }
+
+        // Upload to Vercel Blob. Key shape mirrors user-image route:
+        // `intake/{orgSlug}/{questionId}/{uuid}-{filename}`.
+        const safeName = file.name.replace(/[^a-zA-Z0-9.\-_]/g, "-").slice(0, 128);
+        const blobKey = `intake/${orgSlug}/${questionId}/${randomUUID()}-${safeName}`;
+        try {
+          const blob = await put(blobKey, file, {
+            access: "public",
+            contentType: file.type || "application/octet-stream",
+            addRandomSuffix: false,
+            token: process.env.BLOB_READ_WRITE_TOKEN,
+          });
+          urls.push(blob.url);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              event: "public_intake_blob_upload_failed",
+              org_slug: orgSlug,
+              question_id: questionId,
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+          return NextResponse.json(
+            { error: "File upload failed. Please try again." },
+            { status: 500 },
+          );
+        }
+      }
+
+      // Store single URL string or array, consistent with how text
+      // answers look downstream.
+      answers[questionId] = multi || urls.length > 1 ? urls : (urls[0] ?? null);
+    }
   }
 
   // 2026-05-19 — server-side dedup against intake_submissions. The

--- a/packages/crm/src/app/api/webhooks/stripe/connect/route.ts
+++ b/packages/crm/src/app/api/webhooks/stripe/connect/route.ts
@@ -5,6 +5,7 @@ import Stripe from "stripe";
 import { db } from "@/db";
 import {
   invoices,
+  onboardingLinks,
   organizations,
   paymentEvents,
   paymentRecords,
@@ -15,8 +16,11 @@ import {
 } from "@/db/schema";
 import { emitSeldonEvent } from "@/lib/events/bus";
 import { logEvent } from "@/lib/observability/log";
+import { seedOnboardingForm } from "@/lib/onboarding/onboarding-form-definition";
+import { createOnboardingLink } from "@/lib/onboarding/links";
 import { notifyAgencyOfAcceptance } from "@/lib/proposals/notify-agency";
 import { notifyProspectOfActivation } from "@/lib/proposals/notify-prospect";
+import { sendEmailFromApi } from "@/lib/emails/api";
 import { createDealOnAcceptance } from "@/lib/proposals/create-deal-on-acceptance";
 
 export const runtime = "nodejs";
@@ -563,6 +567,62 @@ export async function POST(request: Request) {
         });
       } catch (err: unknown) {
         logEvent("proposal_acceptance_crm_failed", {
+          proposalId: proposal.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      // L2 — Seed onboarding intake + email the tokenized link to the client.
+      // Must NEVER throw out of the webhook — activation already succeeded.
+      // Idempotency: skip entirely if an onboarding_links row already exists
+      // for this org (handles webhook retries / duplicate events).
+      try {
+        const activationOrgId = proposal.previewWorkspaceId ?? orgId;
+
+        const [existingLink] = await db
+          .select({ id: onboardingLinks.id })
+          .from(onboardingLinks)
+          .where(eq(onboardingLinks.orgId, activationOrgId))
+          .limit(1);
+
+        if (!existingLink) {
+          await seedOnboardingForm(activationOrgId);
+          const { token } = await createOnboardingLink(activationOrgId);
+
+          const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.seldonframe.com";
+          const onboardUrl = `${appUrl}/onboard/${token}`;
+
+          const greetingName = proposal.prospectFirstName?.trim() || proposal.prospectName;
+          const subject = `Your new workspace is ready — tell us about your business`;
+          const body = `Hi ${greetingName},
+
+Your workspace is live. Before we customize it to fit your business, we need a few details from you — it takes about 10 minutes.
+
+Set up your workspace here: ${onboardUrl}
+
+We'll use your answers to configure your booking page, website, and front office. The link is personal to you, no account needed.
+
+Talk soon,
+The team`;
+
+          await sendEmailFromApi({
+            orgId: activationOrgId,
+            userId: null,
+            contactId: null,
+            toEmail: proposal.prospectEmail,
+            subject,
+            body,
+            ctaLabel: "Set up my workspace →",
+            ctaHref: onboardUrl,
+          });
+
+          logEvent("onboarding_link_sent", {
+            proposalId: proposal.id,
+            orgId: activationOrgId,
+          });
+        }
+      } catch (err: unknown) {
+        logEvent("onboarding_seed_email_failed", {
           proposalId: proposal.id,
           error: err instanceof Error ? err.message : String(err),
         });

--- a/packages/crm/src/app/onboard/[token]/page.tsx
+++ b/packages/crm/src/app/onboard/[token]/page.tsx
@@ -1,0 +1,188 @@
+// packages/crm/src/app/onboard/[token]/page.tsx
+// 2026-06-04 — Public onboarding intake route. No auth required.
+// Clients receive /onboard/<token> after paying; the link renders
+// the 7-chapter intake card flow so we can configure their workspace.
+//
+// Conventions:
+// - await params (Next.js 15 async params)
+// - Validate token + load row before any expensive work
+// - Render "link no longer active" panel for invalid / applied links
+// - Render formbricks-stack-v1 fresh from ONBOARDING_QUESTIONS for valid links
+// Mirrors: app/p/[token]/page.tsx (proposal public page)
+//          app/forms/[id]/[formSlug]/page.tsx (public intake)
+
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { organizations } from "@/db/schema";
+import { loadOnboardingLinkByToken } from "@/lib/onboarding/links";
+import { ONBOARDING_QUESTIONS } from "@/lib/onboarding/onboarding-form-definition";
+import { renderFormbricksStackV1 } from "@/lib/blueprint/renderers/formbricks-stack-v1";
+import type { Blueprint, Intake } from "@/lib/blueprint/types";
+
+export const dynamic = "force-dynamic";
+
+// ─── Blueprint stub ───────────────────────────────────────────────────────────
+// The onboarding form has no pre-rendered blueprint HTML stored in the DB.
+// We synthesise a minimal Blueprint on-the-fly so renderFormbricksStackV1
+// can produce the card-flow HTML/CSS. Only the fields the renderer actually
+// reads are populated; the rest use safe defaults.
+
+function buildOnboardingBlueprint(workspaceName: string, orgSlug: string): Blueprint {
+  const intake: Intake = {
+    renderer: "formbricks-stack-v1",
+    title: "Let's build your new front office",
+    description:
+      "About 10 minutes. Upload what you have; skip the rest and we'll handle it.",
+    questions: ONBOARDING_QUESTIONS,
+    completion: {
+      headline: "That's everything!",
+      message:
+        "We're building your front office now — you'll get an email the moment it's ready.",
+    },
+  };
+
+  return {
+    version: 1,
+    workspace: {
+      name: workspaceName,
+      slug: orgSlug,
+      tagline: "",
+      industry: "service",
+      theme: {
+        mode: "light",
+        accent: "#0ea5e9",
+      },
+      contact: {
+        phone: "",
+        email: null,
+        address: {
+          street: "",
+          city: "",
+          region: "",
+          postalCode: "",
+          country: "US",
+        },
+        hours: {
+          mon: [9, 17],
+          tue: [9, 17],
+          wed: [9, 17],
+          thu: [9, 17],
+          fri: [9, 17],
+          sat: null,
+          sun: null,
+        },
+        timezone: "America/New_York",
+      },
+    },
+    // landing/booking/admin are required by the Blueprint type but not
+    // consumed by renderFormbricksStackV1. Provide minimal valid stubs.
+    landing: {
+      renderer: "general-service-v1",
+      sections: [],
+    } as Blueprint["landing"],
+    booking: {
+      renderer: "calcom-month-v1",
+      eventType: {
+        title: "Consultation",
+        durationMinutes: 60,
+      },
+      availability: {
+        weekly: {
+          mon: [9, 17],
+          tue: [9, 17],
+          wed: [9, 17],
+          thu: [9, 17],
+          fri: [9, 17],
+          sat: null,
+          sun: null,
+        },
+      },
+      formFields: [],
+      confirmation: {},
+    },
+    admin: {
+      renderer: "twenty-shell-v1",
+      objects: [],
+      sidebarOrder: [],
+    },
+    intake,
+  };
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function OnboardTokenPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+
+  // Validate + load the link row. loadOnboardingLinkByToken pre-validates
+  // the token shape before hitting the DB (cheap bot defence).
+  const link = await loadOnboardingLinkByToken(token);
+
+  // Render a friendly "no longer active" panel for:
+  //   - invalid token (null from pre-validation)
+  //   - missing token (no DB row)
+  //   - already-applied links (workspace is already configured)
+  if (!link || link.status === "applied") {
+    return (
+      <main className="min-h-screen bg-[#ededed] flex items-center justify-center p-6">
+        <div className="max-w-md w-full rounded-2xl bg-white shadow-sm border border-black/5 p-10 text-center space-y-4">
+          <div
+            className="mx-auto flex items-center justify-center w-16 h-16 rounded-full"
+            style={{ background: "rgba(239, 68, 68, 0.1)" }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="32"
+              height="32"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#EF4444"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+          </div>
+          <h1
+            className="text-xl font-semibold tracking-tight"
+            style={{ fontFamily: "var(--sf-font-display, inherit)", color: "#0f172a" }}
+          >
+            This link is no longer active
+          </h1>
+          <p className="text-sm text-gray-500 leading-relaxed">
+            Your onboarding link has already been used or has expired. If you
+            believe this is a mistake, please contact your account manager.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // Load workspace name for the navbar + footer (renderer uses blueprint.workspace.name).
+  const [org] = await db
+    .select({ name: organizations.name, slug: organizations.slug })
+    .from(organizations)
+    .where(eq(organizations.id, link.orgId))
+    .limit(1);
+
+  const workspaceName = org?.name ?? "Your workspace";
+  const orgSlug = org?.slug ?? "";
+
+  const blueprint = buildOnboardingBlueprint(workspaceName, orgSlug);
+  const { html, css } = renderFormbricksStackV1(blueprint);
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: css }} />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  );
+}

--- a/packages/crm/src/db/schema/index.ts
+++ b/packages/crm/src/db/schema/index.ts
@@ -117,3 +117,7 @@ export * from "./proposal-events";
 
 // 2026-05-22 — Phase T: natural-language landing editor + undo history.
 export * from "./landing-payload-versions";
+
+// 2026-06-04 — Client-onboarding intake (Task 1): tokenized intake links +
+// wiring-agent change plans.
+export * from "./onboarding";

--- a/packages/crm/src/db/schema/intake-forms.ts
+++ b/packages/crm/src/db/schema/intake-forms.ts
@@ -9,6 +9,10 @@ export type IntakeFormField = {
   type: string;
   required: boolean;
   options?: string[];
+  // File-question config — only present when type === "file".
+  accept?: string[];
+  maxSizeMb?: number;
+  multiple?: boolean;
 };
 
 export const intakeForms = pgTable(

--- a/packages/crm/src/db/schema/onboarding.ts
+++ b/packages/crm/src/db/schema/onboarding.ts
@@ -1,0 +1,58 @@
+// packages/crm/src/db/schema/onboarding.ts
+// 2026-06-04 — Client-onboarding intake. Two tables:
+//   onboarding_links — tokenized intake links sent to clients post-payment.
+//   change_plans     — wiring-agent output: a validated diff to apply to
+//                      the workspace (services, hours, branding, etc.).
+// Spec: docs/superpowers/specs/2026-06-04-client-onboarding-intake-design.md
+
+import { index, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
+import { organizations } from "./organizations";
+
+// Status flow: pending → submitted → applied
+export type OnboardingLinkStatus = "pending" | "submitted" | "applied";
+
+// Status flow: pending_review → applied | discarded
+export type ChangePlanStatus = "pending_review" | "applied" | "discarded";
+
+export const onboardingLinks = pgTable(
+  "onboarding_links",
+  {
+    id: uuid("id").default(sql`gen_random_uuid()`).primaryKey(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    token: text("token").notNull(),
+    status: text("status")
+      .$type<OnboardingLinkStatus>()
+      .notNull()
+      .default("pending"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    submittedAt: timestamp("submitted_at", { withTimezone: true }),
+  },
+  (t) => [index("onboarding_links_token_idx").on(t.token)],
+);
+
+export const changePlans = pgTable(
+  "change_plans",
+  {
+    id: uuid("id").default(sql`gen_random_uuid()`).primaryKey(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    submissionId: uuid("submission_id"),
+    plan: jsonb("plan").notNull(),
+    status: text("status")
+      .$type<ChangePlanStatus>()
+      .notNull()
+      .default("pending_review"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    appliedAt: timestamp("applied_at", { withTimezone: true }),
+  },
+  (t) => [index("change_plans_org_idx").on(t.orgId)],
+);
+
+export type OnboardingLink = typeof onboardingLinks.$inferSelect;
+export type OnboardingLinkInsert = typeof onboardingLinks.$inferInsert;
+export type ChangePlan = typeof changePlans.$inferSelect;
+export type ChangePlanInsert = typeof changePlans.$inferInsert;

--- a/packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts
+++ b/packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts
@@ -322,6 +322,16 @@ function renderQuestionInput(q: IntakeQuestion): string {
       return `<input class="sf-intake__input" type="tel" inputmode="tel" autocomplete="tel" data-field-id="${escapeAttr(q.id)}" ${placeholder} />
       <p class="sf-intake__hint">Press <kbd>Enter</kbd> to continue</p>`;
 
+    case "file": {
+      const acceptAttr = q.file && q.file.accept && q.file.accept.length > 0
+        ? ` accept="${escapeAttr(q.file.accept.join(","))}"`
+        : "";
+      const multipleAttr = q.file && q.file.multiple ? " multiple" : "";
+      const requiredAttr = q.required ? " required" : "";
+      return `<input class="sf-intake__input sf-intake__file-input" type="file" data-field-id="${escapeAttr(q.id)}"${acceptAttr}${multipleAttr}${requiredAttr} />
+      <p class="sf-intake__hint">Click to choose a file, then click <strong>Continue</strong>.</p>`;
+    }
+
     case "text":
     default:
       return `<input class="sf-intake__input" type="text" data-field-id="${escapeAttr(q.id)}" ${placeholder} />
@@ -512,6 +522,12 @@ const INTAKE_INTERACTIVITY_SCRIPT = `<script data-sf-intake="formbricks-stack-v1
 
   // ─── Validation ──────────────────────────────────────────────────
   function validate(q, value){
+    if (q.type === 'file') {
+      if (q.required && (!value || (value && value.length === 0))) {
+        return 'Please select a file.';
+      }
+      return null;
+    }
     if (q.required && (value === undefined || value === null || value === '' || (Array.isArray(value) && value.length === 0))) {
       return 'This question is required.';
     }
@@ -586,6 +602,10 @@ const INTAKE_INTERACTIVITY_SCRIPT = `<script data-sf-intake="formbricks-stack-v1
     }
     var input = inputs[0];
     if (!input) return '';
+    if (q.type === 'file') {
+      var fileInput = /** @type {HTMLInputElement} */ (input);
+      return fileInput.files && fileInput.files.length > 0 ? fileInput.files : null;
+    }
     return input.value;
   }
 
@@ -761,21 +781,60 @@ const INTAKE_INTERACTIVITY_SCRIPT = `<script data-sf-intake="formbricks-stack-v1
         orgSlug = labels[0];
       }
     }
-    var payload = {
-      orgSlug: orgSlug,
-      formSlug: formSlug,
-      answers: state.answers,
-      workspace: data.workspaceName,
-      idempotencyKey: state.idempotencyKey,
-    };
-    fetch('/api/v1/public/intake', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Idempotency-Key': state.idempotencyKey,
-      },
-      body: JSON.stringify(payload),
-    }).then(function(res){
+    // Determine if any visible question is a file question with actual files.
+    var visible = visibleQuestions();
+    var hasFiles = visible.some(function(q) {
+      return q.type === 'file' && state.answers[q.id] && state.answers[q.id].length > 0;
+    });
+
+    var fetchInit;
+    if (hasFiles) {
+      // multipart/form-data — include file File objects alongside JSON-encoded answers.
+      var fd = new FormData();
+      fd.append('orgSlug', orgSlug);
+      fd.append('formSlug', formSlug);
+      fd.append('workspace', data.workspaceName);
+      fd.append('idempotencyKey', state.idempotencyKey);
+      // Serialize non-file answers as a JSON blob so the server can parse them uniformly.
+      var textAnswers = {};
+      for (var aKey in state.answers) {
+        if (Object.prototype.hasOwnProperty.call(state.answers, aKey)) {
+          var aVal = state.answers[aKey];
+          if (aVal && typeof aVal === 'object' && typeof aVal.length === 'number' && aVal[0] instanceof File) {
+            // File question — append each File under the question's field key.
+            for (var fi = 0; fi < aVal.length; fi++) {
+              fd.append('file:' + aKey, aVal[fi]);
+            }
+          } else {
+            textAnswers[aKey] = aVal;
+          }
+        }
+      }
+      fd.append('answers', JSON.stringify(textAnswers));
+      fetchInit = {
+        method: 'POST',
+        headers: { 'Idempotency-Key': state.idempotencyKey },
+        body: fd,
+      };
+    } else {
+      var payload = {
+        orgSlug: orgSlug,
+        formSlug: formSlug,
+        answers: state.answers,
+        workspace: data.workspaceName,
+        idempotencyKey: state.idempotencyKey,
+      };
+      fetchInit = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Idempotency-Key': state.idempotencyKey,
+        },
+        body: JSON.stringify(payload),
+      };
+    }
+
+    fetch('/api/v1/public/intake', fetchInit).then(function(res){
       // Show completion regardless of response — submission failures are
       // logged server-side but the operator-facing message stays positive.
       // For local-file previews (file://) this falls through to the catch

--- a/packages/crm/src/lib/blueprint/types.ts
+++ b/packages/crm/src/lib/blueprint/types.ts
@@ -298,12 +298,17 @@ export interface Booking {
 
 export interface IntakeQuestion {
   id: string;
-  type: "text" | "textarea" | "email" | "phone" | "number" | "select" | "multi-select" | "rating" | "date";
+  type: "text" | "textarea" | "email" | "phone" | "number" | "select" | "multi-select" | "rating" | "date" | "file";
   label: string;
   helper?: string;
   required?: boolean;
   options?: string[];
   ratingScale?: "number-1-5" | "number-1-10" | "stars-1-5";
+  file?: {
+    accept: string[];
+    maxSizeMb: number;
+    multiple: boolean;
+  };
   validation?: {
     minLength?: number;
     maxLength?: number;

--- a/packages/crm/src/lib/events/listeners.ts
+++ b/packages/crm/src/lib/events/listeners.ts
@@ -3,7 +3,7 @@ import { getSeldonEventBus } from "@seldonframe/core/events";
 import { getCoreRuntimeConfig } from "@seldonframe/core/config";
 import { configureTelemetry, trackTelemetryEvent } from "@seldonframe/core/telemetry";
 import { db } from "@/db";
-import { bookings, intakeForms } from "@/db/schema";
+import { bookings, changePlans, intakeForms, intakeSubmissions, onboardingLinks } from "@/db/schema";
 import { dispatchEventToDeployedAgents } from "@/lib/agents/dispatcher";
 import { sendTriggeredEmailsForContactEvent, sendWelcomeEmailForContact } from "@/lib/emails/actions";
 import { syncContactToNewsletter } from "@/lib/integrations/newsletter-sync";
@@ -12,6 +12,9 @@ import { dispatchOutboundMessagesForEvent } from "@/lib/messaging/dispatch";
 // 2026-05-18 — Slice 6: cancel pending scheduled sends (e.g. 24h
 // reminders) when their target booking is cancelled.
 import { cancelScheduledSendsForBooking } from "@/lib/messaging/schedule";
+// 2026-06-04 — Onboarding T12: persist change plan on onboarding submission.
+import { buildChangePlan } from "@/lib/onboarding/change-plan";
+import { sendNewSignupAlert } from "@/lib/notifications/ops-notifications";
 
 /**
  * The SeldonEvent typed schema doesn't include orgId on form.submitted /
@@ -143,6 +146,118 @@ export function registerCrmEventListeners() {
         console.warn(
           `[listeners] dispatchOutboundMessagesForEvent form.submitted failed:`,
           err,
+        );
+      }
+
+      // 2026-06-04 — Onboarding T12: if this is the workspace's
+      // onboarding intake form (slug === "onboarding"), build a
+      // ChangePlan from the answers and persist it for agency review.
+      // Also flip onboardingLinks.status → "submitted" and notify ops.
+      // Non-fatal — a failure here must never break other listeners or
+      // the submission response.
+      try {
+        // Resolve the form slug to decide whether to act.
+        const [formRow] = await db
+          .select({ slug: intakeForms.slug })
+          .from(intakeForms)
+          .where(eq(intakeForms.id, formId))
+          .limit(1);
+
+        if (formRow?.slug === "onboarding") {
+          const eventData = event.data as Record<string, unknown>;
+
+          // Load submission answers. Prefer the payload's `data` field
+          // if present (avoids an extra query); otherwise fetch from the
+          // intake_submissions table via submissionId.
+          let answers: Record<string, unknown> | null = null;
+
+          if (
+            eventData.data !== undefined &&
+            eventData.data !== null &&
+            typeof eventData.data === "object" &&
+            !Array.isArray(eventData.data)
+          ) {
+            answers = eventData.data as Record<string, unknown>;
+          } else if (typeof eventData.submissionId === "string" && eventData.submissionId) {
+            const [subRow] = await db
+              .select({ data: intakeSubmissions.data })
+              .from(intakeSubmissions)
+              .where(eq(intakeSubmissions.id, eventData.submissionId))
+              .limit(1);
+            answers = subRow?.data ?? null;
+          } else {
+            // Fall back: query the most recent submission for this form
+            // in this org (best-effort when submissionId isn't on payload).
+            const [latestRow] = await db
+              .select({ data: intakeSubmissions.data })
+              .from(intakeSubmissions)
+              .where(eq(intakeSubmissions.formId, formId))
+              .limit(1);
+            answers = latestRow?.data ?? null;
+          }
+
+          if (answers) {
+            // Build the structured change plan.
+            const plan = buildChangePlan(answers);
+
+            const submissionId =
+              typeof eventData.submissionId === "string" ? eventData.submissionId : null;
+
+            // Persist the change plan row.
+            await db.insert(changePlans).values({
+              orgId: formOrgId,
+              ...(submissionId ? { submissionId } : {}),
+              plan: plan as unknown as Record<string, unknown>,
+              status: "pending_review",
+            });
+
+            // Flip the matching onboardingLinks row to "submitted".
+            await db
+              .update(onboardingLinks)
+              .set({ status: "submitted", submittedAt: new Date() })
+              .where(eq(onboardingLinks.orgId, formOrgId));
+
+            // Notify ops — reuse the new-signup alert channel (same
+            // Resend pipeline, same recipient resolution). We signal
+            // an onboarding submission via the source field.
+            const businessName =
+              typeof answers["business_name"] === "string"
+                ? answers["business_name"]
+                : formOrgId;
+            await sendNewSignupAlert({
+              email: typeof answers["email"] === "string" ? answers["email"] : "(no email in answers)",
+              userId: formOrgId,
+              createdAt: new Date(),
+              source: `onboarding_intake:${businessName} — ${plan.summaries.length} change(s): ${plan.summaries.slice(0, 2).join("; ")}`,
+            });
+
+            console.log(
+              JSON.stringify({
+                action: "onboarding.change_plan_persisted",
+                orgId: formOrgId,
+                submissionId,
+                planSummaries: plan.summaries,
+              }),
+            );
+          } else {
+            console.warn(
+              JSON.stringify({
+                action: "onboarding.change_plan_skipped",
+                reason: "no_answers_resolved",
+                orgId: formOrgId,
+                formId,
+              }),
+            );
+          }
+        }
+      } catch (err) {
+        console.warn(
+          JSON.stringify({
+            action: "onboarding.change_plan_failed",
+            orgId: formOrgId,
+            formId,
+            error: err instanceof Error ? err.message : String(err),
+          }),
         );
       }
     }

--- a/packages/crm/src/lib/onboarding/change-plan.ts
+++ b/packages/crm/src/lib/onboarding/change-plan.ts
@@ -1,0 +1,214 @@
+/**
+ * change-plan.ts — Pure mapper: submitted intake answers → ChangePlan
+ *
+ * Composes parseHoursText + parseServicesText into a structured review
+ * payload the agency approves before applying to the workspace.
+ */
+
+import { parseHoursText, WeeklyAvailability } from "./parse-hours";
+import { parseServicesText } from "./parse-services";
+
+// ── exported payload type ─────────────────────────────────────────────────────
+
+export type ChangePlan = {
+  soul: Record<string, unknown>;
+  theme?: { primaryColor?: string; accentColor?: string };
+  bookingDefault?: { availability: WeeklyAvailability; primaryServiceName?: string };
+  appointmentTypes: { title: string; durationMinutes: number; price: number }[];
+  contactsFileUrl?: string;
+  bookingsFileUrl?: string;
+  callHandling: "ai_voice" | "human_then_text" | "none";
+  leadRouting: ("email" | "text")[];
+  domain?: string;
+  summaries: string[];
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+function strArr(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map(String);
+  if (typeof v === "string") return [v];
+  return [];
+}
+
+/** Extract the first hex color (#rrggbb or #rgb) from a string. */
+function firstHex(s: string): string | undefined {
+  const m = /#([0-9a-f]{6}|[0-9a-f]{3})\b/i.exec(s);
+  return m ? m[0] : undefined;
+}
+
+/** Extract all hex colors from a string. */
+function allHex(s: string): string[] {
+  return [...s.matchAll(/#([0-9a-f]{6}|[0-9a-f]{3})\b/gi)].map(m => m[0]);
+}
+
+// ── soul builder ──────────────────────────────────────────────────────────────
+
+function buildSoul(data: Record<string, unknown>): Record<string, unknown> {
+  const soul: Record<string, unknown> = {};
+
+  const pick = (key: string, soulKey = key) => {
+    const v = data[key];
+    if (v !== undefined && v !== null && v !== "") soul[soulKey] = v;
+  };
+
+  pick("business_name");
+  pick("tagline");
+  pick("phone");
+  pick("email");
+
+  // address / service_area
+  if (str(data["has_public_address"]).toLowerCase() === "yes" && str(data["address"])) {
+    soul["service_area"] = data["address"];
+  } else if (str(data["address"])) {
+    soul["service_area"] = data["address"];
+  }
+
+  pick("website_url", "website");
+  pick("google_reviews_url", "google_place_url");
+
+  // testimonials: split multi-line string into array
+  const testimonials = str(data["testimonials"]);
+  if (testimonials) {
+    soul["testimonials"] = testimonials.split(/\n/).map(l => l.trim()).filter(Boolean);
+  }
+
+  // socials
+  const socials = data["socials"];
+  if (socials !== undefined && socials !== null && socials !== "") soul["socials"] = socials;
+
+  return soul;
+}
+
+// ── theme builder ─────────────────────────────────────────────────────────────
+
+function buildTheme(data: Record<string, unknown>): ChangePlan["theme"] {
+  const raw = str(data["brand_colors"]);
+  if (!raw) return undefined;
+
+  const colors = allHex(raw);
+  if (colors.length === 0) return undefined;
+
+  const theme: ChangePlan["theme"] = {};
+  if (colors[0]) theme.primaryColor = colors[0];
+  if (colors[1]) theme.accentColor = colors[1];
+  return theme;
+}
+
+// ── call-handling mapper ──────────────────────────────────────────────────────
+
+function mapCallHandling(raw: string): ChangePlan["callHandling"] {
+  const s = raw.trim().toLowerCase();
+  if (s.includes("ai answers")) return "ai_voice";
+  if (s.includes("text me missed")) return "human_then_text";
+  return "none";
+}
+
+// ── lead routing mapper ───────────────────────────────────────────────────────
+
+function mapLeadRouting(raw: unknown): ChangePlan["leadRouting"] {
+  const allowed = new Set<"email" | "text">(["email", "text"]);
+  return strArr(raw)
+    .map(v => v.toLowerCase() as "email" | "text")
+    .filter(v => allowed.has(v));
+}
+
+// ── summaries builder ─────────────────────────────────────────────────────────
+
+function buildSummaries(plan: Omit<ChangePlan, "summaries">): string[] {
+  const lines: string[] = [];
+
+  const name = str(plan.soul["business_name"]) || "your business";
+
+  if (plan.soul["business_name"]) lines.push(`Website: set up landing page for ${name}`);
+
+  if (plan.bookingDefault) {
+    const days = Object.entries(plan.bookingDefault.availability)
+      .filter(([, s]) => s.enabled)
+      .map(([d]) => d)
+      .join(", ");
+    lines.push(`Booking: availability set for ${days}`);
+  }
+
+  if (plan.appointmentTypes.length > 0) {
+    lines.push(
+      `Services: ${plan.appointmentTypes.length} appointment type(s) created (${plan.appointmentTypes.map(a => a.title).join(", ")})`
+    );
+  }
+
+  if (plan.contactsFileUrl) lines.push("CRM: contacts CSV queued for import");
+  if (plan.bookingsFileUrl) lines.push("Bookings: bookings CSV queued for import");
+
+  if (plan.domain) lines.push(`Domain: ${plan.domain} → connect custom domain`);
+
+  if (plan.callHandling !== "none") {
+    const label = plan.callHandling === "ai_voice" ? "AI voice agent" : "human-first + text fallback";
+    lines.push(`Call handling: ${label}`);
+  }
+
+  if (plan.theme) lines.push("Theme: brand colors applied");
+
+  if (lines.length === 0) lines.push("Workspace: basic profile updated");
+
+  return lines;
+}
+
+// ── main export ───────────────────────────────────────────────────────────────
+
+export function buildChangePlan(data: Record<string, unknown>): ChangePlan {
+  // Soul
+  const soul = buildSoul(data);
+
+  // Theme
+  const theme = buildTheme(data);
+
+  // Booking default
+  const hoursText = str(data["hours_text"]);
+  const primaryService = str(data["primary_service"]) || undefined;
+  const bookingDefault: ChangePlan["bookingDefault"] = hoursText
+    ? { availability: parseHoursText(hoursText), primaryServiceName: primaryService }
+    : undefined;
+
+  // Appointment types
+  const servicesText = str(data["services_text"]);
+  const appointmentTypes = servicesText
+    ? parseServicesText(servicesText).map(s => ({
+        title: s.name,
+        durationMinutes: s.durationMinutes,
+        price: s.price,
+      }))
+    : [];
+
+  // File URLs
+  const contactsFileUrl = str(data["contacts_file"]) || undefined;
+  const bookingsFileUrl = str(data["bookings_file"]) || undefined;
+
+  // Call handling
+  const callHandling = mapCallHandling(str(data["call_handling"]));
+
+  // Lead routing
+  const leadRouting = mapLeadRouting(data["lead_routing"]);
+
+  // Domain
+  const hasDomain = str(data["has_domain"]).toLowerCase() === "yes";
+  const domainRaw = str(data["domain"]);
+  const domain = hasDomain && domainRaw ? domainRaw : undefined;
+
+  const partial: Omit<ChangePlan, "summaries"> = {
+    soul,
+    ...(theme ? { theme } : {}),
+    ...(bookingDefault ? { bookingDefault } : {}),
+    appointmentTypes,
+    ...(contactsFileUrl ? { contactsFileUrl } : {}),
+    ...(bookingsFileUrl ? { bookingsFileUrl } : {}),
+    callHandling,
+    leadRouting,
+    ...(domain ? { domain } : {}),
+  };
+
+  return { ...partial, summaries: buildSummaries(partial) };
+}

--- a/packages/crm/src/lib/onboarding/execute-change-plan.ts
+++ b/packages/crm/src/lib/onboarding/execute-change-plan.ts
@@ -1,0 +1,321 @@
+// ============================================================================
+// execute-change-plan.ts — Apply a ChangePlan to a live workspace.
+// ============================================================================
+//
+// Onboarding T13. Runs 6 surfaces in a fixed order; each surface is wrapped
+// in its own try/catch so a single failure never aborts the rest. Returns a
+// per-surface result map so callers (agency review screen, integration tests)
+// can see exactly what succeeded and what didn't.
+//
+// Dependency-injected for unit-testability without DB/network. Pass custom
+// deps in tests; omit (or pass undefined) to use the real implementations.
+
+import type { ChangePlan } from "./change-plan";
+
+// ── result type ───────────────────────────────────────────────────────────────
+
+export type SurfaceResult = {
+  ok: boolean;
+  error?: string;
+};
+
+export type ApplyChangePlanResult = {
+  soul: SurfaceResult;
+  landing: SurfaceResult;
+  booking: SurfaceResult;
+  theme: SurfaceResult;
+  chatbot: SurfaceResult;
+  contacts: SurfaceResult;
+};
+
+// ── deps interface ────────────────────────────────────────────────────────────
+
+export interface ApplyChangePlanDeps {
+  writeSoul: (orgId: string, soul: Record<string, unknown>) => Promise<void>;
+  seedLanding: (orgId: string) => Promise<void>;
+  applyBooking: (orgId: string, plan: ChangePlan) => Promise<void>;
+  /** Always called — no-ops internally when plan has no theme. */
+  applyTheme: (orgId: string, plan: ChangePlan) => Promise<void>;
+  refreshChatbot: (orgId: string) => Promise<void>;
+  importContacts: (orgId: string, plan: ChangePlan) => Promise<void>;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+async function runSurface(fn: () => Promise<void>): Promise<SurfaceResult> {
+  try {
+    await fn();
+    return { ok: true };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { ok: false, error };
+  }
+}
+
+// ── main export ───────────────────────────────────────────────────────────────
+
+export async function applyChangePlan(
+  orgId: string,
+  plan: ChangePlan,
+  deps: ApplyChangePlanDeps = realDeps
+): Promise<ApplyChangePlanResult> {
+  // Run all 6 surfaces IN ORDER, each isolated. Never abort on failure.
+  const soul = await runSurface(() => deps.writeSoul(orgId, plan.soul));
+  const landing = await runSurface(() => deps.seedLanding(orgId));
+  const booking = await runSurface(() => deps.applyBooking(orgId, plan));
+  const theme = await runSurface(() => deps.applyTheme(orgId, plan));
+  const chatbot = await runSurface(() => deps.refreshChatbot(orgId));
+  const contacts = await runSurface(() => deps.importContacts(orgId, plan));
+
+  return { soul, landing, booking, theme, chatbot, contacts };
+}
+
+// ── real deps — wired to DB-layer helpers ─────────────────────────────────────
+//
+// NOTE: These use direct DB operations (not Next.js server actions) because
+// server actions depend on getOrgId() / getCurrentUser() which require an
+// active HTTP session. The executor runs in a background job context.
+
+// Lazy imports are used so this file never pulls server-only modules into
+// unit-test environments. In production, all these modules are available.
+
+const realDeps: ApplyChangePlanDeps = {
+  // ── Step 1: write soul ────────────────────────────────────────────────────
+  // Merges plan.soul into organizations.soul (snake_case + camelCase both),
+  // then re-seeds the pipeline stages — same contract as /api/v1/soul/submit.
+  async writeSoul(orgId, soul) {
+    const { db } = await import("@/db");
+    const { organizations } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const { applyPipelineStagesFromSoul } = await import(
+      "@/lib/soul/apply-pipeline-stages"
+    );
+
+    // Read existing soul and deep-merge so we don't blow away operator data.
+    const [org] = await db
+      .select({ soul: organizations.soul })
+      .from(organizations)
+      .where(eq(organizations.id, orgId))
+      .limit(1);
+
+    const existingSoul =
+      org?.soul && typeof org.soul === "object"
+        ? (org.soul as unknown as Record<string, unknown>)
+        : {};
+
+    // 2026-05-18 pattern: write BOTH snake_case AND camelCase keys.
+    // business_name → for backward compat; businessName → for settings UI.
+    const merged: Record<string, unknown> = { ...existingSoul };
+    for (const [k, v] of Object.entries(soul)) {
+      merged[k] = v;
+      // Promote snake_case keys to camelCase mirrors for the settings UI.
+      if (k === "business_name") merged.businessName = v;
+      if (k === "soul_description") merged.businessDescription = v;
+    }
+
+    await db
+      .update(organizations)
+      .set({
+        soul: merged as unknown as typeof organizations.$inferInsert.soul,
+        soulCompletedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(organizations.id, orgId));
+
+    // Best-effort pipeline re-seed (mirrors soul/submit/route.ts).
+    try {
+      await applyPipelineStagesFromSoul(orgId, merged, null);
+    } catch (err) {
+      console.warn(
+        `[execute-change-plan] pipeline re-seed failed for ${orgId}:`,
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  },
+
+  // ── Step 2: re-render the landing from the updated soul ───────────────────
+  async seedLanding(orgId) {
+    const { seedLandingFromSoul } = await import(
+      "@/lib/page-schema/seed-landing-from-soul"
+    );
+    const result = await seedLandingFromSoul(orgId);
+    if (!result.ok) {
+      throw new Error(`seedLanding skipped: ${result.reason ?? "unknown"}`);
+    }
+  },
+
+  // ── Step 3: apply booking availability + extra appointment types ──────────
+  // Uses listAppointmentTypes(orgId) — supports orgId override — to find the
+  // default booking-type row, then updates it. Extra types are created via
+  // direct DB inserts mirroring createBookingTypeForSeldonAction.
+  async applyBooking(orgId, plan) {
+    if (!plan.bookingDefault && plan.appointmentTypes.length === 0) return;
+
+    const { db } = await import("@/db");
+    const { bookings } = await import("@/db/schema");
+    const { and, asc, eq } = await import("drizzle-orm");
+
+    if (plan.bookingDefault) {
+      // Find the workspace's default (first) appointment-type template.
+      const [defaultType] = await db
+        .select({ id: bookings.id, metadata: bookings.metadata })
+        .from(bookings)
+        .where(and(eq(bookings.orgId, orgId), eq(bookings.status, "template")))
+        .orderBy(asc(bookings.createdAt))
+        .limit(1);
+
+      if (defaultType) {
+        const existing =
+          defaultType.metadata && typeof defaultType.metadata === "object"
+            ? (defaultType.metadata as Record<string, unknown>)
+            : {};
+        await db
+          .update(bookings)
+          .set({
+            metadata: {
+              ...existing,
+              kind: "appointment_type",
+              availability: plan.bookingDefault.availability,
+            },
+            updatedAt: new Date(),
+          })
+          .where(
+            and(eq(bookings.orgId, orgId), eq(bookings.id, defaultType.id))
+          );
+      }
+    }
+
+    // Create extra appointment types from plan.appointmentTypes.
+    for (const appt of plan.appointmentTypes) {
+      const slug = appt.title
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-");
+      const now = new Date();
+      const endsAt = new Date(now.getTime() + appt.durationMinutes * 60_000);
+      await db.insert(bookings).values({
+        orgId,
+        userId: null as unknown as string, // server-side create, no session user
+        title: appt.title,
+        bookingSlug: slug || "appointment",
+        fullName: null,
+        email: null,
+        notes: null,
+        provider: "manual",
+        status: "template",
+        startsAt: now,
+        endsAt,
+        metadata: {
+          kind: "appointment_type",
+          durationMinutes: appt.durationMinutes,
+          description: "",
+          price: appt.price,
+        },
+      });
+    }
+  },
+
+  // ── Step 4: apply brand theme ─────────────────────────────────────────────
+  // Direct DB write — mirrors saveThemeSettingsAction but without session
+  // auth or revalidatePath (those are HTTP-only concerns).
+  // No-op when plan has no theme (avoids resetting to defaults).
+  async applyTheme(orgId, plan) {
+    if (!plan.theme) return;
+    const { db } = await import("@/db");
+    const { organizations } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const { normalizeTheme } = await import("@/lib/theme/normalize-theme");
+
+    const nextTheme = normalizeTheme(plan.theme);
+    await db
+      .update(organizations)
+      .set({ theme: nextTheme, updatedAt: new Date() })
+      .where(eq(organizations.id, orgId));
+  },
+
+  // ── Step 5: refresh chatbot persona from soul ─────────────────────────────
+  // There is no clean server-callable function that refreshes only the
+  // chatbot prompt from the soul without creating a new agent or going
+  // through the HTTP layer. The chatbot's prompt is rebuilt at runtime from
+  // org.soul each time a conversation starts (see lib/agents/prompt.ts).
+  // No persistent per-agent copy needs to be flushed here.
+  //
+  // LOGGED NO-OP: flagged in report per plan instructions.
+  async refreshChatbot(_orgId) {
+    console.info(
+      "[execute-change-plan] refreshChatbot: no-op — chatbot prompt is " +
+        "derived from org.soul at runtime; no flush required."
+    );
+  },
+
+  // ── Step 6: import contacts from CSV URL ──────────────────────────────────
+  // Uses papaparse to parse the CSV, maps columns to ImportedContactRow, then
+  // inserts via a minimal direct DB insert (mirrors bulkImportContactsAction
+  // but passes orgId directly instead of pulling from session).
+  async importContacts(orgId, plan) {
+    if (!plan.contactsFileUrl) return;
+
+    const Papa = await import("papaparse");
+    const { db } = await import("@/db");
+    const { contacts } = await import("@/db/schema");
+
+    const response = await fetch(plan.contactsFileUrl);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch contacts file: ${response.status} ${response.statusText}`
+      );
+    }
+    const csv = await response.text();
+
+    const parsed = Papa.parse<Record<string, string>>(csv, {
+      header: true,
+      skipEmptyLines: true,
+    });
+
+    if (parsed.errors.length > 0) {
+      console.warn(
+        "[execute-change-plan] CSV parse warnings:",
+        parsed.errors.slice(0, 3)
+      );
+    }
+
+    const rows = parsed.data;
+    if (rows.length === 0) return;
+
+    // Map loose CSV headers (case-insensitive) to ImportedContactRow shape.
+    const toInsert = rows.map((row) => {
+      const get = (keys: string[]) => {
+        for (const k of keys) {
+          const found = Object.keys(row).find(
+            (rk) => rk.trim().toLowerCase() === k.toLowerCase()
+          );
+          if (found) return String(row[found] ?? "").trim();
+        }
+        return "";
+      };
+      const firstName = get(["firstName", "first_name", "first"]);
+      const lastName = get(["lastName", "last_name", "last"]);
+      const email = get(["email"]);
+      const phone = get(["phone", "phoneNumber", "phone_number"]);
+      const company = get(["company", "organization"]);
+      const notes = get(["notes", "note"]);
+      return {
+        orgId,
+        firstName: firstName || (email ? email.split("@")[0] : "Contact"),
+        lastName,
+        email,
+        phone,
+        company,
+        status: "lead",
+        source: "csv_import",
+        customFields: notes ? { notes } : {},
+      };
+    });
+
+    // Batch insert in chunks of 50 (same as bulkImportContactsAction).
+    for (let i = 0; i < toInsert.length; i += 50) {
+      await db.insert(contacts).values(toInsert.slice(i, i + 50));
+    }
+  },
+};

--- a/packages/crm/src/lib/onboarding/links.ts
+++ b/packages/crm/src/lib/onboarding/links.ts
@@ -1,0 +1,69 @@
+// packages/crm/src/lib/onboarding/links.ts
+// 2026-06-04 — Tokenized onboarding links. Clients receive a no-login
+// /onboard/[token] URL after paying; this module mints, validates, and
+// loads those tokens from the onboarding_links table.
+// Mirrors the proposal signed-token pattern (lib/proposals/load-by-token.ts).
+
+import { randomBytes } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { onboardingLinks, type OnboardingLink } from "@/db/schema";
+
+// ─── Validator ────────────────────────────────────────────────────────────────
+
+const TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,}$/;
+
+/**
+ * Pre-validates the shape of a token before hitting the DB.
+ * Cheap defense against scanner bots and malformed requests.
+ */
+export function isValidOnboardingToken(t: string): boolean {
+  return TOKEN_PATTERN.test(t);
+}
+
+// ─── Mint ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a cryptographically-random base64url token (≥ 32 chars, always
+ * URL-safe — no +, /, or = characters).
+ */
+export function mintOnboardingToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+// ─── Create ───────────────────────────────────────────────────────────────────
+
+/**
+ * Inserts an onboarding_links row for `orgId` with status "pending" and
+ * returns the fresh token. Call this after the client pays.
+ */
+export async function createOnboardingLink(
+  orgId: string,
+): Promise<{ token: string }> {
+  const token = mintOnboardingToken();
+  await db.insert(onboardingLinks).values({
+    orgId,
+    token,
+    status: "pending",
+  });
+  return { token };
+}
+
+// ─── Load ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Validates the token shape then does a DB lookup.
+ * Returns the row or null (invalid token / not found).
+ * Mirrors `loadProposalByToken` in lib/proposals/load-by-token.ts.
+ */
+export async function loadOnboardingLinkByToken(
+  token: string,
+): Promise<OnboardingLink | null> {
+  if (!isValidOnboardingToken(token)) return null;
+  const [row] = await db
+    .select()
+    .from(onboardingLinks)
+    .where(eq(onboardingLinks.token, token))
+    .limit(1);
+  return row ?? null;
+}

--- a/packages/crm/src/lib/onboarding/onboarding-form-definition.ts
+++ b/packages/crm/src/lib/onboarding/onboarding-form-definition.ts
@@ -244,6 +244,13 @@ export async function seedOnboardingForm(
     type: q.type,
     required: q.required ?? false,
     ...(q.options ? { options: q.options } : {}),
+    ...(q.type === "file" && q.file
+      ? {
+          accept: q.file.accept,
+          maxSizeMb: q.file.maxSizeMb,
+          multiple: q.file.multiple,
+        }
+      : {}),
   }));
 
   const [created] = await db

--- a/packages/crm/src/lib/onboarding/onboarding-form-definition.ts
+++ b/packages/crm/src/lib/onboarding/onboarding-form-definition.ts
@@ -1,0 +1,279 @@
+/**
+ * Onboarding intake form — question set + seeder.
+ *
+ * Shown to clients after they pay. The renderer displays ONE question
+ * per card (formbricks-stack-v1 flow). Seeder creates the intake_forms
+ * row with slug="onboarding" using the same DB pattern as
+ * createDefaultIntakeForm in lib/blocks/templates.ts.
+ *
+ * Intro/outro: the Intake blueprint shape does not have a dedicated
+ * welcome/closing panel at the question level — those are expressed via
+ * Intake.title, Intake.description, and Intake.completion, not as
+ * IntakeQuestion entries. We therefore set friendly copy on those fields
+ * inside seedOnboardingForm rather than adding fake questions.
+ */
+
+import { eq, and } from "drizzle-orm";
+import { db } from "@/db";
+import { intakeForms } from "@/db/schema";
+import type { IntakeQuestion } from "@/lib/blueprint/types";
+
+// ─── Question set ────────────────────────────────────────────────────────────
+
+export const ONBOARDING_QUESTIONS: IntakeQuestion[] = [
+  // ── Business ──────────────────────────────────────────────────────────────
+  {
+    id: "business_name",
+    type: "text",
+    label: "What's your business called?",
+    required: true,
+  },
+  {
+    id: "tagline",
+    type: "text",
+    label: "Describe what you do in one line",
+    required: true,
+  },
+  {
+    id: "phone",
+    type: "phone",
+    label: "Business phone number",
+    required: true,
+  },
+  {
+    id: "email",
+    type: "email",
+    label: "Business email address",
+    required: true,
+  },
+  {
+    id: "has_public_address",
+    type: "select",
+    label: "Do clients visit you at an address?",
+    required: true,
+    options: ["Yes", "No"],
+  },
+  {
+    id: "address",
+    type: "text",
+    label: "Your address",
+    required: false,
+    showIf: {
+      questionId: "has_public_address",
+      operator: "equals",
+      value: "Yes",
+    },
+  },
+  {
+    id: "hours_text",
+    type: "textarea",
+    label: "What are your hours? e.g. Mon–Fri 9–5, Sat 10–2, closed Sun",
+    required: true,
+  },
+
+  // ── Services ───────────────────────────────────────────────────────────────
+  {
+    id: "services_text",
+    type: "textarea",
+    label: "List your services and prices, one per line — e.g. 60-min massage — $90",
+    required: true,
+  },
+  {
+    id: "primary_service",
+    type: "text",
+    label: "Which service is your main 'Book now' button?",
+    required: true,
+  },
+
+  // ── Brand ──────────────────────────────────────────────────────────────────
+  {
+    id: "logo",
+    type: "file",
+    label: "Upload your logo",
+    required: false,
+    file: {
+      accept: [".png", ".jpg", ".jpeg", ".webp", ".svg"],
+      maxSizeMb: 5,
+      multiple: false,
+    },
+  },
+  {
+    id: "brand_colors",
+    type: "text",
+    label: "Brand colors? (or leave blank to use your logo's)",
+    required: false,
+  },
+  {
+    id: "photos",
+    type: "file",
+    label: "Upload a few photos of your space/team/work",
+    required: false,
+    file: {
+      accept: [".png", ".jpg", ".jpeg", ".webp"],
+      maxSizeMb: 10,
+      multiple: true,
+    },
+  },
+  {
+    id: "website_url",
+    type: "text",
+    label: "Your current website URL (if any)",
+    required: false,
+  },
+  {
+    id: "socials",
+    type: "textarea",
+    label: "Social links (Instagram, Facebook…)",
+    required: false,
+  },
+
+  // ── Reviews ────────────────────────────────────────────────────────────────
+  {
+    id: "google_reviews_url",
+    type: "text",
+    label: "Your Google Business / reviews link",
+    required: false,
+  },
+  {
+    id: "testimonials",
+    type: "textarea",
+    label: "A few things clients always say about you (or leave blank — we'll pull from Google)",
+    required: false,
+  },
+
+  // ── Data ───────────────────────────────────────────────────────────────────
+  {
+    id: "contacts_file",
+    type: "file",
+    label: "Upload your contacts (CSV/Excel from your old CRM)",
+    required: false,
+    file: {
+      accept: [".csv", ".xlsx", ".xls"],
+      maxSizeMb: 10,
+      multiple: false,
+    },
+  },
+  {
+    id: "bookings_file",
+    type: "file",
+    label: "Upload your upcoming appointments (CSV)",
+    required: false,
+    file: {
+      accept: [".csv"],
+      maxSizeMb: 10,
+      multiple: false,
+    },
+  },
+
+  // ── Phones ─────────────────────────────────────────────────────────────────
+  {
+    id: "call_handling",
+    type: "select",
+    label: "How should we handle your phone?",
+    required: true,
+    options: ["AI answers my calls", "I answer — text me missed callers", "Not yet"],
+  },
+  {
+    id: "lead_routing",
+    type: "multi-select",
+    label: "Where should new leads reach you?",
+    required: true,
+    options: ["Email", "Text"],
+  },
+
+  // ── Domain ─────────────────────────────────────────────────────────────────
+  {
+    id: "has_domain",
+    type: "select",
+    label: "Do you have a website domain?",
+    required: true,
+    options: ["Yes", "No"],
+  },
+  {
+    id: "domain",
+    type: "text",
+    label: "Enter your domain, e.g. yourpractice.com",
+    required: false,
+    showIf: {
+      questionId: "has_domain",
+      operator: "equals",
+      value: "Yes",
+    },
+  },
+];
+
+// ─── Seeder ───────────────────────────────────────────────────────────────────
+
+const ONBOARDING_SLUG = "onboarding";
+const ONBOARDING_FORM_NAME = "Client Onboarding";
+
+/**
+ * Creates an intake_forms row for this org with slug="onboarding".
+ * Idempotent: returns the existing form's id if it already exists.
+ *
+ * Mirrors the createDefaultIntakeForm pattern in lib/blocks/templates.ts:
+ * maps IntakeQuestion → IntakeFormField (key/label/type/required/options)
+ * and inserts into intake_forms. No blueprint rendering is performed here
+ * because the /onboard/[token] route serves its own card-flow renderer.
+ */
+export async function seedOnboardingForm(
+  orgId: string,
+): Promise<{ formId: string }> {
+  const [existing] = await db
+    .select({ id: intakeForms.id })
+    .from(intakeForms)
+    .where(
+      and(
+        eq(intakeForms.orgId, orgId),
+        eq(intakeForms.slug, ONBOARDING_SLUG),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    return { formId: existing.id };
+  }
+
+  // Map IntakeQuestion → the simpler IntakeFormField shape the DB row uses.
+  // options is omitted when undefined (not stored on the row for file/text
+  // types); the full question metadata lives in ONBOARDING_QUESTIONS at
+  // call time and will be threaded into the card renderer by the route.
+  const fields = ONBOARDING_QUESTIONS.map((q) => ({
+    key: q.id,
+    label: q.label,
+    type: q.type,
+    required: q.required ?? false,
+    ...(q.options ? { options: q.options } : {}),
+  }));
+
+  const [created] = await db
+    .insert(intakeForms)
+    .values({
+      orgId,
+      name: ONBOARDING_FORM_NAME,
+      slug: ONBOARDING_SLUG,
+      fields,
+      settings: {
+        // Friendly intro/outro copy. The /onboard/[token] renderer reads
+        // these from settings because the Intake blueprint shape carries
+        // title/description/completion at the Intake level, not inside
+        // IntakeQuestion items.
+        introTitle: "Let's build your new front office",
+        introBody:
+          "About 10 minutes. Upload what you have; skip the rest and we'll handle it.",
+        outroTitle: "That's everything!",
+        outroBody:
+          "We're building your front office now — you'll get an email the moment it's ready.",
+        theme: "dark",
+        submitLabel: "Submit",
+      },
+      isActive: true,
+    })
+    .returning({ id: intakeForms.id });
+
+  if (!created?.id) {
+    throw new Error(`seedOnboardingForm: insert returned no id for org ${orgId}`);
+  }
+
+  return { formId: created.id };
+}

--- a/packages/crm/src/lib/onboarding/parse-hours.ts
+++ b/packages/crm/src/lib/onboarding/parse-hours.ts
@@ -1,0 +1,218 @@
+/**
+ * parseHoursText — convert a free-text weekly hours answer into the
+ * AvailabilitySchedule shape used by the booking engine.
+ *
+ * Examples handled:
+ *   "Mon-Fri 9-5, Sat 10-2, closed Sun"
+ *   "Monday through Friday 9am-5pm"
+ *   "we're flexible"   → default Mon-Fri 09:00-17:00, weekends off
+ */
+
+export type DayKey =
+  | "sunday"
+  | "monday"
+  | "tuesday"
+  | "wednesday"
+  | "thursday"
+  | "friday"
+  | "saturday";
+
+export type DaySettings = {
+  enabled: boolean;
+  start: string; // "HH:MM" 24-hour zero-padded
+  end: string;   // "HH:MM" 24-hour zero-padded
+};
+
+export type WeeklyAvailability = Record<DayKey, DaySettings>;
+
+// ── constants ────────────────────────────────────────────────────────────────
+
+const ALL_DAYS: DayKey[] = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+];
+
+const DAY_INDEX: Record<DayKey, number> = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+// Map every abbreviation / alias to a canonical DayKey
+const NAME_TO_DAY: Record<string, DayKey> = {
+  sun: "sunday",
+  sunday: "sunday",
+  mon: "monday",
+  monday: "monday",
+  tue: "tuesday",
+  tues: "tuesday",
+  tuesday: "tuesday",
+  wed: "wednesday",
+  weds: "wednesday",
+  wednesday: "wednesday",
+  thu: "thursday",
+  thur: "thursday",
+  thurs: "thursday",
+  thursday: "thursday",
+  fri: "friday",
+  friday: "friday",
+  sat: "saturday",
+  saturday: "saturday",
+};
+
+const DEFAULT_SETTINGS: DaySettings = { enabled: true, start: "09:00", end: "17:00" };
+const WEEKEND_DEFAULT: DaySettings = { enabled: false, start: "09:00", end: "17:00" };
+
+function defaultSchedule(): WeeklyAvailability {
+  return {
+    sunday: { ...WEEKEND_DEFAULT },
+    monday: { ...DEFAULT_SETTINGS },
+    tuesday: { ...DEFAULT_SETTINGS },
+    wednesday: { ...DEFAULT_SETTINGS },
+    thursday: { ...DEFAULT_SETTINGS },
+    friday: { ...DEFAULT_SETTINGS },
+    saturday: { ...WEEKEND_DEFAULT },
+  };
+}
+
+// ── time parsing ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert "9", "9am", "9pm", "14", "09:00" → "HH:MM" (24h).
+ * Returns null when the input isn't recognisable.
+ */
+function parseTimeToken(raw: string): string | null {
+  const s = raw.trim().toLowerCase();
+
+  // already HH:MM
+  if (/^\d{1,2}:\d{2}$/.test(s)) {
+    const [h, m] = s.split(":").map(Number);
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  }
+
+  const ampm = /^(\d{1,2})([ap]m?)$/.exec(s);
+  if (ampm) {
+    let h = parseInt(ampm[1], 10);
+    const meridiem = ampm[2];
+    if (meridiem.startsWith("p") && h !== 12) h += 12;
+    if (meridiem.startsWith("a") && h === 12) h = 0;
+    return `${String(h).padStart(2, "0")}:00`;
+  }
+
+  const plain = /^(\d{1,2})$/.exec(s);
+  if (plain) {
+    const h = parseInt(plain[1], 10);
+    // Heuristic: 1-8 with no meridiem → PM (e.g. "5" → 17:00, "1" → 13:00)
+    // 9-12 → AM; 13-23 → 24h already
+    let hour = h;
+    if (h >= 1 && h <= 8) hour = h + 12;
+    return `${String(hour).padStart(2, "0")}:00`;
+  }
+
+  return null;
+}
+
+/** Parse "9-5", "9am-5pm", "09:00-17:00" → { start, end } or null. */
+function parseTimeRange(raw: string): { start: string; end: string } | null {
+  // split on " - " or "-" but not inside a day-range context (handled upstream)
+  const parts = raw.split(/\s*-\s*/);
+  if (parts.length !== 2) return null;
+  const start = parseTimeToken(parts[0]);
+  const end = parseTimeToken(parts[1]);
+  if (!start || !end) return null;
+  return { start, end };
+}
+
+// ── day range expansion ───────────────────────────────────────────────────────
+
+/** "Mon-Fri" → ["monday","tuesday","wednesday","thursday","friday"] */
+function expandDayRange(from: DayKey, to: DayKey): DayKey[] {
+  const start = DAY_INDEX[from];
+  const end = DAY_INDEX[to];
+  if (start <= end) {
+    return ALL_DAYS.slice(start, end + 1);
+  }
+  // wrap-around e.g. Fri-Mon
+  return [...ALL_DAYS.slice(start), ...ALL_DAYS.slice(0, end + 1)];
+}
+
+// ── token classifier ─────────────────────────────────────────────────────────
+
+/**
+ * Recognise day name(s) at the start of a chunk.
+ * Returns { days: DayKey[], rest: string } where rest is the remainder
+ * (possibly a time range), or null if no day found.
+ */
+function extractDays(chunk: string): { days: DayKey[]; rest: string } | null {
+  // Pattern: optional "closed" prefix  then  Day(-Day)?  then remainder
+  // e.g. "closed Sun", "Mon-Fri 9-5", "Sat 10-2"
+  const re =
+    /^(closed\s+)?(sun(?:day)?|mon(?:day)?|tue(?:s(?:day)?)?|wed(?:nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?)(?:\s*[-–]\s*(sun(?:day)?|mon(?:day)?|tue(?:s(?:day)?)?|wed(?:nesday)?|thu(?:r(?:s(?:day)?)?)?|fri(?:day)?|sat(?:urday)?))?(.*)/i;
+
+  const m = re.exec(chunk.trim());
+  if (!m) return null;
+
+  const closed = Boolean(m[1]);
+  const fromKey = NAME_TO_DAY[m[2].toLowerCase()];
+  const toKey = m[3] ? NAME_TO_DAY[m[3].toLowerCase()] : undefined;
+  const rest = m[4]?.trim() ?? "";
+
+  if (!fromKey) return null;
+
+  const days = toKey ? expandDayRange(fromKey, toKey) : [fromKey];
+
+  return { days: closed ? days.map(d => d) : days, rest };
+}
+
+// ── main parser ───────────────────────────────────────────────────────────────
+
+export function parseHoursText(text: string): WeeklyAvailability {
+  const schedule = defaultSchedule();
+  const mentionedDays = new Set<DayKey>();
+
+  // Split on commas; also try newlines
+  const chunks = text.split(/[,\n]+/).map(c => c.trim()).filter(Boolean);
+
+  for (const chunk of chunks) {
+    const dayResult = extractDays(chunk);
+    if (!dayResult) continue;
+
+    const { days, rest } = dayResult;
+
+    // check for "closed" keyword
+    const isClosed =
+      /\bclosed\b/i.test(chunk) && !rest.trim();
+
+    for (const day of days) {
+      mentionedDays.add(day);
+
+      if (isClosed || /\bclosed\b/i.test(chunk.replace(rest, ""))) {
+        schedule[day] = { enabled: false, start: "09:00", end: "17:00" };
+        continue;
+      }
+
+      const timeRange = parseTimeRange(rest);
+      if (timeRange) {
+        schedule[day] = { enabled: true, start: timeRange.start, end: timeRange.end };
+      } else {
+        // day mentioned without times → keep default enabled/times
+        const isWeekend = day === "saturday" || day === "sunday";
+        schedule[day] = isWeekend
+          ? { ...WEEKEND_DEFAULT, enabled: true }
+          : { ...DEFAULT_SETTINGS };
+      }
+    }
+  }
+
+  // Days not mentioned stay at defaults (already set by defaultSchedule)
+  return schedule;
+}

--- a/packages/crm/src/lib/onboarding/parse-services.ts
+++ b/packages/crm/src/lib/onboarding/parse-services.ts
@@ -1,0 +1,132 @@
+/**
+ * parseServicesText — convert a free-text services answer into structured
+ * service records.
+ *
+ * Formats handled per line:
+ *   "60-min massage — $90"
+ *   "Deep tissue (90 min) - $130"
+ *   "Consult: free"
+ *   "Hair cut $45"
+ *   "Facial 60min $80"
+ */
+
+export type ParsedService = {
+  name: string;
+  price: number;
+  durationMinutes: number;
+};
+
+const DEFAULT_DURATION = 30;
+
+// ── duration extraction ───────────────────────────────────────────────────────
+
+/**
+ * Find and extract a duration token from the line.
+ * Returns { durationMinutes, lineWithoutDuration } or null if not found.
+ *
+ * Patterns matched:
+ *   "60-min"        → prefixed before the service name
+ *   "(90 min)"      → parenthesised
+ *   "90 min"        → bare
+ *   "60min"         → no space
+ */
+function extractDuration(line: string): { durationMinutes: number; rest: string } {
+  // Pattern 1: leading "NN-min" (e.g. "60-min massage")
+  let m = /^(\d+)-min\s+/i.exec(line);
+  if (m) {
+    return {
+      durationMinutes: parseInt(m[1], 10),
+      rest: line.slice(m[0].length),
+    };
+  }
+
+  // Pattern 2: parenthesised "(NN min)" anywhere
+  m = /\(\s*(\d+)\s*min(?:utes?)?\s*\)/i.exec(line);
+  if (m) {
+    return {
+      durationMinutes: parseInt(m[1], 10),
+      rest: (line.slice(0, m.index) + line.slice(m.index + m[0].length)).trim(),
+    };
+  }
+
+  // Pattern 3: "NN min" or "NNmin" (no parens)
+  m = /\b(\d+)\s*min(?:utes?)?\b/i.exec(line);
+  if (m) {
+    return {
+      durationMinutes: parseInt(m[1], 10),
+      rest: (line.slice(0, m.index) + line.slice(m.index + m[0].length)).trim(),
+    };
+  }
+
+  return { durationMinutes: DEFAULT_DURATION, rest: line };
+}
+
+// ── price extraction ──────────────────────────────────────────────────────────
+
+/**
+ * Find and extract the price token from the line.
+ * Returns { price, lineWithoutPrice }.
+ *
+ * Patterns:
+ *   "$NNN" or "$NNN.NN"
+ *   "free" / "Free" / "FREE"  → 0
+ */
+function extractPrice(line: string): { price: number; rest: string } {
+  // Dollar amount
+  let m = /\$(\d+(?:\.\d{1,2})?)/i.exec(line);
+  if (m) {
+    return {
+      price: parseFloat(m[1]),
+      rest: (line.slice(0, m.index) + line.slice(m.index + m[0].length)).trim(),
+    };
+  }
+
+  // "free"
+  m = /\bfree\b/i.exec(line);
+  if (m) {
+    return {
+      price: 0,
+      rest: (line.slice(0, m.index) + line.slice(m.index + m[0].length)).trim(),
+    };
+  }
+
+  return { price: 0, rest: line };
+}
+
+// ── name cleanup ──────────────────────────────────────────────────────────────
+
+/**
+ * Strip leading/trailing separators (—, –, -, :) and whitespace from the
+ * name remainder so we get a clean service name.
+ */
+function cleanName(raw: string): string {
+  return raw
+    .replace(/^[\s—–\-:]+/, "") // leading separators
+    .replace(/[\s—–\-:]+$/, "") // trailing separators
+    .trim();
+}
+
+// ── main parser ───────────────────────────────────────────────────────────────
+
+export function parseServicesText(text: string): ParsedService[] {
+  if (!text.trim()) return [];
+
+  const lines = text.split(/\n/).map(l => l.trim()).filter(Boolean);
+  const results: ParsedService[] = [];
+
+  for (const rawLine of lines) {
+    // Step 1: extract duration
+    const { durationMinutes, rest: afterDuration } = extractDuration(rawLine);
+
+    // Step 2: extract price from the duration-stripped line
+    const { price, rest: afterPrice } = extractPrice(afterDuration);
+
+    // Step 3: what remains is the name
+    const name = cleanName(afterPrice);
+    if (!name) continue;
+
+    results.push({ name, price, durationMinutes });
+  }
+
+  return results;
+}

--- a/packages/crm/src/lib/uploads/file-validation.ts
+++ b/packages/crm/src/lib/uploads/file-validation.ts
@@ -1,0 +1,20 @@
+// packages/crm/src/lib/uploads/file-validation.ts
+//
+// Pure helper — no IO, no DB.  Validates an uploaded file candidate against
+// a field's accept-list and size cap.  Used by the client-onboarding intake
+// upload component (T2) and the blob-upload route (T5).
+
+export type UploadFieldConfig = { accept: string[]; maxSizeMb: number };
+export type UploadCandidate = { name: string; sizeBytes: number };
+export type UploadValidation = { ok: true } | { ok: false; reason: "type" | "size" };
+
+export function validateUploadField(
+  file: UploadCandidate,
+  cfg: UploadFieldConfig,
+): UploadValidation {
+  const lower = file.name.toLowerCase();
+  const okType = cfg.accept.some((ext) => lower.endsWith(ext.toLowerCase()));
+  if (!okType) return { ok: false, reason: "type" };
+  if (file.sizeBytes > cfg.maxSizeMb * 1024 * 1024) return { ok: false, reason: "size" };
+  return { ok: true };
+}

--- a/packages/crm/tests/unit/onboarding/change-plan.spec.ts
+++ b/packages/crm/tests/unit/onboarding/change-plan.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildChangePlan } from "../../../src/lib/onboarding/change-plan";
+
+const data = {
+  business_name: "Calm Hands Massage", tagline: "Therapeutic massage in Austin",
+  phone: "(512) 555-0100", email: "hi@calmhands.com",
+  has_public_address: "Yes", address: "123 Main St, Austin TX",
+  hours_text: "Mon-Fri 9-5, Sat 10-2, closed Sun",
+  services_text: "60-min massage — $90\nDeep tissue (90 min) - $130",
+  primary_service: "60-min massage",
+  call_handling: "I answer — text me missed callers",
+  lead_routing: ["Email", "Text"],
+  has_domain: "Yes", domain: "calmhands.com",
+  contacts_file: "https://blob/contacts.csv",
+};
+
+describe("buildChangePlan", () => {
+  it("maps answers into a structured change plan", () => {
+    const plan = buildChangePlan(data);
+    assert.equal(plan.soul.business_name, "Calm Hands Massage");
+    assert.equal(plan.soul.tagline, "Therapeutic massage in Austin");
+    assert.equal(plan.bookingDefault?.availability.monday.enabled, true);
+    assert.equal(plan.bookingDefault?.availability.sunday.enabled, false);
+    assert.equal(plan.appointmentTypes.length, 2);
+    assert.deepEqual(plan.appointmentTypes[0], { title: "massage", durationMinutes: 60, price: 90 });
+    assert.equal(plan.callHandling, "human_then_text");
+    assert.deepEqual(plan.leadRouting, ["email", "text"]);
+    assert.equal(plan.domain, "calmhands.com");
+    assert.equal(plan.contactsFileUrl, "https://blob/contacts.csv");
+    assert.ok(plan.summaries.length > 0);
+  });
+  it("omits domain when has_domain is No", () => {
+    const plan = buildChangePlan({ ...data, has_domain: "No", domain: "" });
+    assert.equal(plan.domain, undefined);
+  });
+});

--- a/packages/crm/tests/unit/onboarding/execute-change-plan.spec.ts
+++ b/packages/crm/tests/unit/onboarding/execute-change-plan.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyChangePlan } from "../../../src/lib/onboarding/execute-change-plan";
+
+describe("applyChangePlan", () => {
+  it("runs the surfaces in order and reports per-surface results", async () => {
+    const calls: string[] = [];
+    const deps = {
+      writeSoul: async () => { calls.push("soul"); },
+      seedLanding: async () => { calls.push("seedLanding"); },
+      applyBooking: async () => { calls.push("booking"); },
+      applyTheme: async () => { calls.push("theme"); },
+      refreshChatbot: async () => { calls.push("chatbot"); },
+      importContacts: async () => { calls.push("contacts"); },
+    };
+    const plan = { soul: {}, appointmentTypes: [], callHandling: "none" as const, leadRouting: [], summaries: [] };
+    const result = await applyChangePlan("org-1", plan, deps);
+    assert.deepEqual(calls, ["soul","seedLanding","booking","theme","chatbot","contacts"]);
+    assert.equal(result.soul.ok, true);
+  });
+  it("a failing surface does not abort the others", async () => {
+    const calls: string[] = [];
+    const deps = {
+      writeSoul: async () => { calls.push("soul"); throw new Error("boom"); },
+      seedLanding: async () => { calls.push("seedLanding"); },
+      applyBooking: async () => { calls.push("booking"); },
+      applyTheme: async () => { calls.push("theme"); },
+      refreshChatbot: async () => { calls.push("chatbot"); },
+      importContacts: async () => { calls.push("contacts"); },
+    };
+    const plan = { soul: {}, appointmentTypes: [], callHandling: "none" as const, leadRouting: [], summaries: [] };
+    const result = await applyChangePlan("org-1", plan, deps);
+    assert.deepEqual(calls, ["soul","seedLanding","booking","theme","chatbot","contacts"]);
+    assert.equal(result.soul.ok, false);
+  });
+});

--- a/packages/crm/tests/unit/onboarding/file-validation.spec.ts
+++ b/packages/crm/tests/unit/onboarding/file-validation.spec.ts
@@ -1,0 +1,41 @@
+// packages/crm/tests/unit/onboarding/file-validation.spec.ts
+//
+// TDD step 1 — file-upload field validation helper (pure, no IO).
+// Uses node:test + assert/strict (project convention; no vitest).
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { validateUploadField } from "../../../src/lib/uploads/file-validation";
+
+describe("validateUploadField", () => {
+  const cfg = { accept: [".csv", ".xlsx"], maxSizeMb: 10 };
+
+  it("accepts an allowed type under the size cap", () => {
+    assert.deepEqual(
+      validateUploadField({ name: "contacts.csv", sizeBytes: 1_000 }, cfg),
+      { ok: true },
+    );
+  });
+
+  it("rejects a disallowed extension", () => {
+    assert.deepEqual(
+      validateUploadField({ name: "evil.exe", sizeBytes: 10 }, cfg),
+      { ok: false, reason: "type" },
+    );
+  });
+
+  it("rejects a file over the size cap", () => {
+    assert.deepEqual(
+      validateUploadField({ name: "big.csv", sizeBytes: 11 * 1024 * 1024 }, cfg),
+      { ok: false, reason: "size" },
+    );
+  });
+
+  it("matches accept case-insensitively", () => {
+    assert.deepEqual(
+      validateUploadField({ name: "CONTACTS.CSV", sizeBytes: 1 }, cfg),
+      { ok: true },
+    );
+  });
+});

--- a/packages/crm/tests/unit/onboarding/links.spec.ts
+++ b/packages/crm/tests/unit/onboarding/links.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { isValidOnboardingToken } from "../../../src/lib/onboarding/links";
+
+describe("isValidOnboardingToken", () => {
+  it("accepts a 32+ char url-safe token", () => {
+    assert.equal(isValidOnboardingToken("A".repeat(32)), true);
+  });
+  it("rejects short or unsafe tokens", () => {
+    assert.equal(isValidOnboardingToken("short"), false);
+    assert.equal(isValidOnboardingToken("bad/" + "x".repeat(40)), false);
+  });
+});

--- a/packages/crm/tests/unit/onboarding/onboarding-flow.spec.ts
+++ b/packages/crm/tests/unit/onboarding/onboarding-flow.spec.ts
@@ -1,0 +1,264 @@
+/**
+ * onboarding-flow.spec.ts — End-to-end integration test
+ *
+ * Exercises the full submission → buildChangePlan → applyChangePlan pipeline
+ * without any DB or network. Uses capturing mock deps so we can assert that:
+ *
+ *  1. All 6 surfaces ran in order.
+ *  2. The data flowed correctly: writeSoul got the right soul keys; applyBooking
+ *     received a plan with Monday enabled + Sunday disabled; importContacts
+ *     received a plan with the contacts_file URL; applyTheme got the plan with
+ *     brand colors; every surface reports ok: true.
+ *  3. Surfaces are resilient: a single failure leaves the other five ok.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildChangePlan } from "../../../src/lib/onboarding/change-plan";
+import { applyChangePlan } from "../../../src/lib/onboarding/execute-change-plan";
+import type { ChangePlan } from "../../../src/lib/onboarding/change-plan";
+import type { ApplyChangePlanDeps } from "../../../src/lib/onboarding/execute-change-plan";
+
+// ── representative submission data ───────────────────────────────────────────
+
+const submissionData: Record<string, unknown> = {
+  business_name: "Calm Hands Massage",
+  tagline: "Therapeutic massage in Austin, TX",
+  phone: "(512) 555-0100",
+  email: "hello@calmhands.com",
+  has_public_address: "Yes",
+  address: "400 Lavaca St, Austin TX 78701",
+  // hours_text deliberately sets Mon–Sat enabled, Sun closed
+  hours_text: "Mon-Fri 9am-5pm, Sat 10am-2pm, closed Sun",
+  // services_text has two appointment types
+  services_text: "60-min massage — $90\nDeep tissue (90 min) - $130",
+  primary_service: "60-min massage",
+  call_handling: "AI answers every call",
+  lead_routing: ["email", "text"],
+  has_domain: "Yes",
+  domain: "calmhands.com",
+  // contacts_file: a blob URL the dep should receive as-is
+  contacts_file: "https://blob.vercel-storage.com/contacts-abc123.csv",
+  // brand colors so the theme surface is exercised
+  brand_colors: "Primary: #1a7a6e  Accent: #f4a261",
+  google_reviews_url: "https://maps.google.com/?cid=12345",
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/** Build capturing mock deps. Each dep pushes a record for inspection. */
+function buildMockDeps(): {
+  deps: ApplyChangePlanDeps;
+  calls: { name: string; orgId: string; args: unknown[] }[];
+} {
+  const calls: { name: string; orgId: string; args: unknown[] }[] = [];
+
+  const deps: ApplyChangePlanDeps = {
+    async writeSoul(orgId, soul) {
+      calls.push({ name: "writeSoul", orgId, args: [soul] });
+    },
+    async seedLanding(orgId) {
+      calls.push({ name: "seedLanding", orgId, args: [] });
+    },
+    async applyBooking(orgId, plan) {
+      calls.push({ name: "applyBooking", orgId, args: [plan] });
+    },
+    async applyTheme(orgId, plan) {
+      calls.push({ name: "applyTheme", orgId, args: [plan] });
+    },
+    async refreshChatbot(orgId) {
+      calls.push({ name: "refreshChatbot", orgId, args: [] });
+    },
+    async importContacts(orgId, plan) {
+      calls.push({ name: "importContacts", orgId, args: [plan] });
+    },
+  };
+
+  return { deps, calls };
+}
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("onboarding-flow integration", () => {
+  it("buildChangePlan produces a fully-populated plan from submission data", () => {
+    const plan = buildChangePlan(submissionData);
+
+    // Soul fields
+    assert.equal(plan.soul.business_name, "Calm Hands Massage");
+    assert.equal(plan.soul.tagline, "Therapeutic massage in Austin, TX");
+    assert.equal(plan.soul.phone, "(512) 555-0100");
+    assert.equal(plan.soul.email, "hello@calmhands.com");
+
+    // Booking: weekday enabled, Sunday disabled
+    assert.ok(plan.bookingDefault, "bookingDefault should be defined");
+    assert.equal(plan.bookingDefault!.availability.monday.enabled, true, "Monday enabled");
+    assert.equal(plan.bookingDefault!.availability.friday.enabled, true, "Friday enabled");
+    assert.equal(plan.bookingDefault!.availability.saturday.enabled, true, "Saturday enabled");
+    assert.equal(plan.bookingDefault!.availability.sunday.enabled, false, "Sunday disabled");
+    assert.equal(plan.bookingDefault!.primaryServiceName, "60-min massage");
+
+    // Appointment types from services_text
+    assert.equal(plan.appointmentTypes.length, 2, "two appointment types parsed");
+    assert.equal(plan.appointmentTypes[0]!.durationMinutes, 60);
+    assert.equal(plan.appointmentTypes[0]!.price, 90);
+    assert.equal(plan.appointmentTypes[1]!.durationMinutes, 90);
+    assert.equal(plan.appointmentTypes[1]!.price, 130);
+
+    // Contacts file URL
+    assert.equal(plan.contactsFileUrl, "https://blob.vercel-storage.com/contacts-abc123.csv");
+
+    // Call handling
+    assert.equal(plan.callHandling, "ai_voice");
+
+    // Lead routing
+    assert.deepEqual(plan.leadRouting, ["email", "text"]);
+
+    // Domain
+    assert.equal(plan.domain, "calmhands.com");
+
+    // Theme (hex colors extracted)
+    assert.ok(plan.theme, "theme should be defined when brand_colors present");
+    assert.equal(plan.theme!.primaryColor, "#1a7a6e");
+    assert.equal(plan.theme!.accentColor, "#f4a261");
+
+    // Summaries are non-empty
+    assert.ok(plan.summaries.length > 0, "summaries populated");
+  });
+
+  it("applyChangePlan runs all 6 surfaces in order and every surface reports ok", async () => {
+    const plan = buildChangePlan(submissionData);
+    const { deps, calls } = buildMockDeps();
+
+    const result = await applyChangePlan("org-test", plan, deps);
+
+    // ── order assertion ──────────────────────────────────────────────────────
+    const order = calls.map(c => c.name);
+    assert.deepEqual(
+      order,
+      ["writeSoul", "seedLanding", "applyBooking", "applyTheme", "refreshChatbot", "importContacts"],
+      "surfaces run in declared order"
+    );
+
+    // ── all surfaces targeted the right org ─────────────────────────────────
+    for (const call of calls) {
+      assert.equal(call.orgId, "org-test", `${call.name} received correct orgId`);
+    }
+
+    // ── result: every surface ok ─────────────────────────────────────────────
+    assert.equal(result.soul.ok, true, "soul ok");
+    assert.equal(result.landing.ok, true, "landing ok");
+    assert.equal(result.booking.ok, true, "booking ok");
+    assert.equal(result.theme.ok, true, "theme ok");
+    assert.equal(result.chatbot.ok, true, "chatbot ok");
+    assert.equal(result.contacts.ok, true, "contacts ok");
+  });
+
+  it("writeSoul received the correct soul data (business_name, email, phone)", () => {
+    const plan = buildChangePlan(submissionData);
+    const { deps, calls } = buildMockDeps();
+
+    return applyChangePlan("org-test", plan, deps).then(() => {
+      const soulCall = calls.find(c => c.name === "writeSoul");
+      assert.ok(soulCall, "writeSoul was called");
+      const soul = soulCall!.args[0] as Record<string, unknown>;
+      assert.equal(soul.business_name, "Calm Hands Massage");
+      assert.equal(soul.email, "hello@calmhands.com");
+      assert.equal(soul.phone, "(512) 555-0100");
+    });
+  });
+
+  it("applyBooking received a plan with Monday enabled and Sunday disabled", () => {
+    const plan = buildChangePlan(submissionData);
+    const { deps, calls } = buildMockDeps();
+
+    return applyChangePlan("org-test", plan, deps).then(() => {
+      const bookingCall = calls.find(c => c.name === "applyBooking");
+      assert.ok(bookingCall, "applyBooking was called");
+      const receivedPlan = bookingCall!.args[0] as ChangePlan;
+      assert.equal(
+        receivedPlan.bookingDefault?.availability.monday.enabled,
+        true,
+        "Monday is enabled in the plan passed to applyBooking"
+      );
+      assert.equal(
+        receivedPlan.bookingDefault?.availability.sunday.enabled,
+        false,
+        "Sunday is disabled in the plan passed to applyBooking"
+      );
+      assert.equal(receivedPlan.appointmentTypes.length, 2, "two appointment types in plan");
+    });
+  });
+
+  it("importContacts received a plan carrying the contacts_file URL", () => {
+    const plan = buildChangePlan(submissionData);
+    const { deps, calls } = buildMockDeps();
+
+    return applyChangePlan("org-test", plan, deps).then(() => {
+      const contactsCall = calls.find(c => c.name === "importContacts");
+      assert.ok(contactsCall, "importContacts was called");
+      const receivedPlan = contactsCall!.args[0] as ChangePlan;
+      assert.equal(
+        receivedPlan.contactsFileUrl,
+        "https://blob.vercel-storage.com/contacts-abc123.csv",
+        "contactsFileUrl passed through to importContacts"
+      );
+    });
+  });
+
+  it("applyTheme received a plan with the extracted brand colors", () => {
+    const plan = buildChangePlan(submissionData);
+    const { deps, calls } = buildMockDeps();
+
+    return applyChangePlan("org-test", plan, deps).then(() => {
+      const themeCall = calls.find(c => c.name === "applyTheme");
+      assert.ok(themeCall, "applyTheme was called");
+      const receivedPlan = themeCall!.args[0] as ChangePlan;
+      assert.equal(receivedPlan.theme?.primaryColor, "#1a7a6e");
+      assert.equal(receivedPlan.theme?.accentColor, "#f4a261");
+    });
+  });
+
+  it("a single surface failure does not abort the remaining surfaces", async () => {
+    const plan = buildChangePlan(submissionData);
+    const calls: string[] = [];
+
+    const faultyDeps: ApplyChangePlanDeps = {
+      async writeSoul() { calls.push("writeSoul"); throw new Error("db timeout"); },
+      async seedLanding() { calls.push("seedLanding"); },
+      async applyBooking() { calls.push("applyBooking"); },
+      async applyTheme() { calls.push("applyTheme"); },
+      async refreshChatbot() { calls.push("refreshChatbot"); },
+      async importContacts() { calls.push("importContacts"); },
+    };
+
+    const result = await applyChangePlan("org-test", plan, faultyDeps);
+
+    // All 6 surfaces ran despite the first one failing
+    assert.deepEqual(
+      calls,
+      ["writeSoul", "seedLanding", "applyBooking", "applyTheme", "refreshChatbot", "importContacts"]
+    );
+    // Failed surface
+    assert.equal(result.soul.ok, false);
+    assert.ok(result.soul.error?.includes("db timeout"), "error message forwarded");
+    // Remaining surfaces succeeded
+    assert.equal(result.landing.ok, true);
+    assert.equal(result.booking.ok, true);
+    assert.equal(result.theme.ok, true);
+    assert.equal(result.chatbot.ok, true);
+    assert.equal(result.contacts.ok, true);
+  });
+
+  it("end-to-end: summaries mention all configured surfaces", () => {
+    const plan = buildChangePlan(submissionData);
+    const joined = plan.summaries.join("\n").toLowerCase();
+    assert.ok(joined.includes("website") || joined.includes("landing"), "landing summary present");
+    assert.ok(joined.includes("booking"), "booking summary present");
+    assert.ok(joined.includes("service"), "services summary present");
+    assert.ok(joined.includes("crm") || joined.includes("contact"), "contacts summary present");
+    assert.ok(joined.includes("domain"), "domain summary present");
+    assert.ok(joined.includes("call"), "call handling summary present");
+    assert.ok(joined.includes("theme") || joined.includes("brand"), "theme summary present");
+  });
+});

--- a/packages/crm/tests/unit/onboarding/parse-hours.spec.ts
+++ b/packages/crm/tests/unit/onboarding/parse-hours.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseHoursText } from "../../../src/lib/onboarding/parse-hours";
+
+describe("parseHoursText", () => {
+  it("parses a weekday range with a Saturday and a closed Sunday", () => {
+    const a = parseHoursText("Mon-Fri 9-5, Sat 10-2, closed Sun");
+    assert.deepEqual(a.monday, { enabled: true, start: "09:00", end: "17:00" });
+    assert.deepEqual(a.friday, { enabled: true, start: "09:00", end: "17:00" });
+    assert.deepEqual(a.saturday, { enabled: true, start: "10:00", end: "14:00" });
+    assert.equal(a.sunday.enabled, false);
+  });
+  it("defaults unmatched input to Mon-Fri 9-5, weekends off", () => {
+    const a = parseHoursText("we're flexible");
+    assert.equal(a.monday.enabled, true);
+    assert.equal(a.saturday.enabled, false);
+  });
+});

--- a/packages/crm/tests/unit/onboarding/parse-services.spec.ts
+++ b/packages/crm/tests/unit/onboarding/parse-services.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseServicesText } from "../../../src/lib/onboarding/parse-services";
+
+describe("parseServicesText", () => {
+  it("parses name, price, and duration from common formats", () => {
+    const s = parseServicesText("60-min massage — $90\nDeep tissue (90 min) - $130\nConsult: free");
+    assert.deepEqual(s[0], { name: "massage", price: 90, durationMinutes: 60 });
+    assert.deepEqual(s[1], { name: "Deep tissue", price: 130, durationMinutes: 90 });
+    assert.deepEqual(s[2], { name: "Consult", price: 0, durationMinutes: 30 });
+  });
+  it("returns [] for empty input", () => {
+    assert.deepEqual(parseServicesText(""), []);
+  });
+});


### PR DESCRIPTION
## Summary
After a client pays, they get a no-login multi-step intake at `/onboard/[token]`. On submit, a wiring agent builds a staged change-plan the agency reviews and applies with one click — updating Soul → website → booking → chatbot → CRM.

**New:**
- `file` question type (logo + CSV uploads) + blob upload + validation
- `onboarding_links` + `change_plans` tables (migration 0056)
- 7-section onboarding form + tokenized `/onboard/[token]` page + auto-email on activation
- Deterministic hours/services parsers → `buildChangePlan` mapper → persist-on-submit → ordered/isolated executor → `/onboarding/[id]` review-and-apply screen

Reuses the existing intake renderer, event bus, `/p/[token]` pattern, per-surface server logic. **39 new unit tests pass; typecheck + build green.** The ~70 other unit failures are pre-existing/unrelated.

## Test plan
- [ ] Preview smoke: proposal → Stripe test pay → emailed `/onboard/[token]` → fill w/ logo + contacts CSV → `pending_review` at `/onboarding/[id]` → Apply all → verify landing/booking/contacts updated
- [ ] File-less intake forms unchanged (JSON submit untouched)

## Known follow-ups (not blockers)
- Chatbot pricing/FAQ don't auto-refresh on apply (services/voice/tone do)
- Bookings-CSV stored but not imported (intentional stub)