### PR TITLE
feat(voice): cedar voice + post-call follow-up SMS (META loop)

### DIFF
--- a/packages/crm/src/app/api/v1/voice/openai/webhook/route.ts
+++ b/packages/crm/src/app/api/v1/voice/openai/webhook/route.ts
@@ -34,12 +34,20 @@ import {
   extractWebhookHeaders,
   verifyOpenAiWebhook,
 } from "@/lib/agents/voice/openai-webhook-verify";
-import { acceptCall, runVoiceCall } from "@/lib/agents/voice/openai-realtime";
+import {
+  acceptCall,
+  runVoiceCall,
+  buildPostCallSmsBody,
+} from "@/lib/agents/voice/openai-realtime";
 import {
   resolveVoiceContextByNumber,
   loadVoicePersonaInputs,
 } from "@/lib/agents/voice/voice-workspace";
-import { extractDialedNumber } from "@/lib/agents/voice/sip-headers";
+import {
+  extractDialedNumber,
+  extractCallerNumber,
+} from "@/lib/agents/voice/sip-headers";
+import { sendSmsFromApi } from "@/lib/sms/api";
 import { composeVoicePersona } from "@/lib/agents/voice/persona";
 import {
   loadAgentBrainContext,
@@ -193,6 +201,9 @@ export async function POST(request: Request): Promise<Response> {
       // transcript. All best-effort: a miss degrades to a working greeting, never
       // a dropped call.
       const dialedNumber = extractDialedNumber(event.data?.sip_headers);
+      // META loop — extract the caller's own number for the post-call follow-up SMS.
+      // From / P-Asserted-Identity SIP headers carry it. Null for anonymous callers.
+      const callerNumber = extractCallerNumber(event.data?.sip_headers);
       const resolved = await resolveVoiceContextByNumber({ dialedNumber }).catch((err) => {
         logEvent(
           "voice_call_workspace_resolve_error",
@@ -211,6 +222,8 @@ export async function POST(request: Request): Promise<Response> {
       // + the vertical for the outcome row.
       let brainNoteIds: string[] = [];
       let vertical: string | null = null;
+      // META loop — business name for the post-call SMS (loaded with persona inputs).
+      let smsBusinessName: string | null = null;
 
       if (resolved?.ok) {
         logEvent("voice_call_workspace_resolved", {
@@ -238,6 +251,11 @@ export async function POST(request: Request): Promise<Response> {
           brainNoteIds = brain.consumedNoteIds;
           const soulRec = personaInputs.soul as Record<string, unknown> | null;
           vertical = typeof soulRec?.industry === "string" ? soulRec.industry : null;
+          // META loop — capture business name for the post-call SMS body.
+          smsBusinessName =
+            (typeof soulRec?.businessName === "string" && soulRec.businessName.trim()) ||
+            (typeof soulRec?.business_name === "string" && soulRec.business_name.trim()) ||
+            null;
           instructions = composeVoicePersona({
             soul: personaInputs.soul,
             blueprint: personaInputs.blueprint,
@@ -309,6 +327,58 @@ export async function POST(request: Request): Promise<Response> {
           }
         : undefined;
 
+      // META loop — post-call follow-up SMS. Fires when the call ends (any
+      // reason). Requires: a resolved workspace (orgId), a valid caller number
+      // (not anonymous), and the workspace's Twilio credentials (sendSmsFromApi
+      // throws if fromNumber is not configured — caught below).
+      // Best-effort: wrapped in try/catch, never blocks call teardown.
+      const smsOrgId = resolved?.ok ? resolved.ctx.orgId : null;
+      const smsOrgSlug = resolved?.ok ? resolved.ctx.orgSlug : null;
+      const onPostCallSms =
+        smsOrgId && smsOrgSlug && callerNumber
+          ? () => {
+              const baseDomain =
+                process.env.WORKSPACE_BASE_DOMAIN?.trim() || "app.seldonframe.com";
+              const bookUrl = `https://${smsOrgSlug}.${baseDomain}/book`;
+              const businessName = smsBusinessName || "us";
+              const body = buildPostCallSmsBody({ businessName, bookUrl });
+              void (async () => {
+                try {
+                  await sendSmsFromApi({
+                    orgId: smsOrgId,
+                    userId: null,
+                    contactId: null,
+                    toNumber: callerNumber,
+                    body,
+                  });
+                  logEvent("voice_call_post_call_sms_sent", {
+                    call_id: callId,
+                    org_id: smsOrgId,
+                    to: callerNumber,
+                  });
+                } catch (err) {
+                  logEvent(
+                    "voice_call_post_call_sms_failed",
+                    {
+                      call_id: callId,
+                      org_id: smsOrgId,
+                      to: callerNumber,
+                      error: err instanceof Error ? err.message : String(err),
+                    },
+                    { severity: "warn" },
+                  );
+                }
+              })();
+            }
+          : undefined;
+
+      if (callerNumber && !smsOrgId) {
+        logEvent("voice_call_post_call_sms_skipped", {
+          call_id: callId,
+          reason: "no_resolved_workspace",
+        });
+      }
+
       // WS open happens immediately inside runVoiceCall — adjacent to accept.
       // Tools + per-workspace persona + per-agent voice are passed only when the
       // workspace resolved; otherwise the call falls back to the greeting persona.
@@ -320,6 +390,7 @@ export async function POST(request: Request): Promise<Response> {
         audioVoice,
         greeting,
         onBookingCompleted,
+        onPostCallSms,
         ...transcriptCallbacks,
       });
     } catch (err) {

--- a/packages/crm/src/lib/agents/voice/card-status.ts
+++ b/packages/crm/src/lib/agents/voice/card-status.ts
@@ -21,13 +21,16 @@ import { toE164 } from "@/lib/sms/providers";
 // NOT in actions.ts — a "use server" file may only export async functions, so a
 // const array there fails the next build (check-use-server.sh). Both the server
 // action's zod enum and the editor's <select> import it from here.
+// cedar/marin are the newest gpt-realtime voices; if OpenAI rejects cedar for this model, "sage" is the safe fallback.
 export const VOICE_OPTIONS = [
   "alloy",
   "echo",
   "shimmer",
   "ash",
   "ballad",
+  "cedar",
   "coral",
+  "marin",
   "sage",
   "verse",
 ] as const;

--- a/packages/crm/src/lib/agents/voice/openai-realtime.ts
+++ b/packages/crm/src/lib/agents/voice/openai-realtime.ts
@@ -99,9 +99,10 @@ export const VOICE_SDR_INSTRUCTIONS =
 /**
  * Voice for the realtime session. Set via `session.update` under
  * `audio.output.voice` (NOT in the /accept body — a top-level `voice` at accept
- * breaks session creation; see acceptCall). `alloy` is a safe GA voice.
+ * breaks session creation; see acceptCall).
+ * cedar/marin are the newest gpt-realtime voices; if OpenAI rejects cedar for this model, "sage" is the safe fallback.
  */
-export const VOICE_AUDIO_OUTPUT_VOICE = "alloy";
+export const VOICE_AUDIO_OUTPUT_VOICE = "cedar";
 
 /**
  * The exact model id used for the call. Confirmed from the OpenAI Realtime SIP
@@ -110,17 +111,23 @@ export const VOICE_AUDIO_OUTPUT_VOICE = "alloy";
  */
 export const VOICE_MODEL = "gpt-realtime-2";
 
-/** Voice for the greeting. `alloy` is a safe, widely-available default. */
-export const VOICE_NAME = "alloy";
+/** Voice for the greeting. cedar/marin are the newest gpt-realtime voices; if OpenAI rejects cedar for this model, "sage" is the safe fallback. */
+export const VOICE_NAME = "cedar";
 
 /**
- * The hard-coded Phase 0 persona. Single greeting, no per-workspace anything.
- * Phase 2 replaces this with per-workspace agent resolution.
+ * The hard-coded Phase 0 / fallback persona — used when no per-workspace persona
+ * can be composed (unresolved workspace or persona-compose error). Warm, concise,
+ * receptionist-style; greets by business context, offers concrete help, and ends
+ * politely. Phase 2 replaces this with per-workspace agent resolution.
  */
 export const PHASE0_GREETING_INSTRUCTIONS =
-  "You are a friendly receptionist for a test business. Greet the caller " +
-  "warmly, ask how you can help, and keep your replies short. If the caller " +
-  "says goodbye, thank them and end the call.";
+  "You are a warm, helpful phone receptionist. Greet the caller by saying " +
+  "'Thanks for calling — how can I help you today?' Keep every reply short " +
+  "and natural (one or two sentences). You can answer questions about the " +
+  "business, help the caller book an appointment, or connect them to the right " +
+  "person. If the caller asks to book, offer to take their name and preferred " +
+  "time and let them know someone will confirm shortly. Always be friendly and " +
+  "unhurried. If the caller says goodbye, thank them warmly and end the call.";
 
 /**
  * Safety cap on assistant turns. gpt-realtime-2 normally ends the call itself
@@ -130,6 +137,26 @@ export const PHASE0_GREETING_INSTRUCTIONS =
  * the pipe.
  */
 export const MAX_ASSISTANT_TURNS = 12;
+
+/**
+ * Build the body of the post-call follow-up SMS sent to the caller after a
+ * voice call ends. Pure function — no I/O, no side effects. Unit-tested.
+ *
+ * Includes a warm thank-you, the workspace booking link, and a light meta pitch
+ * for SeldonFrame. `bookUrl` should be the full `https://` URL.
+ */
+export function buildPostCallSmsBody(params: {
+  businessName: string;
+  bookUrl: string;
+}): string {
+  const { businessName, bookUrl } = params;
+  return (
+    `Thanks for calling ${businessName}! 🙏 ` +
+    `Book or reschedule anytime at ${bookUrl} — ` +
+    `we look forward to seeing you. ` +
+    `P.S. Want your own AI receptionist like this? Reply DEMO or visit https://app.seldonframe.com`
+  );
+}
 
 /**
  * Hard wall-clock cap (ms) for a single call's WS hold. Kept under the Vercel
@@ -300,6 +327,11 @@ export async function runVoiceCall(params: {
   // record a brain "win" (booking landed) against the consumed patterns.
   // Best-effort, fire-and-forget.
   onBookingCompleted?: () => void;
+  // META loop — fired once the call ends (all reasons). When set, the caller
+  // should send a post-call follow-up SMS to the caller's number. Best-effort:
+  // a throw here must never affect call teardown. The SMS itself is sent by the
+  // webhook (not here) so this is a plain signal callback with no arguments.
+  onPostCallSms?: () => void;
 }): Promise<CallEndReason> {
   const WS: ControlSocketCtor =
     params.WebSocketImpl ?? (WsWebSocket as unknown as ControlSocketCtor);
@@ -395,6 +427,13 @@ export async function runVoiceCall(params: {
         params.onCallEnd?.();
       } catch {
         // ignore — best-effort transcript close-out
+      }
+      // META loop — signal the webhook to send a post-call follow-up SMS.
+      // Best-effort: a throw here must never affect teardown.
+      try {
+        params.onPostCallSms?.();
+      } catch {
+        // ignore — best-effort post-call SMS signal
       }
       logEvent("voice_call_ws_closed", { call_id: params.callId, reason });
       resolve(reason);

--- a/packages/crm/src/lib/agents/voice/sip-headers.ts
+++ b/packages/crm/src/lib/agents/voice/sip-headers.ts
@@ -7,7 +7,9 @@
 // Twilio's Elastic SIP Trunk forwards the originally-dialed DID in the
 // `Diversion` header (`<sip:+13254132487@twilio.com>;reason=unconditional`).
 // The caller's own number is in From / P-Asserted-Identity / Contact, which we
-// deliberately do NOT read (we want the called number, not the caller).
+// deliberately do NOT read for dialed-number resolution (we want the called
+// number, not the caller) — but extractCallerNumber() below reads those for the
+// post-call SMS META loop.
 //
 // So we prefer `Diversion`, then fall back to `To` / request-URI / X-Original-To
 // for other SIP topologies — skipping any value that points at the OpenAI
@@ -39,4 +41,33 @@ function parseUserPart(value: string | undefined): string | null {
   const digits = match[0].replace(/[^\d+]/g, "");
   const e164 = digits.startsWith("+") ? digits : `+${digits}`;
   return /^\+\d{8,15}$/.test(e164) ? e164 : null;
+}
+
+/**
+ * Extract the CALLER'S phone number from SIP headers for post-call SMS.
+ * Pure. Returns E.164 (e.g. "+16505551234") or null.
+ *
+ * Prefers `P-Asserted-Identity` (set by the carrier, harder to spoof) then
+ * `From`. Returns null for anonymous callers ("anonymous", empty user part, or
+ * no valid E.164 extracted). Does NOT read the OpenAI-endpoint `To` header —
+ * that's the called URI, not the caller.
+ */
+// The header names to check for the caller's own number, in preference order.
+const CALLER_HEADER_NAMES = ["p-asserted-identity", "from", "contact"];
+
+export function extractCallerNumber(
+  sipHeaders: ReadonlyArray<{ name?: string; value?: string }> | undefined | null,
+): string | null {
+  if (!sipHeaders) return null;
+  for (const wanted of CALLER_HEADER_NAMES) {
+    const header = sipHeaders.find((h) => (h.name ?? "").trim().toLowerCase() === wanted);
+    if (!header?.value) continue;
+    // Skip anonymous callers (carrier sends "anonymous" or "Anonymous").
+    if (/\banonymous\b/i.test(header.value)) continue;
+    // Skip anything pointing at the OpenAI SIP endpoint (never a caller number).
+    if (header.value.includes(OPENAI_SIP_HOST)) continue;
+    const num = parseUserPart(header.value);
+    if (num) return num;
+  }
+  return null;
 }

--- a/packages/crm/src/lib/agents/voice/voice-agent.ts
+++ b/packages/crm/src/lib/agents/voice/voice-agent.ts
@@ -66,7 +66,7 @@ export async function getOrCreateVoiceAgent({
     };
   }
 
-  const blueprint: AgentBlueprint = { voice: "alloy" };
+  const blueprint: AgentBlueprint = { voice: "cedar" };
   const values: Record<string, unknown> = {
     orgId,
     channel: "voice",

--- a/packages/crm/tests/unit/voice-post-call-sms.spec.ts
+++ b/packages/crm/tests/unit/voice-post-call-sms.spec.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildPostCallSmsBody } from "@/lib/agents/voice/openai-realtime";
+import { extractCallerNumber } from "@/lib/agents/voice/sip-headers";
+
+// 2026-06-10 — META loop: when a voice call ends, the webhook texts the caller a
+// booking link plus a light SeldonFrame pitch. Both helpers are pure so the
+// post-call SMS behavior is unit-testable without a live call or Twilio.
+
+test("buildPostCallSmsBody includes the business name, booking link, and demo pitch", () => {
+  const body = buildPostCallSmsBody({
+    businessName: "Seldon Studio",
+    bookUrl: "https://seldon-studio.app.seldonframe.com/book",
+  });
+  assert.ok(body.includes("Seldon Studio"), body);
+  assert.ok(body.includes("https://seldon-studio.app.seldonframe.com/book"), body);
+  // The SeldonFrame meta pitch (our own funnel) must be present.
+  assert.ok(body.includes("DEMO"), body);
+  assert.ok(body.includes("seldonframe.com"), body);
+});
+
+test("buildPostCallSmsBody never leaks an undefined when the name is generic", () => {
+  const body = buildPostCallSmsBody({
+    businessName: "us",
+    bookUrl: "https://acme.app.seldonframe.com/book",
+  });
+  assert.ok(body.startsWith("Thanks for calling us!"), body);
+  assert.ok(!body.includes("undefined"), body);
+});
+
+test("extractCallerNumber reads the From header user part as E.164", () => {
+  const headers = [
+    { name: "From", value: "<sip:+14505161803@pstn.twilio.com:5060>;tag=abc" },
+    { name: "To", value: "<sip:proj_x@sip.api.openai.com;transport=tls>" },
+  ];
+  assert.equal(extractCallerNumber(headers), "+14505161803");
+});
+
+test("extractCallerNumber prefers P-Asserted-Identity over From", () => {
+  const headers = [
+    { name: "From", value: "<sip:+14505161803@pstn.twilio.com:5060>;tag=abc" },
+    { name: "P-Asserted-Identity", value: "<sip:+15145550123@206.147.72.73:5060>" },
+  ];
+  assert.equal(extractCallerNumber(headers), "+15145550123");
+});
+
+test("extractCallerNumber returns null for anonymous callers", () => {
+  const headers = [
+    { name: "From", value: '"Anonymous" <sip:anonymous@anonymous.invalid>;tag=z' },
+  ];
+  assert.equal(extractCallerNumber(headers), null);
+});
+
+test("extractCallerNumber returns null when no usable caller header exists", () => {
+  assert.equal(extractCallerNumber(null), null);
+  assert.equal(extractCallerNumber(undefined), null);
+  assert.equal(extractCallerNumber([]), null);
+  // A From pointing at the OpenAI endpoint is the session target, never a caller.
+  assert.equal(
+    extractCallerNumber([{ name: "From", value: "<sip:proj_x@sip.api.openai.com>" }]),
+    null,
+  );
+});


### PR DESCRIPTION
When a voice call ends, text the caller a booking link plus a light SeldonFrame pitch — the "META loop". Best-effort and fire-and-forget: a failure never affects call teardown.

- route.ts: on WS close, when the workspace resolved and the caller's number is non-anonymous, send buildPostCallSmsBody({businessName, bookUrl}) via sendSmsFromApi. bookUrl = https://<slug>.app.seldonframe .com/book (matches the proxy /book rewrite). Logs sent/failed/skipped.
- sip-headers.ts: extractCallerNumber() reads P-Asserted-Identity / From for the caller's own E.164 (extractDialedNumber reads the called DID).
- openai-realtime.ts: buildPostCallSmsBody() (pure); switch realtime + greeting voice to "cedar"; warmer receptionist fallback persona.
- card-status.ts: add cedar + marin to VOICE_OPTIONS.
- voice-agent.ts: default new voice agents to the cedar voice.
- tests: unit-cover buildPostCallSmsBody + extractCallerNumber.

Verified: pnpm test:unit 11/11 green, tsc --noEmit 0 errors.

Note: outbound delivery still requires the workspace's Twilio A2P campaign to be approved; until then sends are attempted and logged as voice_call_post_call_sms_failed with the carrier error.

## Summary

What does this PR change and why?

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

Closes #

## Testing

- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit` passes
- [ ] Manually verified the change in the browser (if UI)

## Screenshots / GIFs

(Required for UI changes)

## Notes for reviewers

Anything reviewers should focus on, schema/env changes, follow-up work, etc.
