### PR TITLE
fix(automations): dispatch call.missed + booking.completed to deployed agents

### DIFF
--- a/packages/crm/src/lib/events/listeners-testable.ts
+++ b/packages/crm/src/lib/events/listeners-testable.ts
@@ -1,0 +1,271 @@
+// Dependency-injectable version of registerCrmEventListeners for unit tests.
+//
+// Production code (listeners.ts) imports DB modules and the dispatcher at
+// the top of the file, making it impossible to mock with node:test's built-in
+// framework (no jest.mock() equivalent). This module exposes a factory that
+// accepts all dependencies as arguments so tests can inject stubs without
+// touching the DB.
+//
+// Usage in tests:
+//   import { registerListenersWithDeps, type ListenerDeps } from
+//     "../../src/lib/events/listeners-testable";
+//
+// NOT used in production — production code uses listeners.ts directly.
+
+import type { SeldonEventBus } from "@seldonframe/core/events";
+import type { AgentDispatchInput, AgentDispatchResult } from "@/lib/agents/dispatcher";
+
+export type ListenerDeps = {
+  // DB resolvers
+  resolveOrgIdForFormId: (formId: string) => Promise<string | null>;
+  resolveOrgIdForBookingId: (bookingId: string) => Promise<string | null>;
+  resolveOrgIdForPhoneNumber: (toNumber: string) => Promise<string | null>;
+
+  // Dispatcher
+  dispatchEventToDeployedAgents: (input: AgentDispatchInput) => Promise<AgentDispatchResult>;
+
+  // Side effects (stubbed in tests)
+  sendTriggeredEmailsForContactEvent: (args: { eventType: string; contactId: string }) => Promise<void>;
+  sendWelcomeEmailForContact: (contactId: string) => Promise<void>;
+  syncContactToNewsletter: (args: { contactId: string }) => Promise<void>;
+  trackTelemetryEvent: (event: string, data: Record<string, unknown>) => void;
+  dispatchOutboundMessagesForEvent: (args: {
+    orgId: string;
+    eventType: string;
+    payload: Record<string, unknown>;
+  }) => Promise<void>;
+  cancelScheduledSendsForBooking: (orgId: string, bookingId: string) => Promise<void>;
+  buildChangePlan: (answers: Record<string, unknown>) => { summaries: string[] };
+  sendNewSignupAlert: (args: {
+    email: string;
+    userId: string;
+    createdAt: Date;
+    source: string;
+  }) => Promise<void>;
+};
+
+/**
+ * Registers all CRM event listeners on the provided bus using injectable
+ * dependencies. Mirrors the logic of registerCrmEventListeners in listeners.ts
+ * exactly — any change to listeners.ts must be reflected here.
+ *
+ * Returns an unregister function that removes all handlers.
+ */
+export function registerListenersWithDeps(
+  bus: SeldonEventBus,
+  deps: ListenerDeps,
+): () => void {
+  const unsubscribers: (() => void)[] = [];
+
+  const off = (fn: () => void) => unsubscribers.push(fn);
+
+  off(bus.onAny(async (event) => {
+    const maybeContactId = (event.data as Record<string, unknown> | null)?.contactId;
+    if (typeof maybeContactId === "string" && maybeContactId) {
+      await deps.sendTriggeredEmailsForContactEvent({
+        eventType: event.type,
+        contactId: maybeContactId,
+      });
+    }
+  }));
+
+  off(bus.on("contact.created", async (event) => {
+    await deps.sendWelcomeEmailForContact(event.data.contactId);
+    void deps.syncContactToNewsletter({ contactId: event.data.contactId }).catch(() => undefined);
+    deps.trackTelemetryEvent("churn_signal", {
+      industry: "unknown",
+      days_inactive: 0,
+      last_action: "contact_created",
+      churned_30d: false,
+    });
+  }));
+
+  off(bus.on("deal.stage_changed", async (event) => {
+    deps.trackTelemetryEvent("pipeline_stage_used", {
+      industry: "unknown",
+      stage_name: event.data.to,
+      conversion_rate: 0,
+    });
+  }));
+
+  off(bus.on("form.submitted", async (event) => {
+    deps.trackTelemetryEvent("landing_performance", {
+      industry: "unknown",
+      section_types: ["form"],
+      conversion_rate: 1,
+    });
+
+    const formId = event.data.formId;
+    const formOrgId = await deps.resolveOrgIdForFormId(formId).catch(() => null);
+    if (formOrgId) {
+      try {
+        await deps.dispatchEventToDeployedAgents({
+          orgId: formOrgId,
+          triggerEventType: "form.submitted",
+          triggerEventId: null,
+          triggerPayload: event.data as Record<string, unknown>,
+          matcherPlaceholder: "$formId",
+          matcherValue: formId,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchEventToDeployedAgents form.submitted failed:`, err);
+      }
+
+      try {
+        await deps.dispatchOutboundMessagesForEvent({
+          orgId: formOrgId,
+          eventType: "form.submitted",
+          payload: event.data as Record<string, unknown>,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchOutboundMessagesForEvent form.submitted failed:`, err);
+      }
+    }
+  }));
+
+  off(bus.on("booking.created", async (event) => {
+    deps.trackTelemetryEvent("booking_performance", {
+      industry: "unknown",
+      type: "created",
+      no_show_rate: 0,
+      conversion_rate: 1,
+    });
+
+    const data = event.data as Record<string, unknown>;
+    const bookingId =
+      (typeof data.bookingId === "string" && data.bookingId) ||
+      (typeof data.appointmentId === "string" && data.appointmentId) ||
+      "";
+    const apptTypeId =
+      typeof data.appointmentTypeId === "string" ? data.appointmentTypeId : null;
+    const bookingOrgId = await deps.resolveOrgIdForBookingId(bookingId).catch(() => null);
+    if (bookingOrgId) {
+      try {
+        await deps.dispatchEventToDeployedAgents({
+          orgId: bookingOrgId,
+          triggerEventType: "booking.created",
+          triggerEventId: null,
+          triggerPayload: data,
+          matcherPlaceholder: "$appointmentTypeId",
+          matcherValue: apptTypeId,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchEventToDeployedAgents booking.created failed:`, err);
+      }
+
+      try {
+        await deps.dispatchOutboundMessagesForEvent({
+          orgId: bookingOrgId,
+          eventType: "booking.created",
+          payload: data,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchOutboundMessagesForEvent booking.created failed:`, err);
+      }
+    }
+  }));
+
+  off(bus.on("booking.completed", async (event) => {
+    deps.trackTelemetryEvent("booking_performance", {
+      industry: "unknown",
+      type: "completed",
+      no_show_rate: 0,
+      conversion_rate: 1,
+    });
+
+    void deps.syncContactToNewsletter({ contactId: event.data.contactId }).catch(() => undefined);
+
+    // 2026-06-09 — wire booking.completed to deployed agents (review-requester
+    // archetype trigger). orgId resolved from appointmentId via booking lookup.
+    const data = event.data as Record<string, unknown>;
+    const appointmentId =
+      typeof data.appointmentId === "string" ? data.appointmentId : "";
+    const completedOrgId = await deps.resolveOrgIdForBookingId(appointmentId).catch(() => null);
+    if (completedOrgId) {
+      try {
+        await deps.dispatchEventToDeployedAgents({
+          orgId: completedOrgId,
+          triggerEventType: "booking.completed",
+          triggerEventId: null,
+          triggerPayload: data,
+          matcherPlaceholder: null,
+          matcherValue: null,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchEventToDeployedAgents booking.completed failed:`, err);
+      }
+    }
+  }));
+
+  off(bus.on("booking.cancelled", async (event) => {
+    deps.trackTelemetryEvent("booking_performance", {
+      industry: "unknown",
+      type: "cancelled",
+      no_show_rate: 0,
+      conversion_rate: 0,
+    });
+
+    const data = event.data as Record<string, unknown>;
+    const appointmentId =
+      typeof data.appointmentId === "string" ? data.appointmentId : "";
+    const cancelOrgId = await deps.resolveOrgIdForBookingId(appointmentId).catch(() => null);
+    if (cancelOrgId) {
+      try {
+        await deps.dispatchOutboundMessagesForEvent({
+          orgId: cancelOrgId,
+          eventType: "booking.cancelled",
+          payload: data,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchOutboundMessagesForEvent booking.cancelled failed:`, err);
+      }
+
+      const bookingIdForCancel =
+        typeof data.bookingId === "string"
+          ? data.bookingId
+          : typeof data.appointmentId === "string"
+            ? data.appointmentId
+            : "";
+      if (bookingIdForCancel) {
+        try {
+          await deps.cancelScheduledSendsForBooking(cancelOrgId, bookingIdForCancel);
+        } catch (err) {
+          console.warn(`[listeners-testable] cancelScheduledSendsForBooking failed:`, err);
+        }
+      }
+    }
+  }));
+
+  off(bus.on("call.missed", async (event) => {
+    // 2026-06-09 — wire call.missed to deployed agents (missed-call-text-back
+    // archetype trigger). orgId is NOT on the typed event data payload (bus
+    // design — see listeners.ts comment). We resolve it from the toNumber
+    // field, which is the agency's Twilio number — the same resolution path
+    // used by the voice webhook itself (resolveWorkspaceByPhoneNumber).
+    // No resource matcher needed: missed-call archetypes are not filtered by
+    // a sub-resource (unlike booking.created → $appointmentTypeId or
+    // form.submitted → $formId). Any deployed missed-call-text-back agent
+    // for the org fires on any missed call.
+    const data = event.data as Record<string, unknown>;
+    const toNumber = typeof data.toNumber === "string" ? data.toNumber : "";
+    const callOrgId = await deps.resolveOrgIdForPhoneNumber(toNumber).catch(() => null);
+    if (callOrgId) {
+      try {
+        await deps.dispatchEventToDeployedAgents({
+          orgId: callOrgId,
+          triggerEventType: "call.missed",
+          triggerEventId: null,
+          triggerPayload: data,
+          matcherPlaceholder: null,
+          matcherValue: null,
+        });
+      } catch (err) {
+        console.warn(`[listeners-testable] dispatchEventToDeployedAgents call.missed failed:`, err);
+      }
+    }
+  }));
+
+  return () => {
+    for (const unsub of unsubscribers) unsub();
+  };
+}

--- a/packages/crm/src/lib/events/listeners.ts
+++ b/packages/crm/src/lib/events/listeners.ts
@@ -15,6 +15,8 @@ import { cancelScheduledSendsForBooking } from "@/lib/messaging/schedule";
 // 2026-06-04 — Onboarding T12: persist change plan on onboarding submission.
 import { buildChangePlan } from "@/lib/onboarding/change-plan";
 import { sendNewSignupAlert } from "@/lib/notifications/ops-notifications";
+// 2026-06-09 — call.missed orgId resolution via Twilio number lookup.
+import { resolveWorkspaceByPhoneNumber } from "@/lib/agents/voice/resolve-workspace-by-number";
 
 /**
  * The SeldonEvent typed schema doesn't include orgId on form.submitted /
@@ -352,6 +354,35 @@ export function registerCrmEventListeners() {
     void syncContactToNewsletter({ contactId: event.data.contactId }).catch(() => {
       return;
     });
+
+    // 2026-06-09 — fan out to deployed agents listening for booking.completed
+    // (review-requester archetype trigger). No resource matcher: unlike
+    // booking.created (filtered by $appointmentTypeId), the review-requester
+    // fires on any completed booking for the org — the operator configures one
+    // review agent per workspace, not per appointment type.
+    // orgId resolved from appointmentId via the bookings table, same pattern
+    // as booking.cancelled above.
+    const data = event.data as Record<string, unknown>;
+    const appointmentId =
+      typeof data.appointmentId === "string" ? data.appointmentId : "";
+    const completedOrgId = await resolveOrgIdForBookingId(appointmentId).catch(() => null);
+    if (completedOrgId) {
+      try {
+        await dispatchEventToDeployedAgents({
+          orgId: completedOrgId,
+          triggerEventType: "booking.completed",
+          triggerEventId: null,
+          triggerPayload: data,
+          matcherPlaceholder: null,
+          matcherValue: null,
+        });
+      } catch (err) {
+        console.warn(
+          `[listeners] dispatchEventToDeployedAgents booking.completed failed:`,
+          err,
+        );
+      }
+    }
   });
 
   bus.on("booking.cancelled", async (event) => {
@@ -410,6 +441,46 @@ export function registerCrmEventListeners() {
             err,
           );
         }
+      }
+    }
+  });
+
+  // 2026-06-09 — Missed-Call-Text-Back archetype trigger.
+  //
+  // The Twilio voice webhook emits call.missed with
+  //   { callSid, contactId, fromNumber, toNumber, status, durationSeconds }
+  // orgId is NOT on the typed event data payload (bus design — the
+  // SeldonEventBus only carries the typed payload, not the emit options.orgId
+  // context used for durable logging). We resolve orgId from toNumber, which
+  // is the agency's Twilio number — the same resolution path used by the voice
+  // webhook itself (resolveWorkspaceByPhoneNumber). This is an indexed DB
+  // query (all org integrations) — acceptable given how infrequently calls
+  // arrive vs. the value of firing the text-back.
+  //
+  // No resource matcher: the missed-call-text-back archetype fires on any
+  // missed call for the org. Operators configure one agent per workspace, not
+  // per phone number (V1 design; per-number routing is a V1.1 concern).
+  bus.on("call.missed", async (event) => {
+    console.log(JSON.stringify({ action: "event.call.missed", ...event }));
+
+    const data = event.data as Record<string, unknown>;
+    const toNumber = typeof data.toNumber === "string" ? data.toNumber : "";
+    const callOrgId = await resolveWorkspaceByPhoneNumber(toNumber).catch(() => null);
+    if (callOrgId) {
+      try {
+        await dispatchEventToDeployedAgents({
+          orgId: callOrgId,
+          triggerEventType: "call.missed",
+          triggerEventId: null,
+          triggerPayload: data,
+          matcherPlaceholder: null,
+          matcherValue: null,
+        });
+      } catch (err) {
+        console.warn(
+          `[listeners] dispatchEventToDeployedAgents call.missed failed:`,
+          err,
+        );
       }
     }
   });

--- a/packages/crm/tests/unit/automation-trigger-dispatch.spec.ts
+++ b/packages/crm/tests/unit/automation-trigger-dispatch.spec.ts
@@ -1,0 +1,330 @@
+// Unit tests for the automation trigger dispatch wiring in listeners.ts.
+//
+// Asserts that:
+//   1. Emitting "call.missed" results in dispatchEventToDeployedAgents
+//      being called with triggerEventType="call.missed" and the orgId
+//      resolved from the toNumber field via resolveWorkspaceByPhoneNumber.
+//   2. Emitting "booking.completed" results in dispatchEventToDeployedAgents
+//      being called with triggerEventType="booking.completed" and the orgId
+//      resolved from the appointmentId field via resolveOrgIdForBookingId.
+//
+// Both cases mock out the dispatcher and orgId resolver so no DB is needed.
+// The pre-existing form.submitted / booking.created / booking.cancelled
+// dispatch paths are NOT tested here (they have their own coverage); we
+// only assert the two new paths are additive and correct.
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createInMemoryEventBus, setSeldonEventBus } from "@seldonframe/core/events";
+
+// ── Module-mock stubs ────────────────────────────────────────────────────────
+// We replace the production modules that touch the DB/dispatcher before
+// importing listeners.ts. Node.js ESM doesn't support jest-style automocking;
+// instead we register the stubs via a module-resolution trick the project
+// already uses (see event-bus.spec.ts pattern: replace the global bus then
+// import the module that reads it lazily).
+//
+// For the dispatcher + resolver, listeners.ts imports them at the top of the
+// file, so we need them to be mockable at import time. The simplest
+// compatible approach: the listeners module reads them via their module paths
+// which are aliased as @/ path aliases. We pre-populate the mock registry
+// on the module-level singletons exposed by each module, but since
+// node:test doesn't support jest.mock(), we instead:
+//   1. Keep listeners.ts "injectable" by ensuring it respects the module
+//      singleton reset pattern (listenersRegistered flag resets per fresh bus).
+//   2. Use the module-level mock registry pattern from the existing
+//      "message-trigger-wiring.spec.ts" style: the test sets up a fresh bus,
+//      registers spy handlers, and validates dispatch without going through
+//      the real listeners.ts (which is tightly coupled to DB modules).
+//
+// TDD approach: these tests are INTEGRATION-STYLE UNIT TESTS that isolate at
+// the bus boundary. We:
+//   a. Create a fresh in-memory event bus.
+//   b. Register spy handlers that capture what would be dispatched (simulating
+//      what the listener should do).
+//   c. Emit the event and assert the spy captured the right dispatch call.
+//
+// This pattern lets us write the tests first (they will fail until listeners.ts
+// is updated), then implement, then watch them pass.
+//
+// IMPORTANT: because listeners.ts is stateful (listenersRegistered flag), we
+// work with the bus directly and test the observable CONTRACT — not the
+// internal implementation. The contract is:
+//   "After emitting call.missed / booking.completed on the bus, within the
+//    same Promise.allSettled() tick, dispatchEventToDeployedAgents is called
+//    with the correct triggerEventType and a resolved orgId."
+//
+// We achieve this by importing the ACTUAL listeners module (with DB mocked
+// to return known values) after resetting the bus and the registration flag.
+
+// ── Approach: direct listener unit tests with module-level spy injection ─────
+//
+// Since listeners.ts uses module-level imports that hit DB, and node:test
+// doesn't support import mocking, we test via a dependency-injection shim.
+// We export a testable factory from a sibling test helper that mirrors the
+// exact logic in listeners.ts but accepts injectable resolvers and dispatcher.
+
+import {
+  registerListenersWithDeps,
+  type ListenerDeps,
+} from "../../src/lib/events/listeners-testable";
+
+// ── Test harness ─────────────────────────────────────────────────────────────
+
+type DispatchCall = {
+  orgId: string;
+  triggerEventType: string;
+  matcherPlaceholder: string | null;
+  matcherValue: string | null;
+  triggerPayload: Record<string, unknown>;
+};
+
+function makeHarness(overrides: Partial<ListenerDeps> = {}) {
+  const bus = createInMemoryEventBus();
+  setSeldonEventBus(bus);
+
+  const dispatchCalls: DispatchCall[] = [];
+
+  const deps: ListenerDeps = {
+    resolveOrgIdForFormId: overrides.resolveOrgIdForFormId ?? (async () => null),
+    resolveOrgIdForBookingId: overrides.resolveOrgIdForBookingId ?? (async () => null),
+    resolveOrgIdForPhoneNumber: overrides.resolveOrgIdForPhoneNumber ?? (async () => null),
+    dispatchEventToDeployedAgents: overrides.dispatchEventToDeployedAgents ?? (async (input) => {
+      dispatchCalls.push({
+        orgId: input.orgId,
+        triggerEventType: input.triggerEventType,
+        matcherPlaceholder: input.matcherPlaceholder,
+        matcherValue: input.matcherValue,
+        triggerPayload: input.triggerPayload,
+      });
+      return { attempted: 1, started: [], failed: [], blockedByLimit: [] };
+    }),
+    // No-ops for side-effectful functions we don't care about in these tests.
+    sendTriggeredEmailsForContactEvent: async () => undefined,
+    sendWelcomeEmailForContact: async () => undefined,
+    syncContactToNewsletter: async () => undefined,
+    trackTelemetryEvent: () => undefined,
+    dispatchOutboundMessagesForEvent: async () => undefined,
+    cancelScheduledSendsForBooking: async () => undefined,
+    buildChangePlan: () => ({ summaries: [] }),
+    sendNewSignupAlert: async () => undefined,
+  };
+
+  registerListenersWithDeps(bus, deps);
+
+  return { bus, dispatchCalls, deps };
+}
+
+// ── Tests for call.missed ─────────────────────────────────────────────────────
+
+describe("automation triggers — call.missed → dispatchEventToDeployedAgents", () => {
+  test("call.missed with resolved orgId calls dispatcher with correct triggerEventType", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForPhoneNumber: async (toNumber) => {
+        if (toNumber === "+15551234567") return "org_test_001";
+        return null;
+      },
+    });
+
+    await bus.emit("call.missed", {
+      callSid: "CA_test_001",
+      contactId: "ctc_001",
+      fromNumber: "+15559876543",
+      toNumber: "+15551234567",
+      status: "no-answer",
+      durationSeconds: 0,
+    });
+
+    assert.equal(
+      dispatchCalls.filter((c) => c.triggerEventType === "call.missed").length,
+      1,
+      "dispatchEventToDeployedAgents must be called exactly once for call.missed",
+    );
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "call.missed");
+    assert.ok(call, "call.missed dispatch call must exist");
+    assert.equal(call!.orgId, "org_test_001", "orgId must be resolved from toNumber");
+    assert.equal(call!.triggerEventType, "call.missed");
+    // call.missed has no resource matcher (no formId/appointmentTypeId to filter on)
+    assert.equal(call!.matcherPlaceholder, null, "call.missed matcherPlaceholder must be null");
+    assert.equal(call!.matcherValue, null, "call.missed matcherValue must be null");
+  });
+
+  test("call.missed with unresolvable toNumber → dispatcher NOT called", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForPhoneNumber: async () => null,
+    });
+
+    await bus.emit("call.missed", {
+      callSid: "CA_test_002",
+      contactId: null,
+      fromNumber: "+15559999999",
+      toNumber: "+15550000000",
+      status: "busy",
+      durationSeconds: 0,
+    });
+
+    const missedCalls = dispatchCalls.filter((c) => c.triggerEventType === "call.missed");
+    assert.equal(missedCalls.length, 0, "dispatcher must not be called when orgId cannot be resolved");
+  });
+
+  test("call.missed triggerPayload contains full event data", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForPhoneNumber: async () => "org_payload_test",
+    });
+
+    await bus.emit("call.missed", {
+      callSid: "CA_payload_test",
+      contactId: "ctc_payload",
+      fromNumber: "+15551111111",
+      toNumber: "+15552222222",
+      status: "failed",
+      durationSeconds: 3,
+    });
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "call.missed");
+    assert.ok(call);
+    const payload = call!.triggerPayload;
+    assert.equal(payload.callSid, "CA_payload_test");
+    assert.equal(payload.fromNumber, "+15551111111");
+    assert.equal(payload.toNumber, "+15552222222");
+    assert.equal(payload.status, "failed");
+    assert.equal(payload.durationSeconds, 3);
+    assert.equal(payload.contactId, "ctc_payload");
+  });
+});
+
+// ── Tests for booking.completed ───────────────────────────────────────────────
+
+describe("automation triggers — booking.completed → dispatchEventToDeployedAgents", () => {
+  test("booking.completed calls dispatcher with triggerEventType=booking.completed", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForBookingId: async (id) => {
+        if (id === "appt_complete_001") return "org_booking_001";
+        return null;
+      },
+    });
+
+    await bus.emit("booking.completed", {
+      appointmentId: "appt_complete_001",
+      contactId: "ctc_complete_001",
+    });
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "booking.completed");
+    assert.ok(call, "dispatchEventToDeployedAgents must be called for booking.completed");
+    assert.equal(call!.orgId, "org_booking_001", "orgId must be resolved from appointmentId");
+    assert.equal(call!.triggerEventType, "booking.completed");
+  });
+
+  test("booking.completed with unresolvable appointmentId → dispatcher NOT called", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForBookingId: async () => null,
+    });
+
+    await bus.emit("booking.completed", {
+      appointmentId: "appt_unknown",
+      contactId: "ctc_unknown",
+    });
+
+    const completedCalls = dispatchCalls.filter((c) => c.triggerEventType === "booking.completed");
+    assert.equal(completedCalls.length, 0, "dispatcher must not be called when orgId cannot be resolved");
+  });
+
+  test("booking.completed triggerPayload contains appointmentId and contactId", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForBookingId: async () => "org_payload_booking",
+    });
+
+    await bus.emit("booking.completed", {
+      appointmentId: "appt_payload_001",
+      contactId: "ctc_payload_001",
+    });
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "booking.completed");
+    assert.ok(call);
+    assert.equal(call!.triggerPayload.appointmentId, "appt_payload_001");
+    assert.equal(call!.triggerPayload.contactId, "ctc_payload_001");
+  });
+
+  test("booking.completed dispatch does not break when dispatchEventToDeployedAgents throws", async () => {
+    const { bus } = makeHarness({
+      resolveOrgIdForBookingId: async () => "org_throw_test",
+      dispatchEventToDeployedAgents: async () => {
+        throw new Error("dispatcher_kaboom");
+      },
+    });
+
+    // Must not propagate — the listener should catch and warn, not throw.
+    await assert.doesNotReject(
+      () => bus.emit("booking.completed", {
+        appointmentId: "appt_throw_test",
+        contactId: "ctc_throw_test",
+      }),
+      "booking.completed listener must not propagate dispatcher errors",
+    );
+  });
+
+  test("call.missed dispatch does not break when dispatchEventToDeployedAgents throws", async () => {
+    const { bus } = makeHarness({
+      resolveOrgIdForPhoneNumber: async () => "org_throw_test",
+      dispatchEventToDeployedAgents: async () => {
+        throw new Error("dispatcher_kaboom");
+      },
+    });
+
+    await assert.doesNotReject(
+      () => bus.emit("call.missed", {
+        callSid: "CA_throw_test",
+        contactId: null,
+        fromNumber: "+15550000001",
+        toNumber: "+15550000002",
+        status: "no-answer",
+        durationSeconds: 0,
+      }),
+      "call.missed listener must not propagate dispatcher errors",
+    );
+  });
+});
+
+// ── Regression: pre-existing dispatches still fire ────────────────────────────
+
+describe("automation triggers — regression: existing dispatches not broken", () => {
+  test("form.submitted still dispatches (existing path preserved)", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForFormId: async (id) => {
+        if (id === "form_001") return "org_form_001";
+        return null;
+      },
+    });
+
+    await bus.emit("form.submitted", {
+      formId: "form_001",
+      contactId: "ctc_001",
+      data: { name: "Test" },
+    });
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "form.submitted");
+    assert.ok(call, "form.submitted dispatch must still fire");
+    assert.equal(call!.orgId, "org_form_001");
+    assert.equal(call!.matcherPlaceholder, "$formId");
+    assert.equal(call!.matcherValue, "form_001");
+  });
+
+  test("booking.created still dispatches (existing path preserved)", async () => {
+    const { bus, dispatchCalls } = makeHarness({
+      resolveOrgIdForBookingId: async (id) => {
+        if (id === "appt_created_001") return "org_created_001";
+        return null;
+      },
+    });
+
+    await bus.emit("booking.created", {
+      appointmentId: "appt_created_001",
+      contactId: "ctc_created_001",
+    });
+
+    const call = dispatchCalls.find((c) => c.triggerEventType === "booking.created");
+    assert.ok(call, "booking.created dispatch must still fire");
+    assert.equal(call!.orgId, "org_created_001");
+  });
+});


### PR DESCRIPTION
## Summary
Two automations never fired — their trigger events weren't dispatched to deployed agents:
- **Missed-Call Text-Back:** `call.missed` (Twilio voice webhook) had no listener starting the run. Added a handler that resolves orgId from the Twilio number → dispatches.
- **Review Requester:** `booking.completed` was emitted but the listener only ran telemetry. Added a dispatch (orgId via `resolveOrgIdForBookingId`).
Both mirror the existing `booking.created` dispatch; additive; existing dispatches unchanged. (Speed-to-Lead's `form.submitted` was already wired — just needs per-workspace Configure + Deploy.)
Adds `listeners-testable.ts` (DI mirror; node:test lacks jest.mock()) + 10 unit tests. Follow-up: make prod delegate to the factory to remove the duplication.

## Test plan
- [ ] On seldon-studio: Configure + Deploy the 3 agents; point Twilio Voice URL → /api/webhooks/twilio/voice
- [ ] Submit intake → speed-to-lead SMS · complete booking → review request · miss a call → text-back
- [ ] 10 new unit tests pass; no new suite failures; build green