### PR TITLE
feat(tools): 6 free intent-capture tools (speed-to-lead, no-show, AI-visibility + 3)

### DIFF
--- a/packages/crm/src/app/(public)/tools/ai-receptionist-script-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/ai-receptionist-script-generator/page.tsx
@@ -1,0 +1,128 @@
+// /tools/ai-receptionist-script-generator — free tool (the PostPlanify
+// free-tools SEO motion): server-rendered GEO copy + FAQ around a small client
+// template generator island. The generated call script IS a live demo of what
+// SeldonFrame deploys onto a real phone number or web chat. Additive: no DB, no
+// AI calls — pure client-side string composition from the operator's inputs.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { AiReceptionistScriptGenerator } from "@/components/seo/ai-receptionist-script-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "AI Receptionist Script Generator — free, no signup";
+const DESCRIPTION =
+  "Free AI receptionist script generator: pick your business type, hours, and goal, and get a complete call script — greeting, qualifying questions, booking, objection handling, and after-hours fallback — that you can copy, edit, and deploy.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "AI Receptionist Script Generator", hook: "A complete call script for any business in seconds" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/ai-receptionist-script-generator" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/ai-receptionist-script-generator", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "Is this script ready to put on a live phone line as-is?",
+    a: "Treat it as a strong <strong>starting template</strong>, not a finished agent. A production receptionist also needs to be grounded in your real services and prices, forced to read details back for confirmation, and wrapped in guardrails so it never invents an answer or over-promises. That reliability layer is exactly what SeldonFrame adds — the script is the skeleton, not the whole thing.",
+  },
+  {
+    q: "Does this tool use AI to write the script?",
+    a: "No. The whole script is assembled in your browser from a proven call structure and the details you enter — <strong>no AI model and no network calls</strong>. It's deterministic: the same inputs always produce the same script, so you can trust exactly what it says.",
+  },
+  {
+    q: "How do I turn this script into a real AI receptionist?",
+    a: "Deploy it as an actual agent on a phone number or web chat. In SeldonFrame you point the agent at your booking calendar and CRM, ground it in your services, and it answers calls 24/7 — booking, capturing leads, and texting back after hours. You can <strong>build your first workspace free</strong> and paste this script straight in as the starting point.",
+  },
+];
+
+export default function AiReceptionistScriptGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>AI receptionist script generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          AI Receptionist Script Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Describe your business and get a complete AI receptionist call script — greeting,
+          qualifying questions, booking, objection handling, and an after-hours fallback. Copy it,
+          edit it, then make it real on a live phone number or web chat.
+        </p>
+        <AiReceptionistScriptGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What's in the script</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>A <strong>greeting and identity</strong> that honestly names the agent as a virtual assistant</li>
+            <li>Three to four <strong>qualifying questions tailored to your business type</strong> — the ones a good front desk actually asks</li>
+            <li>A <strong>booking, lead-capture, or FAQ handoff</strong> step matched to your primary goal</li>
+            <li>A calm <strong>"just looking" / objection handle</strong> that still captures the contact</li>
+            <li>An <strong>after-hours fallback</strong> — text back, take a message, or book anyway</li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "20px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>A template, not a finished agent</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            This script is a genuinely good skeleton, but a script alone isn't a reliable
+            receptionist. On a live line it needs to be <strong>grounded</strong> in your real
+            services and prices, made to <strong>read details back</strong> before it commits to
+            anything, and fenced with <strong>guardrails</strong> so it never guesses or
+            over-promises. SeldonFrame adds that reliability layer — and connects the agent to your
+            calendar and CRM so a booking on the call becomes a real appointment.
+          </p>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Explore more{" "}
+            <Link href="/tools" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              free tools
+            </Link>
+            , or see how a real{" "}
+            <Link href="/ai-agents/ai-receptionist" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              AI receptionist
+            </Link>{" "}
+            answers every call for you.
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/ai-visibility-checker/page.tsx
+++ b/packages/crm/src/app/(public)/tools/ai-visibility-checker/page.tsx
@@ -1,0 +1,127 @@
+// /tools/ai-visibility-checker — free tool (the PostPlanify free-tools SEO
+// motion): server-rendered GEO copy + FAQ around a client-side AI-visibility
+// scorecard + prompt-generator island. Additive: no DB, no LLM calls.
+//
+// HONESTY (house rule never-lies): this page never claims we queried
+// ChatGPT/Google/Perplexity or scanned the web. Part A is a self-assessment;
+// Part B hands the user prompts to run themselves. Keep that explicit in copy.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { AiVisibilityChecker } from "@/components/seo/ai-visibility-checker";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "AI Visibility Checker — can ChatGPT recommend your business?";
+const DESCRIPTION =
+  "Free AI visibility checker: grade whether ChatGPT, Google's AI, and Perplexity can recommend your business, get a prioritized GEO fix list, then copy exact prompts to test your real visibility yourself.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "AI Visibility Checker", hook: "Can ChatGPT recommend your business?" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/ai-visibility-checker" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/ai-visibility-checker", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What is GEO / AEO?",
+    a: "GEO (generative engine optimization), sometimes called AEO (answer engine optimization), is making your business easy for AI assistants like <strong>ChatGPT</strong>, <strong>Google's AI Overviews</strong>, and <strong>Perplexity</strong> to understand and recommend. Instead of ranking on a page of blue links, you're trying to be the business the model names in its answer.",
+  },
+  {
+    q: "How do I get cited by AI?",
+    a: "Give models clear, verifiable facts about you: a complete Google Business Profile, plenty of recent reviews, consistent name/address/phone everywhere, plain-text answers to common questions, structured data (schema), and presence on third-party 'best {type} in {city}' lists. Generative engines synthesize answers from these public signals — the more consistent and machine-readable they are, the more confidently a model will name you.",
+  },
+  {
+    q: "Does this tool actually query ChatGPT or Google?",
+    a: "No. This is important: the scorecard is a <strong>self-assessment</strong> — it grades the answers you select, and we do not call any AI model or scan the web or your site. Part B then generates the exact prompts for you to paste into ChatGPT, Perplexity, or Google AI <strong>yourself</strong>, so you can see your real visibility firsthand. We hand you the ruler; we never claim to have measured for you.",
+  },
+];
+
+export default function AiVisibilityCheckerPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>AI visibility checker</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 720 }}>
+          Can ChatGPT recommend your business?
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 680 }}>
+          Grade your AI visibility against the signals ChatGPT, Google's AI, and Perplexity use to decide who to cite —
+          then copy exact prompts to test your real visibility yourself. It's a self-assessment: we never query any AI
+          model or scan the web. No signup needed.
+        </p>
+        <AiVisibilityChecker />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>How it works</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li><strong>Part A — scorecard:</strong> answer eight questions about your visibility signals; the tool weights and grades them (0–100 + a letter)</li>
+            <li>Every gap becomes a prioritized fix with one line on <strong>why generative engines lean on that signal</strong></li>
+            <li><strong>Part B — test it yourself:</strong> enter your business type and city to generate exact prompts, each with a copy button, to paste into ChatGPT / Perplexity / Google AI</li>
+            <li>Honest by design: no AI model is called here, and nothing is scanned — you run the prompts and see your real visibility firsthand</li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "20px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Why AI visibility matters</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            More customers now ask an assistant "who's the <strong>best {"{type}"} in {"{city}"}</strong>?" instead of
+            scrolling search results. If ChatGPT, Google's AI Overviews, or Perplexity can't find clear, consistent facts
+            about you, they recommend a competitor by default. GEO is about being the business the model is confident
+            enough to name.
+          </p>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              browse all free tools
+            </Link>
+            . Or see our pick for the{" "}
+            <Link href="/best/ai-agent-for-small-business" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              best AI agent for small business
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/booking-friction-grader/page.tsx
+++ b/packages/crm/src/app/(public)/tools/booking-friction-grader/page.tsx
@@ -1,0 +1,126 @@
+// /tools/booking-friction-grader — free tool (the PostPlanify free-tools SEO
+// motion): server-rendered GEO copy + FAQ around a small client-side scorecard
+// island that grades how much friction stands between a customer and a booked
+// appointment. Additive: no DB, no network.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { BookingFrictionGrader } from "@/components/seo/booking-friction-grader";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Booking Friction Grader — free online booking scorecard";
+const DESCRIPTION =
+  "Free booking friction grader: answer 8 quick questions about how customers book with you and get a friction score, a letter grade, and a prioritized fix-it list for every booking leak.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Booking Friction Grader", hook: "How much booking friction is costing you?" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/booking-friction-grader" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/booking-friction-grader", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "How is the friction score calculated?",
+    a: "It's a <strong>heuristic self-assessment</strong>. Each answer carries a friction weight based on how much that gap tends to cost businesses in lost bookings, and the weights are added up and scaled to 0–100. It's built to point you at the biggest leaks — it does <strong>not</strong> inspect your real website or booking system.",
+  },
+  {
+    q: "What counts as booking friction?",
+    a: "Anything between a customer's intent and a confirmed appointment: having to call instead of booking online, a clunky mobile flow, too many steps, no after-hours response, no instant confirmation, or no reminders. Each one quietly loses a share of would-be bookings.",
+  },
+  {
+    q: "How do I actually lower my booking friction?",
+    a: "Give people a <strong>one-tap booking link</strong> they can finish on a phone, confirm the slot instantly, send automatic confirmations and reminders, and make sure after-hours interest still gets answered and booked. SeldonFrame does all of this out of the box.",
+  },
+];
+
+export default function BookingFrictionGraderPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Booking friction grader</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Booking Friction Grader
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Eight quick questions about how customers book with you. Get a friction score, a letter grade, and a prioritized
+          list of exactly where you&apos;re losing bookings — plus a one-line fix for each. No signup needed.
+        </p>
+        <BookingFrictionGrader />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>How it works</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>Answer questions about <strong>online booking</strong>, mobile ease, steps to book, after-hours response, confirmations, and lead capture</li>
+            <li>The grader weights each answer by how much that gap tends to cost in lost bookings and returns a 0–100 score</li>
+            <li>Every source of friction is listed <strong>worst first</strong>, each with a one-line fix</li>
+          </ul>
+          <p style={{ margin: "12px 0 0", fontSize: 13.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.6 }}>
+            The grade is a heuristic based only on your answers — it&apos;s a self-assessment, not a measurement of your live
+            site or booking system.
+          </p>
+        </section>
+
+        <section style={{ padding: "20px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Why booking friction matters</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Every extra step between a visitor and a booked appointment is a chance for them to give up and pick a competitor.
+            Most booking intent happens <strong>after hours</strong> and <strong>on a phone</strong> — so if you can&apos;t be
+            booked online in one tap, or nobody answers until you reopen, that interest quietly evaporates. Removing friction
+            is usually the cheapest way to book more jobs from the traffic you already have.
+          </p>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              browse the free tools
+            </Link>
+            . Or read our guide to{" "}
+            <Link href="/best/booking-system-for-small-business" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              the best booking system for small business
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/no-show-cost-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/no-show-cost-calculator/page.tsx
@@ -1,0 +1,96 @@
+// /tools/no-show-cost-calculator — free tool (the PostPlanify free-tools SEO
+// motion): server-rendered GEO copy + FAQ around a small client calculator
+// island. Additive: no DB.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { NoShowCostCalculator } from "@/components/seo/no-show-cost-calculator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "No-Show Cost Calculator — how much revenue are no-shows costing your business?";
+const DESCRIPTION =
+  "Free no-show cost calculator: estimate the monthly and yearly revenue your med spa, salon or dental practice loses to no-shows — and how much automated reminders and AI confirmations can win back.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "No-Show Cost Calculator", hook: "What do no-shows cost you?" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/no-show-cost-calculator" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/no-show-cost-calculator", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What is a normal no-show rate for a med spa, salon or dental practice?",
+    a: "It genuinely varies by business, location and appointment type. Industry reports commonly cite roughly <strong>10–20%</strong> for booking-heavy local businesses, but yours could be higher or lower — that's why the calculator lets you dial in your own rate instead of assuming one.",
+  },
+  {
+    q: "How much does a single no-show cost?",
+    a: "Roughly the value of the slot it burned. A <strong>$150</strong> appointment that no-shows is about <strong>$150</strong> of revenue gone — and often the whole slot, since it's usually too late to rebook it. Multiply that by your no-shows each month and the number adds up fast.",
+  },
+  {
+    q: "Do automated reminders and AI confirmations actually reduce no-shows?",
+    a: "Reminders and confirmations generally help, but the amount they recover varies a lot between businesses, so we don't promise a fixed number. The calculator lets you set the reduction you'd realistically expect — an AI that texts, confirms and offers easy rescheduling keeps more of those slots filled.",
+  },
+];
+
+export default function NoShowCostCalculatorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>No-show cost calculator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          No-Show Cost Calculator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Every no-show is a booked slot that earned nothing. If you run a med spa, salon or dental practice, move the
+          sliders below to see what those empty chairs cost you — and how much reminders and AI confirmations can win
+          back.
+        </p>
+        <NoShowCostCalculator />
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Related: browse the rest of our <Link href="/tools" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>free tools</Link>, or see{" "}
+            <Link href="/ai-agents/ai-receptionist" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>the AI receptionist</Link>{" "}
+            that confirms appointments, texts reminders and rebooks the cancellations for you.
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/page.tsx
+++ b/packages/crm/src/app/(public)/tools/page.tsx
@@ -15,6 +15,36 @@ export const metadata: Metadata = {
 
 const TOOLS = [
   {
+    href: "/tools/ai-visibility-checker",
+    name: "AI Visibility Checker",
+    blurb: "Can ChatGPT recommend your business? Grade your AI visibility and get the exact prompts to test it yourself.",
+  },
+  {
+    href: "/tools/speed-to-lead-calculator",
+    name: "Speed-to-Lead Calculator",
+    blurb: "See the revenue slow lead follow-up costs you — and what replying in under 5 minutes recovers.",
+  },
+  {
+    href: "/tools/no-show-cost-calculator",
+    name: "No-Show Cost Calculator",
+    blurb: "Estimate what no-shows cost your practice each month — and what automated reminders and AI confirmations recover.",
+  },
+  {
+    href: "/tools/ai-receptionist-script-generator",
+    name: "AI Receptionist Script Generator",
+    blurb: "Generate a complete AI receptionist call script for your business — greeting, questions, booking, after-hours. Copy it free.",
+  },
+  {
+    href: "/tools/service-business-faq-generator",
+    name: "Service Business FAQ Generator",
+    blurb: "Generate a ready-to-use customer FAQ for your service business — and your AI agent's knowledge base. Copy free.",
+  },
+  {
+    href: "/tools/booking-friction-grader",
+    name: "Booking Friction Grader",
+    blurb: "Answer 8 questions to score how easy you make it to book — and get the specific fixes losing you appointments.",
+  },
+  {
     href: "/tools/missed-call-calculator",
     name: "Missed Call Cost Calculator",
     blurb: "Estimate the monthly revenue missed calls cost your business — and what an AI receptionist recovers.",

--- a/packages/crm/src/app/(public)/tools/service-business-faq-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/service-business-faq-generator/page.tsx
@@ -1,0 +1,126 @@
+// /tools/service-business-faq-generator — free tool (the SeldonFrame
+// free-tools SEO motion): server-rendered GEO copy + FAQ around a small
+// client template generator island. Additive: no DB, no AI calls —
+// hand-written honest templates the owner fills in. The generated FAQ
+// doubles as the Knowledge base for a SeldonFrame AI agent.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { ServiceBusinessFaqGenerator } from "@/components/seo/service-business-faq-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Service Business FAQ Generator — free, no signup";
+const DESCRIPTION =
+  "Free FAQ generator for service businesses: pick your trade, area, pricing, and booking method, and get a full set of honest, ready-to-post customer FAQ answers — no AI, no signup, and it doubles as your AI agent's knowledge base.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Service Business FAQ Generator", hook: "Ready-to-post FAQ for any trade" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/service-business-faq-generator" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/service-business-faq-generator", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "Does this FAQ generator use AI?",
+    a: "No. Every question and answer comes from <strong>hand-written templates</strong> chosen by your trade, service area, pricing model, and booking method. Nothing is sent to a server or AI model — it all happens in your browser.",
+  },
+  {
+    q: "Why are there placeholders like [your hours] in the answers?",
+    a: "Because we won't invent facts about your business. We can't know your real hours, prices, guarantees, or license number — so we leave an <strong>obvious placeholder</strong> for you to fill in. That way every answer a customer reads is genuinely true, not a made-up specific.",
+  },
+  {
+    q: "How does this connect to a SeldonFrame AI agent?",
+    a: "A good AI front desk needs a <strong>knowledge base</strong> to answer from. This FAQ is exactly that. Import it into your SeldonFrame workspace as your agent's Knowledge, and it answers customers by phone, web chat, or text — grounded in your real answers, never inventing one.",
+  },
+];
+
+export default function ServiceBusinessFaqGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Service business FAQ generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Service Business FAQ Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Pick your trade, service area, pricing, and how customers book. Get a ready set of honest
+          customer FAQ answers you can copy onto your website, Google profile, or booking page — and
+          reuse as your AI agent&apos;s knowledge base. No AI, no signup.
+        </p>
+        <ServiceBusinessFaqGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>How it works</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>Every trade gets <strong>hand-written</strong> questions covering hours, area, pricing, booking, emergencies, guarantees, payment, and what to expect</li>
+            <li>Your service area and choices tailor the wording — the rest stays as <strong>[bracketed placeholders]</strong> you fill in with your real details</li>
+            <li>Copy the whole set or download it as a .txt file</li>
+            <li>Nothing is invented on your behalf — so every answer you post is true</li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "20px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Why it matters</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Most service businesses lose jobs to the same unanswered questions — do you cover my area,
+            what does it cost, how do I book, can you come today. A clear FAQ answers them before a
+            customer ever calls. And the <strong>same FAQ</strong> is exactly what an AI front desk
+            needs to be grounded, so it can answer 24/7 using only your real answers — never a made-up
+            one.
+          </p>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Want more free tools for your front office? Browse{" "}
+            <Link href="/tools" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              all free tools
+            </Link>
+            . Comparing your options? Read{" "}
+            <Link href="/best/ai-receptionist-for-small-business" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              the best AI receptionist for small business
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/speed-to-lead-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/speed-to-lead-calculator/page.tsx
@@ -1,0 +1,95 @@
+// /tools/speed-to-lead-calculator — free tool (the free-tools SEO motion):
+// server-rendered GEO copy + FAQ around a small client calculator island.
+// Additive: no DB.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { SpeedToLeadCalculator } from "@/components/seo/speed-to-lead-calculator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Speed-to-Lead Calculator — how much revenue does slow follow-up cost you?";
+const DESCRIPTION =
+  "Free calculator: estimate the revenue you lose by replying to new leads too slowly, from your lead volume, response time, close rate and deal value — and what instant AI response recovers.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Speed-to-Lead Calculator", hook: "What does slow follow-up cost you?" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "/tools/speed-to-lead-calculator" },
+  openGraph: { title: TITLE, description: DESCRIPTION, url: "/tools/speed-to-lead-calculator", type: "website", images: [{ url: OG_URL, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What is speed-to-lead, and why does it matter so much?",
+    a: "Speed-to-lead is how long it takes you to respond after someone reaches out. Lead-response research keeps finding the same pattern — the <strong>&ldquo;5-minute rule&rdquo;</strong>: the odds of actually reaching and qualifying a lead drop sharply the longer you wait, because they're also contacting your competitors.",
+  },
+  {
+    q: "How is the lost revenue estimated?",
+    a: "It's a simple, transparent model: your close rate when you reply fast, multiplied by a <strong>reach-and-qualify factor</strong> that falls as your response time grows. The gap between replying instantly and replying at your current speed is the revenue left on the table. The factors are a conservative estimate, not a specific study's numbers — your real results will vary.",
+  },
+  {
+    q: "How does an AI agent fix slow follow-up?",
+    a: "It responds the <strong>instant</strong> a lead comes in — call, text, form or chat — 24/7, asks the qualifying questions, and books the appointment before the lead moves on. No lead sits in an inbox waiting for someone to get to it.",
+  },
+];
+
+export default function SpeedToLeadCalculatorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Speed-to-lead calculator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Speed-to-Lead Calculator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          The lead who reaches out is also reaching out to your competitors. Move the sliders to see how much revenue slow
+          follow-up quietly costs you — and what answering instantly recovers.
+        </p>
+        <SpeedToLeadCalculator />
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Related: the <Link href="/ai-agents/ai-receptionist" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>AI receptionist</Link>{" "}
+            that answers instantly, the <Link href="/tools/missed-call-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>missed-call cost calculator</Link>,{" "}
+            or <Link href="/alternatives" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>how SeldonFrame compares</Link>.
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/llms.txt/route.ts
+++ b/packages/crm/src/app/llms.txt/route.ts
@@ -114,6 +114,24 @@ export async function GET(req: Request): Promise<Response> {
   lines.push("## Free tools");
   lines.push("");
   lines.push(
+    `- [Speed-to-Lead Calculator](${base}/tools/speed-to-lead-calculator): estimate the revenue slow lead follow-up costs, and what replying in under 5 minutes recovers.`,
+  );
+  lines.push(
+    `- [No-Show Cost Calculator](${base}/tools/no-show-cost-calculator): estimate the revenue no-shows cost a booking-heavy business, and what automated reminders recover.`,
+  );
+  lines.push(
+    `- [AI Receptionist Script Generator](${base}/tools/ai-receptionist-script-generator): generate a complete AI receptionist call script for any business — greeting, questions, booking, after-hours.`,
+  );
+  lines.push(
+    `- [Service Business FAQ Generator](${base}/tools/service-business-faq-generator): generate a ready customer FAQ (and AI-agent knowledge base) for a service business.`,
+  );
+  lines.push(
+    `- [Booking Friction Grader](${base}/tools/booking-friction-grader): score how easy you make it to book and get the specific fixes losing you appointments.`,
+  );
+  lines.push(
+    `- [AI Visibility Checker](${base}/tools/ai-visibility-checker): grade whether ChatGPT and Google's AI can recommend your business, plus the exact prompts to test it yourself.`,
+  );
+  lines.push(
     `- [Missed Call Cost Calculator](${base}/tools/missed-call-calculator): estimate the revenue missed calls cost a service business.`,
   );
   lines.push(

--- a/packages/crm/src/app/sitemap.ts
+++ b/packages/crm/src/app/sitemap.ts
@@ -149,6 +149,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Free tools.
   entries.push({ url: `${base}/tools`, lastModified: now, changeFrequency: "monthly", priority: 0.7 });
   for (const tool of [
+    "speed-to-lead-calculator",
+    "no-show-cost-calculator",
+    "ai-receptionist-script-generator",
+    "service-business-faq-generator",
+    "booking-friction-grader",
+    "ai-visibility-checker",
     "missed-call-calculator",
     "google-review-link-generator",
     "ai-receptionist-cost-calculator",

--- a/packages/crm/src/components/seo/ai-receptionist-script-generator.tsx
+++ b/packages/crm/src/components/seo/ai-receptionist-script-generator.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+// The AI receptionist script generator — the interactive island of
+// /tools/ai-receptionist-script-generator. Pure client-side template
+// composition: it string-builds a complete call script from the operator's
+// inputs. No LLM, no network calls, no signup. The generated script doubles
+// as a live demo of what SeldonFrame deploys onto a real phone number or web
+// chat — so we present it honestly as a strong STARTING TEMPLATE, not a
+// production-ready agent. Styled on the MKT palette to match the other
+// free-tool pages.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+
+type BizType =
+  | "plumbing"
+  | "hvac"
+  | "electrical"
+  | "salon"
+  | "medspa"
+  | "dental"
+  | "cleaning"
+  | "law"
+  | "other";
+
+type Goal = "book" | "lead" | "faq";
+type AfterHours = "text" | "message" | "book";
+
+const BIZ_TYPES: { id: BizType; label: string }[] = [
+  { id: "plumbing", label: "Plumbing" },
+  { id: "hvac", label: "HVAC" },
+  { id: "electrical", label: "Electrical" },
+  { id: "salon", label: "Salon" },
+  { id: "medspa", label: "Med Spa" },
+  { id: "dental", label: "Dental" },
+  { id: "cleaning", label: "Cleaning" },
+  { id: "law", label: "Law" },
+  { id: "other", label: "Other" },
+];
+
+const GOALS: { id: Goal; label: string }[] = [
+  { id: "book", label: "Book an appointment" },
+  { id: "lead", label: "Capture a lead" },
+  { id: "faq", label: "Answer FAQs" },
+];
+
+const AFTER_HOURS: { id: AfterHours; label: string }[] = [
+  { id: "text", label: "Text the caller back" },
+  { id: "message", label: "Take a message" },
+  { id: "book", label: "Book anyway (24/7)" },
+];
+
+// Common presets so operators don't have to type hours; still free-text.
+const HOURS_PRESETS: string[] = [
+  "Mon–Fri 8am–5pm",
+  "Mon–Sat 7am–7pm",
+  "Mon–Fri 9am–6pm, Sat 9am–1pm",
+  "24/7",
+];
+
+/** Human label for a business type, used inline in the generated script. */
+const BIZ_LABEL: Record<BizType, string> = {
+  plumbing: "plumbing",
+  hvac: "HVAC",
+  electrical: "electrical",
+  salon: "salon",
+  medspa: "med spa",
+  dental: "dental",
+  cleaning: "cleaning",
+  law: "law",
+  other: "business",
+};
+
+/** 3–4 qualifying questions tailored to each business type. These are the
+ *  questions a good human front desk would ask to route or quote the call. */
+const QUALIFYING: Record<BizType, string[]> = {
+  plumbing: [
+    "Is this an emergency — active leak, no water, or a backed-up drain — or something we can schedule?",
+    "What's the address where the work is needed?",
+    "Roughly how long has the issue been going on?",
+    "Is the property a home or a commercial space?",
+  ],
+  hvac: [
+    "Is your system not heating, not cooling, or making a strange noise?",
+    "What's the address of the property?",
+    "Do you know the approximate age of the unit?",
+    "Is this a repair, a maintenance tune-up, or a new install quote?",
+  ],
+  electrical: [
+    "Is this a safety issue — sparking, burning smell, or lost power — or a planned project?",
+    "What's the service address?",
+    "Is the property residential or commercial?",
+    "Roughly what work are you looking to have done?",
+  ],
+  salon: [
+    "Which service are you interested in today?",
+    "Do you have a stylist you usually see, or should I match you with the next available?",
+    "What days and times generally work best for you?",
+    "Is this your first visit with us?",
+  ],
+  medspa: [
+    "Which treatment are you interested in?",
+    "Have you had this treatment with us before, or is this a first consultation?",
+    "Are there any dates or times that work best for you?",
+    "How did you hear about us?",
+  ],
+  dental: [
+    "Are you in any pain right now, or is this a routine visit?",
+    "Are you a current patient, or would this be your first visit?",
+    "Do you have dental insurance you'd like us to check?",
+    "What days and times generally work for you?",
+  ],
+  cleaning: [
+    "Is this for a home or a commercial space?",
+    "Roughly how many bedrooms and bathrooms, or what square footage?",
+    "Are you looking for a one-time clean or recurring service?",
+    "What's the address and your ideal start date?",
+  ],
+  law: [
+    "What type of legal matter can we help you with?",
+    "Is there a deadline or court date we should be aware of?",
+    "Have you worked with an attorney on this matter already?",
+    "What's the best way to reach you for a callback from the attorney?",
+  ],
+  other: [
+    "How can we help you today?",
+    "Is this time-sensitive, or something we can schedule?",
+    "What's the best phone number and email to reach you?",
+    "How did you hear about us?",
+  ],
+};
+
+interface ScriptInputs {
+  businessName: string;
+  bizType: BizType;
+  hours: string;
+  services: string;
+  goal: Goal;
+  afterHours: AfterHours;
+}
+
+/** The heart of the tool: compose a complete, structured call script from the
+ *  inputs. Pure string building — deterministic, no randomness, no network. */
+function buildScript(inp: ScriptInputs): string {
+  const name = inp.businessName.trim() || "your business";
+  const typeLabel = BIZ_LABEL[inp.bizType];
+  const hours = inp.hours.trim() || "our regular business hours";
+  const services = inp.services.trim();
+  const questions = QUALIFYING[inp.bizType];
+
+  const lines: string[] = [];
+
+  // 1. Greeting + identity (with honest AI disclosure)
+  lines.push("── GREETING & IDENTITY ──");
+  lines.push(
+    `"Thanks for calling ${name}. This is the ${name} virtual assistant — I can help you get scheduled or pass your details straight to the team. Who do I have the pleasure of speaking with?"`,
+  );
+  lines.push("");
+  lines.push(
+    `[After the caller gives their name] "Great to meet you, {caller name}. How can I help you today?"`,
+  );
+  lines.push("");
+
+  // 2. Qualifying questions tailored to the business type
+  lines.push(`── QUALIFYING QUESTIONS (${typeLabel}) ──`);
+  lines.push("Ask these one at a time, and wait for each answer:");
+  questions.forEach((q, i) => {
+    lines.push(`${i + 1}. "${q}"`);
+  });
+  if (services) {
+    lines.push("");
+    lines.push(
+      `[If the caller is unsure what they need] "We handle ${services} — does one of those sound like what you're after?"`,
+    );
+  }
+  lines.push("");
+
+  // 3. Primary goal — booking / lead capture / FAQ handoff
+  lines.push("── PRIMARY GOAL ──");
+  if (inp.goal === "book") {
+    lines.push(
+      `"Perfect — let's get you on the calendar. We're open ${hours}. What day works best for you?"`,
+    );
+    lines.push("");
+    lines.push(
+      `[Offer two concrete options] "I have {first option} or {second option} — which is better?"`,
+    );
+    lines.push("");
+    lines.push(
+      `[Confirm by reading it back] "To confirm, I've got you down for {day and time}. I'll text a confirmation to this number — is that the best one to reach you?"`,
+    );
+  } else if (inp.goal === "lead") {
+    lines.push(
+      `"Got it. Let me grab your details so the right person can follow up. What's the best phone number and email for you?"`,
+    );
+    lines.push("");
+    lines.push(
+      `[Read the details back] "Let me make sure I have that right: {phone} and {email} — did I get that correct?"`,
+    );
+    lines.push("");
+    lines.push(
+      `"Thanks, {caller name}. Someone from ${name} will reach out within {your promised window}. Is there anything else I should pass along?"`,
+    );
+  } else {
+    lines.push(
+      `"Happy to help with that. Here's what I can tell you — and if you'd like, I can also get you scheduled or have someone follow up."`,
+    );
+    lines.push("");
+    lines.push(
+      `[Answer only from approved, grounded information; if unsure, say so] "That's a great question — I want to make sure I give you the right answer, so let me have {team member} confirm and get back to you. What's the best number to reach you?"`,
+    );
+    lines.push(`We're open ${hours}.`);
+  }
+  lines.push("");
+
+  // 4. Objection / "just looking" handle
+  lines.push('── "JUST LOOKING" / OBJECTION HANDLE ──');
+  lines.push(
+    `[If the caller is hesitant or just comparing] "Totally understand — no pressure at all. Can I at least grab your name and number so we can send you the details? That way you have everything when you're ready."`,
+  );
+  lines.push("");
+  lines.push(
+    `[If asked about price] "It depends on the specifics, so I don't want to quote you the wrong number. The best next step is a quick {visit / consult} — want me to set that up, or just take your info for a callback?"`,
+  );
+  lines.push("");
+
+  // 5. After-hours fallback
+  lines.push("── AFTER-HOURS FALLBACK ──");
+  lines.push(`Trigger this branch when a call comes in outside ${hours}:`);
+  if (inp.afterHours === "text") {
+    lines.push(
+      `"Thanks for calling ${name}. We're currently closed, but I can text you right back so we don't lose your spot. What's the best number, and what can we help with?"`,
+    );
+  } else if (inp.afterHours === "message") {
+    lines.push(
+      `"Thanks for calling ${name}. Our team is out right now, but I'll take a detailed message and make sure it's the first thing they see. Can I get your name, number, and what you need?"`,
+    );
+  } else {
+    lines.push(
+      `"Thanks for calling ${name}. Even though the office is closed, I can still get you booked right now. What day works best for you?"`,
+    );
+  }
+  lines.push("");
+
+  // 6. Close
+  lines.push("── CLOSE ──");
+  lines.push(
+    `"Thanks so much, {caller name} — you're all set. Have a great {day/evening}, and we'll talk soon!"`,
+  );
+
+  return lines.join("\n");
+}
+
+const STEPS: { emoji: string; label: string }[] = [
+  { emoji: "1️⃣", label: "Describe your business" },
+  { emoji: "2️⃣", label: "Pick the goal" },
+  { emoji: "3️⃣", label: "Copy your script" },
+];
+
+function StepStrip(): ReactElement {
+  return (
+    <div
+      role="img"
+      aria-label="Three steps: describe your business, pick the goal, copy your script."
+      style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8, marginBottom: 24 }}
+    >
+      {STEPS.map((s, i) => (
+        <div key={s.label} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              border: `1px solid ${INK10}`,
+              borderRadius: 12,
+              padding: "10px 14px",
+              background: "#fff",
+              fontSize: 13.5,
+              fontWeight: 700,
+              color: INK,
+            }}
+          >
+            <span style={{ fontSize: 16 }}>{s.emoji}</span>
+            <span>{s.label}</span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <span aria-hidden="true" style={{ color: GREEN, fontWeight: 800, fontSize: 16 }}>
+              →
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ProductionNote(): ReactElement {
+  return (
+    <div
+      role="note"
+      aria-label="This is a starting template, not a production-ready agent."
+      style={{
+        marginTop: 12,
+        border: `1px solid ${INK10}`,
+        borderRadius: 12,
+        padding: "12px 16px",
+        background: "rgba(184,134,11,0.08)",
+        fontSize: 13,
+        lineHeight: 1.6,
+        color: INK,
+      }}
+    >
+      <strong>This is a strong starting template, not a finished agent.</strong> A real phone
+      agent also needs grounding in your actual services and prices, enforced read-back
+      confirmation, and guardrails so it never invents an answer or over-promises. That layer is
+      exactly what SeldonFrame adds on top of a script like this.
+    </div>
+  );
+}
+
+const labelStyle = { display: "block" as const };
+const labelSpan = { fontWeight: 700, fontSize: 15 };
+const fieldStyle = {
+  display: "block" as const,
+  width: "100%",
+  marginTop: 8,
+  padding: "11px 12px",
+  borderRadius: 10,
+  border: `1.5px solid ${INK10}`,
+  fontSize: 15,
+  fontFamily: "inherit",
+  boxSizing: "border-box" as const,
+};
+
+export function AiReceptionistScriptGenerator(): ReactElement {
+  const [businessName, setBusinessName] = useState("");
+  const [bizType, setBizType] = useState<BizType>("plumbing");
+  const [hours, setHours] = useState("Mon–Fri 8am–5pm");
+  const [services, setServices] = useState("");
+  const [goal, setGoal] = useState<Goal>("book");
+  const [afterHours, setAfterHours] = useState<AfterHours>("text");
+  const [copied, setCopied] = useState(false);
+
+  const script = useMemo(
+    () => buildScript({ businessName, bizType, hours, services, goal, afterHours }),
+    [businessName, bizType, hours, services, goal, afterHours],
+  );
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(script);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  function handleDownload(): void {
+    if (typeof document === "undefined") return;
+    const blob = new Blob([script], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const safe = (businessName.trim() || "ai-receptionist").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${safe || "ai-receptionist"}-script.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <StepStrip />
+
+      <div style={{ display: "grid", gap: 20 }}>
+        <div style={{ display: "grid", gap: 20, gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Business name</span>
+            <input
+              type="text"
+              value={businessName}
+              onChange={(e) => setBusinessName(e.target.value)}
+              placeholder="Sunrise Plumbing Co."
+              style={fieldStyle}
+            />
+          </label>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Business type</span>
+            <select value={bizType} onChange={(e) => setBizType(e.target.value as BizType)} style={fieldStyle}>
+              {BIZ_TYPES.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <label style={labelStyle}>
+          <span style={labelSpan}>Business hours</span>
+          <input
+            type="text"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            list="sf-hours-presets"
+            placeholder="Mon–Fri 8am–5pm"
+            style={fieldStyle}
+          />
+          <datalist id="sf-hours-presets">
+            {HOURS_PRESETS.map((h) => (
+              <option key={h} value={h} />
+            ))}
+          </datalist>
+        </label>
+
+        <label style={labelStyle}>
+          <span style={labelSpan}>Top services (comma separated)</span>
+          <input
+            type="text"
+            value={services}
+            onChange={(e) => setServices(e.target.value)}
+            placeholder="drain cleaning, water heaters, leak repair"
+            style={fieldStyle}
+          />
+        </label>
+
+        <div style={{ display: "grid", gap: 20, gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Primary goal of the call</span>
+            <select value={goal} onChange={(e) => setGoal(e.target.value as Goal)} style={fieldStyle}>
+              {GOALS.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={labelStyle}>
+            <span style={labelSpan}>After-hours behavior</span>
+            <select value={afterHours} onChange={(e) => setAfterHours(e.target.value as AfterHours)} style={fieldStyle}>
+              {AFTER_HOURS.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 22 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 8 }}>
+          Your AI receptionist script
+        </div>
+        <pre
+          style={{
+            border: `1px solid ${INK10}`,
+            borderRadius: 12,
+            padding: "16px 18px",
+            background: "#fff",
+            fontSize: 13.5,
+            lineHeight: 1.6,
+            color: INK,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            fontFamily: "'Hanken Grotesk',system-ui,sans-serif",
+            margin: 0,
+            maxHeight: 460,
+            overflowY: "auto",
+          }}
+        >
+          {script}
+        </pre>
+        <div style={{ display: "flex", gap: 10, marginTop: 14, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: copied ? GREEN : INK, color: "#F6F2EA", border: "none", padding: "11px 22px", borderRadius: 10, fontWeight: 700, fontSize: 14.5, cursor: "pointer" }}
+          >
+            {copied ? "Copied!" : "Copy script"}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, background: "rgba(255,255,255,0.6)", padding: "10px 20px", borderRadius: 10, fontWeight: 700, fontSize: 14.5, cursor: "pointer" }}
+          >
+            Download .txt
+          </button>
+        </div>
+        <ProductionNote />
+        <p style={{ margin: "16px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+          No AI, no signup — this is built in your browser by filling in a proven call structure.
+          Placeholders in {"{curly braces}"} are cues for the agent to fill live on the call.
+        </p>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 24 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Deploy this agent free
+        </a>
+        <a
+          href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+          style={{ border: `1.5px solid ${INK10}`, color: INK, background: "rgba(255,255,255,0.6)", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}
+        >
+          Book a demo call
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/ai-visibility-checker.tsx
+++ b/packages/crm/src/components/seo/ai-visibility-checker.tsx
@@ -1,0 +1,372 @@
+"use client";
+
+// The AI Visibility Checker — the interactive island of
+// /tools/ai-visibility-checker. Two honest, fully client-side parts:
+//   Part A — a self-assessment scorecard (no network, no LLM call) that grades
+//            how "citable" a business is by generative engines (ChatGPT,
+//            Google's AI Overviews, Perplexity) and returns a prioritized fix
+//            list, each fix explaining WHY LLMs lean on that signal.
+//   Part B — a prompt generator: given a business type + city, it hands the
+//            user the exact prompts to paste into ChatGPT/Perplexity/Google AI
+//            themselves. We never query any model — we give them the ruler.
+// Styled on the MKT palette to match the other free-tool pages.
+
+import { useState, type ReactElement } from "react";
+import { copyToClipboard } from "./result-card";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+const AMBER = "#B8860B";
+const RED = "#C0392B";
+
+type Answer = "yes" | "no" | "unsure" | null;
+
+type Question = {
+  id: string;
+  text: string;
+  /** Relative weight — some signals move an LLM's citation more than others. */
+  weight: number;
+  /** Fix-it copy shown when the answer is "no" or "unsure": one line on WHY
+   *  generative engines lean on this signal. */
+  fixIt: string;
+};
+
+// Ordered roughly by how much each signal moves a generative engine. The
+// scorecard is a self-assessment: the user reports these, we do not detect them.
+const QUESTIONS: Question[] = [
+  {
+    id: "gbp",
+    text: "Is your Google Business Profile claimed and fully filled out (categories, hours, services, photos)?",
+    weight: 3,
+    fixIt: "Assistants lean heavily on Google's local data for 'near me' and 'best in [city]' answers. A thin or unclaimed profile means the model has little verified fact to repeat about you.",
+  },
+  {
+    id: "reviews",
+    text: "Do you have 25+ reviews, with recent ones in the last 90 days?",
+    weight: 3,
+    fixIt: "Review count and freshness are the clearest public proxy for 'is this business real and active.' Models surface the places others vouch for, and stale review history reads as a dormant business.",
+  },
+  {
+    id: "listicles",
+    text: "Do you appear on third-party 'best {type} in {city}' listicles or directories?",
+    weight: 3,
+    fixIt: "Generative engines synthesize 'best of' answers largely from existing ranked lists. If no one else has put you on a list, the model has nothing to aggregate you into.",
+  },
+  {
+    id: "nap",
+    text: "Is your name, address, and phone number identical everywhere it appears online?",
+    weight: 2,
+    fixIt: "Conflicting contact details lower the model's confidence that listings refer to the same business, so it hedges or omits you rather than risk citing a wrong number.",
+  },
+  {
+    id: "plaintext",
+    text: "Does your site answer common customer questions in plain, readable text (not buried in images or PDFs)?",
+    weight: 2,
+    fixIt: "Models can only cite what they can parse. Answers locked inside images, video, or script-rendered widgets are invisible; a plain-text FAQ is quotable verbatim.",
+  },
+  {
+    id: "schema",
+    text: "Does your site use structured data / schema markup (LocalBusiness, FAQ, Service)?",
+    weight: 2,
+    fixIt: "Schema spells out your hours, location, and services as machine-readable facts, so the engine repeats them with confidence instead of guessing from prose.",
+  },
+  {
+    id: "questions",
+    text: "Have you published pages that directly answer the questions people ask (pricing, service area, 'how much does X cost')?",
+    weight: 2,
+    fixIt: "Assistants match a user's question to the page that answers it most plainly. If you never wrote the answer down, a competitor who did gets cited in your place.",
+  },
+  {
+    id: "llmstxt",
+    text: "Do you offer a clean machine-readable version of key pages (an llms.txt, or Markdown/plain-text copies)?",
+    weight: 1,
+    fixIt: "A clean text surface removes the parsing friction of a heavy site, giving crawlers an unambiguous, low-noise copy of your facts to quote — the same reason docs sites ship an llms.txt.",
+  },
+];
+
+const MAX_SCORE = QUESTIONS.reduce((sum, q) => sum + q.weight, 0);
+
+function letterGrade(pct: number): { letter: string; color: string; label: string } {
+  if (pct >= 90) return { letter: "A", color: GREEN, label: "Highly citable" };
+  if (pct >= 75) return { letter: "B", color: GREEN, label: "Mostly citable" };
+  if (pct >= 55) return { letter: "C", color: AMBER, label: "Partly citable" };
+  if (pct >= 35) return { letter: "D", color: AMBER, label: "Hard to cite" };
+  return { letter: "F", color: RED, label: "Nearly invisible" };
+}
+
+type PromptTemplate = { label: string; build: (type: string, city: string) => string };
+
+// The prompts we hand the user to run THEMSELVES. We never send these anywhere.
+const PROMPT_TEMPLATES: PromptTemplate[] = [
+  { label: "Best-of list", build: (t, c) => `What are the best ${t} in ${c}? List the top 5 with a one-line reason for each.` },
+  { label: "Direct recommendation", build: (t, c) => `I need a ${t} in ${c}. Who should I call, and why would you recommend them?` },
+  { label: "Comparison", build: (t, c) => `Compare the top-rated ${t} in ${c}. Which has the best reviews and reputation?` },
+  { label: "Named check", build: (t, c) => `Is there a well-reviewed ${t} in ${c} you'd trust for a same-week appointment?` },
+];
+
+const AI_TOOLS = ["ChatGPT", "Perplexity", "Google AI Mode / AI Overviews"];
+
+function CopyPromptRow({ text }: { text: string }): ReactElement {
+  const [copied, setCopied] = useState(false);
+  async function onCopy(): Promise<void> {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    }
+  }
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 12, padding: "12px 14px", background: "rgba(255,255,255,0.7)", display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+      <span style={{ flex: "1 1 240px", fontSize: 14, lineHeight: 1.5, color: INK }}>{text}</span>
+      <button
+        type="button"
+        onClick={onCopy}
+        style={{
+          padding: "8px 16px",
+          borderRadius: 10,
+          border: `1.5px solid ${copied ? GREEN : INK10}`,
+          background: copied ? "rgba(0,137,123,0.12)" : "#fff",
+          color: copied ? GREEN : INK,
+          fontWeight: 700,
+          fontSize: 13,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {copied ? "Copied ✓" : "Copy prompt"}
+      </button>
+    </div>
+  );
+}
+
+export function AiVisibilityChecker(): ReactElement {
+  // ── Part A: scorecard state ──
+  const [answers, setAnswers] = useState<Record<string, Answer>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const answeredCount = QUESTIONS.filter((q) => answers[q.id] !== undefined && answers[q.id] !== null).length;
+  const earned = QUESTIONS.filter((q) => answers[q.id] === "yes").reduce((sum, q) => sum + q.weight, 0);
+  const pct = Math.round((earned / MAX_SCORE) * 100);
+  const grade = letterGrade(pct);
+  // Prioritized: heaviest signals first, "no" ahead of "unsure".
+  const gaps = QUESTIONS.filter((q) => answers[q.id] === "no" || answers[q.id] === "unsure").sort(
+    (a, b) => b.weight - a.weight || (answers[a.id] === "no" ? -1 : 1) - (answers[b.id] === "no" ? -1 : 1),
+  );
+
+  function setAnswer(id: string, value: Answer): void {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  }
+
+  // ── Part B: prompt generator state ──
+  const [bizType, setBizType] = useState("");
+  const [city, setCity] = useState("");
+  const type = bizType.trim() || "plumbers";
+  const place = city.trim() || "Austin, TX";
+
+  return (
+    <div style={{ display: "grid", gap: 28 }}>
+      {/* ── PART A: Visibility scorecard ── */}
+      <section style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+        <div style={{ marginBottom: 20 }}>
+          <div style={{ fontSize: 12.5, fontWeight: 800, letterSpacing: "0.08em", textTransform: "uppercase", color: GREEN }}>Part A</div>
+          <h2 style={{ margin: "6px 0 4px", fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>Visibility scorecard</h2>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: "rgba(34,29,23,0.65)" }}>
+            A self-assessment of the signals generative engines use to decide who to cite. Answer honestly — this scores
+            what you tell it; it does not scan your website.
+          </p>
+        </div>
+
+        <div style={{ display: "grid", gap: 20 }}>
+          {QUESTIONS.map((q, i) => (
+            <fieldset key={q.id} style={{ border: "none", padding: 0, margin: 0 }}>
+              <legend style={{ fontWeight: 700, fontSize: 15, lineHeight: 1.4, padding: 0 }}>
+                {i + 1}. {q.text}
+              </legend>
+              <div style={{ display: "flex", gap: 8, marginTop: 10, flexWrap: "wrap" }}>
+                {(["yes", "no", "unsure"] as const).map((opt) => {
+                  const active = answers[q.id] === opt;
+                  return (
+                    <button
+                      key={opt}
+                      type="button"
+                      onClick={() => setAnswer(q.id, opt)}
+                      aria-pressed={active}
+                      style={{
+                        padding: "8px 18px",
+                        borderRadius: 10,
+                        border: `1.5px solid ${active ? GREEN : INK10}`,
+                        background: active ? "rgba(0,137,123,0.12)" : "#fff",
+                        color: active ? GREEN : INK,
+                        fontWeight: 700,
+                        fontSize: 13.5,
+                        cursor: "pointer",
+                        textTransform: "capitalize",
+                      }}
+                    >
+                      {opt}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+          <button
+            type="button"
+            onClick={() => setSubmitted(true)}
+            disabled={answeredCount < QUESTIONS.length}
+            style={{
+              background: answeredCount < QUESTIONS.length ? "rgba(34,29,23,0.25)" : INK,
+              color: "#F6F2EA",
+              border: "none",
+              padding: "13px 26px",
+              borderRadius: 12,
+              fontWeight: 700,
+              fontSize: 15.5,
+              cursor: answeredCount < QUESTIONS.length ? "not-allowed" : "pointer",
+            }}
+          >
+            Grade my AI visibility ({answeredCount}/{QUESTIONS.length} answered)
+          </button>
+        </div>
+
+        {submitted && (
+          <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap" }}>
+              <div
+                aria-hidden="true"
+                style={{
+                  width: 76,
+                  height: 76,
+                  borderRadius: 18,
+                  border: `2.5px solid ${grade.color}`,
+                  background: `${grade.color}1A`,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 40,
+                  fontWeight: 900,
+                  color: grade.color,
+                }}
+              >
+                {grade.letter}
+              </div>
+              <div>
+                <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+                  AI visibility score
+                </div>
+                <div style={{ fontSize: 30, fontWeight: 800, color: grade.color, lineHeight: 1.1 }}>
+                  {pct}/100 · {grade.label}
+                </div>
+              </div>
+            </div>
+
+            {gaps.length > 0 ? (
+              <div style={{ marginTop: 22, display: "grid", gap: 12 }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: "rgba(34,29,23,0.65)" }}>
+                  Fix these first — highest-impact signals at the top:
+                </div>
+                {gaps.map((g, idx) => (
+                  <div key={g.id} style={{ border: `1px solid ${INK10}`, borderRadius: 12, padding: "12px 16px", background: "rgba(255,255,255,0.7)" }}>
+                    <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 4 }}>
+                      {idx + 1}. {g.text}
+                    </div>
+                    <div style={{ fontSize: 13.5, color: "rgba(34,29,23,0.68)", lineHeight: 1.5 }}>{g.fixIt}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p style={{ marginTop: 14, fontSize: 14.5, color: "rgba(34,29,23,0.7)" }}>
+                Strong — you cover the signals generative engines look for. Now run the prompts in Part B to see it live.
+              </p>
+            )}
+
+            <p style={{ margin: "20px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+              How this works: this is a self-assessment scorecard, not a live audit. We did not query ChatGPT, Google, or
+              Perplexity and we did not scan the web or your site — the grade reflects only the answers you selected. To
+              see your real visibility, run the prompts in Part B yourself.
+            </p>
+          </div>
+        )}
+      </section>
+
+      {/* ── PART B: Test it yourself ── */}
+      <section style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+        <div style={{ marginBottom: 18 }}>
+          <div style={{ fontSize: 12.5, fontWeight: 800, letterSpacing: "0.08em", textTransform: "uppercase", color: GREEN }}>Part B</div>
+          <h2 style={{ margin: "6px 0 4px", fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>Test it yourself</h2>
+          <p style={{ margin: 0, fontSize: 14, lineHeight: 1.55, color: "rgba(34,29,23,0.65)" }}>
+            Enter your business type and city. We generate the exact prompts — you paste them into{" "}
+            {AI_TOOLS.join(", ")} and see whether your business comes up. We hand you the questions; we never run them for
+            you.
+          </p>
+        </div>
+
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 18 }}>
+          <label style={{ flex: "1 1 200px", display: "grid", gap: 6 }}>
+            <span style={{ fontSize: 12.5, fontWeight: 700, color: "rgba(34,29,23,0.6)" }}>Business type</span>
+            <input
+              type="text"
+              value={bizType}
+              onChange={(e) => setBizType(e.target.value)}
+              placeholder="plumbers"
+              style={{ padding: "11px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, color: INK, background: "#fff" }}
+            />
+          </label>
+          <label style={{ flex: "1 1 200px", display: "grid", gap: 6 }}>
+            <span style={{ fontSize: 12.5, fontWeight: 700, color: "rgba(34,29,23,0.6)" }}>City</span>
+            <input
+              type="text"
+              value={city}
+              onChange={(e) => setCity(e.target.value)}
+              placeholder="Austin, TX"
+              style={{ padding: "11px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, color: INK, background: "#fff" }}
+            />
+          </label>
+        </div>
+
+        <div style={{ display: "grid", gap: 10 }}>
+          {PROMPT_TEMPLATES.map((tpl) => (
+            <div key={tpl.label}>
+              <div style={{ fontSize: 11.5, fontWeight: 800, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.5)", marginBottom: 5 }}>
+                {tpl.label}
+              </div>
+              <CopyPromptRow text={tpl.build(type, place)} />
+            </div>
+          ))}
+        </div>
+
+        <p style={{ margin: "18px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+          Honest by design: these prompts run on your device, in your own AI account. SeldonFrame does not call any AI
+          model here and makes no claim about what the answer will say — try them and see for yourself.
+        </p>
+      </section>
+
+      {/* ── Bridge / CTA ── */}
+      <section style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(0,137,123,0.06)", padding: "26px 28px" }}>
+        <h2 style={{ margin: "0 0 8px", fontSize: 20, fontWeight: 800, letterSpacing: "-0.02em" }}>
+          Want AI to actually recommend you?
+        </h2>
+        <p style={{ margin: "0 0 18px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)", maxWidth: 620 }}>
+          SeldonFrame makes a business citable: structured, honest content generative engines can parse, a clean{" "}
+          <strong>.md / llms.txt</strong> surface for the facts about you, and the listicle presence that best-of answers
+          are built from. No tricks — just the signals models trust.
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            Get your business cited — start free
+          </a>
+          <a
+            href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+            style={{ background: "#fff", color: INK, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", border: `1.5px solid ${INK10}` }}
+          >
+            Book a demo call
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/booking-friction-grader.tsx
+++ b/packages/crm/src/components/seo/booking-friction-grader.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+// The Booking Friction Grader — the interactive island of
+// /tools/booking-friction-grader. Pure client-side scorecard, no network
+// calls: a short questionnaire → friction score + letter grade + a
+// prioritized list of the specific frictions the answers revealed, each with
+// a one-line fix. Styled on the MKT palette to match the other free-tool pages.
+
+import { useState, type ReactElement } from "react";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+const AMBER = "#B8860B";
+const RED = "#C0392B";
+
+type Option = { label: string; friction: number };
+
+type Question = {
+  id: string;
+  text: string;
+  hint: string;
+  options: Option[];
+  /** Name of the specific friction this question surfaces (shown when the
+   *  chosen answer scores any friction). */
+  frictionLabel: string;
+  /** One-line fix shown alongside the friction. */
+  fix: string;
+};
+
+// Each option carries a friction weight (0 = frictionless). The higher the
+// weight, the more bookings that answer tends to leak. Weights are summed and
+// normalized to a 0–100 friction score — see scoreFriction().
+const QUESTIONS: Question[] = [
+  {
+    id: "selfServe",
+    text: "Can a customer book online by themselves, without calling or messaging you first?",
+    hint: "A public booking link or scheduler they can complete on their own",
+    options: [
+      { label: "Yes — they book online themselves", friction: 0 },
+      { label: "Only by calling or messaging us", friction: 25 },
+    ],
+    frictionLabel: "No self-serve online booking",
+    fix: "Put a public one-tap booking link everywhere — website, Google, social bio — so people book at 11pm without you.",
+  },
+  {
+    id: "afterHours",
+    text: "If someone tries to reach you after hours, do they get an immediate response?",
+    hint: "Most booking intent happens evenings and weekends",
+    options: [
+      { label: "Yes — instant reply or booking, 24/7", friction: 0 },
+      { label: "They hear back the next business day", friction: 12 },
+      { label: "No — voicemail or nothing until we open", friction: 20 },
+    ],
+    frictionLabel: "No after-hours response",
+    fix: "Let AI answer and book after hours so evening and weekend interest turns into appointments instead of missed calls.",
+  },
+  {
+    id: "instant",
+    text: "When a customer books, do they get instant confirmation the slot is theirs?",
+    hint: "Confirmed on the spot vs. 'we'll get back to you to confirm'",
+    options: [
+      { label: "Yes — confirmed instantly", friction: 0 },
+      { label: "No — we confirm manually later", friction: 15 },
+    ],
+    frictionLabel: "No instant confirmation",
+    fix: "Use real-time availability so the slot is locked the moment they pick it — no 'pending' limbo that lets them drift.",
+  },
+  {
+    id: "callback",
+    text: "Does booking require a call back or an email exchange to actually lock it in?",
+    hint: "Any back-and-forth after they first reach out",
+    options: [
+      { label: "No — booking completes in one go", friction: 0 },
+      { label: "Yes — we have to call or email to confirm", friction: 15 },
+    ],
+    frictionLabel: "Booking needs a manual back-and-forth",
+    fix: "Remove the confirmation phone-tag — let them self-book a real slot in one uninterrupted flow.",
+  },
+  {
+    id: "steps",
+    text: "How many steps does it take to go from 'I want to book' to 'booked'?",
+    hint: "Count the taps, screens, and form fields",
+    options: [
+      { label: "1–2 taps", friction: 0 },
+      { label: "3–5 steps", friction: 8 },
+      { label: "A long form or 6+ steps", friction: 16 },
+    ],
+    frictionLabel: "Too many steps to book",
+    fix: "Cut the flow to the essentials — every extra field or screen loses a share of people before they finish.",
+  },
+  {
+    id: "mobile",
+    text: "Is your booking flow effortless to complete on a phone?",
+    hint: "Most customers are booking one-handed on mobile",
+    options: [
+      { label: "Yes — effortless on mobile", friction: 0 },
+      { label: "It works, but it's clunky", friction: 8 },
+      { label: "No — it's hard or broken on phones", friction: 15 },
+    ],
+    frictionLabel: "Not mobile-friendly",
+    fix: "Make the booking flow thumb-friendly and fast on a phone — that's where most of your customers actually are.",
+  },
+  {
+    id: "reminders",
+    text: "Do you automatically send booking confirmations AND reminders?",
+    hint: "Reminders are what cut no-shows",
+    options: [
+      { label: "Yes — confirmation and reminders, automatic", friction: 0 },
+      { label: "Confirmation only, no reminders", friction: 6 },
+      { label: "Neither is automatic", friction: 12 },
+    ],
+    frictionLabel: "No automatic confirmations and reminders",
+    fix: "Turn on automatic confirmations plus reminders so booked customers actually show up.",
+  },
+  {
+    id: "leadCapture",
+    text: "If someone starts to book but doesn't finish, do you capture their info to follow up?",
+    hint: "The half-finished bookings you never see",
+    options: [
+      { label: "Yes — we capture and follow up", friction: 0 },
+      { label: "No — if they don't finish, they're gone", friction: 12 },
+    ],
+    frictionLabel: "Abandoned bookings aren't captured",
+    fix: "Capture the lead as soon as they start so a quick follow-up can win back the ones who drop off.",
+  },
+];
+
+// Highest friction any set of answers could produce — used to normalize the
+// raw friction total onto a 0–100 scale.
+const MAX_FRICTION = QUESTIONS.reduce((sum, q) => sum + Math.max(...q.options.map((o) => o.friction)), 0);
+
+/** Higher score = more friction = more lost bookings. 0 is frictionless. */
+function grade(score: number): { letter: string; label: string; color: string } {
+  if (score <= 12) return { letter: "A", label: "Nearly frictionless", color: GREEN };
+  if (score <= 28) return { letter: "B", label: "Low friction", color: GREEN };
+  if (score <= 48) return { letter: "C", label: "Moderate friction", color: AMBER };
+  if (score <= 70) return { letter: "D", label: "High friction", color: RED };
+  return { letter: "F", label: "Severe friction", color: RED };
+}
+
+/** RED for the heavy leaks, AMBER for the lighter ones. */
+function severityColor(friction: number): string {
+  return friction >= 15 ? RED : AMBER;
+}
+
+export function BookingFrictionGrader(): ReactElement {
+  const [answers, setAnswers] = useState<Record<string, number>>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  const answeredCount = QUESTIONS.filter((q) => answers[q.id] !== undefined).length;
+  const allAnswered = answeredCount === QUESTIONS.length;
+
+  const rawFriction = QUESTIONS.reduce((sum, q) => {
+    const idx = answers[q.id];
+    return idx === undefined ? sum : sum + q.options[idx].friction;
+  }, 0);
+  const score = Math.round((rawFriction / MAX_FRICTION) * 100);
+  const result = grade(score);
+
+  // The specific frictions the answers revealed, worst first.
+  const frictions = QUESTIONS.filter((q) => {
+    const idx = answers[q.id];
+    return idx !== undefined && q.options[idx].friction > 0;
+  })
+    .map((q) => ({ q, friction: q.options[answers[q.id]].friction }))
+    .sort((a, b) => b.friction - a.friction);
+
+  function setAnswer(id: string, idx: number): void {
+    setAnswers((prev) => ({ ...prev, [id]: idx }));
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gap: 22 }}>
+        {QUESTIONS.map((q, i) => (
+          <fieldset key={q.id} style={{ border: "none", padding: 0, margin: 0 }}>
+            <legend style={{ fontWeight: 700, fontSize: 15, lineHeight: 1.4, padding: 0 }}>
+              {i + 1}. {q.text}
+            </legend>
+            <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{q.hint}</div>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+              {q.options.map((opt, oi) => {
+                const active = answers[q.id] === oi;
+                return (
+                  <button
+                    key={opt.label}
+                    type="button"
+                    onClick={() => setAnswer(q.id, oi)}
+                    aria-pressed={active}
+                    style={{
+                      padding: "8px 16px",
+                      borderRadius: 10,
+                      border: `1.5px solid ${active ? GREEN : INK10}`,
+                      background: active ? "rgba(0,137,123,0.12)" : "#fff",
+                      color: active ? GREEN : INK,
+                      fontWeight: 700,
+                      fontSize: 13.5,
+                      cursor: "pointer",
+                      textAlign: "left",
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+        <button
+          type="button"
+          onClick={() => setSubmitted(true)}
+          disabled={!allAnswered}
+          style={{
+            background: allAnswered ? INK : "rgba(34,29,23,0.25)",
+            color: "#F6F2EA",
+            border: "none",
+            padding: "13px 26px",
+            borderRadius: 12,
+            fontWeight: 700,
+            fontSize: 15.5,
+            cursor: allAnswered ? "pointer" : "not-allowed",
+          }}
+        >
+          Grade my booking flow ({answeredCount}/{QUESTIONS.length} answered)
+        </button>
+      </div>
+
+      {submitted && (
+        <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 18, flexWrap: "wrap" }}>
+            <div
+              style={{
+                width: 72,
+                height: 72,
+                borderRadius: 16,
+                border: `2px solid ${result.color}`,
+                background: `${result.color}1A`,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: 36,
+                fontWeight: 800,
+                color: result.color,
+                flex: "0 0 auto",
+              }}
+            >
+              {result.letter}
+            </div>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+                Friction score
+              </div>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 10 }}>
+                <span style={{ fontSize: 30, fontWeight: 800, color: result.color }}>{score}/100</span>
+                <span style={{ fontSize: 15, fontWeight: 700, color: result.color }}>{result.label}</span>
+              </div>
+              <div style={{ fontSize: 13, color: "rgba(34,29,23,0.55)" }}>Higher friction means more customers give up before they book.</div>
+            </div>
+          </div>
+
+          {/* Friction meter — 0 (frictionless) to 100 (severe). */}
+          <div
+            role="img"
+            aria-label={`Friction meter: ${score} out of 100, grade ${result.letter}, ${result.label}.`}
+            style={{ marginTop: 20, height: 16, borderRadius: 8, background: "rgba(34,29,23,0.06)", overflow: "hidden" }}
+          >
+            <div style={{ height: "100%", width: `${Math.max(4, score)}%`, background: result.color, borderRadius: 8, transition: "width 0.2s ease" }} />
+          </div>
+
+          {frictions.length > 0 ? (
+            <div style={{ marginTop: 22, display: "grid", gap: 12 }}>
+              <div style={{ fontSize: 13, fontWeight: 700, color: "rgba(34,29,23,0.65)" }}>
+                Your biggest booking leaks, worst first:
+              </div>
+              {frictions.map(({ q, friction }, i) => (
+                <div key={q.id} style={{ border: `1px solid ${INK10}`, borderLeft: `4px solid ${severityColor(friction)}`, borderRadius: 12, padding: "12px 16px", background: "rgba(255,255,255,0.7)" }}>
+                  <div style={{ fontWeight: 700, fontSize: 14, marginBottom: 4 }}>
+                    {i + 1}. {q.frictionLabel}
+                  </div>
+                  <div style={{ fontSize: 13.5, color: "rgba(34,29,23,0.68)", lineHeight: 1.5 }}>{q.fix}</div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p style={{ marginTop: 16, fontSize: 14.5, color: "rgba(34,29,23,0.7)" }}>
+              Impressive — your answers show a booking flow with almost nothing standing between a customer and a booked appointment.
+            </p>
+          )}
+
+          <p style={{ margin: "20px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+            This grade is a heuristic self-assessment based only on your answers — it hasn't inspected your real website or
+            booking system, so treat it as a prompt for where to look, not a measurement of your actual flow.
+          </p>
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 24 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Make booking one tap — start free
+        </a>
+        <a
+          href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+          style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}
+        >
+          Book a demo call
+        </a>
+      </div>
+      <p style={{ margin: "14px 0 0", fontSize: 13.5, fontWeight: 700, color: GREEN }}>
+        SeldonFrame gives you a one-tap booking link plus AI that answers and books after hours — so the leaks above stop
+        costing you appointments.
+      </p>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/no-show-cost-calculator.tsx
+++ b/packages/crm/src/components/seo/no-show-cost-calculator.tsx
@@ -1,0 +1,383 @@
+"use client";
+
+// The no-show cost calculator — the interactive island of
+// /tools/no-show-cost-calculator. Pure client math, no network calls: sliders →
+// revenue-lost-to-no-shows estimate → CTA. Styled on the MKT palette to match
+// the SEO pages. URL permalink state is kept LOCAL to this file (small
+// parseNum/clamp helpers below) so the shared result-card module stays generic.
+
+import { useState, useEffect, useRef, type ReactElement, type CSSProperties } from "react";
+
+import {
+  renderResultCard,
+  buildShareUrl,
+  copyToClipboard,
+  downloadCanvasAsImage,
+  shareResultCard,
+} from "./result-card";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+const RED = "#C0392B";
+const AMBER = "#B8860B";
+
+// ─── Local URL-state (kept out of the shared result-card module) ──────────
+//
+// Short, stable query keys so shared links stay compact:
+//   na = appts/month, nr = no-show rate %, nv = avg appt value, nx = reduction %
+
+interface NoShowState {
+  apptsPerMonth: number;
+  noShowRate: number;
+  apptValue: number;
+  reductionPct: number;
+}
+
+const BOUNDS = {
+  apptsPerMonth: { min: 10, max: 600 },
+  noShowRate: { min: 2, max: 40 },
+  apptValue: { min: 20, max: 2000 },
+  reductionPct: { min: 10, max: 70 },
+} as const;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+/** Parse a query param as a finite number, or return undefined if invalid/missing. */
+function parseNum(params: URLSearchParams, key: string): number | undefined {
+  const raw = params.get(key);
+  if (raw === null || raw === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function encodeState(state: NoShowState): string {
+  const params = new URLSearchParams();
+  params.set("na", String(Math.round(state.apptsPerMonth)));
+  params.set("nr", String(Math.round(state.noShowRate)));
+  params.set("nv", String(Math.round(state.apptValue)));
+  params.set("nx", String(Math.round(state.reductionPct)));
+  return params.toString();
+}
+
+/**
+ * Decode + clamp a query string into a partial state. Only present, numeric
+ * keys are returned; out-of-range input is clamped to the slider bounds rather
+ * than rejected, so a hand-edited URL never crashes the page.
+ */
+function decodeState(search: string): Partial<NoShowState> {
+  const params = new URLSearchParams(search);
+  const out: Partial<NoShowState> = {};
+
+  const na = parseNum(params, "na");
+  if (na !== undefined) out.apptsPerMonth = clamp(na, BOUNDS.apptsPerMonth.min, BOUNDS.apptsPerMonth.max);
+
+  const nr = parseNum(params, "nr");
+  if (nr !== undefined) out.noShowRate = clamp(nr, BOUNDS.noShowRate.min, BOUNDS.noShowRate.max);
+
+  const nv = parseNum(params, "nv");
+  if (nv !== undefined) out.apptValue = clamp(nv, BOUNDS.apptValue.min, BOUNDS.apptValue.max);
+
+  const nx = parseNum(params, "nx");
+  if (nx !== undefined) out.reductionPct = clamp(nx, BOUNDS.reductionPct.min, BOUNDS.reductionPct.max);
+
+  return out;
+}
+
+function money(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+}
+
+export function NoShowCostCalculator(): ReactElement {
+  const [apptsPerMonth, setApptsPerMonth] = useState(200);
+  const [noShowRate, setNoShowRate] = useState(15);
+  const [apptValue, setApptValue] = useState(150);
+  const [reductionPct, setReductionPct] = useState(40);
+  const replaceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from the URL on mount only — never during SSR (no `window`).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const decoded = decodeState(window.location.search);
+    if (decoded.apptsPerMonth !== undefined) setApptsPerMonth(decoded.apptsPerMonth);
+    if (decoded.noShowRate !== undefined) setNoShowRate(decoded.noShowRate);
+    if (decoded.apptValue !== undefined) setApptValue(decoded.apptValue);
+    if (decoded.reductionPct !== undefined) setReductionPct(decoded.reductionPct);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the address bar in sync with the current inputs (throttled) so the
+  // URL is always a shareable permalink of whatever's on screen.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    replaceTimer.current = setTimeout(() => {
+      const qs = encodeState({ apptsPerMonth, noShowRate, apptValue, reductionPct });
+      const url = `${window.location.pathname}?${qs}`;
+      window.history.replaceState(null, "", url);
+    }, 150);
+    return () => {
+      if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    };
+  }, [apptsPerMonth, noShowRate, apptValue, reductionPct]);
+
+  // A no-show only costs you the value of the slot it burned.
+  const noShowsPerMonth = Math.round(apptsPerMonth * (noShowRate / 100));
+  const lostMonthly = Math.round(noShowsPerMonth * apptValue);
+  const lostYearly = lostMonthly * 12;
+  // Reminders + AI confirmations cut *some* no-shows, not all — the slider is
+  // the recovery fraction the owner assumes.
+  const recoveredMonthly = Math.round(lostMonthly * (reductionPct / 100));
+  const recoveredYearly = recoveredMonthly * 12;
+
+  // Money-leak funnel widths, all relative to the largest bar (appointments
+  // booked) so the shrink is honest at any input combination.
+  const funnelMax = Math.max(apptsPerMonth, 1);
+  const barWidth = (v: number) => `${Math.max(6, Math.round((v / funnelMax) * 100))}%`;
+
+  // ─── Shareable result card ───
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const renderTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const canShare = typeof window !== "undefined" && typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  useEffect(() => {
+    if (renderTimer.current) clearTimeout(renderTimer.current);
+    renderTimer.current = setTimeout(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      renderResultCard(canvas, {
+        headline: "No-shows are costing this business",
+        bigNumber: `${money(lostMonthly)}/mo`,
+        subline: `${noShowsPerMonth} no-shows/mo × ${money(apptValue)} avg appointment (${noShowRate}% no-show rate)`,
+        footer: "built free at seldonframe.com/tools",
+      });
+    }, 150);
+    return () => {
+      if (renderTimer.current) clearTimeout(renderTimer.current);
+    };
+  }, [lostMonthly, noShowsPerMonth, apptValue, noShowRate]);
+
+  const handleCopyLink = async () => {
+    const url = buildShareUrl(window.location.search);
+    const ok = await copyToClipboard(url);
+    setCopyFeedback(ok ? "Copied ✓" : "Copy failed");
+    setTimeout(() => setCopyFeedback(null), 2000);
+  };
+
+  const handleDownload = () => {
+    if (canvasRef.current) downloadCanvasAsImage(canvasRef.current, "no-show-cost.png");
+  };
+
+  const handleNativeShare = async () => {
+    const url = buildShareUrl(window.location.search);
+    await shareResultCard(canvasRef.current, {
+      title: "No-shows are costing this business",
+      text: `We're losing ~${money(lostMonthly)}/mo to no-shows.`,
+      url,
+      filename: "no-show-cost.png",
+    });
+  };
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gap: 22 }}>
+        <Slider
+          label="Appointments booked per month"
+          hint="Total bookings across your chairs, rooms or providers"
+          value={apptsPerMonth}
+          min={BOUNDS.apptsPerMonth.min}
+          max={BOUNDS.apptsPerMonth.max}
+          step={10}
+          format={(v) => `${v} appts`}
+          onChange={setApptsPerMonth}
+        />
+        <Slider
+          label="No-show rate"
+          hint="Booked appointments that never walk in. Industry reports commonly cite roughly 10–20% — dial in your own."
+          value={noShowRate}
+          min={BOUNDS.noShowRate.min}
+          max={BOUNDS.noShowRate.max}
+          step={1}
+          format={(v) => `${v}%`}
+          onChange={setNoShowRate}
+        />
+        <Slider
+          label="Average appointment value"
+          hint="What a typical booked appointment is worth to you"
+          value={apptValue}
+          min={BOUNDS.apptValue.min}
+          max={BOUNDS.apptValue.max}
+          step={10}
+          format={(v) => money(v)}
+          onChange={setApptValue}
+        />
+        <Slider
+          label="With automated reminders + AI confirmations"
+          hint="How much they cut no-shows. Results genuinely vary — set the recovery you'd expect."
+          value={reductionPct}
+          min={BOUNDS.reductionPct.min}
+          max={BOUNDS.reductionPct.max}
+          step={5}
+          format={(v) => `−${v}% no-shows`}
+          onChange={setReductionPct}
+        />
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 16 }}>
+        <Stat label="Lost revenue / month" value={money(lostMonthly)} tone="red" />
+        <Stat label="Lost revenue / year" value={money(lostYearly)} tone="red" />
+        <Stat label="Recoverable with reminders + AI*" value={`~${money(recoveredMonthly)}/mo`} tone="green" />
+      </div>
+
+      <div
+        role="img"
+        aria-label={`Money-leak funnel: about ${apptsPerMonth} appointments booked a month, ${noShowsPerMonth} of them no-shows, worth about ${money(lostMonthly)} in lost revenue every month.`}
+        style={{ marginTop: 26, display: "grid", gap: 10 }}
+      >
+        <FunnelBar emoji="📅" label="Appointments booked" value={`~${apptsPerMonth}/mo`} width={barWidth(apptsPerMonth)} color={GREEN} />
+        <FunnelBar emoji="🚫" label="No-shows" value={`~${noShowsPerMonth}/mo`} width={barWidth(noShowsPerMonth)} color={AMBER} />
+        <FunnelBar emoji="💸" label="Revenue walking away" value={`${money(lostMonthly)}/mo`} width={barWidth(Math.max(noShowsPerMonth * 0.35, funnelMax * 0.08))} color={RED} />
+      </div>
+      <p style={{ margin: "14px 0 0", fontSize: 14.5, fontWeight: 700, color: GREEN }}>
+        Automated reminders + AI confirmations win back an estimated {money(recoveredYearly)}/yr of this.
+      </p>
+
+      <p style={{ margin: "16px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+        *Recoverable assumes reminders + AI confirmations cut no-shows by the amount you set above — real results vary by
+        business, so treat it as a planning estimate, not a guarantee. SeldonFrame is $29/mo flat — at these numbers it
+        pays for itself with{" "}
+        <strong>
+          {recoveredMonthly > 0 ? (apptValue >= 29 ? "a single recovered appointment" : "a handful of recovered appointments") : "one recovered appointment"}
+        </strong>
+        .
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 20 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Cut no-shows — start free
+        </a>
+        <a
+          href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+          style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}
+        >
+          Book a demo call
+        </a>
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 12 }}>
+          Share your result
+        </div>
+        <div style={{ borderRadius: 14, overflow: "hidden", border: `1px solid ${INK10}`, background: "#1F2B24", maxWidth: 640 }}>
+          <canvas ref={canvasRef} style={{ display: "block", width: "100%", height: "auto" }} aria-label="Downloadable result card showing the estimated monthly cost of no-shows" />
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14, alignItems: "center" }}>
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+          >
+            ⬇ Download image
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyLink}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+          >
+            🔗 {copyFeedback ?? "Copy link"}
+          </button>
+          {canShare && (
+            <button
+              type="button"
+              onClick={handleNativeShare}
+              style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+            >
+              Share
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Slider({
+  label,
+  hint,
+  value,
+  min,
+  max,
+  step,
+  format,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>{label}</span>
+        <span style={{ fontWeight: 800, fontSize: 16, color: GREEN, whiteSpace: "nowrap" }}>{format(value)}</span>
+      </div>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ width: "100%", accentColor: GREEN }}
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+function FunnelBar({
+  emoji,
+  label,
+  value,
+  width,
+  color,
+}: {
+  emoji: string;
+  label: string;
+  value: string;
+  width: string;
+  color: string;
+}): ReactElement {
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13.5, fontWeight: 700, marginBottom: 4 }}>
+        <span>
+          {emoji} {label}
+        </span>
+        <span style={{ color }}>{value}</span>
+      </div>
+      <div style={{ height: 18, borderRadius: 8, background: "rgba(34,29,23,0.06)", overflow: "hidden" }}>
+        <div style={{ height: "100%", width, background: color, borderRadius: 8, transition: "width 0.2s ease" }} />
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone: "red" | "green" }): ReactElement {
+  const color = tone === "red" ? RED : GREEN;
+  const box: CSSProperties = { border: `1px solid ${INK10}`, borderRadius: 14, padding: "16px 18px", background: "rgba(255,255,255,0.6)" };
+  return (
+    <div style={box}>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 800, marginTop: 6, color }}>{value}</div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/service-business-faq-generator.tsx
+++ b/packages/crm/src/components/seo/service-business-faq-generator.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+// The service-business FAQ generator — the interactive island of
+// /tools/service-business-faq-generator. Pure client-side template
+// composition: it string-builds a ready set of customer-facing FAQ
+// question+answer pairs from a few inputs. No LLM, no network calls, no
+// signup. Honesty rule (never-lies): every business-specific fact the tool
+// can't know — hours, prices, guarantees, license numbers — is left as an
+// obvious [bracketed placeholder] for the owner to fill in, rather than
+// invented. The output doubles as a knowledge base an AI agent can be
+// grounded on, which is exactly what SeldonFrame deploys. Styled on the MKT
+// palette to match the other free-tool pages.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+
+type BizType =
+  | "plumbing"
+  | "hvac"
+  | "electrical"
+  | "salon"
+  | "medspa"
+  | "dental"
+  | "cleaning"
+  | "landscaping"
+  | "roofing"
+  | "law"
+  | "other";
+
+type Pricing = "free-estimates" | "flat-rate" | "hourly" | "quote-based";
+type Booking = "online" | "call" | "text";
+
+const BIZ_TYPES: { id: BizType; label: string }[] = [
+  { id: "plumbing", label: "Plumbing" },
+  { id: "hvac", label: "HVAC" },
+  { id: "electrical", label: "Electrical" },
+  { id: "salon", label: "Salon" },
+  { id: "medspa", label: "Med Spa" },
+  { id: "dental", label: "Dental" },
+  { id: "cleaning", label: "Cleaning" },
+  { id: "landscaping", label: "Landscaping" },
+  { id: "roofing", label: "Roofing" },
+  { id: "law", label: "Law" },
+  { id: "other", label: "Other" },
+];
+
+const PRICING_MODELS: { id: Pricing; label: string }[] = [
+  { id: "free-estimates", label: "Free estimates" },
+  { id: "flat-rate", label: "Flat-rate pricing" },
+  { id: "hourly", label: "Hourly rate" },
+  { id: "quote-based", label: "Quote-based / per project" },
+];
+
+const BOOKING_METHODS: { id: Booking; label: string }[] = [
+  { id: "online", label: "Online booking" },
+  { id: "call", label: "Call us" },
+  { id: "text", label: "Text us" },
+];
+
+/** Business types where an emergency / same-day question belongs, mapped to
+ *  the kinds of urgent problem their customers actually call about. */
+const EMERGENCY_EXAMPLES: Partial<Record<BizType, string>> = {
+  plumbing: "a burst pipe, no water, or a major leak",
+  hvac: "no heat in winter or no cooling in a heat wave",
+  electrical: "sparking, a burning smell, or a total power loss",
+  roofing: "an active leak or storm damage",
+};
+
+/** What a customer should expect at the appointment, tailored per trade.
+ *  Kept honest: describes the flow, never promises a specific price or time. */
+const WHAT_TO_EXPECT: Record<BizType, string> = {
+  plumbing:
+    "Our technician will arrive within your booking window, diagnose the issue, and walk you through your options and pricing before starting any work.",
+  hvac:
+    "Our technician will inspect your system, explain what's going on in plain language, and confirm the price with you before any repair or install.",
+  electrical:
+    "Our electrician will assess the work safely, explain what's needed and why, and confirm pricing with you before starting.",
+  salon:
+    "Please arrive a few minutes early. We'll talk through exactly what you're looking for, and your stylist will confirm the plan before getting started.",
+  medspa:
+    "We'll start with a short consultation to confirm the treatment is right for you, review any prep and aftercare, and answer your questions before we begin.",
+  dental:
+    "We'll review your history, complete your exam, and go over any recommended treatment and its cost before moving forward — no surprises.",
+  cleaning:
+    "Our team arrives within your scheduled window with all supplies. Point out any priorities or problem areas and we'll take it from there.",
+  landscaping:
+    "We'll walk the property with you, confirm the scope of work, and provide pricing before starting. [Note anything to prepare — e.g. pets indoors, gate access.]",
+  roofing:
+    "We'll inspect the roof, document any issues (photos on request), and give you a clear written assessment and quote before any work begins.",
+  law:
+    "Your first meeting is a chance to explain your situation. We'll review the details, outline your options, and explain next steps and any fees before you commit.",
+  other:
+    "We'll confirm exactly what you need, walk you through your options and pricing, and get your approval before starting any work.",
+};
+
+const PRICING_ANSWER: Record<Pricing, string> = {
+  "free-estimates":
+    "We offer free estimates. [Add any conditions here — e.g. free within [your service area], with a trip fee beyond it.] The final price depends on the scope of the job, and we'll confirm it with you in writing before any work begins.",
+  "flat-rate":
+    "We use flat-rate pricing, so you know the full price before we start — no surprise hourly charges. [Add your typical price ranges for common jobs here so customers have a ballpark.]",
+  hourly:
+    "We bill hourly at [your hourly rate]. [Note any minimum charge, trip fee, or how you estimate total hours here.] We'll give you an estimate up front so there are no surprises.",
+  "quote-based":
+    "Every job is quoted individually based on the scope and materials involved. Tell us what you need and we'll put together a detailed written quote — [note your typical turnaround, e.g. same day or within 24 hours].",
+};
+
+interface FaqInputs {
+  bizType: BizType;
+  area: string;
+  pricing: Pricing;
+  booking: Booking;
+}
+
+interface FaqItem {
+  q: string;
+  a: string;
+}
+
+function bookingAnswer(booking: Booking): string {
+  switch (booking) {
+    case "online":
+      return "The fastest way to book is online at [your booking link]. Pick a time that works for you and you'll get an instant confirmation.";
+    case "call":
+      return "The best way to book is to call us at [your phone number]. [Your hours] — leave a message any time outside those hours and we'll call you right back.";
+    case "text":
+      return "The easiest way to book is to text us at [your number]. Send over what you need and a couple of times that work, and we'll confirm your appointment.";
+  }
+}
+
+/** Compose the full customer-facing FAQ set from the inputs. Pure string
+ *  building — deterministic, no randomness, no network. Base questions are
+ *  shared by every service business; a couple more are added per trade so the
+ *  set always lands between 10 and 14 pairs. */
+function buildFaqs(inp: FaqInputs): FaqItem[] {
+  const areaText = inp.area.trim() || "[your service area]";
+  const isEmergency = inp.bizType in EMERGENCY_EXAMPLES;
+
+  const faqs: FaqItem[] = [];
+
+  faqs.push({
+    q: "What areas do you serve?",
+    a: `We serve ${areaText} and the surrounding areas. [List the specific towns, neighborhoods, or zip codes you cover here so customers can quickly tell whether they're in range.]`,
+  });
+
+  faqs.push({
+    q: "What are your hours?",
+    a: "Our hours are [your hours — e.g. Mon–Fri 8am–5pm]. [Add weekend, holiday, or after-hours availability here.]",
+  });
+
+  if (isEmergency) {
+    const examples = EMERGENCY_EXAMPLES[inp.bizType] ?? "an urgent problem";
+    faqs.push({
+      q: "Do you offer emergency or same-day service?",
+      a: `[State whether you offer 24/7, after-hours, or same-day emergency service — and any emergency rate — here.] For urgent issues like ${examples}, [tell customers the fastest way to reach you].`,
+    });
+  }
+
+  faqs.push({
+    q: "How do I book an appointment?",
+    a: bookingAnswer(inp.booking),
+  });
+
+  faqs.push({
+    q: "How does your pricing work?",
+    a: PRICING_ANSWER[inp.pricing],
+  });
+
+  faqs.push({
+    q: "Will I know the price before any work starts?",
+    a: "Yes. We'll confirm the full price with you in writing before any work begins — no hidden fees or surprise charges. [Note any diagnostic or trip fee here, and whether it's applied to the final bill.]",
+  });
+
+  faqs.push({
+    q: "What payment methods do you accept?",
+    a: "We accept [list your accepted payment methods — e.g. cash, all major cards, check]. [Note any deposit, financing options, or invoicing terms here.]",
+  });
+
+  faqs.push({
+    q: "Are you licensed and insured?",
+    a: "[State your license number(s) and confirm that you're fully insured here.] We're happy to provide proof of insurance on request.",
+  });
+
+  faqs.push({
+    q: "Do you guarantee your work?",
+    a: "[Describe your workmanship or satisfaction guarantee here, including any warranty period.] If something isn't right, [tell customers exactly how to reach you and what you'll do to make it right].",
+  });
+
+  faqs.push({
+    q: "How soon can I get an appointment?",
+    a: "[Share your typical availability here — e.g. same-week, next-day, or a current wait time.] [If you keep slots open for last-minute or emergency work, mention that here.] Booking early gives you the best choice of times.",
+  });
+
+  faqs.push({
+    q: "What should I expect at my appointment?",
+    a: WHAT_TO_EXPECT[inp.bizType],
+  });
+
+  faqs.push({
+    q: "What is your cancellation or rescheduling policy?",
+    a: "[Describe your cancellation and rescheduling policy here — e.g. how much notice you need and any fee.] The easiest way to change an appointment is to reach out the same way you booked.",
+  });
+
+  // One or two trade-specific additions so the set stays rich and relevant.
+  switch (inp.bizType) {
+    case "salon":
+      faqs.push({
+        q: "I'm a new client — what should I know?",
+        a: "Welcome! [Note anything new clients should bring or do — e.g. arrive 10 minutes early, whether a consultation is included.] If you have photos or ideas, bring them and we'll match you with the right stylist.",
+      });
+      break;
+    case "medspa":
+      faqs.push({
+        q: "Is this my first treatment — what happens at a consultation?",
+        a: "For new clients we start with a consultation to make sure the treatment is right for you and to review prep and aftercare. [Note whether the consultation is free and roughly how long it takes here.]",
+      });
+      break;
+    case "dental":
+      faqs.push({
+        q: "I'm a new patient — how do I get started?",
+        a: "Welcome! Please bring [your photo ID and insurance card]. [Describe your new-patient exam and any paperwork to complete in advance here.] We'll check your coverage and go over any costs before treatment.",
+      });
+      break;
+    case "cleaning":
+      faqs.push({
+        q: "Do you offer recurring or one-time cleaning?",
+        a: "We offer both. [Describe your recurring options — e.g. weekly, bi-weekly, or monthly — and any discount for regular service here.] Tell us what works for you and we'll set up a schedule.",
+      });
+      break;
+    case "landscaping":
+      faqs.push({
+        q: "Do you offer recurring maintenance or one-time projects?",
+        a: "We handle both ongoing maintenance and one-time projects. [Describe your recurring maintenance plans and pricing here.] Let us know your goals and we'll recommend the right plan.",
+      });
+      break;
+    case "law":
+      faqs.push({
+        q: "Do you offer a free consultation?",
+        a: "[State whether your initial consultation is free or paid, and how long it typically lasts, here.] Reach out and we'll get you scheduled with the right attorney for your matter.",
+      });
+      break;
+    default:
+      break;
+  }
+
+  return faqs;
+}
+
+function faqsToText(faqs: FaqItem[]): string {
+  return faqs.map((f) => `Q: ${f.q}\nA: ${f.a}`).join("\n\n");
+}
+
+const STEPS: { emoji: string; label: string }[] = [
+  { emoji: "1️⃣", label: "Describe your business" },
+  { emoji: "2️⃣", label: "Pick pricing & booking" },
+  { emoji: "3️⃣", label: "Copy your FAQ" },
+];
+
+function StepStrip(): ReactElement {
+  return (
+    <div
+      role="img"
+      aria-label="Three steps: describe your business, pick pricing and booking, copy your FAQ."
+      style={{ display: "flex", flexWrap: "wrap", alignItems: "center", gap: 8, marginBottom: 24 }}
+    >
+      {STEPS.map((s, i) => (
+        <div key={s.label} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              border: `1px solid ${INK10}`,
+              borderRadius: 12,
+              padding: "10px 14px",
+              background: "#fff",
+              fontSize: 13.5,
+              fontWeight: 700,
+              color: INK,
+            }}
+          >
+            <span style={{ fontSize: 16 }}>{s.emoji}</span>
+            <span>{s.label}</span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <span aria-hidden="true" style={{ color: GREEN, fontWeight: 800, fontSize: 16 }}>
+              →
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function HonestyNote(): ReactElement {
+  return (
+    <div
+      role="note"
+      aria-label="Answers are honest templates — the bracketed placeholders are yours to fill in."
+      style={{
+        marginTop: 12,
+        border: `1px solid ${INK10}`,
+        borderRadius: 12,
+        padding: "12px 16px",
+        background: "rgba(184,134,11,0.08)",
+        fontSize: 13,
+        lineHeight: 1.6,
+        color: INK,
+      }}
+    >
+      <strong>These are honest templates, not invented facts.</strong> We never make up your hours,
+      prices, guarantees, or license numbers. Anything in [square brackets] is a cue for you to fill
+      in with your real details before you publish — so every answer a customer reads is true.
+    </div>
+  );
+}
+
+const labelStyle = { display: "block" as const };
+const labelSpan = { fontWeight: 700, fontSize: 15 };
+const fieldStyle = {
+  display: "block" as const,
+  width: "100%",
+  marginTop: 8,
+  padding: "11px 12px",
+  borderRadius: 10,
+  border: `1.5px solid ${INK10}`,
+  fontSize: 15,
+  fontFamily: "inherit",
+  boxSizing: "border-box" as const,
+};
+
+export function ServiceBusinessFaqGenerator(): ReactElement {
+  const [bizType, setBizType] = useState<BizType>("plumbing");
+  const [area, setArea] = useState("");
+  const [pricing, setPricing] = useState<Pricing>("free-estimates");
+  const [booking, setBooking] = useState<Booking>("call");
+  const [copied, setCopied] = useState(false);
+
+  const faqs = useMemo(
+    () => buildFaqs({ bizType, area, pricing, booking }),
+    [bizType, area, pricing, booking],
+  );
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(faqsToText(faqs));
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  function handleDownload(): void {
+    if (typeof document === "undefined") return;
+    const blob = new Blob([faqsToText(faqs)], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const safe = (area.trim() || bizType).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${safe || "service-business"}-faq.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <StepStrip />
+
+      <div style={{ display: "grid", gap: 20 }}>
+        <div style={{ display: "grid", gap: 20, gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Business type</span>
+            <select value={bizType} onChange={(e) => setBizType(e.target.value as BizType)} style={fieldStyle}>
+              {BIZ_TYPES.map((b) => (
+                <option key={b.id} value={b.id}>
+                  {b.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Service area / city</span>
+            <input
+              type="text"
+              value={area}
+              onChange={(e) => setArea(e.target.value)}
+              placeholder="Austin, TX"
+              style={fieldStyle}
+            />
+          </label>
+        </div>
+
+        <div style={{ display: "grid", gap: 20, gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))" }}>
+          <label style={labelStyle}>
+            <span style={labelSpan}>Pricing model</span>
+            <select value={pricing} onChange={(e) => setPricing(e.target.value as Pricing)} style={fieldStyle}>
+              {PRICING_MODELS.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={labelStyle}>
+            <span style={labelSpan}>How customers book</span>
+            <select value={booking} onChange={(e) => setBooking(e.target.value as Booking)} style={fieldStyle}>
+              {BOOKING_METHODS.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 22 }}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 10, marginBottom: 10, flexWrap: "wrap" }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+            Your customer FAQ
+          </div>
+          <div style={{ fontSize: 12.5, fontWeight: 700, color: GREEN }}>{faqs.length} questions</div>
+        </div>
+
+        <div style={{ display: "grid", gap: 10, maxHeight: 460, overflowY: "auto", paddingRight: 4 }}>
+          {faqs.map((f, i) => (
+            <div
+              key={f.q}
+              style={{ border: `1px solid ${INK10}`, borderRadius: 12, padding: "14px 18px", background: "#fff" }}
+            >
+              <div style={{ fontWeight: 700, fontSize: 15, color: INK, marginBottom: 6 }}>
+                {i + 1}. {f.q}
+              </div>
+              <div style={{ fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.78)" }}>{f.a}</div>
+            </div>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", gap: 10, marginTop: 14, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: copied ? GREEN : INK, color: "#F6F2EA", border: "none", padding: "11px 22px", borderRadius: 10, fontWeight: 700, fontSize: 14.5, cursor: "pointer" }}
+          >
+            {copied ? "Copied!" : "Copy all"}
+          </button>
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, background: "rgba(255,255,255,0.6)", padding: "10px 20px", borderRadius: 10, fontWeight: 700, fontSize: 14.5, cursor: "pointer" }}
+          >
+            Download .txt
+          </button>
+        </div>
+
+        <HonestyNote />
+
+        <p style={{ margin: "16px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+          No AI, no signup — this is built in your browser from a proven FAQ structure. Fill in the
+          [bracketed placeholders] with your real details before you post it.
+        </p>
+      </div>
+
+      <div
+        style={{
+          marginTop: 22,
+          border: `1px solid ${INK10}`,
+          borderRadius: 14,
+          padding: "18px 20px",
+          background: "rgba(0,137,123,0.06)",
+        }}
+      >
+        <div style={{ fontWeight: 800, fontSize: 16, color: INK, marginBottom: 6 }}>
+          Turn this FAQ into an AI agent that answers 24/7
+        </div>
+        <p style={{ margin: "0 0 14px", fontSize: 14, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }}>
+          This same FAQ is exactly what an AI front desk needs to be grounded. Import it straight into
+          your SeldonFrame workspace as your agent&apos;s Knowledge, and it answers every customer
+          question by phone, web chat, or text — using only your real answers, never made-up ones.
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            Turn this into your AI agent&apos;s knowledge — free
+          </a>
+          <a
+            href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+            style={{ border: `1.5px solid ${INK10}`, color: INK, background: "rgba(255,255,255,0.6)", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}
+          >
+            Book a demo call
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/speed-to-lead-calculator.tsx
+++ b/packages/crm/src/components/seo/speed-to-lead-calculator.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+// The speed-to-lead calculator — the interactive island of
+// /tools/speed-to-lead-calculator. Pure client math, no network calls:
+// leads + how fast you reply + deal value → revenue left on the table by slow
+// follow-up, and what instant (AI) response recovers. Styled on the MKT palette
+// to match the other /tools calculators; reuses the shared result-card canvas.
+
+import { useState, useEffect, useRef, type ReactElement, type CSSProperties } from "react";
+
+import {
+  renderResultCard,
+  buildShareUrl,
+  copyToClipboard,
+  downloadCanvasAsImage,
+  shareResultCard,
+} from "./result-card";
+
+const INK = "#221D17";
+const GREEN = "#00897B";
+const INK10 = "rgba(34,29,23,0.10)";
+const RED = "#C0392B";
+const AMBER = "#B8860B";
+
+function money(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+}
+
+// Response-time buckets and a relative "reach & qualify" factor vs. replying in
+// under 5 minutes (= 1.00). The steep drop after the first few minutes is a
+// well-documented pattern in lead-response research (the "5-minute rule"); the
+// exact factors here are a conservative, illustrative model — NOT a claim about
+// any single study's numbers. Real results vary by business.
+const BUCKETS: { label: string; short: string; factor: number }[] = [
+  { label: "Under 5 minutes", short: "<5 min", factor: 1.0 },
+  { label: "5–30 minutes", short: "5–30 min", factor: 0.75 },
+  { label: "30–60 minutes", short: "30–60 min", factor: 0.55 },
+  { label: "1–4 hours", short: "1–4 hr", factor: 0.4 },
+  { label: "4–24 hours", short: "4–24 hr", factor: 0.25 },
+  { label: "More than a day", short: "1+ day", factor: 0.12 },
+];
+
+const BOUNDS = {
+  leadsPerMonth: { min: 5, max: 1000 },
+  dealValue: { min: 100, max: 5000 },
+  baseClose: { min: 5, max: 60 },
+  bucket: { min: 0, max: BUCKETS.length - 1 },
+};
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function parseNum(params: URLSearchParams, key: string): number | undefined {
+  const raw = params.get(key);
+  if (raw === null || raw === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function SpeedToLeadCalculator(): ReactElement {
+  const [leadsPerMonth, setLeadsPerMonth] = useState(50);
+  const [dealValue, setDealValue] = useState(500);
+  const [baseClose, setBaseClose] = useState(30);
+  const [bucketIdx, setBucketIdx] = useState(3); // default: 1–4 hours
+  const replaceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from URL on mount only (never during SSR).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const lm = parseNum(params, "lm");
+    if (lm !== undefined) setLeadsPerMonth(clamp(lm, BOUNDS.leadsPerMonth.min, BOUNDS.leadsPerMonth.max));
+    const dv = parseNum(params, "dv");
+    if (dv !== undefined) setDealValue(clamp(dv, BOUNDS.dealValue.min, BOUNDS.dealValue.max));
+    const bc = parseNum(params, "bc");
+    if (bc !== undefined) setBaseClose(clamp(bc, BOUNDS.baseClose.min, BOUNDS.baseClose.max));
+    const rt = parseNum(params, "rt");
+    if (rt !== undefined) setBucketIdx(clamp(Math.round(rt), BOUNDS.bucket.min, BOUNDS.bucket.max));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Keep the address bar in sync (throttled) so the URL is a shareable permalink.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    replaceTimer.current = setTimeout(() => {
+      const params = new URLSearchParams();
+      params.set("lm", String(Math.round(leadsPerMonth)));
+      params.set("dv", String(Math.round(dealValue)));
+      params.set("bc", String(Math.round(baseClose)));
+      params.set("rt", String(bucketIdx));
+      window.history.replaceState(null, "", `${window.location.pathname}?${params.toString()}`);
+    }, 150);
+    return () => {
+      if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    };
+  }, [leadsPerMonth, dealValue, baseClose, bucketIdx]);
+
+  const factor = BUCKETS[bucketIdx].factor;
+  const closedFast = leadsPerMonth * (baseClose / 100); // deals if you reply in <5 min
+  const closedNow = closedFast * factor; // deals at the current response time
+  const revenueFast = Math.round(closedFast * dealValue);
+  const revenueNow = Math.round(closedNow * dealValue);
+  const lostMonthly = Math.max(0, revenueFast - revenueNow);
+  const lostYearly = lostMonthly * 12;
+
+  const barMax = Math.max(revenueFast, 1);
+  const barWidth = (v: number) => `${Math.max(6, Math.round((v / barMax) * 100))}%`;
+
+  // ─── Shareable result card ───
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const renderTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const canShare = typeof window !== "undefined" && typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  useEffect(() => {
+    if (renderTimer.current) clearTimeout(renderTimer.current);
+    renderTimer.current = setTimeout(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      renderResultCard(canvas, {
+        headline: "Slow lead follow-up is costing this business",
+        bigNumber: `${money(lostMonthly)}/mo`,
+        subline: `${leadsPerMonth} leads/mo · replying in ${BUCKETS[bucketIdx].short} vs. under 5 min`,
+        footer: "built free at seldonframe.com/tools",
+      });
+    }, 150);
+    return () => {
+      if (renderTimer.current) clearTimeout(renderTimer.current);
+    };
+  }, [lostMonthly, leadsPerMonth, bucketIdx]);
+
+  const handleCopyLink = async () => {
+    const url = buildShareUrl(window.location.search);
+    const ok = await copyToClipboard(url);
+    setCopyFeedback(ok ? "Copied ✓" : "Copy failed");
+    setTimeout(() => setCopyFeedback(null), 2000);
+  };
+
+  const handleDownload = () => {
+    if (canvasRef.current) downloadCanvasAsImage(canvasRef.current, "speed-to-lead-cost.png");
+  };
+
+  const handleNativeShare = async () => {
+    const url = buildShareUrl(window.location.search);
+    await shareResultCard(canvasRef.current, {
+      title: "Slow lead follow-up is costing this business",
+      text: `We're leaving ~${money(lostMonthly)}/mo on the table by replying to leads too slowly.`,
+      url,
+      filename: "speed-to-lead-cost.png",
+    });
+  };
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gap: 22 }}>
+        <Slider
+          label="New leads per month"
+          hint="Calls, form fills, texts, DMs — anyone who reaches out"
+          value={leadsPerMonth}
+          min={BOUNDS.leadsPerMonth.min}
+          max={BOUNDS.leadsPerMonth.max}
+          step={5}
+          format={(v) => `${v} leads`}
+          onChange={setLeadsPerMonth}
+        />
+        <Slider
+          label="How fast you reply on average"
+          hint="From when a lead reaches out to your first real response"
+          value={bucketIdx}
+          min={BOUNDS.bucket.min}
+          max={BOUNDS.bucket.max}
+          step={1}
+          format={(v) => BUCKETS[v].label}
+          onChange={(v) => setBucketIdx(Math.round(v))}
+        />
+        <Slider
+          label="Close rate when you reply fast"
+          hint="Your best-case close rate on leads you reach quickly"
+          value={baseClose}
+          min={BOUNDS.baseClose.min}
+          max={BOUNDS.baseClose.max}
+          step={5}
+          format={(v) => `${v}%`}
+          onChange={setBaseClose}
+        />
+        <Slider
+          label="Average deal / job value"
+          hint="What a typical won customer is worth"
+          value={dealValue}
+          min={BOUNDS.dealValue.min}
+          max={BOUNDS.dealValue.max}
+          step={50}
+          format={(v) => money(v)}
+          onChange={setDealValue}
+        />
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 16 }}>
+        <Stat label="Revenue you win now" value={`${money(revenueNow)}/mo`} tone="amber" />
+        <Stat label="Revenue if you replied in <5 min" value={`${money(revenueFast)}/mo`} tone="green" />
+        <Stat label="Left on the table / month" value={money(lostMonthly)} tone="red" />
+      </div>
+
+      <div
+        role="img"
+        aria-label={`At ${BUCKETS[bucketIdx].label} response time you win about ${money(revenueNow)} a month; replying in under 5 minutes could win about ${money(revenueFast)} — a gap of about ${money(lostMonthly)} a month.`}
+        style={{ marginTop: 26, display: "grid", gap: 10 }}
+      >
+        <FunnelBar emoji="⚡" label="If you replied in <5 min" value={`${money(revenueFast)}/mo`} width={barWidth(revenueFast)} color={GREEN} />
+        <FunnelBar emoji="🐌" label={`At ${BUCKETS[bucketIdx].short}`} value={`${money(revenueNow)}/mo`} width={barWidth(revenueNow)} color={AMBER} />
+        <FunnelBar emoji="💸" label="Lost to slow follow-up" value={`${money(lostMonthly)}/mo`} width={barWidth(lostMonthly)} color={RED} />
+      </div>
+      <p style={{ margin: "14px 0 0", fontSize: 14.5, fontWeight: 700, color: GREEN }}>
+        An AI that answers instantly, 24/7, closes this gap.
+      </p>
+
+      <p style={{ margin: "16px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.5 }}>
+        *Illustrative model based on the widely-documented &ldquo;5-minute rule&rdquo; in lead-response research: the odds of
+        reaching and qualifying a lead drop sharply the longer you wait. The factors here are a conservative estimate, not a
+        specific study&rsquo;s numbers — your real results will vary. SeldonFrame is $29/mo flat and responds the instant a
+        lead comes in.
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 20 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Respond in seconds — start free
+        </a>
+        <a
+          href="https://app.seldonframe.com/book/seldonframes-workspace-7798/default"
+          style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}
+        >
+          Book a demo call
+        </a>
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 12 }}>
+          Share your result
+        </div>
+        <div style={{ borderRadius: 14, overflow: "hidden", border: `1px solid ${INK10}`, background: "#1F2B24", maxWidth: 640 }}>
+          <canvas ref={canvasRef} style={{ display: "block", width: "100%", height: "auto" }} aria-label="Downloadable result card showing revenue lost to slow lead follow-up" />
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14, alignItems: "center" }}>
+          <button type="button" onClick={handleDownload} style={btnStyle}>
+            ⬇ Download image
+          </button>
+          <button type="button" onClick={handleCopyLink} style={btnStyle}>
+            🔗 {copyFeedback ?? "Copy link"}
+          </button>
+          {canShare && (
+            <button type="button" onClick={handleNativeShare} style={btnStyle}>
+              Share
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const btnStyle: CSSProperties = {
+  border: `1.5px solid ${INK10}`,
+  color: INK,
+  padding: "10px 18px",
+  borderRadius: 10,
+  fontWeight: 700,
+  fontSize: 14,
+  background: "rgba(255,255,255,0.6)",
+  cursor: "pointer",
+};
+
+function Slider({
+  label,
+  hint,
+  value,
+  min,
+  max,
+  step,
+  format,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>{label}</span>
+        <span style={{ fontWeight: 800, fontSize: 16, color: GREEN, whiteSpace: "nowrap" }}>{format(value)}</span>
+      </div>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ width: "100%", accentColor: GREEN }}
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+function FunnelBar({ emoji, label, value, width, color }: { emoji: string; label: string; value: string; width: string; color: string }): ReactElement {
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13.5, fontWeight: 700, marginBottom: 4 }}>
+        <span>
+          {emoji} {label}
+        </span>
+        <span style={{ color }}>{value}</span>
+      </div>
+      <div style={{ height: 18, borderRadius: 8, background: "rgba(34,29,23,0.06)", overflow: "hidden" }}>
+        <div style={{ height: "100%", width, background: color, borderRadius: 8, transition: "width 0.2s ease" }} />
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone: "red" | "green" | "amber" }): ReactElement {
+  const color = tone === "red" ? RED : tone === "amber" ? AMBER : GREEN;
+  const box: CSSProperties = { border: `1px solid ${INK10}`, borderRadius: 14, padding: "16px 18px", background: "rgba(255,255,255,0.6)" };
+  return (
+    <div style={box}>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>{label}</div>
+      <div style={{ fontSize: 24, fontWeight: 800, marginTop: 6, color }}>{value}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Six new client-side `/tools` pages on the existing free-tools pattern (server page + `use client` island; zero COGS, no runtime LLM/network), registered in the tools hub, `sitemap.xml` and `llms.txt`:
speed-to-lead-calculator, no-show-cost-calculator, ai-receptionist-script-generator, service-business-faq-generator, booking-friction-grader, ai-visibility-checker.

## never-lies
ROI models labelled illustrative/hedged (no invented studies); generators emit obvious `[placeholders]` rather than fabricate a business's facts; the AI-visibility checker states plainly it does NOT query any AI — it hands the user prompts to run themselves.

## Verification
typecheck clean (no new errors), 469 SEO unit tests green, `next build` green — 612 static pages, all 6 routes in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)