### PR TITLE
feat(voice): greet + fire text-back on inbound call when missed-call agent is deployed

### DIFF
--- a/packages/crm/src/app/api/webhooks/twilio/voice/route.ts
+++ b/packages/crm/src/app/api/webhooks/twilio/voice/route.ts
@@ -57,6 +57,11 @@ import { findContactByPhone } from "@/lib/sms/api";
 import { toE164 } from "@/lib/sms/providers";
 import { verifyTwilioSignature } from "@/lib/sms/webhook-verify";
 import { resolveWorkspaceByPhoneNumber } from "@/lib/agents/voice/resolve-workspace-by-number";
+import {
+  buildGreetingTwiml,
+  buildVoiceGreeting,
+  shouldGreetOnInbound,
+} from "@/lib/agents/voice/greeting";
 
 export const runtime = "nodejs";
 
@@ -93,6 +98,40 @@ async function loadTwilioAuthTokenForOrg(orgId: string) {
     }
   }
   return raw;
+}
+
+// 2026-06-10 — Load what the inbound-greeting decision needs: whether the
+// missed-call-text-back agent is deployed for this workspace, plus the
+// business name for the spoken greeting.
+async function loadGreetingContext(orgId: string): Promise<{
+  deployedAt: string | null;
+  pausedAt: string | null;
+  businessName: string | null;
+}> {
+  const [row] = await db
+    .select({ settings: organizations.settings, soul: organizations.soul })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  const settings = (row?.settings ?? {}) as Record<string, unknown>;
+  const agentConfigs = (settings.agentConfigs ?? {}) as Record<
+    string,
+    { deployedAt?: string | null; pausedAt?: string | null }
+  >;
+  const cfg = agentConfigs["missed-call-text-back"] ?? {};
+
+  const soul = (row?.soul ?? {}) as Record<string, unknown>;
+  const businessName =
+    (typeof soul.business_name === "string" && soul.business_name.trim()) ||
+    (typeof soul.businessName === "string" && soul.businessName.trim()) ||
+    null;
+
+  return {
+    deployedAt: cfg.deployedAt ?? null,
+    pausedAt: cfg.pausedAt ?? null,
+    businessName,
+  };
 }
 
 function fullRequestUrl(request: Request) {
@@ -196,10 +235,46 @@ export async function POST(request: Request) {
     }
   }
 
-  // Initial voice-URL hit (no terminal status). Return empty TwiML
-  // so Twilio hangs up; the status callback fires next with the
-  // terminal state.
+  // 2026-06-10 — Inbound greeting decision, shared by the voice-URL hit and
+  // the status callback. When the missed-call agent is deployed we answer +
+  // emit on the inbound hit, so the status callback must not double-emit.
+  const greetCtx = await loadGreetingContext(orgId);
+  const greetMode = shouldGreetOnInbound(greetCtx.deployedAt, greetCtx.pausedAt);
+
+  // Initial voice-URL hit (no terminal status).
   if (!callStatus || callStatus === "ringing" || callStatus === "in-progress") {
+    if (greetMode) {
+      // Deterministic path: answer with a branded greeting and fire the
+      // text-back NOW — don't wait for Twilio to classify a "missed" status.
+      const contactId = fromNumber
+        ? await findContactByPhone(orgId, fromNumber)
+        : null;
+      await emitSeldonEvent(
+        "call.missed",
+        {
+          callSid,
+          contactId,
+          fromNumber,
+          toNumber,
+          status: "no-answer",
+          durationSeconds: 0,
+        },
+        { orgId },
+      );
+      logEvent("twilio_voice_webhook_greeted_and_emitted", {
+        org_id: orgId,
+        call_sid: callSid,
+        from: fromNumber,
+        to: toNumber,
+        contact_id: contactId,
+      });
+      return twimlResponse(
+        buildGreetingTwiml(buildVoiceGreeting(greetCtx.businessName)),
+      );
+    }
+
+    // Legacy path: empty TwiML; rely on the status callback to detect a
+    // missed call (when no missed-call agent is deployed).
     logEvent("twilio_voice_webhook_voice_url_hit", {
       org_id: orgId,
       call_sid: callSid,
@@ -211,6 +286,19 @@ export async function POST(request: Request) {
 
   // Status callback path — terminal state reached.
   if (isMissedStatus(callStatus)) {
+    // When greet-mode is on, the inbound voice-URL hit already emitted
+    // call.missed and answered the call. Skip here so a caller who hangs up
+    // mid-greeting (which can surface a no-answer callback) doesn't trigger
+    // a SECOND text-back.
+    if (greetMode) {
+      logEvent("twilio_voice_webhook_missed_skipped_greeted", {
+        org_id: orgId,
+        call_sid: callSid,
+        status: callStatus,
+      });
+      return NextResponse.json({ ok: true, skipped: "greeted_on_inbound" });
+    }
+
     const contactId = fromNumber ? await findContactByPhone(orgId, fromNumber) : null;
 
     await emitSeldonEvent(

--- a/packages/crm/src/lib/agents/voice/greeting.ts
+++ b/packages/crm/src/lib/agents/voice/greeting.ts
@@ -1,0 +1,53 @@
+// packages/crm/src/lib/agents/voice/greeting.ts
+//
+// Friendly inbound-call greeting for missed-call-text-back.
+//
+// 2026-06-10 — When a workspace has the missed-call-text-back agent
+// DEPLOYED, the Twilio voice webhook ANSWERS the call with a short branded
+// message and fires the text-back immediately, instead of returning empty
+// TwiML and depending on Twilio later classifying the call as
+// no-answer/busy/failed.
+//
+// Why: the empty-TwiML + "wait for a missed CallStatus" path is
+// non-deterministic for a directly-dialed number — Twilio sometimes
+// reports the call differently, the run never fires, and the caller hears
+// the carrier's "your call cannot be completed as dialed." Answering on the
+// initial voice-URL hit is deterministic (the hit always happens) and lets
+// us play a real message. The call then ends "completed", so the status
+// callback does NOT double-emit (see the route's guard).
+//
+// These three helpers are pure so the behavior is unit-testable without a
+// running webhook or DB.
+
+/** True when the missed-call agent is live for the workspace (deployed and
+ *  not paused). Mirrors the dispatcher's deployed-agent check. */
+export function shouldGreetOnInbound(
+  deployedAt: string | null | undefined,
+  pausedAt: string | null | undefined,
+): boolean {
+  return Boolean(deployedAt) && !pausedAt;
+}
+
+/** Branded one-line greeting spoken to the caller before we text them.
+ *  Falls back to a generic line when the workspace has no business name. */
+export function buildVoiceGreeting(businessName: string | null | undefined): string {
+  const name = (businessName ?? "").trim();
+  const who = name.length > 0 ? name : "us";
+  return `Thanks for calling ${who}! We just sent you a text with a link to book in seconds. Talk soon!`;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** TwiML that speaks the greeting then hangs up. The call ends "completed",
+ *  which is intentional — the route's status-callback path treats a
+ *  greeted call as already-handled so it never double-fires the text. */
+export function buildGreetingTwiml(greeting: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Say>${escapeXml(greeting)}</Say><Hangup/></Response>`;
+}

--- a/packages/crm/tests/unit/voice-greeting.spec.ts
+++ b/packages/crm/tests/unit/voice-greeting.spec.ts
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  shouldGreetOnInbound,
+  buildVoiceGreeting,
+  buildGreetingTwiml,
+} from "@/lib/agents/voice/greeting";
+
+// 2026-06-10 — Inbound-call greeting for missed-call-text-back. The voice
+// webhook answers + texts deterministically when the agent is deployed,
+// instead of relying on Twilio's flaky "missed" classification.
+
+test("shouldGreetOnInbound is true only when deployed and not paused", () => {
+  assert.equal(shouldGreetOnInbound("2026-06-10T18:05:00Z", null), true);
+  assert.equal(shouldGreetOnInbound(null, null), false);
+  assert.equal(shouldGreetOnInbound(undefined, undefined), false);
+  // Deployed but paused → do not greet.
+  assert.equal(
+    shouldGreetOnInbound("2026-06-10T18:05:00Z", "2026-06-10T19:00:00Z"),
+    false,
+  );
+});
+
+test("buildVoiceGreeting names the business when provided", () => {
+  const g = buildVoiceGreeting("Seldon Studio");
+  assert.ok(g.includes("Seldon Studio"), g);
+  assert.ok(g.toLowerCase().includes("text"), g);
+});
+
+test("buildVoiceGreeting falls back to a generic line when no usable name", () => {
+  const g = buildVoiceGreeting("   ");
+  assert.ok(g.includes("calling us"), g);
+  assert.ok(!g.includes("undefined"), g);
+});
+
+test("buildGreetingTwiml produces valid TwiML with Say + Hangup", () => {
+  const xml = buildGreetingTwiml("Hi there");
+  assert.ok(xml.startsWith("<?xml"), xml);
+  assert.ok(xml.includes("<Response>"), xml);
+  assert.ok(xml.includes("<Say>Hi there</Say>"), xml);
+  assert.ok(xml.includes("<Hangup/>"), xml);
+});
+
+test("buildGreetingTwiml escapes XML-special characters", () => {
+  const xml = buildGreetingTwiml("Tom & Jerry's <Plumbing>");
+  assert.ok(xml.includes("Tom &amp; Jerry&apos;s &lt;Plumbing&gt;"), xml);
+  // The raw, unescaped tag must NOT leak into the TwiML.
+  assert.ok(!xml.includes("<Plumbing>"), xml);
+});


### PR DESCRIPTION
## Summary
Direct-dialing a Twilio number to trigger missed-call-text-back was non-deterministic (it depended on Twilio classifying the call as no-answer/busy/failed; the caller heard the carrier intercept; the run often never fired). Now, when the missed-call-text-back agent is **deployed**, the voice webhook **answers** the inbound call with a branded greeting (from the workspace's business name) and **emits `call.missed` immediately** — deterministic. The status callback skips emitting in greet-mode (no double text). Workspaces without the agent keep the legacy empty-TwiML path. New pure helpers + 5 unit tests; typecheck + build green.

## Test plan
- [ ] Deploy missed-call agent → call its Twilio number → caller hears the greeting + a row appears in `/automations/missed-call-text-back/runs`
- [ ] Workspace without the agent → call → empty TwiML (unchanged)