### PR TITLE
content: 18-guide GoHighLevel-alternative cluster

### DIFF
--- a/docs/strategy/2026-07-10-gohighlevel-alternative-cluster.md
+++ b/docs/strategy/2026-07-10-gohighlevel-alternative-cluster.md
@@ -1,0 +1,47 @@
+# GoHighLevel-alternative content cluster (2026-07-10)
+
+18 long-form guides added to the `/guides` engine under a new `gohighlevel`
+cluster, positioning SeldonFrame as a GoHighLevel alternative. Data-only files
+(`src/lib/seo/guides/<slug>.ts`) — they inherit the citable-listicle machinery
+(HTML + `.md` twin, Article/FAQPage JSON-LD, author byline, sitemap/llms.txt,
+IndexNow) and the `guides.spec.ts` gate.
+
+## Strategy
+- The head term ("best gohighlevel alternatives") is a saturated listicle SERP.
+  We field one branded pillar there and win the long-tail cost / comparison /
+  how-to / decision intent around it.
+- **Fairness is the moat** (and the GEO play): every article concedes, honestly,
+  where GoHighLevel genuinely wins (funnel builder, snapshot/template library,
+  deep email/SMS automation, community) and names who should stay on it. Balanced,
+  sourced pages are what answer engines cite.
+- **never-lies:** every GoHighLevel figure is hedged ("reported", "listed at ~")
+  and traces to a real entry in the article's `sources` (enforced by the spec).
+- **never-taxes framing:** flat $29, AI included (not a per-location add-on),
+  runs on your own keys at raw provider cost. BYO-key is the *mechanism*, never
+  the headline. Sell on value — "one booked job pays for it."
+
+## Interlinking
+Structural (guide `body` is plain text — no inline links): each article funnels
+via one `relatedTool` (a free calculator/tool) + one `relatedBest` money page,
+and the cluster hub auto-groups them at `/guides`.
+- Tools used: gohighlevel-cost-calculator, agency-margin-calculator,
+  ai-receptionist-cost-calculator, voice-ai-cost-calculator, hubspot-pricing-calculator,
+  ai-website-generator, free-booking-page.
+- Money pages: `/alternative-to-gohighlevel`, `/gohighlevel-pricing`,
+  `/best/crm`, `/best/small-business`.
+
+## The 18 articles
+Cost & pricing truth — how-much-does-gohighlevel-cost · gohighlevel-pricing-plans-explained ·
+hidden-gohighlevel-fees · is-gohighlevel-ai-employee-worth-it.
+Alternatives & comparison — best-gohighlevel-alternatives (pillar) · gohighlevel-vs-seldonframe ·
+best-gohighlevel-alternative-for-solopreneurs · gohighlevel-vs-hubspot.
+Reasons & decisions — why-agencies-leave-gohighlevel · is-gohighlevel-worth-it-for-small-business ·
+is-gohighlevel-hard-to-learn · do-i-need-gohighlevel.
+How-to, migration & agency margin — how-to-switch-from-gohighlevel · how-to-replace-gohighlevel ·
+how-to-price-an-ai-receptionist-service · run-client-ai-on-your-own-keys ·
+gohighlevel-saas-mode-vs-flat-pricing · white-label-ai-front-office-without-agency-pro.
+
+## Gate
+`guides.spec.ts` 366/366 green; `next build` compiled 682/682 pages.
+Sources verified during research (2026-07-10): GoHighLevel pricing/AI/billing
+support docs, GoHighLevel ideas board, NetPartners, Ruzuku, SchedulingKit, Tekpon.

--- a/packages/crm/src/lib/seo/guides/best-gohighlevel-alternative-for-solopreneurs.ts
+++ b/packages/crm/src/lib/seo/guides/best-gohighlevel-alternative-for-solopreneurs.ts
@@ -1,0 +1,57 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "best-gohighlevel-alternative-for-solopreneurs",
+  title: "The Best GoHighLevel Alternative for Solopreneurs and Solo Agencies",
+  description:
+    "GoHighLevel can be overkill for a one-person business. Here is a simpler, flat-priced alternative with an AI receptionist, site, and booking, minus the learning curve.",
+  targetKeyword: "gohighlevel alternative for solopreneurs",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/ai-receptionist-cost-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel was built for agencies managing dozens of clients, and that shows in its price, its add-ons, and its learning curve. If you are a party of one, there is a lighter way to answer every lead and book every job.",
+  sections: [
+    {
+      h2: "Why GoHighLevel is often too much for a solo operator",
+      body: "GoHighLevel is a genuinely powerful platform, but power has a cost, and a solo operator pays it twice. You pay in money, and you pay in time. The base plans start at 97 dollars a month for Starter, climb to 297 dollars a month for Unlimited, and reach 497 dollars a month for the Agency Pro tier, according to its published pricing. Annual billing knocks off roughly two months, but you are still committing to a number that assumes you are running a business on top of the software, not just running one small shop. When it is only you, most of that horsepower sits idle.\n\nThe learning curve is the part nobody warns you about until you are inside it. Independent guides report that it takes roughly one to three weeks to become functional in GoHighLevel, and longer than that to truly master it. That is fine if you are an agency hiring a specialist to run the platform full time. It is a real problem when you are the receptionist, the salesperson, the technician, and the bookkeeper all at once. Every hour spent wiring up pipelines and triggers is an hour you did not spend doing the work that actually pays you.\n\nThen there is the AI, which is the feature most solo operators actually want, and it is not included in the base price. On GoHighLevel the AI Employee is an add-on. Reported pricing puts it around 50 dollars a month per location on the Growth option or around 97 dollars a month per location on the Unlimited option, or roughly 0.02 to 0.05 dollars per minute on usage-based billing. So the tool you came for is stacked on top of a plan built for a use case you do not have. You end up paying for agency scale you will never reach, plus an add-on, plus usage, to get one phone answered.",
+    },
+    {
+      h2: "What a solo actually needs",
+      body: "Strip away the agency framing and a solo operator's needs get very simple. You need to answer every lead, because the ones you miss do not leave a voicemail, they call the next name on the list. You need to book jobs onto a calendar without playing phone tag. And you need to look professional enough that a first-time caller trusts you with their money. That is the whole job. Everything past it is nice-to-have.\n\nAnswering every lead is the one that quietly makes or breaks a small business. If you are on a ladder, under a sink, or in a chair with a client, you cannot pick up. A missed call at 2 p.m. on a Tuesday is a booked job that went to a competitor, and you never even knew it happened. What you need is something that picks up every single time, in your business's name, gets the caller's details, answers the obvious questions, and puts the appointment on your calendar. Voice, chat, and text all matter, because different customers reach out in different ways.\n\nLooking professional is the other half. A solo operator competes against bigger outfits with front desks and marketing budgets, and the great equalizer is a clean website, a real booking link, and reviews that show up when someone searches your name. You do not need a fifty-page funnel builder to get there. You need a site, a calendar, a way to collect reviews, and a place for clients to see their appointments. The trap with a big platform is that it gives you a hundred tools to assemble those basics yourself, when what you wanted was the basics already assembled.",
+    },
+    {
+      h2: "The flat-priced AI-front-office alternative",
+      body: "SeldonFrame takes the opposite approach to GoHighLevel. Instead of an agency toolkit you configure, it gives you a finished front office. It is 29 dollars a month, flat, with unlimited workspaces, and the first workspace is free forever. There is no trial gate to schedule around and cancel anytime. One booked job pays for the whole month, which is the honest way to think about the price: it is not an expense you have to justify, it is a rounding error against a single sale.\n\nThe AI receptionist is not an add-on here. It is the product, and it is included. It answers by voice, chat, and SMS in your business's name, handles the common questions, captures the lead, and books the appointment. Alongside it you get a website, a CRM, a booking calendar, review collection, a client portal, and a custom domain, all in the base price. There is no per-location AI fee, no separate plan to unlock the feature you came for. The thing GoHighLevel treats as a paid extra is the thing SeldonFrame is built around.\n\nThe setup difference is just as sharp. Instead of one to three weeks of learning, you describe your business in one conversation and get a full working workspace in about three minutes. The reason the price can stay flat is that SeldonFrame runs on your own AI keys and your own Twilio account, so the calls and messages bill at raw provider cost with no platform markup in the middle. You do not need to understand that plumbing to use it. You just need to know that when a lead calls while you are busy, someone answers, and the job gets booked.",
+    },
+    {
+      h2: "When GoHighLevel still makes sense for a solo",
+      body: "This is not a case that GoHighLevel is bad. For the right solo operator it is the right tool, and it is worth being honest about who that is. If funnels are the actual product you sell, GoHighLevel is hard to beat. Its funnel builder, its templates, and its snapshots let you spin up multi-step landing pages and offers fast, and if you are a solo marketer or a course creator whose whole business runs on funnels, that depth is the reason to be there.\n\nThe same goes for deep email and SMS marketing. If your revenue comes from large nurture sequences, tagged segments, and long automated campaigns, GoHighLevel's automation engine is built for exactly that, and it goes further than a front-office tool needs to. Solo consultants who live inside their email list, or affiliate marketers running elaborate drip campaigns, will use features that a service business would never touch. There is also a large, active community around GoHighLevel, which matters a lot when you are learning a complex platform alone.\n\nThe deciding question is what your business actually runs on. If it runs on funnels and email campaigns, GoHighLevel's depth earns its price and its learning curve. If it runs on answering the phone, booking jobs, and looking credible, that depth is weight you carry without using. A plumber, a cleaner, a barber, a solo law practice, or a mobile detailer does not need a funnel empire. They need the phone answered and the calendar filled, and for that a flat-priced, AI-first front office is the simpler, cheaper, faster fit.",
+    },
+  ],
+  faq: [
+    {
+      q: "Is GoHighLevel overkill for a solopreneur?",
+      a: "Often, yes. GoHighLevel is built for agencies managing many client accounts, so a one-person business pays for scale and features it will not use. Base plans run from 97 to 497 dollars a month, the AI you probably want is a separate add-on, and independent guides report a one to three week learning curve to become functional. If your core work is not funnels or large email campaigns, most of that is weight without benefit.",
+    },
+    {
+      q: "What is the easiest GoHighLevel alternative?",
+      a: "SeldonFrame is built to be the simple option. Instead of assembling tools yourself, you describe your business in one conversation and get a finished workspace in about three minutes, with the AI receptionist, website, CRM, booking, reviews, and a custom domain already set up. It is 29 dollars a month flat, the first workspace is free forever, and there is no trial gate.",
+    },
+    {
+      q: "Can I get an AI receptionist without an agency plan?",
+      a: "Yes. On GoHighLevel the AI Employee is an add-on, reported at roughly 50 to 97 dollars a month per location or usage-based pricing on top of a base plan. With SeldonFrame the AI receptionist is the core product and is included at 29 dollars a month flat, no agency tier required. It runs on your own AI keys and Twilio, so usage bills at raw provider cost.",
+    },
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+    {
+      label: "NetPartners — Is GoHighLevel Hard to Learn?",
+      url: "https://netpartners.marketing/is-it-hard-to-learn-gohighlevel-a-practical-guide-for-business-owners-agencies-and-certified-experts/",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/best-gohighlevel-alternatives.ts
+++ b/packages/crm/src/lib/seo/guides/best-gohighlevel-alternatives.ts
@@ -1,0 +1,64 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "best-gohighlevel-alternatives",
+  title: "10 Best GoHighLevel Alternatives in 2026 (Cheaper, Simpler, AI-First)",
+  description:
+    "The best GoHighLevel alternatives for 2026, compared on price model, AI, white-label, and learning curve so you can match the right tool to your business.",
+  targetKeyword: "gohighlevel alternatives",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel is powerful, but its costs stack and its AI is an add-on. This guide walks ten alternatives and shows how to match the right one to how you actually work.",
+  sections: [
+    {
+      h2: "Why people look for a GoHighLevel alternative",
+      body: "GoHighLevel is a capable all-in-one platform, and plenty of agencies are happy on it. But three things send people searching for an alternative, and they show up again and again. The first is cost stacking. The base plans run from $97 per month to $297 and $497, and the price on the page is rarely the price you end up paying once you add features and usage.\n\nThe second is that the AI is an add-on, not something included. The AI Employee sits outside every base plan and is billed per location, reported at around $50 to $97 per month per client, with voice and messaging usage charged on top. For an agency running several clients, a 10-client roster on the flat-rate AI Employee is reported to reach around $970 per month in AI fees alone. That is a lot for a feature many people assumed came with the platform.\n\nThe third is the learning curve. GoHighLevel does a great deal, and doing a great deal means there is a great deal to learn. Getting functional with it is reported to take somewhere between one and three weeks. For a small team or a solo operator who just wants leads answered and booked, that is real time before you see any value. None of these are dealbreakers on their own, but together they are why the search for a lighter, cheaper, or more AI-first option keeps coming up.",
+    },
+    {
+      h2: "How to choose the right one for you",
+      body: "Before you look at names, get clear on the criteria that actually change your monthly bill and your day-to-day. The first is pricing model: flat versus metered. A flat price is predictable and easy to resell to clients. A metered model can be cheaper when usage is low and painful when a client gets busy, which is exactly when you least want a surprise.\n\nThe second is whether AI is included or an add-on. If an AI receptionist is the thing you want in front of clients, a platform that includes it will almost always beat one that charges per location on top of a base plan, because the add-on cost grows with every client you win. The third is white-label. If you are an agency reselling under your own brand, you need to know whether white-label is standard or locked behind the most expensive tier.\n\nThe fourth is the learning curve and setup time. Some tools are ready in minutes; others expect you to build funnels and workflows before they do anything useful. Match this to your patience and your team. A funnel-obsessed agency will happily invest weeks. A plumber who wants missed calls answered will not. With those four criteria in hand, the list below is easy to read: for each option, ask what its pricing model is, whether AI is included, whether white-label is standard, and how long it takes to get running.",
+    },
+    {
+      h2: "The 10 best alternatives, and who each is for",
+      body: "SeldonFrame is the AI-first pick and the reason this list exists. It gives each client a whitelabel AI front office: an AI receptionist across voice, chat, and SMS, plus a website, CRM, booking, reviews, a client portal, and a custom domain, all agency-branded and generated from one conversation in about three minutes. It is $29 per month flat with unlimited workspaces, the first workspace free forever, and no trial gate, and it runs on your own AI keys and Twilio so usage bills at raw provider cost. Who it is for: agencies and local-service operators who want AI answering and booking included, not metered, on a price they can resell without doing per-client math.\n\nHubSpot is the free-CRM starting point. It is a well-known platform with a genuinely useful free tier for contacts and basic pipeline, and it scales up into serious marketing and sales tooling. Who it is for: teams that want a trusted CRM to grow into and are comfortable that the powerful pieces sit in paid tiers. ActiveCampaign is email-first automation. Its strength is deep, flexible email and marketing sequences built around customer behavior. Who it is for: businesses whose growth runs on email nurture and who want automation depth more than an all-in-one dashboard.\n\nClickFunnels is the funnel specialist. It exists to build landing pages and sales funnels that convert, and it does that one job well. Who it is for: marketers and course sellers whose whole model is a funnel, not a CRM. Kartra leans into courses and checkout. It bundles pages, memberships, and payments for people selling digital products. Who it is for: creators and coaches who need to host and sell content in one place. Keap is a small-business CRM with automation aimed at owner-operated companies that want contacts, follow-up, and simple sales tracking without a steep build. Who it is for: small service businesses that want a tidy CRM and light automation.\n\nVendasta is the agency marketplace and white-label play. It is built for resellers who want to sell a catalog of marketing products under their own brand. Who it is for: agencies whose model is reselling a marketplace of services rather than running one core app. Systeme.io is the budget all-in-one, known for a generous free tier that covers funnels, email, and basic sites. Who it is for: solo founders and early businesses who want broad coverage at the lowest possible entry cost. Podium is reviews and messaging, focused on collecting reviews and running customer conversations over text. Who it is for: local businesses whose priority is reputation and quick replies. Softr builds client portals and simple apps on top of your data without code. Who it is for: teams that mainly need a branded portal or lightweight internal tool rather than a full CRM.",
+    },
+    {
+      h2: "How SeldonFrame stacks up on the four criteria",
+      body: "Run SeldonFrame through the same four questions and it lands cleanly. Pricing model: flat, at $29 per month, with unlimited workspaces and the first one free forever. There is no per-location seat and no metered platform margin, because it runs on your own AI keys and Twilio, so calls and messages bill at raw provider cost. That is a price you can quote a client and not flinch when they get busy.\n\nAI included: yes, and this is the core of the product rather than a bolt-on. The receptionist across voice, chat, and SMS is what you are buying, along with the website, CRM, booking, reviews, and portal around it. White-label: standard, not gated behind a top tier. Every client workspace is agency-branded on a custom domain. Learning curve: a full workspace is generated from one conversation in about three minutes, so setup time is close to zero.\n\nThe honest framing is value, not just the number. The point is not that $29 is small; it is that one booked job from an answered call usually covers the month, and the cost does not balloon as you add clients. If your business is local-service work or an agency serving those clients, and you want AI answering and booking without an add-on bill that grows per account, SeldonFrame is built for exactly that shape. Match it against your four criteria and, for that use case, it is the strongest fit on the list.",
+    },
+    {
+      h2: "When you should just stay on GoHighLevel",
+      body: "It would be dishonest to end without saying where GoHighLevel is simply the better choice. If your business is funnel-heavy, stay. The funnel builder is a genuine strength, and the template and snapshot library lets you spin up proven layouts fast. If your growth engine is elaborate email and SMS automation, GoHighLevel's depth there is hard to beat, and rebuilding those flows elsewhere is not worth it.\n\nThere is also the community and ecosystem. GoHighLevel has a large user base, a lot of shared snapshots, and a deep well of tutorials and consultants. If you value being able to buy a done-for-you setup or ask a big community for help, that is real, and a newer or narrower tool cannot match it overnight. Agencies that have already invested weeks learning the platform and built their whole delivery around it have little reason to move.\n\nSo the decision is not about which tool is best in the abstract. It is about which one fits how you work. Funnel-heavy agency deep in automation and snapshots: stay on GoHighLevel. Local-service business or agency that wants AI answering and booking included on flat, resellable pricing with near-zero setup: SeldonFrame. Something in between, where you want budget breadth or a single specialty like email, reviews, or portals: pick the option above whose one strength matches your one need. The criteria, not the brand, should make the call.",
+    },
+  ],
+  faq: [
+    {
+      q: "What is the best GoHighLevel alternative?",
+      a: "There is no single best; it depends on how you work. For agencies and local-service businesses that want an AI receptionist and booking included on flat, resellable pricing, SeldonFrame is the strongest fit at $29 per month with AI included. For funnel-heavy marketers ClickFunnels, for email-driven automation ActiveCampaign, and for reselling a marketplace Vendasta may fit better.",
+    },
+    {
+      q: "Is there a free GoHighLevel alternative?",
+      a: "Some alternatives offer a free tier to start. HubSpot has a free CRM tier and Systeme.io is known for a generous free tier covering funnels and email. SeldonFrame does not have a free trial, but its first workspace is free forever and the flat plan is $29 per month with unlimited workspaces. Compare what each free tier actually includes before deciding.",
+    },
+    {
+      q: "What is the cheapest all-in-one with AI included?",
+      a: "SeldonFrame is built around AI being included rather than an add-on. At $29 per month flat it bundles the AI receptionist across voice, chat, and SMS with a website, CRM, booking, reviews, and client portal, and it runs on your own AI keys and Twilio so usage bills at raw provider cost with no platform markup.",
+    },
+  ],
+  sources: [
+    {
+      label: "Tekpon — GoHighLevel Alternatives",
+      url: "https://tekpon.com/software/highlevel/alternatives/",
+    },
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/do-i-need-gohighlevel.ts
+++ b/packages/crm/src/lib/seo/guides/do-i-need-gohighlevel.ts
@@ -1,0 +1,63 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "do-i-need-gohighlevel",
+  title: "Do I Really Need GoHighLevel — or Just an AI Receptionist and a Booking Page?",
+  description:
+    "Many businesses buy GoHighLevel for one job: stop missing leads. Here is how to tell if you need the full platform or just an AI receptionist and booking.",
+  targetKeyword: "do i need gohighlevel",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/free-booking-page",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "Most owners buy GoHighLevel to solve one problem: stop missing leads. Here is how to tell whether you need the whole marketing platform or just an AI receptionist and an online booking page.",
+  sections: [
+    {
+      h2: "The real job most people hire GoHighLevel for",
+      body:
+        "Before you compare features, it is worth being honest about why you started looking at GoHighLevel in the first place. For most owners of a service business, the trigger is not a burning desire to build marketing funnels. It is a specific pain: leads are slipping through the cracks. The phone rings while you are on a job and nobody answers. A text comes in at nine at night and gets a reply the next afternoon, by which point the customer already booked someone else. A quote request sits in an inbox for two days. Every one of those is money that walked out the door.\n\nSo the real job you are hiring software to do is usually this: never miss a lead, and turn the ones you catch into booked jobs. That is it. When you strip away the feature lists and the demos, that is the outcome you are actually paying for. Everything else is a means to that end or a nice-to-have on top of it.\n\nThis matters because GoHighLevel can absolutely do that job, but it does far more than that job, and you pay for the whole thing. The platform bundles a CRM, funnels, email and SMS campaigns, reputation tools, and agency features into one product. That breadth is a strength if you need it. But if your real problem is a missed phone and an empty calendar, it is worth asking whether you need the entire platform or just the two or three pieces that solve your actual pain. The rest of this guide helps you tell the difference."
+    },
+    {
+      h2: "Signs you genuinely need the full platform",
+      body:
+        "Let us be fair to GoHighLevel first, because there are clear situations where the full platform is the right call and a lighter tool would leave you short. The clearest sign is that you are running real marketing funnels. If you build landing pages, drive paid traffic to them, capture leads, and move those leads through multi-step nurture sequences, you need a platform with a deep funnel builder. That is one of GoHighLevel's genuine strengths, and a stripped-down receptionist tool will not replace it.\n\nThe second sign is that you run ongoing email and SMS campaigns as a core part of how you grow. Not the occasional appointment reminder, but real campaigns: newsletters, promotions, long automated sequences that branch based on what a contact does. GoHighLevel's automation depth is built for exactly this, and if this is central to your business, you will use and appreciate that depth. Trying to force a minimal tool to do it will frustrate you.\n\nThe third and biggest sign is that you resell to clients. If you are an agency or a consultant who wants to manage many businesses under your own brand, spin up sub-accounts, and rebill the software as your own, GoHighLevel was built for you specifically. The unlimited sub-accounts and rebilling machinery on the higher tiers exist for this exact use. If any of these three describe you, the honest answer is yes, you probably do need GoHighLevel, and you should not talk yourself out of it just to save on the monthly price."
+    },
+    {
+      h2: "Signs you are overbuying",
+      body:
+        "Now the other side, just as honestly. There are clear signs that GoHighLevel is more platform than your situation calls for, and recognizing them can save you both money and weeks of setup. The biggest sign is that when you picture success, it looks like the phone getting answered and the calendar filling up, not a funnel dashboard full of conversion charts. If you do not actually want to build funnels or run campaigns, most of what you are paying for will sit unused.\n\nAnother sign is that you keep hearing about features you are not sure you will ever open. Pipeline automations, snapshot marketplaces, sub-account management, multi-step email branching. If reading that list makes you tired rather than excited, that is useful information. It usually means those features are not solving a problem you have. Paying for capability you will not touch is the most common way small businesses overspend on software, and it is quiet, because the bill looks the same whether you use ten percent or ninety.\n\nThe cost side sharpens the point. On GoHighLevel the AI features that many owners actually want come as an add-on. The AI Employee is reported at roughly $50 a month per location on one option or around $97 a month per location on another, or about two to five cents per minute, and that sits on top of a base plan reported at $97 to $297 a month, plus rebilled usage for calls, texts, and email. For an agency running many locations, that math works. One report described a ten-client agency paying roughly $970 a month in AI fees alone. For a single business that just wants its phone answered, paying platform-plus-add-on-plus-usage to reach the one feature you care about is a sign you are buying the warehouse for one shelf."
+    },
+    {
+      h2: "The minimal stack that does the job",
+      body:
+        "If the honest read is that you want the phone answered and the calendar filled, then the minimal stack that does that job is short. You need three things. First, an AI receptionist that answers every call, chat, and text instantly, day or night, so no lead goes unanswered. Second, an online booking page so an interested lead can put a job on your calendar without a game of phone tag. Third, a CRM so every one of those contacts is captured and followed up instead of lost in a notebook or a phone.\n\nThose three pieces, working together, solve the actual problem most owners hire GoHighLevel for. The receptionist catches the lead. The booking page converts it. The CRM makes sure nobody falls through. You do not need funnels, snapshot libraries, or rebilling to accomplish that. You need the front office covered. Everything beyond those three things is either a growth tool you will grow into later or a feature aimed at a different kind of user.\n\nThis is exactly the stack SeldonFrame is built around, and it comes as one included product rather than a base plan plus add-ons. You get an AI receptionist that handles voice, chat, and SMS, plus online booking, a CRM, a website, review collection, a client portal, and a custom domain, all bundled together. The AI receptionist is the product, not an extra you switch on and pay for separately. It runs on your own AI keys and your own Twilio account, so the calls and texts flow through at raw provider cost with no platform markup, which is what keeps the price flat as you grow. For a service business, one booked job usually pays for the whole month."
+    },
+    {
+      h2: "How to try it and decide",
+      body:
+        "The good news is you do not have to guess. The right way to answer do I need GoHighLevel is to first name the one job you are hiring software for, then try the smallest tool that does that job and see if it is enough. If you name your real job as never miss a lead and book more work, then the minimal front-office stack is the thing to test, and you can find out quickly whether it closes the gap without committing to a platform and a multi-week setup.\n\nWith SeldonFrame, trying it is straightforward. Pricing is $29 a month flat, your first workspace is free forever, and there is no trial gate to work around, so you can stand up a real workspace without a countdown clock hanging over you, and you can cancel anytime. You build the whole thing from a single conversation about your business in about three minutes, and it comes out live, with the receptionist, website, and booking already wired together. That means you can test the actual outcome, not a sales demo, before you decide anything.\n\nHere is the fair way to make the call. Run the front-office stack and watch what happens to your missed calls and your booking rate. If it fills the gap, you have your answer, and you have saved yourself a platform you would have half-used. If, on the other hand, you find yourself wishing for real funnels, deep multi-step campaigns, or the ability to resell accounts to clients, that is a genuine signal that you have grown into what GoHighLevel does well, and moving up makes sense. Either way you will have decided based on your actual needs instead of a feature list, which is the whole point."
+    }
+  ],
+  faq: [
+    {
+      q: "What does GoHighLevel actually do?",
+      a: "GoHighLevel is an all-in-one marketing and CRM platform originally built for agencies. It combines a CRM, a funnel and landing page builder, email and SMS automation, booking, reputation and review tools, and, on higher tiers, the ability to manage and rebill client sub-accounts. It is powerful and broad, which is a strength if you use the depth and an overspend if you only need a piece of it."
+    },
+    {
+      q: "Do I need it if I just want to stop missing calls?",
+      a: "Probably not. Stopping missed calls and booking more jobs takes an AI receptionist, an online booking page, and a CRM to capture contacts. GoHighLevel can do that, but it also bundles funnels, campaigns, and agency features you would pay for and not use. If catching leads is the real goal, a focused front-office tool solves it with far less to learn."
+    },
+    {
+      q: "What is the minimum I need to book more jobs?",
+      a: "Three things working together: an AI receptionist that answers every call, chat, and text so no lead is missed, an online booking page so leads can schedule themselves, and a CRM so every contact is captured and followed up. SeldonFrame bundles all three, plus a website and reviews, for $29 a month flat, with the first workspace free forever."
+    }
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing"
+    },
+    { label: "Tekpon — GoHighLevel Alternatives", url: "https://tekpon.com/software/highlevel/alternatives/" }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/gohighlevel-pricing-plans-explained.ts
+++ b/packages/crm/src/lib/seo/guides/gohighlevel-pricing-plans-explained.ts
@@ -1,0 +1,65 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "gohighlevel-pricing-plans-explained",
+  title: "GoHighLevel Pricing Plans Explained: Starter vs Unlimited vs Agency Pro",
+  description:
+    "A plain-English guide to GoHighLevel's $97, $297, and $497 plans — what each tier unlocks, who it is for, and where the add-on costs begin.",
+  targetKeyword: "gohighlevel pricing plans explained",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/gohighlevel-pricing",
+  dek: "GoHighLevel has three tiers, and the difference between them is mostly about sub-accounts and rebilling. Here is what each one really unlocks.",
+  sections: [
+    {
+      h2: "Starter at $97 — three sub-accounts, best for solo operators",
+      body: "The Starter plan is listed at $97 per month and is the entry point into GoHighLevel. It gives you the core platform: a CRM, sales pipelines, calendars and booking, forms, and the funnel and website builder that the product is known for. The defining limit is sub-accounts. Starter caps you at three, and each sub-account is a separate client or business workspace.\n\nThat cap tells you who this plan is for. It fits a solo marketer, a freelancer, or a small business running its own marketing, plus maybe one or two clients on the side. If you are learning the platform or testing whether it fits your workflow, Starter is where you begin.\n\nThe moment you win a fourth client, though, you hit the wall. Three sub-accounts is a hard ceiling, and the only way past it is to move up a tier. So Starter is best understood as a proving-ground plan rather than a place an active agency stays for long."
+    },
+    {
+      h2: "Unlimited at $297 — unlimited sub-accounts and rebilling at cost",
+      body: "The Unlimited plan is listed at $297 per month and removes the sub-account cap entirely. This is the plan most working agencies settle on, because it lets you add as many client accounts as you can sell without paying more for the base platform each time.\n\nUnlimited also unlocks rebilling. On this plan you can pass usage charges, such as texts, calls, and email, through to your clients at cost, so those metered fees do not come out of your own margin. What you cannot do on this tier is add your own markup on top of that usage. You recover the cost, but you do not profit from the usage itself.\n\nFor an agency that mainly wants unlimited clients and clean cost recovery, Unlimited is the natural home. It is the plan where GoHighLevel starts to make sense as an agency operating system rather than a single-business tool, which is why the jump from Starter to Unlimited is the one most people eventually make."
+    },
+    {
+      h2: "Agency Pro / SaaS at $497 — SaaS mode and rebilling with markup",
+      body: "The Agency Pro or SaaS Mode plan is listed at $497 per month and is aimed at agencies that want to sell GoHighLevel as their own product. This is where SaaS mode lives. You can package the platform under your own brand, set your own plans and prices, and sign clients up on a self-serve basis.\n\nThe billing difference is the real reason to be here. Rebilling usage without markup is available on the $297 and $497 plans, but rebilling usage with your own markup is only on the $497 SaaS or Agency Pro tier. In other words, if you want to turn client texts, calls, and AI minutes into a profit center rather than just recovering their cost, this is the only plan that allows it.\n\nThat makes the $497 tier a business-model decision, not just a bigger bucket of features. You are paying for the ability to run a productized, resold SaaS. If that is your model, the plan pays for itself. If it is not, you are likely paying for capabilities you will never switch on."
+    },
+    {
+      h2: "Annual billing math — roughly two months free",
+      body: "GoHighLevel offers a discount for paying yearly. Annual billing gives about two months free compared with paying month to month. That works out to roughly $81 per month equivalent on Starter, around $248 on Unlimited, and around $414 on Agency Pro.\n\nThe savings are real, but so is the commitment. To get the discount you pay for the full year up front, which means you are locking in the plan whether or not it still fits your business in month four or month eight. For a stable, established agency that already knows GoHighLevel is its long-term platform, that trade is easy to make.\n\nFor anyone still deciding, the calculation is different. Prepaying a year to save two months only helps if you are certain you will stay. If there is any chance you outgrow the tool, switch platforms, or lose the client volume that justified it, the annual commitment turns a discount into risk. Weigh the saving against how sure you are before you lock in twelve months."
+    },
+    {
+      h2: "Which plan you actually need — and when flat $29 beats all three",
+      body: "The honest summary is that most solo operators need Starter, most agencies need Unlimited, and only agencies running a resold SaaS with marked-up usage need Agency Pro. Where it gets complicated is that none of these numbers includes the AI Employee add-on or the metered usage that stacks on top, so the tier you pick is only the beginning of the bill.\n\nSeldonFrame collapses that entire ladder into one price. It is $29 per month, flat, with unlimited workspaces and client sub-accounts, the first workspace free forever, no trial gate, and cancel anytime. There is no separate tier to unlock more clients and no add-on to turn on the AI receptionist, because the receptionist is the product and it is included, along with the website, CRM, booking, reviews, client portal, and custom domains. It stays flat because it runs on your own AI keys and your own Twilio, so AI and telephony are billed at raw provider cost with no platform markup. A full client workspace is generated from one conversation in about three minutes, and one booked job tends to cover the month.\n\nTo be fair, the three-tier structure exists for a reason, and GoHighLevel genuinely wins for funnel-heavy agencies. Its funnel builder, its deep library of templates and snapshots, its advanced email and SMS campaign automation, and its large community are hard to match if that is the core of your business. If you live inside complex funnels and multi-step campaigns, one of the GoHighLevel tiers is probably right for you. If you mainly want a branded AI front office for each client without choosing a tier or watching per-location fees pile up, a flat $29 platform is the simpler answer."
+    }
+  ],
+  faq: [
+    {
+      q: "What's the difference between Unlimited and Agency Pro?",
+      a: "Both give you unlimited sub-accounts and both let you rebill client usage at cost. The difference is markup and SaaS mode. Rebilling usage with your own markup is only available on the $497 Agency Pro or SaaS plan, along with the tools to package and resell GoHighLevel as your own branded product. The $297 Unlimited plan lets you recover usage costs but not profit from them. Choose Agency Pro only if reselling the platform as a SaaS is your business model."
+    },
+    {
+      q: "Do I need the $497 plan to white-label?",
+      a: "You need the $497 Agency Pro or SaaS plan for full SaaS mode, self-serve client signups, and rebilling usage with your own markup. If your goal is simply to run unlimited client accounts and pass usage through at cost, the $297 Unlimited plan covers that. If your goal is a fully branded, resold product with marked-up usage, the $497 tier is the one that allows it."
+    },
+    {
+      q: "Is annual billing worth it?",
+      a: "Annual billing gives about two months free, roughly $81, $248, and $414 per month equivalent across the three tiers, which is a genuine saving. It is worth it if you are already sure GoHighLevel is your long-term platform, because you prepay the full year up front. If you are still evaluating the tool or your client volume is uncertain, the twelve-month commitment carries more risk than the discount is worth."
+    }
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide"
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/"
+    },
+    {
+      label: "Ruzuku — GoHighLevel Pricing: Plans, Add-Ons & Hidden Costs",
+      url: "https://www.ruzuku.com/compare/gohighlevel-pricing"
+    }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/gohighlevel-saas-mode-vs-flat-pricing.ts
+++ b/packages/crm/src/lib/seo/guides/gohighlevel-saas-mode-vs-flat-pricing.ts
@@ -1,0 +1,69 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "gohighlevel-saas-mode-vs-flat-pricing",
+  title: "GoHighLevel SaaS Mode vs Flat White-Label: Which Makes Agencies More Money?",
+  description:
+    "GoHighLevel SaaS Mode lets you resell at markup, but only on the $497 plan. Here is how that margin math compares to a flat-priced white-label platform.",
+  targetKeyword: "gohighlevel saas mode reselling",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/agency-margin-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "SaaS Mode is a real reselling engine, but the markup you get to charge lives on the most expensive plan and rides on top of per-location AI fees. A flat white-label platform changes where the spread comes from.",
+  sections: [
+    {
+      h2: "What SaaS Mode actually is",
+      body:
+        "SaaS Mode is GoHighLevel's reselling engine. It lets an agency package the platform as its own branded software, create sub-accounts for clients under that brand, set prices, and bill those clients directly through the agency's own Stripe. To the client, it looks like your product. Behind the scenes, it is GoHighLevel doing the work. This is a genuinely powerful idea, and it is the reason a lot of agencies chose GoHighLevel in the first place. You stop selling one-off services and start selling recurring software seats with your logo on them.\n\nThe appeal is that reselling software has better economics than reselling labor. A retainer for hands-on work is capped by your hours. A software subscription is not, because the marginal cost of one more client is close to nothing once the system exists. SaaS Mode leans directly into that. You can set a monthly price, add usage rebilling, bundle features into tiers, and let the platform run the plumbing while you keep the customer relationship. On paper it turns an agency into a software company.\n\nThe part that decides whether it makes you money is not the concept. It is where the markup lives and what sits underneath it. SaaS Mode is only worth analyzing once you know which plan unlocks the ability to actually charge a markup, and what recurring costs stack up before you get to keep a dollar. That is where the picture gets more complicated than the pitch.",
+    },
+    {
+      h2: "The catch: markup lives on the $497 Agency Pro plan",
+      body:
+        "GoHighLevel sells three base plans, reported at ninety-seven dollars a month for Starter, two hundred ninety-seven for Unlimited, and four hundred ninety-seven for Agency Pro, which is where SaaS Mode lives. That top number is the gate. White-label reselling of sub-accounts under your own brand is the Agency Pro plan, so the whole SaaS Mode pitch assumes you are paying four hundred ninety-seven dollars a month before you sign a single client.\n\nRebilling deserves a careful distinction here, because it is easy to blur. Rebilling client usage without your own markup, meaning you pass the real cost of SMS and calls straight through, is available on the two hundred ninety-seven and four hundred ninety-seven dollar plans. But rebilling with your own markup, the part that turns usage into a profit center, is only on the four hundred ninety-seven dollar SaaS or Agency Pro plan. So the specific ability that makes SaaS Mode a money-maker, adding your spread on top of usage, is exactly the ability locked to the most expensive tier. Below it, you can pass cost through, but you cannot mark it up.\n\nOn top of the base plan sit the AI fees, and this is where the monthly number climbs. The AI Employee is an add-on, reported at around fifty dollars per location on Growth or ninety-seven per location on Unlimited, or roughly two to five cents a minute on usage. Those are per-location, so they scale with your client list rather than staying fixed. One agency running ten clients on flat-rate AI Employee reported around nine hundred seventy dollars a month in AI fees alone. Treat that as reported, not a quote, but it shows the pattern. Your recurring cost base is the four hundred ninety-seven dollar plan plus a per-location AI fee for every client plus usage, and all of it comes out before your resale margin.",
+    },
+    {
+      h2: "The margin math, laid out honestly",
+      body:
+        "Put the two sides next to each other. On the GoHighLevel side, your monthly cost floor is the Agency Pro plan at a reported four hundred ninety-seven dollars, plus a per-location AI Employee fee for each client, plus rebilled usage. Your revenue is whatever you charge each client for their branded sub-account. Your margin is revenue minus that stacked cost base. The base plan is fixed, which actually helps you as you add clients, because you spread four hundred ninety-seven across more accounts. But the AI fees are per-location, so they climb in lockstep with your client count and eat back into the spread you just gained. The reported nine hundred seventy dollars in AI fees at ten clients is the shape of that: the cost that scales with you.\n\nThe flat white-label alternative changes the structure, not just the number. Instead of a high fixed plan plus per-location fees plus usage markup, you pay a flat platform fee and run the AI and telephony on your own accounts at raw provider cost. SeldonFrame charges twenty-nine dollars a month flat, with unlimited workspaces and the first workspace free forever. The branded client portal and custom domains are included at that price, not gated behind a top tier. The AI receptionist is the product rather than a per-location add-on, and it runs on your own AI keys and your own Twilio, so there is no per-seat AI fee climbing with your client list and no platform markup on minutes.\n\nThe reason this widens the spread is subtraction. Your resale price to the client can be the same either way. What changes is the cost you subtract from it. On the flat model, the platform fee is small and does not grow, the AI cost is provider-raw, and there is no per-location tax. The room between what your client pays and what you pay is simply larger, and it is yours. You are still charging for software with your brand on it. You are just not handing back a slice of every client to a per-location fee schedule.",
+    },
+    {
+      h2: "Which wins at 3, 10, and 25 clients",
+      body:
+        "Think about it qualitatively across three points, because the exact dollars depend on your prices and your clients' usage. At three clients, GoHighLevel's four hundred ninety-seven dollar plan is a heavy fixed cost spread across very few accounts, so a big share of your revenue goes to just standing up SaaS Mode. This is the point where a new or small agency feels the gate most, because you are paying top-tier pricing before you have the client base to absorb it. A flat twenty-nine dollar platform with a free first workspace barely registers as a cost here, so almost all of your resale price is margin from client one.\n\nAt ten clients, GoHighLevel's fixed plan is now spread more efficiently, which is the strongest case for its model. But the per-location AI fees are now doing real damage, on the order of the reported nine hundred seventy dollars, and that number keeps pace with every client you add. On the flat model, your platform cost is still effectively flat and your AI cost is still raw provider cost, so the spread per client has not narrowed at all. The gap between the two models is wider at ten than at three, not smaller.\n\nAt twenty-five clients the divergence is the whole story. GoHighLevel's base plan is fully amortized and no longer the issue, but the per-location AI fees are now a large, growing line that scales one-for-one with your roster. The flat model's cost curve stays nearly flat because unlimited workspaces do not add platform cost and the AI runs on your keys. The plain conclusion is that margin grows on the flat model as you scale, while on the per-location model your biggest cost grows right alongside your revenue. That is the never-taxes point in numbers: you should not pay more to the platform simply because you succeeded at adding clients.",
+    },
+    {
+      h2: "Where GoHighLevel genuinely wins",
+      body:
+        "It would be dishonest to end there, because GoHighLevel earns its place for real reasons and plenty of agencies should stay on it. The snapshot and template marketplace is the biggest one. Years of agencies building and sharing account snapshots mean you can drop in a mature, pre-built configuration for a niche, funnels, pipelines, and automations included, and be running in an afternoon. That library is deep, and a flat newcomer platform cannot match its breadth on day one. If your workflow is built around snapshots, that is a genuine reason to stay.\n\nThe SaaS configurator is the other real advantage. GoHighLevel gives you fine-grained control over how you package and price your reselling: building tiers, controlling which features appear in which plan, wiring the client signup and billing flow, and running the whole thing as a polished product. It is a mature reselling machine with years of iteration behind it. Its funnel builder and email-campaign depth are also more developed than most alternatives, and its community is large, which means answers, contractors, and courses are easy to find. Those are not small things.\n\nSo the honest recommendation splits by who you are. If you are an established agency whose business is built on the snapshot ecosystem and a finely tuned SaaS configurator, and the per-location AI math still works for your client mix, GoHighLevel is a reasonable home and switching would cost you real assets. If you are a small, new, or growth-stage agency whose margin is being eaten by the four hundred ninety-seven dollar gate and per-location AI fees, and you mainly need a branded AI front office you can resell without the tax, a flat white-label platform will make you more money per client and keep making more as you grow. Pick on where your margin actually leaks, not on the pitch.",
+    },
+  ],
+  faq: [
+    {
+      q: "What is GoHighLevel SaaS Mode?",
+      a: "SaaS Mode is GoHighLevel's reselling engine. It lets an agency package the platform as its own branded software, create client sub-accounts under that brand, set prices, and bill clients directly. To the client it looks like your product, while GoHighLevel runs the underlying system. White-label reselling of sub-accounts is the Agency Pro plan, reported at four hundred ninety-seven dollars a month.",
+    },
+    {
+      q: "Do I need the $497 plan to resell?",
+      a: "To resell with your own markup, yes. Reselling sub-accounts under your own brand is the Agency Pro plan, reported at four hundred ninety-seven dollars a month, and rebilling usage with your own markup lives only there. Passing usage cost through without markup is available on the two hundred ninety-seven and four hundred ninety-seven dollar plans, but the profitable markup is gated to the top tier.",
+    },
+    {
+      q: "Which pricing model gives agencies a better margin?",
+      a: "A flat model widens the spread as you scale. GoHighLevel stacks a four hundred ninety-seven dollar plan plus per-location AI fees that grow with your client list, reported near nine hundred seventy dollars at ten clients. A flat platform like SeldonFrame charges twenty-nine dollars with unlimited workspaces and AI on your own keys, so your per-client margin does not shrink as you add clients.",
+    },
+  ],
+  sources: [
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/gohighlevel-vs-hubspot.ts
+++ b/packages/crm/src/lib/seo/guides/gohighlevel-vs-hubspot.ts
@@ -1,0 +1,61 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "gohighlevel-vs-hubspot",
+  title: "GoHighLevel vs HubSpot vs SeldonFrame: Which CRM Fits a Small Service Business?",
+  description:
+    "GoHighLevel, HubSpot, and SeldonFrame compared for small service businesses on price model, AI, and how fast you can actually go live.",
+  targetKeyword: "gohighlevel vs hubspot",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/hubspot-pricing-calculator",
+  relatedBest: "/best/crm",
+  dek: "These three tools get lumped together as CRMs, but they are built for three different jobs. Here is how they compare on price, AI, and speed to value for a small service business.",
+  sections: [
+    {
+      h2: "The three, in one line each",
+      body: "HubSpot is a full sales and marketing CRM built for teams that manage pipelines, run content marketing, and want deep reporting on both. It is polished, widely trusted, and generous at the free end, and it is designed to grow with a company that has salespeople to feed and a marketing function to measure. When people say CRM in the corporate sense, HubSpot is often the picture in their head.\n\nGoHighLevel is an all-in-one platform built for agencies. Its center of gravity is funnels, email and SMS automation, and the ability to resell the whole system to clients under your own brand. It bundles a CRM, but the CRM is one room in a much larger house that also holds a funnel builder, a campaign engine, and a reseller layer. It is powerful, and it assumes you have the time and the reason to run all of it.\n\nSeldonFrame is a whitelabel AI front office for service businesses. The product is an AI receptionist that answers by voice, chat, and SMS, wrapped together with a website, CRM, booking, reviews, a client portal, and a custom domain. It is not trying to be a sales-team CRM or an agency funnel platform. It is trying to make sure a small service business answers every lead and books every job, and looks professional doing it, without anyone learning a platform first.",
+    },
+    {
+      h2: "Pricing models compared",
+      body: "The three price in three completely different ways, and the model matters more than any single number. GoHighLevel uses tiered subscriptions: Starter at 97 dollars a month, Unlimited at 297 dollars a month, and Agency Pro at 497 dollars a month, per its published pricing, with annual billing saving roughly two months. On top of the base plan, the AI Employee is an add-on, reported at around 50 dollars a month per location on Growth or around 97 dollars a month per location on Unlimited, plus usage that gets rebilled at cost. So the real monthly figure depends on how many locations you run and how much you use it.\n\nHubSpot uses a freemium model that is easy to start and gets more expensive as you grow. You can begin free, which is a genuine advantage for testing the waters, but the pricing scales steeply as you add paid seats, contact tiers, and the marketing and sales hubs that unlock the features most businesses actually came for. The pattern is familiar to anyone who has used it: the entry point is friendly, and the bill climbs as your list and your team grow. The exact figures depend heavily on which hubs and seat counts you choose, so the honest advice is to price your specific configuration before committing.\n\nSeldonFrame is 29 dollars a month, flat, with unlimited workspaces and the first workspace free forever, and no trial gate. There is no per-seat ladder, no add-on to unlock the AI, and no separate plan to get the features that matter. The reason it can stay flat is that it runs on your own AI keys and your own Twilio account, so voice and messaging bill at raw provider cost with no platform markup. One booked job pays for the month, which reframes the decision away from cost and toward fit.",
+    },
+    {
+      h2: "Which fits which business",
+      body: "Match the tool to the shape of the business and the answer usually gets obvious. HubSpot fits a company with a sales team working a pipeline, or a marketing function running content and measuring it. If you have reps who need deal stages, forecasting, and activity tracking, or marketers who need landing pages, email nurture, and attribution reporting, HubSpot's depth and reporting are exactly what you are paying for. It is a poor fit for a solo tradesperson, and an excellent one for a growing B2B team.\n\nGoHighLevel fits agencies. If your business is running funnels and email campaigns for clients, and reselling a branded platform to them, GoHighLevel is built for that from the ground up. Its funnel builder, its templates and snapshots, and its whitelabel reseller layer are the reason agencies choose it, and no front-office tool matches that depth. If you are the agency, GoHighLevel is a serious contender and often the right call.\n\nSeldonFrame fits service businesses that need the phone answered and jobs booked. A cleaning company, an HVAC shop, a dental practice, a law office, a med spa, a landscaper: businesses where a missed call is a lost customer and the job is delivered in person, not through a funnel. These businesses do not need pipeline forecasting or a campaign engine. They need every lead answered, every appointment on the calendar, and a professional face online, which is the exact job SeldonFrame is built to do.",
+    },
+    {
+      h2: "AI and speed to value",
+      body: "AI is where the three diverge most, because they treat it as three different things. On HubSpot, AI shows up as assistive features layered across a sales and marketing suite, helpful for drafting and analysis but built around a human team using the CRM. On GoHighLevel, AI is a capable add-on you attach to a plan and configure, with the AI Employee reported at roughly 50 to 97 dollars a month per location or usage-based pricing on top of the base subscription. In both cases the AI supports the platform. In neither case is the AI the point.\n\nOn SeldonFrame, the AI receptionist is the point. It is the core product, included in the flat price, and its job is concrete: answer the call, chat, or text in your business's name, handle the common questions, capture the lead, and book the appointment. For a service business that loses money every time a call goes unanswered, an AI whose whole purpose is answering is a different proposition than an AI feature bolted onto a CRM you still have to staff and run.\n\nSpeed to value follows the same split. HubSpot and GoHighLevel are both platforms you learn and configure, and GoHighLevel in particular has a reported one to three week learning curve to become functional. That is reasonable when a team is adopting a system for the long haul. SeldonFrame is built to skip that entirely: you describe your business in one conversation and get a full working workspace, receptionist and website and booking included, in about three minutes. For an owner who does not have a spare week, that gap is the whole decision.",
+    },
+    {
+      h2: "The bottom line",
+      body: "None of these tools is the best, because best only means anything once you name the job. HubSpot is the best when the job is running a sales pipeline and a content-marketing engine with a team behind it, and you want mature reporting to prove it is working. Its free tier lets you start small, and its depth rewards companies that grow into it. If that is you, the steeper bill that comes with scale is buying real capability.\n\nGoHighLevel is the best when the job is running an agency: building funnels, running email and SMS campaigns for clients, and reselling a branded platform. Its funnel builder, snapshots, automation depth, and reseller layer are genuinely strong, and its community is large and active. If your revenue depends on those features, GoHighLevel earns its price and its learning curve, and you should not talk yourself out of it.\n\nSeldonFrame is the best when the job is answering the phone and booking jobs for a service business, without hiring a receptionist or learning a platform. It is 29 dollars a month flat, the AI receptionist and website and booking are all included, the first workspace is free forever, and you can be live in about three minutes. If you are a local service business, that is the fit, and the price is small enough that a single booked job covers it. Pick the tool that matches your job, not the one with the longest feature list.",
+    },
+  ],
+  faq: [
+    {
+      q: "Is HubSpot cheaper than GoHighLevel?",
+      a: "It depends entirely on your configuration. HubSpot can start free, which makes it cheaper to begin, but its pricing scales steeply as you add paid seats, contact tiers, and the sales and marketing hubs that unlock the features most businesses want. GoHighLevel starts at 97 dollars a month and goes up to 497 dollars, plus AI and usage add-ons. Price your specific setup on both before deciding, because the entry price and the real price can be very different.",
+    },
+    {
+      q: "Which is best for a small local or service business?",
+      a: "For a local service business whose main need is answering leads and booking jobs, SeldonFrame is usually the closest fit. HubSpot is built around sales pipelines and content marketing, and GoHighLevel is built for agencies running funnels and campaigns. A cleaner, plumber, clinic, or salon does not need those engines. SeldonFrame gives an AI receptionist, website, booking, and reviews at 29 dollars a month flat, with a workspace live in about three minutes.",
+    },
+    {
+      q: "Do any of them include an AI receptionist?",
+      a: "SeldonFrame includes one as its core product, answering by voice, chat, and SMS in your business's name at 29 dollars a month flat. GoHighLevel offers AI as an add-on, reported at roughly 50 to 97 dollars a month per location or usage-based pricing on top of a base plan. HubSpot's AI is mainly assistive features across its sales and marketing suite rather than a receptionist that answers calls and books appointments.",
+    },
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+    {
+      label: "Tekpon — GoHighLevel Alternatives",
+      url: "https://tekpon.com/software/highlevel/alternatives/",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/gohighlevel-vs-seldonframe.ts
+++ b/packages/crm/src/lib/seo/guides/gohighlevel-vs-seldonframe.ts
@@ -1,0 +1,64 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "gohighlevel-vs-seldonframe",
+  title: "GoHighLevel vs SeldonFrame: An Honest 2026 Comparison",
+  description:
+    "GoHighLevel vs SeldonFrame compared on price, AI receptionist, white-label, and setup time, including where GoHighLevel is still the better pick.",
+  targetKeyword: "gohighlevel vs seldonframe",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel and SeldonFrame solve overlapping problems in very different ways. This comparison walks price, AI, white-label, and setup, and it names where GoHighLevel still wins.",
+  sections: [
+    {
+      h2: "The quick verdict",
+      body: "GoHighLevel and SeldonFrame both promise an all-in-one home for client marketing and follow-up, but they are built for different jobs. GoHighLevel is a broad platform with deep funnel building, heavy email and SMS automation, and a large ecosystem, priced in base plans with AI and usage added on top. SeldonFrame is an AI-first front office where the receptionist is the product, bundled with a site, CRM, booking, reviews, and portal on a flat $29 per month.\n\nThe short version: if you live in funnels and complex automations, GoHighLevel is the stronger tool and worth its complexity. If you want AI answering and booking for clients, included and resellable, with almost no setup, SeldonFrame is the better and cheaper fit. Neither is a trick answer. They genuinely serve different shapes of business.\n\nThe sections below compare them on the four things that decide most switches: price, the AI receptionist, white-label and setup, and where GoHighLevel simply wins. Read to the end before deciding, because the honest answer depends on which of those matters most to you.",
+    },
+    {
+      h2: "Pricing head to head",
+      body: "GoHighLevel's base plans run at $97 per month for Starter, $297 for Unlimited, and $497 for the Agency Pro and SaaS Mode tier, with annual billing bringing roughly two months free. That is the entry number. On top of it, the AI Employee is a separate add-on reported at around $50 to $97 per month per location, and usage is rebilled on top of that: SMS around $0.0079 per segment, email around $0.675 per 1,000, and calls around $0.014 per minute. Rebilling comes without markup on the $297 and up plans and with markup on the $497 plan.\n\nSeldonFrame is one flat number: $29 per month, with unlimited workspaces and the first workspace free forever, cancel anytime, and no trial gate. The AI receptionist is included, not added. Usage is not marked up by a platform reseller margin, because SeldonFrame runs on your own AI keys and your own Twilio, so calls and messages bill at raw provider cost. There is a marketplace usage fee and a GMV fee that steps down from 5 to 3 to 2 percent, but only when SeldonFrame is the actual sales channel, so it does not touch the base monthly cost.\n\nThe point is not simply that $29 is smaller than $97. It is that the two prices behave differently as you grow. GoHighLevel's total rises with each location's AI seat and each client's usage, while SeldonFrame's monthly stays flat as you add workspaces. For a roster of clients, the difference compounds. One booked job from an answered call usually covers a month, which is the frame that matters more than the sticker.",
+    },
+    {
+      h2: "The AI receptionist: add-on versus the product",
+      body: "This is the sharpest difference between the two. On GoHighLevel, the AI Employee is a layer you buy on top of a platform whose core is funnels, pipelines, and automation. You can run GoHighLevel for a long time without it. When you do turn it on, you pay the per-location seat plus usage, and the voice AI specifically is reported at around $0.163 per minute in platform cost, often resold at around $0.40 per minute. It is a good add-on to a CRM, but it is an add-on.\n\nOn SeldonFrame, the AI receptionist is the product. The whole system is built around an agent that answers voice, chat, and SMS, books the job, and hands a tidy record to the CRM. The website, booking, reviews, and portal exist to support that front office. Because the AI is the core and it runs on your own keys, it is included in the flat price rather than metered into a seat that grows per client.\n\nThat difference shows up in how the two feel to run. With GoHighLevel you are configuring an AI feature inside a large marketing suite. With SeldonFrame you are deploying an AI receptionist that happens to bring a CRM and site with it. If AI answering is your main goal, buying the tool that is built around it usually beats bolting AI onto a tool built around funnels.",
+    },
+    {
+      h2: "White-label and setup time",
+      body: "For agencies, white-label and setup time decide how fast you can put something branded in front of a client. On GoHighLevel, full white-label SaaS Mode lives on the $497 Agency Pro tier. It is powerful, letting you resell the platform under your own brand, but it is the top plan, and getting functional with the platform is reported to take somewhere between one and three weeks. That is real time and, at the SaaS tier, real money before the first client is live.\n\nSeldonFrame is agency-branded by default, not gated behind a premium tier. Every workspace ships white-label on a custom domain at the flat $29 price. And setup is fast: a full client workspace, receptionist, site, CRM, booking, and portal, is generated from a single conversation in about three minutes. You can stand up a branded client front office in the time it takes to describe the business.\n\nThe honest reading is that GoHighLevel's SaaS Mode is more configurable if you want to build a deep, custom reseller platform and are willing to invest the weeks. SeldonFrame trades some of that configurability for speed and a flat price, so you get a branded, working client workspace almost immediately. Which is better depends on whether your bottleneck is customization depth or time to launch.",
+    },
+    {
+      h2: "Where GoHighLevel wins, and who should pick which",
+      body: "GoHighLevel wins in several places, and pretending otherwise would not help you decide. Its funnel builder is genuinely strong, and the template and snapshot library lets you deploy proven layouts quickly. Its email and SMS campaign automation is deep and flexible, well beyond what an AI-first front office needs to be. And its community and ecosystem are large, with shared snapshots, consultants, and tutorials that make help easy to find. If those are your priorities, GoHighLevel is the better tool, full stop.\n\nSeldonFrame wins when the job is AI answering and booking for clients, delivered branded, flat-priced, and fast. It is built for local-service businesses and the agencies that serve them, where a missed call is a lost job and setup time is the enemy. It does not try to out-funnel GoHighLevel, and it should not be your pick if elaborate marketing funnels are the point of your business.\n\nSo choose by fit. Pick GoHighLevel if you are a funnel-heavy or automation-heavy agency, you want the deepest campaign tooling, or you rely on the snapshot library and community, and you are comfortable with the base plans, the AI add-on, and the learning curve. Pick SeldonFrame if you want an AI receptionist included, white-label by default, flat at $29 per month, and live in about three minutes, especially across a roster of clients where the add-on and usage costs on GoHighLevel would compound. Match the tool to the shape of your work and the answer is usually clear.",
+    },
+  ],
+  faq: [
+    {
+      q: "Is SeldonFrame a full GoHighLevel replacement?",
+      a: "For AI answering, booking, CRM, reviews, a client site, and a portal, yes, and it delivers those included on a flat plan. For deep funnel building, large template and snapshot libraries, and elaborate email and SMS campaign automation, GoHighLevel goes further, so a funnel-heavy or automation-heavy agency may not consider it a full replacement. It depends on which capabilities your business actually leans on.",
+    },
+    {
+      q: "Can I white-label SeldonFrame like GHL SaaS mode?",
+      a: "Yes. SeldonFrame is agency-branded by default on a custom domain at the flat $29 per month price, so white-label is standard rather than gated. On GoHighLevel, full white-label SaaS Mode sits on the $497 Agency Pro tier, and the platform is reported to take one to three weeks to learn, whereas a branded SeldonFrame workspace is generated from one conversation in about three minutes.",
+    },
+    {
+      q: "Which is cheaper for a 10-client agency?",
+      a: "SeldonFrame stays flat as you add workspaces, since it is $29 per month with unlimited workspaces and the first free forever. GoHighLevel adds a base plan plus a per-location AI Employee seat reported at around $50 to $97 per client plus usage; a 10-client agency on the flat-rate AI Employee is reported to reach around $970 per month in AI fees alone before the base plan and usage, so for that roster SeldonFrame is markedly cheaper.",
+    },
+  ],
+  sources: [
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/hidden-gohighlevel-fees.ts
+++ b/packages/crm/src/lib/seo/guides/hidden-gohighlevel-fees.ts
@@ -1,0 +1,69 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "hidden-gohighlevel-fees",
+  title: "7 Hidden GoHighLevel Fees That Aren't in the Sticker Price",
+  description:
+    "The $97/mo plan is only the start. Here are 7 GoHighLevel costs — AI Employee, usage rebilling, and more — that quietly stack onto your real monthly bill.",
+  targetKeyword: "gohighlevel hidden fees",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/gohighlevel-pricing",
+  dek: "GoHighLevel's advertised plans are only the floor of what you pay. These are the seven costs that quietly stack on top of the sticker price.",
+  sections: [
+    {
+      h2: "Why the sticker price is only the floor",
+      body: "GoHighLevel advertises plans starting at $97 per month, and that number does a lot of work in getting people to sign up. What the pricing page does not make loud is that several other costs attach themselves to your account once you actually start using it. Some scale with your client count, some scale with your message and call volume, and one is simply the time it takes to learn the tool.\n\nNone of these are scams. They are normal for a platform this deep. The trouble is that they are easy to miss when you are comparing sticker prices, and they can add up to more than the base plan itself. If you plan your budget around the advertised number, the real invoice will be a surprise.\n\nBelow are seven costs that sit outside the headline price. Read them as a checklist to run before you commit, so the number you plan around is the number you actually pay."
+    },
+    {
+      h2: "Fees 1 and 2 — the AI Employee add-on and per-minute Voice AI",
+      body: "The first hidden cost is the AI Employee. This is the add-on that answers calls, replies to messages, and books appointments, and it is not included in any base plan. It is reported at around $50 per month per location on the Growth option or around $97 per month per location on the Unlimited option, with a usage route reported near $0.02 to $0.05 per minute. The words per location matter, because the fee repeats for every client account you attach it to.\n\nThe second cost is the per-minute Voice AI itself. Running an AI voice agent is metered by the minute on top of the add-on subscription. Voice AI is reported at around $0.163 per minute at the platform level, and agencies commonly resell it to clients at around $0.40 per minute. So the same feature carries both a recurring per-location fee and a running per-minute charge, and both climb as your call volume grows."
+    },
+    {
+      h2: "Fees 3 and 4 — usage rebilled at cost, and markup locked to the $497 plan",
+      body: "The third cost is everyday usage. GoHighLevel rebills the texts, emails, and calls your accounts send and receive. Text messages are reported at around $0.0079 per segment, email at around $0.675 per one thousand sends, and calls at around $0.014 per minute, with inbound near $0.0128 and outbound near $0.021. Each charge is tiny, but appointment reminders, follow-ups, review requests, and phone traffic run through thousands of them a month.\n\nThe fourth cost is really a restriction that shapes your margins. Rebilling usage to clients without markup is available on the $297 and $497 plans, but rebilling with your own markup is only on the $497 SaaS or Agency Pro tier. So if you want usage to be a profit center rather than just a cost you recover, you are pushed onto the most expensive plan. The cheaper tiers let you break even on usage, not earn from it."
+    },
+    {
+      h2: "Fees 5 and 6 — annual commitment for the discount, and setup and premium actions",
+      body: "The fifth cost is the string attached to the discount. Annual billing gives about two months free, which lands at roughly $81, $248, and $414 per month equivalent across the three tiers. To get it, though, you prepay the entire year up front. That is money committed in advance whether or not the plan still fits your business several months in, so the discount comes bundled with lock-in.\n\nThe sixth cost is the setup and configuration layer. Getting real value out of GoHighLevel usually means importing or buying snapshots, wiring up funnels and workflows, and connecting the pieces together. Premium or advanced workflow actions and third-party integrations can carry their own charges or paid dependencies on top of the platform. These vary too much to put a single number on, but they are a genuine line item, and the more sophisticated your automations, the more of them you tend to accumulate."
+    },
+    {
+      h2: "Fee 7 — the time cost of the learning curve",
+      body: "The seventh cost never appears on an invoice, but it is real all the same. GoHighLevel is a broad and deep platform, and that power comes with a learning curve. Most users are reported to become functional in about one to three weeks, with full confidence taking longer than that.\n\nThose weeks are not free. They are hours you spend learning the tool instead of serving clients or selling, and if you are paying staff to ramp up, they are payroll spent on training rather than delivery. For an agency onboarding a team, that adds up quietly in the background.\n\nTo be fair, the depth that creates the learning curve is also what makes GoHighLevel powerful once you are through it. But when you compare it against simpler tools, the ramp-up belongs in the total cost, because time to value is a cost like any other."
+    },
+    {
+      h2: "The flat-priced alternative that avoids the stack",
+      body: "SeldonFrame is built so that most of these seven costs never appear. It is $29 per month, flat, with unlimited workspaces and client sub-accounts, the first workspace free forever, no trial gate, and cancel anytime. The AI receptionist that GoHighLevel sells as a per-location add-on is the core product here and is included, and so are the website, CRM, booking, reviews, client portal, and custom domains.\n\nThe reason there is no per-location AI fee and no resold per-minute markup is the mechanism underneath. SeldonFrame runs on your own AI keys, such as Claude, ChatGPT, or Gemini, and your own Twilio, so AI and telephony are billed at raw provider cost with no platform markup. A full client workspace with a site, CRM, booking, and a live agent is generated from one conversation in about three minutes, which also flattens the setup and learning cost. One booked job usually covers the month.\n\nThis does not make GoHighLevel the wrong choice for everyone. Its funnel builder, its large library of templates and snapshots, its deep email and SMS campaign automation, and its big community are real strengths, and a funnel-heavy agency with the budget and time to master the platform can get enormous value from it. The point of listing the seven fees is not to say the platform is bad. It is to make sure you plan around the real total, and to show that if what you mainly want is a branded AI front office per client, a flat $29 platform gets you there without the stack."
+    }
+  ],
+  faq: [
+    {
+      q: "Does GoHighLevel have hidden fees?",
+      a: "Not hidden in a dishonest sense, but there are several costs beyond the advertised plan price. The main ones are the AI Employee add-on billed per location, per-minute Voice AI, usage rebilling for texts, email, and calls, markup rebilling being locked to the $497 plan, the up-front annual commitment needed for the discount, setup and premium workflow actions, and the time cost of the learning curve. Together these can exceed the base plan, so budget for the full stack rather than the sticker price."
+    },
+    {
+      q: "Is the AI receptionist extra?",
+      a: "On GoHighLevel, yes. The AI Employee is an add-on charged on top of your base plan, reported at around $50 per month per location on the Growth option or around $97 per month per location on the Unlimited option, and it repeats for every client location. On SeldonFrame the AI receptionist is the core product and is included in the flat $29 per month price, with no per-location add-on."
+    },
+    {
+      q: "How do I avoid usage-based surprises?",
+      a: "The surprises come from metered charges for texts, email, calls, and AI minutes that scale with volume and, on GoHighLevel, are often resold with markup. To avoid them, choose a platform where AI and telephony run at raw provider cost with no platform markup. SeldonFrame does this by running on your own AI keys and your own Twilio account, so you pay providers directly and the platform fee stays flat at $29 per month regardless of usage."
+    }
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing"
+    },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide"
+    },
+    {
+      label: "Ruzuku — GoHighLevel Pricing: Plans, Add-Ons & Hidden Costs",
+      url: "https://www.ruzuku.com/compare/gohighlevel-pricing"
+    }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/how-much-does-gohighlevel-cost.ts
+++ b/packages/crm/src/lib/seo/guides/how-much-does-gohighlevel-cost.ts
@@ -1,0 +1,65 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "how-much-does-gohighlevel-cost",
+  title: "How Much Does GoHighLevel Really Cost in 2026? (Full Price Breakdown)",
+  description:
+    "GoHighLevel plans start at $97/mo, but the AI Employee add-on and usage fees push the real bill higher. Here is the full 2026 cost breakdown.",
+  targetKeyword: "how much does gohighlevel cost",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/gohighlevel-pricing",
+  dek: "The sticker price is only the first line of the bill. This is what GoHighLevel actually costs once the AI add-on and usage fees are counted.",
+  sections: [
+    {
+      h2: "The three base plans and what each includes",
+      body: "GoHighLevel sells three main tiers. The Starter plan is listed at $97 per month and gives you a working CRM, pipelines, calendars, and up to three sub-accounts, which is enough to run a small shop or a couple of clients. The Unlimited plan is listed at $297 per month and removes the sub-account cap, which is the plan most agencies land on once they have more than a few clients. The Agency Pro or SaaS Mode plan is listed at $497 per month and adds the SaaS features that let you resell the platform under your own brand.\n\nOn paper this looks simple. Pick a tier, pay the monthly fee, and you have a full marketing platform. The problem is that the number on the pricing page is not the number that lands on your card. Two big categories of cost sit outside those base plans, and both of them scale with how much you actually use the software.\n\nThat gap between the sticker price and the real bill is where most people get surprised. Before you commit, it helps to walk through each cost layer so you can estimate your true monthly spend instead of the advertised one."
+    },
+    {
+      h2: "The AI Employee add-on — the cost most people miss",
+      body: "The feature GoHighLevel markets hardest right now is its AI Employee, the bundle that answers calls, replies to messages, and books appointments. Here is the part that catches people out. The AI Employee is an add-on, not something included in any base plan. You pay for it on top of the $97, $297, or $497 you are already paying.\n\nThe reported pricing is roughly $50 per month per location on the Growth option, or around $97 per month per location on the Unlimited option. There is also a usage-based route reported at around $0.02 to $0.05 per minute. The word to notice is per location. If you run one business you pay it once, but if you run an agency with many client accounts, that fee repeats for every single client who wants AI answering their phone.\n\nThis matters because the AI receptionist is the exact feature most small businesses want the most. So the thing that sells the platform is often the thing that is not in the price you first saw, and it is billed in a way that grows with your client count."
+    },
+    {
+      h2: "Usage fees that stack on top",
+      body: "On top of the base plan and the AI add-on, GoHighLevel rebills you for the messages and calls your accounts send and receive. These are pass-through usage charges. Text messages are reported at around $0.0079 per segment, email at around $0.675 per one thousand sends, and calls at around $0.014 per minute, with inbound reported near $0.0128 and outbound near $0.021.\n\nAny individual charge looks tiny, and that is exactly why it is easy to ignore. But a busy account sending appointment reminders, follow-ups, and review requests, while also taking and making calls, runs through thousands of segments and minutes a month. Voice AI in particular is reported at around $0.163 per minute at the platform level, and agencies commonly resell it to clients at around $0.40 per minute.\n\nThe key thing to understand is that usage is metered and never stops climbing as you grow. More clients and more conversations mean a bigger usage bill every month, layered on top of everything else. It is not a fixed cost you can plan around once."
+    },
+    {
+      h2: "What a real agency bill looks like at 1, 5, and 10 clients",
+      body: "Run the layers together and the picture changes. A single business on the Starter plan pays $97 for the software, then adds the AI Employee, then adds its own usage. Already the real number is well above the advertised $97.\n\nNow scale it. Because the AI Employee is charged per location, the fee multiplies with every client you onboard. A ten-client agency running the flat-rate AI Employee is reported to pay about $970 per month in AI Employee fees alone, and that figure sits on top of the base plan and on top of all the metered usage. At five clients you are roughly halfway to that, again before base and usage.\n\nNone of this makes GoHighLevel a bad tool. It is a warning to model the full stack before you commit. The advertised tier is the floor, not the ceiling, and the ceiling rises with every client and every conversation. If you plan around $97, or even $297, you will likely be planning around the wrong number."
+    },
+    {
+      h2: "The flat-priced alternative — and when GoHighLevel is still worth it",
+      body: "SeldonFrame takes the opposite approach. It is $29 per month, flat, with unlimited workspaces and unlimited client sub-accounts. The first workspace is free forever, you can cancel anytime, and there is no trial gate because the free build, claim, and use flow is the trial. The AI receptionist that GoHighLevel charges extra for is the product here, and it is included. So are the website, CRM, booking, reviews, client portal, and custom domains.\n\nThe reason the price can stay flat is the mechanism underneath it. SeldonFrame runs on your own AI keys, such as Claude, ChatGPT, or Gemini, and your own Twilio account. That means AI and telephony run at raw provider cost with no platform markup, so the per-location fees and resold minutes that inflate a GoHighLevel bill simply are not there. A full client workspace with a site, CRM, booking, and a live agent is generated from one conversation in about three minutes. One booked job usually pays for the whole month.\n\nTo be fair, GoHighLevel earns its keep for the right buyer. Its funnel builder, its huge library of templates and snapshots, its deep email and SMS campaign automation, and its large community are genuine strengths. If your business is built on high-volume funnels and complex multi-step campaigns, and you have the budget and time to master it, GoHighLevel remains a strong choice. If you mainly want an AI front office per client without a bill that grows every time you add one, a flat-priced platform is the safer math."
+    }
+  ],
+  faq: [
+    {
+      q: "Is the AI receptionist included in GoHighLevel's price?",
+      a: "No. GoHighLevel's AI Employee is an add-on billed on top of your base plan, reported at around $50 per month per location on the Growth option or around $97 per month per location on the Unlimited option, with a usage-based route reported near $0.02 to $0.05 per minute. Because it is charged per location, the cost repeats for every client account. By contrast, SeldonFrame includes the AI receptionist in its flat $29 per month price."
+    },
+    {
+      q: "What does a 10-client agency really pay?",
+      a: "More than the sticker price suggests. A ten-client agency on the flat-rate AI Employee is reported to pay about $970 per month in AI Employee fees alone, and that sits on top of the base plan of $97, $297, or $497 and on top of metered usage for texts, email, and calls. The real monthly total depends on message and call volume, but it scales up with every client you add."
+    },
+    {
+      q: "Is there a cheaper flat-price alternative?",
+      a: "Yes. SeldonFrame is $29 per month flat with unlimited workspaces and client sub-accounts, the first workspace free forever, no trial gate, and cancel anytime. The AI receptionist, website, CRM, booking, reviews, client portal, and custom domains are all included. It runs on your own AI keys and your own Twilio, so AI and telephony run at raw provider cost with no platform markup, which is how the price stays flat as you grow."
+    }
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing"
+    },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide"
+    },
+    {
+      label: "NetPartners — GoHighLevel AI Pricing 2026",
+      url: "https://netpartners.marketing/gohighlevel-ai-pricing/"
+    }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/how-to-price-an-ai-receptionist-service.ts
+++ b/packages/crm/src/lib/seo/guides/how-to-price-an-ai-receptionist-service.ts
@@ -1,0 +1,65 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "how-to-price-an-ai-receptionist-service",
+  title: "How to Price Your Agency's AI Receptionist Service (and Keep the Margin)",
+  description:
+    "A pricing playbook for agencies selling an AI receptionist to local clients: setup fees, monthly retainers, and how to protect the margin platform rebilling eats.",
+  targetKeyword: "how to price ai receptionist service",
+  intent: "informational",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/agency-margin-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "Clients do not buy an AI receptionist, they buy never missing a lead. Price it on that value, then make sure the platform underneath does not quietly eat the margin you thought you had.",
+  sections: [
+    {
+      h2: "What clients actually pay for",
+      body:
+        "The mistake that wrecks AI receptionist pricing is selling the technology. When you lead with the model, the voice, the integrations, you invite the client to compare features and haggle on cost, and you cap your price at what the tooling looks like it should be worth. That is the wrong frame. A local-service client does not want an AI receptionist. They want to stop losing money to calls they never answered.\n\nThink about what a missed call actually costs the businesses you serve. A plumber, a roofer, a dentist, a law office. When a lead calls and no one picks up, that lead does not wait, they call the next name on the list, and the job is gone. One missed call can be a job worth hundreds or thousands of dollars. An AI receptionist that answers every call, every chat, and every text, day and night, and turns those conversations into booked appointments is not a software feature to that client. It is recovered revenue that was leaking out the door.\n\nPrice on that value, not on your cost. If the service reliably turns after-hours and overflow leads into booked jobs, its worth to the client is measured against the jobs it saves, not against your monthly platform bill. This is the anchor for every number in this playbook: one booked job usually pays for the whole service, often several times over. When you and the client both understand that, the conversation stops being about whether the price is high and starts being about how many jobs they are currently letting slip. That reframe is what makes healthy pricing possible in the first place.",
+    },
+    {
+      h2: "Setup fee and monthly retainer benchmarks",
+      body:
+        "Agencies selling done-for-you local services tend to price in two parts: a one-time setup fee to get the client live, and a recurring monthly retainer to keep the service running and managed. This structure fits an AI receptionist well, because there is real onboarding work up front, configuring how it answers, connecting the calendar, matching the client's brand, and then ongoing value in keeping it tuned and answering every day after.\n\nAs rough benchmarks, reported monthly retainers in this space commonly land somewhere around 500 to 2,000 dollars a month, and reported one-time setup fees are often described in the range of roughly 500 to 3,000 dollars. Treat those as reported ranges, not rules. Where you sit inside them depends on the value of a client's average job, how much you manage on their behalf, the size of the market, and how much competition they face. An agency serving high-ticket clients like law firms or elective medical practices sits at the top of those ranges without blinking, while one serving smaller local trades sits lower.\n\nThe setup fee does more than cover your onboarding hours. It filters for serious clients and it protects your cash flow, since a client who paid a real setup fee is invested and far less likely to churn after the first month. The retainer is where the relationship lives, so anchor it to outcomes the client feels, calls answered, appointments booked, leads recovered, rather than to a list of features. When the retainer is framed as the cost of never missing a lead again, the specific number inside the reported range becomes far easier for the client to accept.",
+    },
+    {
+      h2: "The margin trap that eats your spread",
+      body:
+        "Here is where agencies quietly lose the money they thought they were making. Your retainer is your revenue, but it is not your profit. Your profit is the retainer minus what the platform underneath charges you to deliver the service, and on a per-location agency platform those charges are engineered to climb with every client you add. If you do not model this before you price, your spread erodes one client at a time.\n\nWalk through how the costs stack on GoHighLevel as the example. The AI Employee is an add-on billed per location, reported at roughly 50 dollars per location on the Growth option or about 97 dollars per location on the Unlimited option. That is a recurring cost that repeats for every single client you onboard. On top of it sits usage, rebilled per message and per minute: SMS at around 0.0079 dollars per segment, email at about 0.675 dollars per thousand, and calls at roughly 0.014 dollars per minute. A chatty client with high call volume runs up real usage, and that usage is a direct charge against your margin on that account.\n\nThe scale of it is easy to underestimate until you multiply. One agency running the flat-rate AI Employee across ten clients reported roughly 970 dollars a month in AI fees alone, before a single text or minute of usage was counted. And the rebilling rules add a twist worth knowing: on the 297-dollar plan and above the usage is passed through at cost without markup, but on the 497-dollar Agency Pro plan the rebilling carries a markup. So the plan that unlocks the most reselling capability is also the one where the platform takes a cut of the usage you pass along. The trap is that per-location AI fees plus usage scale with exactly the thing you want to grow, your client count, so the more you sell, the more the platform takes off the top.",
+    },
+    {
+      h2: "Pricing on a flat platform where the AI runs on your own keys",
+      body:
+        "Now change the variable that actually drives your margin: the cost of goods underneath the service. If the platform is a flat price instead of a per-location one, and if the AI runs on your own keys, the entire per-client cost structure collapses. On SeldonFrame the platform is a flat 29 dollars a month with unlimited workspaces and the first workspace free forever, so adding your tenth client does not add a tenth AI subscription. The per-location fee that stacked to roughly 970 dollars in the earlier example simply does not exist here.\n\nThe usage side changes just as much. SeldonFrame runs on your own AI keys and your own Twilio account, so you pay the raw provider cost for calls and messages directly, with no platform sitting in the middle marking it up. That is the mechanism, not the marketing: because the infrastructure is yours, your cost of goods on each client drops close to zero beyond the actual carrier and model charges, which are cents on real usage. The chatty high-volume client that used to threaten your margin on a rebilled platform is now just a few dollars of pass-through cost you control.\n\nDo the arithmetic and the pricing power is obvious. Your retainer stays where the value justifies it, in that reported 500-to-2,000-dollar range depending on the client, but the cost you subtract to find profit is now a flat platform fee plus near-zero usage instead of a per-location AI subscription plus marked-up rebilling. The spread you thought you were selling is the spread you actually keep. This is the whole point of pricing on a flat, own-keys platform: it does not change what the client pays, it changes how much of what they pay survives to become your margin. And because it survives on every client, the model gets stronger as you grow instead of weaker.",
+    },
+    {
+      h2: "A simple model you can copy",
+      body:
+        "Turn all of this into a plan you can quote tomorrow. Start with the setup fee, priced to cover onboarding and to filter for serious clients, somewhere in the reported 500-to-3,000-dollar range and set by how high-value the client's jobs are. On SeldonFrame the actual onboarding is fast, since a full client workspace with site, CRM, booking, and the AI receptionist is built from one conversation in about three minutes, so most of that setup fee is margin rather than labor. Charge it anyway, because it protects your cash flow and your churn, not just your hours.\n\nThen choose a recurring structure, and two shapes cover almost everyone. Per-location is the clean default: one monthly retainer per client business, anchored on the value of never missing a lead, sitting in the reported 500-to-2,000-dollar range by client value. It is simple to sell and simple to bill. Per-seat is the alternative for larger clients with multiple locations or teams, where you price a base plus an amount for each additional workspace or user, letting the retainer scale as the client's operation scales. Pick whichever the client understands faster, because a pricing model the client can explain back to you is one they will actually pay.\n\nWhatever shape you pick, hold two rules underneath it. First, anchor every number to the value delivered, booked jobs and recovered leads, never to your platform cost, so the client is comparing your price against lost revenue rather than against software. Second, keep your cost of goods flat and own your infrastructure, so that every client you add widens your margin instead of narrowing it. Retainer in the reported range, setup fee up front, and a flat own-keys platform underneath: that is the whole model. It is not the receptionist that makes it profitable, it is pricing on value while refusing to let the platform tax your growth. Run the numbers on your own client list before you quote, and price from what you keep, not from what you charge.",
+    },
+  ],
+  faq: [
+    {
+      q: "How much should I charge for an AI receptionist?",
+      a: "Price it on the value of never missing a lead, not on your software cost. Reported monthly retainers for agency-run local services commonly land somewhere around 500 to 2,000 dollars a month, with the exact number driven by the value of the client's average job and how much you manage for them. A single booked job usually covers the service for the month, so anchor the conversation on the jobs the client is currently losing to missed calls rather than on a feature list.",
+    },
+    {
+      q: "What is a normal setup fee?",
+      a: "Reported one-time setup fees in this space are often described in the range of roughly 500 to 3,000 dollars, treated as a reported range rather than a fixed rule. The fee covers onboarding, filters for serious clients, and protects your cash flow, since a client who paid a real setup fee is far less likely to churn early. On a platform where a full workspace is built from one conversation in about three minutes, most of that fee is margin rather than labor, but charging it still does its job of qualifying the client.",
+    },
+    {
+      q: "How do I keep the margin on AI usage?",
+      a: "Watch the platform underneath, because that is where the margin leaks. On a per-location agency platform the AI can be an add-on billed per client, reported at roughly 50 or 97 dollars per location, and usage is rebilled per message and per minute, with the 497-dollar plan adding a markup on top. Those costs scale with every client you add. Running on a flat platform with the AI on your own keys and your own Twilio drops your cost of goods close to raw provider cost, so your retainer stays where the value justifies it and the spread survives to become profit.",
+    },
+  ],
+  sources: [
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/how-to-replace-gohighlevel.ts
+++ b/packages/crm/src/lib/seo/guides/how-to-replace-gohighlevel.ts
@@ -1,0 +1,70 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "how-to-replace-gohighlevel",
+  title: "How to Replace GoHighLevel With an AI Front Office for $29/mo",
+  description:
+    "You do not need a $97 to $497 agency platform to answer leads and book jobs. Here is how to replace GoHighLevel with a flat-priced AI front office on your own keys.",
+  targetKeyword: "replace gohighlevel",
+  intent: "transactional",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/ai-website-generator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "Most people run a fraction of what GoHighLevel bills them for. Replacing it starts with naming the handful of jobs you actually use, then covering them for a flat 29 dollars a month.",
+  sections: [
+    {
+      h2: "What GoHighLevel bundle you are actually replacing",
+      body:
+        "GoHighLevel sells itself as an everything platform, and the pricing reflects that ambition. The base plans are reported at 97 dollars a month for Starter, 297 for Unlimited, and 497 for the Agency Pro tier, and on top of that the AI Employee is a separate add-on reported at roughly 50 dollars per location on the Growth option or about 97 dollars per location on the Unlimited option. Before you can replace any of that, you have to be honest about which parts of it you touch.\n\nFor most local-service businesses and the agencies that serve them, the real workload is narrow. You need a website that leads land on. A place to hold contacts and deals, which is a CRM. A way for people to book time, which is a calendar. Something that answers the phone and messages when you cannot, which is the AI piece. And for agencies, a client-facing portal so each customer can see their own workspace. That is the working core. Everything else in the suite tends to be capability you are paying to have available, not capability you use every week.\n\nThis matters because replacing GoHighLevel does not mean matching its feature list line for line. It means covering the jobs you actually do at a price that fits them. When you strip the bundle down to the site, the CRM, the booking, the AI, and the portal, you are looking at a much smaller target, and a smaller target is a much easier thing to replace well. The rest of this guide maps each of those jobs to a flat-priced equivalent and is honest about the places where the trade is not even.",
+    },
+    {
+      h2: "Map each GoHighLevel job to its flat-priced equivalent",
+      body:
+        "Take the core one job at a time. The website your leads land on is included in SeldonFrame at the base price, generated for you rather than assembled from a funnel builder. The CRM that holds your contacts and deals is included too, and it is the same system your contact CSV imports into when you move. The booking calendar that lets customers pick a time is built in and connected to the rest, not a separate integration you wire up. Each of these is a line item you were effectively paying for inside the GoHighLevel base plan, now folded into one flat price.\n\nThe piece that changes the math most is the AI. In GoHighLevel the AI Employee is an add-on billed per location on top of your base plan, so every client you add compounds the cost. In SeldonFrame the AI receptionist is not an add-on at all, it is the product, and it is included. It answers by voice, chat, and SMS, and it is the same across every workspace you run. For an agency serving many clients, moving the AI from a per-location surcharge to an included feature is the single largest structural difference between the two approaches.\n\nThe client portal maps directly as well. Where GoHighLevel gives each sub-account its own client-facing view, SeldonFrame gives each client a full whitelabel workspace, a site plus CRM plus booking plus its own AI receptionist, under your brand and on a custom domain. The important shift is that these are not five separate modules you stitch together and hope stay in sync. They are one connected front office, which is why the whole thing can be created from a single conversation instead of a week of setup. You are not replacing GoHighLevel piece by piece so much as replacing the whole assembly with one system that already fits together.",
+    },
+    {
+      h2: "The pricing difference, in plain terms",
+      body:
+        "Here is what the GoHighLevel bill is actually made of. There is the base plan, reported at 97, 297, or 497 dollars a month depending on tier. There is the AI Employee add-on, reported at roughly 50 or 97 dollars per location. And there is usage on top, since messaging and calls are rebilled: SMS at around 0.0079 dollars per segment, email at about 0.675 dollars per thousand, and calls at roughly 0.014 dollars per minute. On the 297-dollar plan and above that usage is rebilled at cost without markup, but on the 497-dollar plan the rebilling carries a markup. Three moving parts, and at least one of them scales with every client and every conversation.\n\nSeldonFrame collapses that to one number: 29 dollars a month, flat, with unlimited workspaces and the first workspace free forever. The AI receptionist, website, CRM, booking, reviews, client portal, and custom domains are all included at that price. There is no per-location AI surcharge to stack, because the AI is the product. You can cancel anytime, and there is no trial gate to clear first.\n\nThe usage question is where the real difference lives, and it is worth being precise. Messaging and calls still cost money on any platform, because carriers charge for them. The difference is who sits in the middle. SeldonFrame runs on your own AI keys and your own Twilio account, so you pay the raw provider cost directly with no platform layer marking it up or wallet to keep topped off. That is the mechanism behind the flat price, not a headline feature, and it is why the honest way to compare the two is not a single dollar figure but the shape of the bill. One is a base plus a per-location add-on plus rebilled usage that can carry a markup. The other is a flat 29 plus whatever the carriers charge you directly. For a business booking real work, one booked job tends to cover the platform for the month, which is the number that actually matters.",
+    },
+    {
+      h2: "What you keep, and what you honestly give up",
+      body:
+        "A fair comparison has to name the losses, not just the wins. GoHighLevel is genuinely strong in places, and if you lean on those places, switching will feel like a downgrade. Its funnel builder is deep and mature, with a large ecosystem of templates and snapshots you can drop in and customize. Its email and SMS automation goes far past answer-and-book into long, branching, multi-step campaigns. And it has a big, active community producing tutorials, prebuilt assets, and answers to almost any question. Those are real advantages built over years.\n\nSeldonFrame does not try to match all of that, and pretending otherwise would not help you decide. It is built around the front-office job, capturing leads and booking them, done fast and priced flat. If your business runs on elaborate marketing funnels, on nurture sequences with a dozen conditional branches, or on a library of snapshots you deploy across clients, those are exactly the strengths you would be trading away. You should weigh that honestly before you move.\n\nWhat you keep is the part most local-service businesses actually run on every day: a professional site, a working CRM, live booking, and an AI receptionist that answers instantly across voice, chat, and SMS, all under your own brand. You also gain things that are awkward or expensive on the other side, chiefly a flat price that does not climb with each client and infrastructure you own through your own keys and Twilio. The clean way to think about it is that you keep the daily front office and give up the heavy marketing-automation depth. For a lot of businesses that trade is obviously worth it. For some it is not, and the next-to-last section is about telling those apart.",
+    },
+    {
+      h2: "How to set it up in about three minutes",
+      body:
+        "The setup is deliberately not a project. You open SeldonFrame and describe your business in one conversation, the way you would explain it to a new employee: what you do, where you work, what you want the receptionist to say, and how you want people to book. From that conversation it builds the whole front office, the website, the CRM, the booking system, and the AI receptionist, and stands the workspace up in about three minutes. There is no funnel to wire, no calendar integration to connect, no AI module to purchase and configure separately.\n\nIf you are moving from GoHighLevel, fold your migration into this. Import the contact CSV you exported from your old account so the CRM opens with your real customers already in it, and confirm your tags and segments carry the meaning they had before. Point your custom domain at the new site, which is included, and if you are keeping your existing phone number, port it into your own Twilio so the receptionist answers on the number your customers already know. Because you control those keys and that number, this is infrastructure you own rather than rent.\n\nFor an agency, the same three-minute conversation is how you onboard each client. Every client gets a full whitelabel workspace built the same way, so adding a client is a short conversation instead of a setup engagement, and there is no per-location AI fee stacking up behind each one. The first workspace is free forever, which means you can build a real client front office and see the whole thing working before you decide to pay for anything. That is the intended way to evaluate the switch: build one for real, watch it answer and book, and judge it against what you were paying before.",
+    },
+    {
+      h2: "When you should not replace GoHighLevel",
+      body:
+        "Some businesses should stay exactly where they are, and it is worth saying so plainly. If your revenue depends on sophisticated marketing funnels with upsells, order bumps, and carefully tuned landing-page sequences, GoHighLevel's funnel builder is a core strength you would be giving up. If you run long, conditional email and SMS campaigns, the kind with many branches reacting to how each lead behaves over weeks, that automation depth is another place the platform genuinely earns its price. Replacing tools you rely on daily to save on a monthly bill is a bad trade.\n\nThe same caution applies to agencies whose product is the funnel and snapshot machine itself. If you sell clients on elaborate campaign builds, resell across a library of snapshots, and lean on the community for prebuilt assets and playbooks, that entire way of working is built on GoHighLevel's strengths. Moving to a front-office-first platform would mean rebuilding your service around a different center of gravity, and for a funnel-heavy agency that is not a switch, it is a change of business model. There is no shame in staying on the tool that fits how you actually make money.\n\nSeldonFrame is the right replacement when the front office is the point: when you are a local-service business or an agency serving them, when the job is answering every lead and booking it before it goes cold, and when you are tired of paying agency-suite prices, per-location AI add-ons, and marked-up usage for capability you never touch. If that describes you, the bundle you have been paying for is mostly shelfware, and replacing it with a flat 29-dollar front office on your own keys is the obvious move. If it does not, keep what works. The honest recommendation depends entirely on which of these two businesses is yours.",
+    },
+  ],
+  faq: [
+    {
+      q: "Can SeldonFrame replace GoHighLevel?",
+      a: "For the front-office job, yes. SeldonFrame includes a website, CRM, booking, an AI receptionist that answers by voice, chat, and SMS, reviews, a client portal, and custom domains, which covers what most local-service businesses and their agencies use GoHighLevel for day to day. It does not try to match GoHighLevel's deep funnel builder or long branching email and SMS campaigns, so whether it is a full replacement depends on whether you rely on those heavier marketing features.",
+    },
+    {
+      q: "What do I give up by switching?",
+      a: "Honestly, the marketing-automation depth. GoHighLevel has a mature funnel builder, a large library of templates and snapshots, deep multi-step email and SMS automation, and a big community. If your business runs on elaborate funnels or long conditional campaigns, those are real strengths you would be trading away. What you keep is the daily front office, the site, CRM, booking, and AI receptionist, under your own brand at a flat price.",
+    },
+    {
+      q: "How much do I save?",
+      a: "It depends on your current plan and how many clients you run, so the honest answer is the shape of the bill rather than a single figure. GoHighLevel stacks a base plan, reported at 97 to 497 dollars a month, a per-location AI add-on reported at roughly 50 or 97 dollars, and rebilled usage. SeldonFrame is a flat 29 dollars a month with the AI included and usage running at raw provider cost through your own keys and Twilio, so the savings grow with every client and every added location you would otherwise pay a per-location AI fee on.",
+    },
+  ],
+  sources: [
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/how-to-switch-from-gohighlevel.ts
+++ b/packages/crm/src/lib/seo/guides/how-to-switch-from-gohighlevel.ts
@@ -1,0 +1,70 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "how-to-switch-from-gohighlevel",
+  title: "How Do I Switch From GoHighLevel Without Losing My Data? (2026 Step-by-Step)",
+  description:
+    "A step-by-step guide to migrating off GoHighLevel: export contacts, move funnels and workflows, and archive the data that does not transfer before you cancel.",
+  targetKeyword: "how to switch from gohighlevel",
+  intent: "transactional",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/ai-website-generator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "Switching off GoHighLevel is mostly a data problem, not a technical one. Do the export in the right order and you keep everything that matters, then cancel with nothing left behind.",
+  sections: [
+    {
+      h2: "Before you switch: inventory what you actually have",
+      body:
+        "The reason people stall on leaving GoHighLevel is not the new platform. It is the fear of hitting cancel and discovering that a client list, a booking calendar, or two years of lead history evaporated with the account. That fear is reasonable, and the fix is simple: before you touch anything, write down everything the account holds. An hour of inventory now saves a weekend of panic later.\n\nWalk through the platform one section at a time and list what lives there. Contacts and their tags. Funnels and landing pages. Websites. Workflows and automations. Calendars and booking links. Forms and surveys. Conversation history across SMS, email, and calls. Phone numbers you are renting. Any custom domain pointed at the account. Snapshots you have saved. For an agency, do this once per sub-account, because each client workspace is its own island of data and each has to be handled separately.\n\nAs you list each item, mark it as one of three things: exports cleanly, moves through a snapshot, or has to be archived by hand. That single label tells you exactly how much work switching will take. Most of your data falls in the first two buckets and moves without drama. The third bucket, the manual-archive items, is small but it is the part people forget, so flag it loudly now while you are still paying for access.",
+    },
+    {
+      h2: "Step 1 — Export your contacts as a CSV",
+      body:
+        "Your contact list is the asset you cannot afford to lose, so handle it first, while the account is fully active. In GoHighLevel this is a built-in feature: open Contacts, then use the Export option to download your contacts as a CSV file. That file is yours to keep, and it is the single most important thing you will pull out of the platform. Do it before you change anything else.\n\nOpen the CSV and check it before you trust it. Make sure names, phone numbers, emails, tags, and any custom fields you rely on actually came through. Tags are easy to overlook and they carry the segmentation logic that tells you who is a lead, who is a past customer, and who opted out. If those columns are missing or garbled, fix the export now rather than discovering the gap after you have canceled. Save at least two copies of the clean file in separate places, such as a cloud drive and your own machine.\n\nA CSV of contacts imports into essentially any modern platform, which is what makes it the safe backbone of your move. Once that file is downloaded, verified, and backed up, the highest-stakes part of switching is already done. Everything after this is either a snapshot transfer or a rebuild, and neither of those can wipe out the customer relationships you spent real money to acquire. Treat this file as the thing you protect first and cancel around.",
+    },
+    {
+      h2: "Step 2 — Move funnels, sites, and workflows via snapshots",
+      body:
+        "Contacts export as a spreadsheet, but funnels, websites, and workflows are structured builds that a CSV cannot hold. In GoHighLevel the mechanism for moving these is the snapshot. A snapshot captures funnels, sites, and workflows together as a reusable package, and it is the standard way this kind of build travels between accounts. If you are staying inside the GoHighLevel world for any reason, snapshots let you carry these assets forward instead of rebuilding them from scratch.\n\nGo through each funnel, landing page, website, and workflow you actually use and decide whether it is worth preserving. Be honest here. A lot of what accumulates in one of these accounts is half-finished tests, one-off campaigns, and templates you copied but never launched. You do not need to migrate any of that. Bundle the assets that earn their keep into a snapshot and leave the clutter behind. Switching platforms is a good moment to shed weight, not to faithfully reproduce every dead experiment.\n\nAlso capture the reference material a snapshot does not carry on its own. Screenshot your workflow logic so you have a plain record of what each automation was supposed to do, who it targeted, and when it fired. Note which forms feed which funnels and which calendars connect where. This documentation matters most if your new platform structures things differently, because then you are not copying a build one-to-one, you are recreating the intent behind it. Written-down intent rebuilds faster and cleaner than a mystery flowchart you no longer understand.",
+    },
+    {
+      h2: "Step 3 — Handle what does not migrate cleanly",
+      body:
+        "Some data will not come across cleanly no matter how careful you are, and the most common casualty is conversation history. The back-and-forth threads of SMS, email, and call logs tied to each contact do not reliably transfer, so plan to archive them manually before you cancel. This is the step that separates a clean exit from a regretful one, because once the account closes, whatever you did not save is simply gone.\n\nDecide how much of that history you genuinely need. For most local-service businesses the answer is the recent and the important: active conversations, anything tied to an open deal, and any thread you might need for a dispute, a warranty question, or a compliance record. You rarely need every message from years ago. For the threads that matter, archive them in whatever form you can capture reliably, whether that is exporting where an export exists or methodically screenshotting the conversations you cannot pull out any other way.\n\nRun the same check across the smaller items from your inventory. Form submissions and survey responses, saved reports, invoices or payment records, and any media or documents uploaded into the account all deserve a quick pass. None of these is as heavy as your contact list, but each one is a thing you paid to collect, and each is a thing you cannot get back after cancellation. Work down the manual-archive column you built in the inventory step and check items off as you save them. When that column is empty, you know nothing important is trapped inside the account.",
+    },
+    {
+      h2: "Step 4 — Rebuild your front office on the new platform",
+      body:
+        "With your data safely out, the next question is where it lands. If the reason you are leaving GoHighLevel is cost, complexity, or paying for a sprawling agency suite you never fully used, this is the moment to switch to something built around the job you actually do: answering leads and booking work. SeldonFrame is designed for exactly that. Instead of assembling funnels, calendars, a CRM, and an AI add-on piece by piece, you describe your business in one conversation and it builds the whole front office for you.\n\nFrom that single conversation SeldonFrame stands up a website, a CRM, a booking system, and an AI receptionist that answers by voice, chat, and SMS, along with reviews, a client portal, and a custom domain. The full workspace comes together in about three minutes, and the AI receptionist is the product itself, included, not a per-location upgrade you bolt on later. For an agency, each client gets their own whitelabel workspace built the same fast way, so onboarding a new client is a conversation, not a project.\n\nOnce the workspace exists, bring your data home. Import the contact CSV you saved in Step 1 and confirm your tags and segments line up with how the new CRM organizes people. Recreate the automations that earned a place on your keep list, using the screenshots and notes from Step 2 as your blueprint rather than trying to mirror the old builder click for click. Because the receptionist, site, booking, and CRM are one connected system here instead of separate modules wired together, most rebuilds are faster than the export was, and the pricing is a flat 29 dollars a month running on your own AI keys and your own Twilio, so what you pay reflects real usage instead of a platform markup.",
+    },
+    {
+      h2: "Step 5 — Port your numbers and domain, then cancel",
+      body:
+        "Do not cancel the day you finish rebuilding. The last real risk in switching is your phone numbers and your domain, because those are the addresses your customers already use to reach you. A number that goes dead or a domain that points at nothing means missed calls and a broken website during the exact window when you are trying to look more professional, not less. Handle both before you close the account, not after.\n\nFor phone numbers, start a port to your new setup rather than letting the number lapse. Porting keeps the number your customers have saved and printed on trucks, cards, and past invoices, and it prevents leads from calling into a void. On SeldonFrame the receptionist runs on your own Twilio, so your numbers live in an account you control and are not hostage to the platform you are leaving. For your domain, point it at the new site and verify it resolves correctly and serves over a secure connection before you flip anything off. A custom domain is included, so this is a matter of pointing records, not buying anything new.\n\nWhen the numbers are ported, the domain resolves, and your saved data is imported and verified, run one last pass against the inventory you built in Step 1. Every item should be either live on the new platform or archived somewhere safe. Only then do you cancel GoHighLevel. How long the whole switch takes depends on how many workspaces you run and how much history you choose to archive, so treat any timeline as an estimate rather than a promise. Done in this order, though, the migration is deliberate and reversible right up until the final click, which is exactly how a switch you cannot undo should feel.",
+    },
+  ],
+  faq: [
+    {
+      q: "Can I export my data from GoHighLevel?",
+      a: "Yes, the most important data exports directly. You can download your contacts as a CSV from the Contacts section using the Export option, and that file carries names, numbers, emails, and tags into a new platform. Funnels, websites, and workflows move as a snapshot rather than a spreadsheet. Some data, most notably conversation history, does not transfer cleanly and has to be archived by hand before you cancel.",
+    },
+    {
+      q: "Will I lose my conversations and history?",
+      a: "You can lose them if you skip this step, which is why it matters. SMS, email, and call history tied to your contacts does not reliably migrate between platforms, so plan to archive the threads you need manually while your account is still active. Focus on active conversations, anything tied to an open deal, and records you might need for a dispute or compliance. Once the account is canceled, anything you did not save is gone.",
+    },
+    {
+      q: "How long does migrating off GoHighLevel take?",
+      a: "It depends on how many workspaces you run and how much history you choose to keep. A single business with a clean contact list and a handful of automations can move quickly, while an agency with many sub-accounts takes longer because each one is exported and rebuilt separately. Rebuilding the front office itself is fast on a platform like SeldonFrame, where a full workspace is generated from one conversation in about three minutes, so the archiving usually takes more time than the setup. Treat any timeline as an estimate.",
+    },
+  ],
+  sources: [
+    {
+      label: "SchedulingKit — Migrate from GoHighLevel",
+      url: "https://schedulingkit.com/migrate-from/gohighlevel",
+    },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/index.ts
+++ b/packages/crm/src/lib/seo/guides/index.ts
@@ -49,6 +49,24 @@ import { guide as howToGetMoreGoogleReviews } from "./how-to-get-more-google-rev
 import { guide as howToRespondToANegativeReview } from "./how-to-respond-to-a-negative-review";
 import { guide as missedCallTextBack } from "./missed-call-text-back";
 import { guide as onePersonCompanyOs } from "./one-person-company-os";
+import { guide as howMuchDoesGohighlevelCost } from "./how-much-does-gohighlevel-cost";
+import { guide as gohighlevelPricingPlansExplained } from "./gohighlevel-pricing-plans-explained";
+import { guide as hiddenGohighlevelFees } from "./hidden-gohighlevel-fees";
+import { guide as isGohighlevelAiEmployeeWorthIt } from "./is-gohighlevel-ai-employee-worth-it";
+import { guide as bestGohighlevelAlternatives } from "./best-gohighlevel-alternatives";
+import { guide as gohighlevelVsSeldonframe } from "./gohighlevel-vs-seldonframe";
+import { guide as bestGohighlevelAlternativeForSolopreneurs } from "./best-gohighlevel-alternative-for-solopreneurs";
+import { guide as gohighlevelVsHubspot } from "./gohighlevel-vs-hubspot";
+import { guide as whyAgenciesLeaveGohighlevel } from "./why-agencies-leave-gohighlevel";
+import { guide as isGohighlevelWorthItForSmallBusiness } from "./is-gohighlevel-worth-it-for-small-business";
+import { guide as isGohighlevelHardToLearn } from "./is-gohighlevel-hard-to-learn";
+import { guide as doINeedGohighlevel } from "./do-i-need-gohighlevel";
+import { guide as howToSwitchFromGohighlevel } from "./how-to-switch-from-gohighlevel";
+import { guide as howToReplaceGohighlevel } from "./how-to-replace-gohighlevel";
+import { guide as howToPriceAnAiReceptionistService } from "./how-to-price-an-ai-receptionist-service";
+import { guide as runClientAiOnYourOwnKeys } from "./run-client-ai-on-your-own-keys";
+import { guide as gohighlevelSaasModeVsFlatPricing } from "./gohighlevel-saas-mode-vs-flat-pricing";
+import { guide as whiteLabelAiFrontOfficeWithoutAgencyPro } from "./white-label-ai-front-office-without-agency-pro";
 
 export { LAST_UPDATED };
 export type { Guide, GuideCluster, GuideSection, GuideFaq, GuideSource, GuideIntent } from "./types";
@@ -63,6 +81,7 @@ export const CLUSTER_LABELS: Record<GuideCluster, string> = {
   "ai-visibility": "AI visibility & GEO",
   reviews: "Reviews & reputation",
   "ai-agents": "Running your business with AI agents",
+  gohighlevel: "GoHighLevel alternatives & pricing",
 };
 
 export const GUIDES: Guide[] = [
@@ -108,6 +127,24 @@ export const GUIDES: Guide[] = [
   howToRespondToANegativeReview,
   missedCallTextBack,
   onePersonCompanyOs,
+  howMuchDoesGohighlevelCost,
+  gohighlevelPricingPlansExplained,
+  hiddenGohighlevelFees,
+  isGohighlevelAiEmployeeWorthIt,
+  bestGohighlevelAlternatives,
+  gohighlevelVsSeldonframe,
+  bestGohighlevelAlternativeForSolopreneurs,
+  gohighlevelVsHubspot,
+  whyAgenciesLeaveGohighlevel,
+  isGohighlevelWorthItForSmallBusiness,
+  isGohighlevelHardToLearn,
+  doINeedGohighlevel,
+  howToSwitchFromGohighlevel,
+  howToReplaceGohighlevel,
+  howToPriceAnAiReceptionistService,
+  runClientAiOnYourOwnKeys,
+  gohighlevelSaasModeVsFlatPricing,
+  whiteLabelAiFrontOfficeWithoutAgencyPro,
 ];
 
 export function getGuide(slug: string): Guide {

--- a/packages/crm/src/lib/seo/guides/is-gohighlevel-ai-employee-worth-it.ts
+++ b/packages/crm/src/lib/seo/guides/is-gohighlevel-ai-employee-worth-it.ts
@@ -1,0 +1,64 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "is-gohighlevel-ai-employee-worth-it",
+  title: "GoHighLevel AI Employee Pricing: Is $50-$97 Per Location Worth It?",
+  description:
+    "GoHighLevel's AI Employee is an add-on at a reported $50-$97 per location plus per-minute voice. Here is when it pays off and when included AI is cheaper.",
+  targetKeyword: "gohighlevel ai employee cost",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/ai-receptionist-cost-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel's AI Employee sits outside every base plan and is billed per location, then again per minute of use. This guide walks the real math per client and shows where included AI wins.",
+  sections: [
+    {
+      h2: "What the AI Employee actually is",
+      body: "The AI Employee is GoHighLevel's bundle of AI features: a voice agent that answers and makes calls, a conversation bot that handles chat and SMS, content and review tools, and a few workflow helpers. On paper it turns your CRM into something that can talk to leads on its own. That is the same job an AI receptionist does, and it is the reason so many agencies want it.\n\nThe important thing to understand up front is that the AI Employee is not part of the platform you already pay for. It is a separate product layered on top of your base subscription. You can run GoHighLevel for months on funnels, pipelines, and automations and never touch it. The moment you want the AI to answer a phone or reply to a text on its own, you are buying a new line item.\n\nThat structure matters because it changes how you should think about the cost. You are not upgrading a plan. You are adding a per-location product and then paying for every minute and message it uses. For a single business that can be fine. For an agency running many clients, the shape of the bill is very different, and that is where people get surprised.",
+    },
+    {
+      h2: "The per-location price, plus usage on top",
+      body: "GoHighLevel prices the AI Employee per location. Reported figures put it at around $50 per month per location on the Growth option and around $97 per month per location on the Unlimited option, or a usage-based route reported at roughly $0.02 to $0.05 per minute instead of the flat fee. A location is one client account, so the number you care about is per client, not per agency.\n\nOn top of that seat cost, you pay for what the AI does. Usage is rebilled at cost: SMS runs around $0.0079 per segment, email around $0.675 per 1,000, and calls around $0.014 per minute. The voice AI specifically is reported at roughly $0.163 per minute in platform cost, which many agencies resell at around $0.40 per minute. None of that is included in the seat price. It stacks.\n\nSo the true monthly cost of one AI-enabled client is the per-location fee plus its share of calls, texts, and emails. A quiet client might barely move the usage meter. A busy one that takes real call volume can push the per-minute charges well past the seat fee. When you quote a client, you are quoting a floor, not a ceiling, and the ceiling depends on how much the AI actually works.",
+    },
+    {
+      h2: "Why margin shrinks as you add clients",
+      body: "The per-location model behaves nicely for one client and badly for ten. Every client you onboard adds another seat fee, so the AI Employee cost grows in a straight line with your client count. There is no volume relief built into the seat price, so the tenth client costs about the same to enable as the first.\n\nA 10-client agency running the flat-rate AI Employee is reported to pay around $970 per month in AI Employee fees alone. That figure is before a single minute of voice, before SMS, before email, and before your GoHighLevel base plan, which starts at $97 per month and runs to $297 or $497 depending on tier. Stack the base plan and the usage on top and the AI line becomes one of your largest recurring costs.\n\nThis is the quiet trap in add-on pricing. It feels affordable when you are testing it on one account. Then you win clients, which is the whole point, and the thing you were selling as a differentiator becomes the thing eating your margin. The more successful you are at putting AI in front of clients, the more the seat fees compound, so growth and cost move together in the wrong direction.",
+    },
+    {
+      h2: "When the AI Employee is genuinely worth it",
+      body: "There is a clear case where paying for the AI Employee makes sense: you are already deep in GoHighLevel. If your funnels, email campaigns, pipelines, and snapshots all live there, and your team already knows the platform, then bolting AI onto that existing setup keeps everything in one place. You avoid a second login and a second system, and for a funnel-heavy agency that convenience can be worth the seat fee.\n\nIt also holds up better for a small number of high-value clients than for a large roster of thin-margin ones. If each client pays you enough that a $50 to $97 seat plus usage is a rounding error in their retainer, the math is comfortable and the integration is a real advantage. The pain only shows up at scale, or when the clients are price-sensitive.\n\nBe honest about which situation you are in. GoHighLevel is strong at the things around the AI: the funnel builder, the template and snapshot library, and deep email and SMS automation. If those are the reason you are on the platform, the AI Employee is a reasonable add-on to an already good fit. If the AI is the main thing you want and the rest is secondary, the add-on model is working against you, and that is the case for looking elsewhere.",
+    },
+    {
+      h2: "The alternative where AI is included, not added",
+      body: "SeldonFrame takes the opposite approach. The AI receptionist is not an add-on you buy per location. It is the product, and it is included. For $29 per month flat you get the receptionist across voice, chat, and SMS, plus a website, CRM, booking, reviews, a client portal, and custom domains, all agency-branded. Workspaces are unlimited, your first workspace is free forever, and you can cancel anytime. There is no free trial gate.\n\nThe reason it stays flat is the mechanism underneath: SeldonFrame runs on your own AI keys and your own Twilio account, so the calls and messages bill at raw provider cost with no platform markup. You are not paying a reseller margin on every minute. That is how the AI can be included instead of metered into a seat fee that grows with every client you add.\n\nThe honest framing is value, not just the smaller number. One booked job from an answered call usually pays for the month. A full client workspace is generated from a single conversation in about three minutes, so the setup cost in time is close to zero. If you are running a roster of clients and the AI receptionist is the thing you actually want in front of them, included AI on flat pricing keeps your margin intact as you grow, which is exactly where the per-location model starts to hurt.",
+    },
+  ],
+  faq: [
+    {
+      q: "Is GoHighLevel's AI Employee included in the base plan?",
+      a: "No. The AI Employee is a separate add-on that sits outside every base plan. You pay your Starter, Unlimited, or Agency plan first, then buy the AI Employee on top of it, and then pay usage for calls, texts, and emails on top of that.",
+    },
+    {
+      q: "How much is the AI Employee per location?",
+      a: "It is priced per location, meaning per client account. Reported figures are around $50 per month per location on the Growth option and around $97 per month per location on the Unlimited option, with a usage-based route reported at roughly $0.02 to $0.05 per minute as an alternative. Voice and messaging usage is billed separately at cost on top.",
+    },
+    {
+      q: "What is a cheaper AI receptionist for multiple clients?",
+      a: "SeldonFrame includes the AI receptionist in a flat $29 per month with unlimited workspaces and the first workspace free forever, so the cost does not grow per client the way a per-location add-on does. It runs on your own AI keys and Twilio, so calls and messages bill at raw provider cost with no platform markup.",
+    },
+  ],
+  sources: [
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+    {
+      label: "NetPartners — GoHighLevel AI Pricing 2026",
+      url: "https://netpartners.marketing/gohighlevel-ai-pricing/",
+    },
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/is-gohighlevel-hard-to-learn.ts
+++ b/packages/crm/src/lib/seo/guides/is-gohighlevel-hard-to-learn.ts
@@ -1,0 +1,66 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "is-gohighlevel-hard-to-learn",
+  title: "Is GoHighLevel Hard to Learn? What the Learning Curve Really Costs You",
+  description:
+    "GoHighLevel's learning curve is real, reported at one to three weeks to get productive. Here is what that time costs and how to go live in minutes instead.",
+  targetKeyword: "is gohighlevel hard to learn",
+  intent: "informational",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/ai-website-generator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel replaces a whole stack of tools, and that power is exactly why it takes time to learn. Here is how long it really takes, what that time costs you, and a lighter path that goes live in minutes.",
+  sections: [
+    {
+      h2: "Why GoHighLevel feels overwhelming",
+      body:
+        "If you have opened GoHighLevel for the first time and felt lost, you are not alone, and you are not doing anything wrong. The reason it feels overwhelming is simple: it is not really one tool. It is a whole stack of tools bolted together under one login. In a single dashboard you get a CRM, a funnel and landing page builder, an email platform, an SMS platform, a calendar and booking system, a reputation and reviews tool, a pipeline manager, and, for agencies, the ability to spin up and rebill client accounts.\n\nEach of those pieces would be its own product from another company, with its own settings and its own way of thinking. GoHighLevel puts them all in front of you at once. That is genuinely valuable if you want everything in one place, but it means the first screen you see is dense with menus and options that assume you already know what you are trying to build. Nothing is hidden, which is part of the problem. You are handed the whole cockpit on day one.\n\nSo when people ask whether GoHighLevel is hard to learn, the honest framing is this. It is not hard because it is badly made. It is hard because it does a lot, and it expects you to bring the plan. If you already know exactly what funnel you want, which automations should fire, and how your pipeline should flow, the platform is a powerful place to build it. If you are starting from scratch and just want customers handled, the sheer surface area is what slows you down."
+    },
+    {
+      h2: "How long it really takes",
+      body:
+        "The commonly reported timeline is worth stating plainly, because it sets expectations. Across reviews and practical guides, becoming functional with GoHighLevel is reported to take somewhere between one and three weeks. Functional here means you can find your way around, set up the core pieces you need, and run day-to-day work without getting stuck. Mastering the platform, meaning you can build advanced automations and multi-step funnels with confidence, is reported to take considerably longer.\n\nIt helps to separate those two stages, because owners often conflate them and get discouraged. Getting to functional is the realistic near-term goal, and one to three weeks is the number to plan around. That does not mean three straight weeks of study. It usually means chipping away over that period, watching tutorials, building something, breaking it, and fixing it. The mastery stage is where the deep power lives, and most owners reach it gradually over months of real use rather than in a single sprint.\n\nThe important point is that this curve is not a bug you can skip past. It is the direct cost of the platform's depth. A tool that replaces eight other tools has, roughly, eight tools worth of concepts to learn. To be fair to GoHighLevel, once you are past the curve, a lot of owners and agencies say the payoff is real and they would not go back to stitching separate apps together. The curve is the entry fee. The question is whether you want to pay it, and whether you have the weeks to spare."
+    },
+    {
+      h2: "The hidden cost of setup time",
+      body:
+        "The one-to-three-week figure is easy to underestimate because it looks like a one-time chore. But that time has a real price, and it shows up in one of two ways. The first is opportunity cost. Every hour you spend learning menus and wiring automations is an hour you did not spend serving customers, closing quotes, or doing the work that actually brings money in. For an owner who is already stretched, weeks of ramp-up is not free time being used. It is billable or growth time being spent on setup.\n\nThe second way the cost shows up is cash. Many owners decide, sensibly, that they do not want to learn the platform themselves, so they hire someone who already knows it. This is common enough that a whole market of GoHighLevel specialists exists. Reported one-time setup fees for that help commonly land somewhere around $500 to $3,000, and ongoing management retainers are reported to run somewhere around $500 to $2,000 a month. Those figures are reported ranges rather than fixed prices, and what you pay depends on how much you want built, but they show the shape of the cost.\n\nEither way, the learning curve is not really about difficulty. It is about time and money you may not have budgeted for. When you compare platforms on monthly price alone, this cost stays invisible, which is exactly why it catches people out. A tool that is cheaper per month but takes three weeks or a paid specialist to stand up may cost more, all in, than a tool that goes live the same day. It is worth putting the setup cost on the same page as the subscription cost before you decide."
+    },
+    {
+      h2: "How snapshots help, and where they stop",
+      body:
+        "GoHighLevel has a genuine answer to the blank-screen problem, and it deserves credit. They are called snapshots. A snapshot is a prebuilt setup, complete with funnels, automations, pipelines, and campaigns, that you can import into an account in one move instead of building everything by hand. There is a large ecosystem of snapshots, some free and some sold, aimed at specific industries. For someone who does not want to start from nothing, snapshots can save a lot of the initial build time.\n\nSnapshots are a real strength, and if you are leaning toward GoHighLevel you should absolutely use them rather than building from scratch. They shortcut the assembly, and a good industry snapshot can get you a working skeleton fast. This is one of the areas where the platform's maturity shows, and a lighter tool simply will not have this depth of prebuilt systems to draw from.\n\nBut a snapshot shortcuts the building, not the learning. Once a snapshot is imported, you still have to understand what it did, so you can edit it, fix it when a customer flow does not match your business, and adjust the automations to your actual services. If something misfires, you need to know enough about the platform to trace why. So snapshots move the starting line closer, which is worth a lot, but they do not remove the one-to-three-week climb to being genuinely comfortable. You get a running start and still have to run."
+    },
+    {
+      h2: "The alternative: one conversation, minutes to live",
+      body:
+        "If the learning curve is the main thing holding you back, it is worth knowing that the weeks of setup are not the only way. The reason GoHighLevel takes time is that it hands you a builder and asks you to assemble the system. A different approach flips that around: describe your business once, and have the system assemble itself. That is how SeldonFrame works. You have one conversation about your business, and in about three minutes you get a full client workspace that is already live.\n\nThat workspace is not a blank shell either. It comes out with an AI receptionist that handles voice, chat, and SMS, plus a website, a CRM, online booking, review collection, a client portal, and a custom domain, all wired together and ready to take calls and bookings. There is nothing to snapshot, import, or reconnect. The AI receptionist is the core of the product rather than a separate add-on you learn and enable later, so the thing most owners actually want, the phone answered and the calendar filled, is working from the first few minutes.\n\nThe pricing matches the simplicity. SeldonFrame is $29 a month, flat, with unlimited workspaces, the first workspace free forever, and no trial gate to wrestle with. It runs on your own AI keys and your own Twilio account, so usage flows through at raw provider cost with no platform markup, which is what keeps the price flat instead of creeping up as you grow. To be fair, this is a trade. You give up the deep funnel building and the huge snapshot library that make GoHighLevel powerful for serious marketers and agencies. If that depth is what you need, GoHighLevel earns its learning curve. But if you mostly want to be live today instead of in three weeks, one conversation beats one to three weeks of study."
+    }
+  ],
+  faq: [
+    {
+      q: "How long does it take to learn GoHighLevel?",
+      a: "Reviews and practical guides commonly report about one to three weeks to become functional, meaning you can navigate the platform and run core tasks, with mastering advanced funnels and automations taking considerably longer. That timeline is a direct result of how much GoHighLevel does, since it replaces many separate tools at once."
+    },
+    {
+      q: "Is GoHighLevel beginner-friendly?",
+      a: "It is capable rather than beginner-friendly. Because it combines a CRM, funnel builder, email and SMS tools, booking, and reputation management in one dashboard, beginners often feel overwhelmed at first. Snapshots, which are prebuilt setups you can import, ease the initial build, but you still need to learn the platform to edit and troubleshoot what they create."
+    },
+    {
+      q: "Is there an easier alternative?",
+      a: "Yes. SeldonFrame lets you build a full, live workspace from one conversation in about three minutes, with an AI receptionist, website, CRM, booking, and reviews already wired together, for $29 a month flat. It trades GoHighLevel's deep funnel building and large snapshot library for a setup that is live the same day rather than after one to three weeks."
+    }
+  ],
+  sources: [
+    {
+      label: "NetPartners — Is GoHighLevel Hard to Learn?",
+      url: "https://netpartners.marketing/is-it-hard-to-learn-gohighlevel-a-practical-guide-for-business-owners-agencies-and-certified-experts/"
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/"
+    },
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/is-gohighlevel-worth-it-for-small-business.ts
+++ b/packages/crm/src/lib/seo/guides/is-gohighlevel-worth-it-for-small-business.ts
@@ -1,0 +1,66 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "is-gohighlevel-worth-it-for-small-business",
+  title: "Is GoHighLevel Worth It for a Small Business? An Honest 2026 Take",
+  description:
+    "GoHighLevel is powerful but built for agencies. An honest look at whether it is worth it for a small service business, and a simpler alternative.",
+  targetKeyword: "is gohighlevel worth it for small business",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/gohighlevel-cost-calculator",
+  relatedBest: "/best/small-business",
+  dek: "GoHighLevel can do almost everything, but it was designed for marketing agencies, not a plumber or a salon owner. Here is the honest case for and against it, plus a lighter option if the full platform is more than you need.",
+  sections: [
+    {
+      h2: "What GoHighLevel is really built for",
+      body:
+        "GoHighLevel gets recommended constantly, and for good reason. It is a genuinely capable platform. But it helps to understand who it was actually built for, because that explains almost everything about how it looks and feels. GoHighLevel was designed for marketing agencies. The whole product is shaped around an agency that manages many client accounts, resells the software under its own brand, and runs campaigns on behalf of dozens of businesses at once.\n\nThat design choice shows up everywhere. The pricing tiers are built around agencies. The Starter plan is reported at $97 a month, the Unlimited plan at $297 a month, and the Agency Pro or SaaS tier at $497 a month, with annual plans reported to work out to roughly two months free. The higher tiers exist so an agency can create unlimited sub-accounts and rebill them. If you are one small business running your own front desk, you are looking at a tool where most of the machinery is aimed at someone reselling it, not someone using it for a single location.\n\nNone of this makes GoHighLevel a bad product. It makes it a specific product. When people ask whether it is worth it for a small business, the honest answer starts with a question back: are you the kind of user it was built for, or are you trying to fit an agency tool around a single storefront? The rest of this guide walks through both sides so you can decide."
+    },
+    {
+      h2: "The honest case for it",
+      body:
+        "There is a real case for GoHighLevel even if you are a small business, and it is worth taking seriously before you dismiss it. The strongest argument is consolidation. If you are currently paying for a separate CRM, a separate email tool, a separate scheduling app, a separate landing page builder, and a separate reputation tool, GoHighLevel can genuinely replace all of them under one login. For an owner who is tired of juggling five subscriptions and five passwords, that alone can justify the cost.\n\nThe second part of the case is depth. When it comes to marketing funnels, GoHighLevel is excellent. Its funnel and landing page builder is deep and flexible. Its email and SMS automation is powerful, and you can build long, branching sequences that fire based on almost any behavior. Its library of templates and snapshots means you can import a whole prebuilt system rather than starting from a blank screen. If your growth actually depends on running campaigns, nurturing leads over weeks, and testing offers, these are real strengths that a lighter tool will not match.\n\nThe honest version of the case for it is conditional. GoHighLevel is worth it for a small business when two things are true at once. First, you will genuinely use the marketing depth, not just admire it. Second, you have the time or the help to run it. If you are the type of owner who lives in your marketing and enjoys building systems, the platform can pay for itself many times over. The trouble is that a lot of small businesses buy it and then use maybe a tenth of what they are paying for."
+    },
+    {
+      h2: "The honest case against it",
+      body:
+        "The case against GoHighLevel for a small business comes down to three things: the learning curve, the way the AI is priced, and the features you will never touch. Start with the learning curve. Reviews and guides commonly report that it takes somewhere between one and three weeks to become functional with GoHighLevel, and longer to truly master it. That is not a knock on the software. It is a direct result of how much it does. But for a busy owner who is already answering phones and running jobs, one to three weeks is a serious ask.\n\nNext is the AI. A lot of the modern interest in GoHighLevel is about its AI features, but on GoHighLevel the AI Employee is an add-on, not part of the base plan. It is reported at roughly $50 a month per location on the Growth option or around $97 a month per location on the Unlimited option, or alternatively priced at around two to five cents per minute of usage. On top of that, usage like calls, texts, and emails is rebilled, with calls reported at around $0.014 a minute, SMS around $0.0079 per segment, and email around $0.675 per thousand. Each piece is small, but they stack, and they stack in a way that is hard to predict before you turn everything on.\n\nThe third argument is the simplest. You will probably pay for capability you never use. Multi-account management, agency rebilling, deep pipeline automation, and sprawling funnel systems are all part of what you are buying. If your actual need is answering the phone, booking jobs, and asking happy customers for reviews, you are renting a warehouse to store a toolbox. To be fair, GoHighLevel does not hide any of this, and plenty of owners are happy to grow into the extra room. The question is whether you will."
+    },
+    {
+      h2: "The real question to ask yourself",
+      body:
+        "Skip the feature comparison for a moment, because the honest deciding question is not about features at all. It is about time. Ask yourself: do I have a few hours a week, every week, to run a marketing platform? Not to set it up once, but to keep it fed with content, keep the automations tuned, and keep the campaigns moving. GoHighLevel rewards owners who put that time in. It quietly punishes the ones who do not, because an unused platform still charges full price every month.\n\nThere is a second question hiding behind the first. What is the one job you actually hired the software to do? For most small service businesses, the honest answer is some version of stop missing leads and fill the calendar. If that is your real goal, be careful not to buy a whole growth suite to solve a front-desk problem. It is easy to talk yourself into the bigger tool because it can do more, and then discover that the extra power is exactly what makes it slow to learn and slow to run.\n\nBe fair to yourself in both directions. If you are ambitious about marketing, run funnels, and want one platform for everything, GoHighLevel may be exactly right, and you should not shy away from it because of the learning curve. But if you mostly need the phone answered and the booking page filled, the same power that makes it great for agencies is what makes it heavy for you. Naming your real job first keeps you from overbuying."
+    },
+    {
+      h2: "The lighter alternative for service businesses",
+      body:
+        "If your honest answer is that you want the phone answered and the calendar filled without becoming a part-time marketing operator, there is a lighter path. SeldonFrame is built for exactly that. It is an AI front office for a service business: an AI receptionist that handles voice, chat, and SMS, plus a website, a CRM, online booking, review collection, a client portal, and a custom domain, all in one place. The AI receptionist is the product, not a bolt-on you switch on later and get billed for separately.\n\nThe pricing is deliberately simple. SeldonFrame is $29 a month, flat. You get unlimited workspaces, your first workspace is free forever, and you can cancel anytime. There is no trial gate to work around and no per-location AI add-on stacking on top. It runs on your own AI keys and your own Twilio account, which means the calls and texts flow through at raw provider cost with no platform markup. That is the mechanism that keeps the price flat instead of climbing every time your call volume grows. For a small business, one booked job usually covers the month.\n\nSetup is the other big difference. Instead of one to three weeks of learning, you build a full client workspace from a single conversation in about three minutes, and it comes out live with the website, booking, and receptionist already wired together. To be clear, this is not GoHighLevel with a discount. If you need advanced funnels, deep multi-step email campaigns, agency rebilling, or a giant template marketplace, GoHighLevel is still the stronger fit and you should stay with it. But if the real job is never miss a lead and book more jobs, a focused AI front office does that job with far less to learn and a bill that does not surprise you."
+    }
+  ],
+  faq: [
+    {
+      q: "Is GoHighLevel good for small businesses?",
+      a: "It can be, but with a condition. GoHighLevel was built for marketing agencies, so a small business benefits most when it will actually use the marketing depth, like funnels and long email campaigns, and has a few hours a week to run it. If your real need is answering the phone and filling the calendar, you will likely pay for a lot of capability you never touch."
+    },
+    {
+      q: "Is GoHighLevel hard to learn?",
+      a: "There is a real learning curve. Guides and reviews commonly report that it takes about one to three weeks to become functional and longer to master, because the platform replaces many separate tools at once. That is a fair trade for its depth, but it is a meaningful time cost for a busy owner who just wants the software running."
+    },
+    {
+      q: "What is a simpler alternative for a local business?",
+      a: "SeldonFrame is a lighter option built for service businesses. It is an AI receptionist for voice, chat, and SMS bundled with a website, CRM, booking, reviews, and a client portal for $29 a month flat, with the first workspace free forever and no trial gate. You build a live workspace from one conversation in about three minutes instead of spending weeks learning a platform."
+    }
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing"
+    },
+    {
+      label: "NetPartners — Is GoHighLevel Hard to Learn?",
+      url: "https://netpartners.marketing/is-it-hard-to-learn-gohighlevel-a-practical-guide-for-business-owners-agencies-and-certified-experts/"
+    }
+  ]
+};

--- a/packages/crm/src/lib/seo/guides/run-client-ai-on-your-own-keys.ts
+++ b/packages/crm/src/lib/seo/guides/run-client-ai-on-your-own-keys.ts
@@ -1,0 +1,69 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "run-client-ai-on-your-own-keys",
+  title: "Run Your Clients' AI on Your Own Keys — and Stop Paying Platform Markup",
+  description:
+    "GoHighLevel bills AI through its own system and won't let you use your own key. Here is why running client AI on your own account protects agency margin.",
+  targetKeyword: "gohighlevel bring your own openai key",
+  intent: "informational",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/voice-ai-cost-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "Most platforms sit between your clients and the AI providers, and that seat is where your margin quietly leaks. Owning the key and the phone number is how you keep client AI at raw provider cost.",
+  sections: [
+    {
+      h2: "How platforms make money on your AI usage",
+      body:
+        "When you run AI for clients through an all-in-one platform, you are almost never talking to the AI provider directly. The platform holds the account with the model provider, the platform holds the telephony account, and every message, call, and minute flows through its billing system before it reaches you. That middle position is valuable, and platforms are built to capture value from it. There are two ways they do it, and it helps to keep them separate in your head.\n\nThe first is rebilling. The platform meters what your clients use and passes the charge back to you, and you pass it to your client. On its own, rebilling is fair. Somebody has to pay for the SMS segments and the call minutes, and metering them is reasonable. The second lever is markup, and this is where margin leaks. Markup is the platform adding a percentage on top of the real provider cost, or gating the ability to rebill at all behind a higher tier, or charging a flat per-seat AI fee that has nothing to do with actual usage. You can be paying provider cost plus a platform tax and never see the tax broken out on a line item.\n\nThe reason this matters for agencies specifically is scale. One client using a chatbot is a rounding error. Ten clients, each running a voice receptionist and an SMS follow-up sequence and an AI that drafts emails, is real money every month, and the markup compounds silently across all of them. If you never control the underlying account, you never see the raw number, so you cannot tell how much of your bill is cost and how much is toll. The first defense is simply knowing the two levers exist.",
+    },
+    {
+      h2: "GoHighLevel's model: no bring-your-own-key",
+      body:
+        "GoHighLevel is a capable platform, and to its credit it has moved toward transparency on token pricing. Since roughly October 2025 it passes AI token cost through at provider rates with no extra token markup, according to its own AI product pricing documentation. That is a genuinely fair change on the raw token line, and it is worth acknowledging plainly. But token pass-through is only one piece of what your clients actually run.\n\nThe piece that agencies keep asking about is the key itself. GoHighLevel does not let you bring your own OpenAI or LLM key. This is not a rumor. It is an open, upvoted feature request that has been sitting on GoHighLevel's own public ideas board, where agencies have asked to plug in their own provider key and have not been given the option. Everything still flows through GoHighLevel's account and GoHighLevel's billing. The AI Employee capability is sold as an add-on, reported at around fifty dollars per month per location on the Growth tier or around ninety-seven dollars per location on Unlimited, or alternatively on usage at roughly two to five cents per minute. Voice AI has been reported at around sixteen cents per minute in platform cost, which agencies commonly resell somewhere near forty cents a minute. Treat every one of these figures as reported rather than guaranteed, because add-on pricing changes, but the shape is clear: usage and voice still run through the platform even when tokens are passed through at cost.\n\nSo the honest read on GoHighLevel is mixed. Token cost has gotten fairer. The structural fact has not changed: you cannot use your own key, so you never hold the account that the AI actually runs on. On the flat per-location AI fees, one agency running ten clients on flat-rate AI Employee reported roughly nine hundred seventy dollars a month in AI fees alone. That is reported, and your mileage will vary, but it shows how a per-seat model behaves as you add clients. The number grows with your client list whether or not those clients are heavy users.",
+    },
+    {
+      h2: "Why owning the key and the number matters",
+      body:
+        "Owning the key is not about wanting to fiddle with API dashboards. It is about three things that decide whether an agency keeps its margin: cost, portability, and lock-in. Take them one at a time.\n\nCost is the obvious one. When the AI runs on your own Anthropic or OpenAI account, you pay the provider's published rate and nothing sits on top of it. There is no per-location seat fee inflating with your client count, and no resale spread built into the minutes. The same is true of telephony when the calls and texts run on your own Twilio account. You pay Twilio's rate. The platform does not get to decide what a minute or a segment is worth to you, because the platform is not the one selling it to you.\n\nPortability and lock-in are the quieter, more important ones. When the account belongs to you, the work you build belongs to you. Your client's phone number is registered to your Twilio, so it moves with you. Your AI configuration runs against your provider key, so it is not trapped inside one vendor's billing relationship. If you ever change platforms, you are not being held in place by the fear of losing numbers and rebuilding integrations from scratch. This is the never-taxes idea in practice: you should not pay a recurring toll for the privilege of using AI you could buy directly, and you should never be financially punished for keeping your options open. A platform that owns your keys owns your leverage. A platform that lets you own your keys is selling you orchestration, not a tollbooth.",
+    },
+    {
+      h2: "What owning your keys looks like in practice",
+      body:
+        "Here is the concrete version, because the principle is only useful if the setup is simple. On a platform built around your keys, you connect your own AI provider account and your own Twilio account once. From that point, every client workspace you spin up runs its receptionist, its chat, its SMS, and its call handling against your accounts. The tokens bill to your AI provider at provider rate. The minutes and segments bill to your Twilio at Twilio rate. Nothing about the AI usage passes through a platform markup, because the platform is not in the billing path for it.\n\nSeldonFrame is built this way on purpose. The platform charges a flat twenty-nine dollars a month to orchestrate everything, and that fee does not change with how much AI your clients use or how many workspaces you run. Workspaces are unlimited, the first one is free forever, and there is no per-location AI seat to buy because the AI receptionist is the product, not an add-on. Website, CRM, booking, and reviews are all included at that same flat price. You are paying for the software that turns your keys into a finished, client-ready front office, and you are not paying a percentage of your own AI bill on top.\n\nThe spin-up is the part agencies tend to not believe until they see it. A full client workspace, with the AI receptionist configured, the website up, the CRM and booking wired in, comes out of a single conversation in about three minutes. You are not stitching together snapshots or configuring a metering system. You describe the client, the workspace is built, and it runs on the accounts you already own. The orchestration is the paid part. The AI cost stays raw.",
+    },
+    {
+      h2: "The honest trade-off",
+      body:
+        "There is a real trade-off, and pretending otherwise would be the kind of thing this whole approach is against. When you bring your own key, you technically hold a provider account and a telephony account. That means there is an account somewhere with your name on it, a card on file with Anthropic or OpenAI, and a Twilio balance to keep funded. Someone has to have set those up. A platform that hides all of it behind its own billing genuinely removes that small chore for you.\n\nThe question is what that convenience costs. When the platform holds the key, the chore disappears and so does your visibility, your portability, and a slice of your margin on every client every month. When you hold the key and a good platform does the orchestration, you do the one-time setup of connecting two accounts, and in exchange you keep the raw cost, the portability, and the leverage for as long as you run the agency. For most agencies the math is not close, because the setup happens once and the margin compounds for years.\n\nSo the fair conclusion is not that keys are magic. It is that owning the key is the mechanism, and the benefit is ownership. If you value having a single vendor absorb every operational detail and you are not price-sensitive on AI, GoHighLevel's model may suit you, and its token pass-through makes it fairer than it used to be. If you are an agency that wants to keep the spread on AI you resell and keep your work portable, running client AI on your own keys is how you stop paying a markup you cannot see. The platform should earn its flat fee by making that easy. It should not earn a percentage of your growth.",
+    },
+  ],
+  faq: [
+    {
+      q: "Can I use my own OpenAI key with GoHighLevel?",
+      a: "No. GoHighLevel does not let you bring your own OpenAI or LLM key. It is an open, upvoted request on GoHighLevel's own public ideas board, and the AI still runs through GoHighLevel's account and billing. Since about October 2025 it passes token cost through at provider rates with no extra token markup, but you still cannot connect your own key.",
+    },
+    {
+      q: "Does GoHighLevel mark up AI usage?",
+      a: "On raw tokens, GoHighLevel reports passing cost through at provider rates since roughly October 2025, which is fair. The cost that adds up for agencies is the AI Employee add-on, reported at around fifty dollars per location on Growth or ninety-seven on Unlimited, plus voice minutes reported near sixteen cents that agencies resell higher. Treat these as reported figures, since add-on pricing changes.",
+    },
+    {
+      q: "What does bring-your-own-key actually save me?",
+      a: "It keeps AI and telephony at raw provider cost with no platform seat fee or resale spread on top, and it keeps your work portable because the accounts and phone numbers are yours. On SeldonFrame the platform charges a flat twenty-nine dollars a month to orchestrate your own keys, so the AI cost you pay is the provider's rate, not a marked-up bill you cannot see inside.",
+    },
+  ],
+  sources: [
+    {
+      label: "HighLevel — AI Products Pricing",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000006652-ai-product-pricing",
+    },
+    {
+      label: "HighLevel Ideas — Let us use our own OpenAI API Keys",
+      url: "https://ideas.gohighlevel.com/conversation-ai/p/let-us-use-our-own-openai-api-keys",
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/types.ts
+++ b/packages/crm/src/lib/seo/guides/types.ts
@@ -17,7 +17,8 @@ export type GuideCluster =
   | "booking"
   | "ai-visibility"
   | "reviews"
-  | "ai-agents";
+  | "ai-agents"
+  | "gohighlevel";
 
 export type GuideIntent = "informational" | "commercial" | "transactional";
 

--- a/packages/crm/src/lib/seo/guides/white-label-ai-front-office-without-agency-pro.ts
+++ b/packages/crm/src/lib/seo/guides/white-label-ai-front-office-without-agency-pro.ts
@@ -1,0 +1,69 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "white-label-ai-front-office-without-agency-pro",
+  title: "How to White-Label a Client AI Front Office Without the $497/mo Agency Pro Plan",
+  description:
+    "White-labeling in GoHighLevel means the $497 SaaS plan. Here is how to give clients a fully branded AI front office, portal, domain and all, on a flat $29 platform.",
+  targetKeyword: "white label gohighlevel cheaper",
+  intent: "transactional",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/agency-margin-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "A branded portal, a custom domain, and your logo are what clients actually see, and in GoHighLevel all of it sits behind the $497 plan. There is a flat path to the same client-facing result.",
+  sections: [
+    {
+      h2: "What white-label really requires",
+      body:
+        "White-label is a word people use loosely, so it helps to nail down what a client actually experiences. A truly white-labeled front office means the client never sees the platform underneath. They log into a portal that carries your agency's brand, at a web address that belongs to you, with your logo where the vendor's logo would normally sit. When they book an appointment, check a message, or look at their reviews, it feels like your software, not a reseller's skin over someone else's product.\n\nBreak that into the concrete pieces. You need a branded client portal, which is the app your client logs into day to day. You need a custom domain, so the address in the browser bar is yours rather than a generic platform URL. You need your logo and colors carried through the interface. And underneath the branding you need the actual front office doing the work: an AI receptionist that answers calls, chats, and texts, a website, a CRM, booking, and reviews. Branding without a working front office is a shell. A working front office without branding is just you reselling someone else's name.\n\nThe reason this matters for pricing is that these pieces are exactly the ones platforms like to gate. A basic sub-account is cheap to hand out. A fully branded, client-facing, custom-domain portal is the thing platforms reserve for their top tier, because it is what lets you look like a software company. So when you compare platforms on white-label, the real question is not whether they say the word. It is which of these specific pieces are included, and at what price, and which are locked behind an upgrade.",
+    },
+    {
+      h2: "How GoHighLevel gates it",
+      body:
+        "In GoHighLevel, the full white-label experience is SaaS Mode, and SaaS Mode is the Agency Pro plan, reported at four hundred ninety-seven dollars a month. That is the gate. The ability to resell branded sub-accounts under your own brand, with the client-facing portal and the reselling flow, lives on that top plan. The lower plans, reported at ninety-seven and two hundred ninety-seven dollars, give you the platform for your own use and, on the two hundred ninety-seven dollar tier, the ability to rebill usage at cost, but not the branded reselling engine.\n\nRebilling with your own markup lands on the same top tier. Passing client usage through at cost is available on the two hundred ninety-seven and four hundred ninety-seven dollar plans, but adding your own margin on top of that usage is only on the four hundred ninety-seven dollar SaaS or Agency Pro plan. So the two things a reselling agency most wants, a branded client-facing product and the right to charge a markup, are bundled together at the top. You cannot buy just the branding cheaply. To look like a software company to your clients, you pay the top-tier price.\n\nThere is more stacked on top of the plan, too. The AI Employee that powers the smart parts of the front office is an add-on, reported at around fifty dollars per location on Growth or ninety-seven per location on Unlimited, or roughly two to five cents a minute on usage. Those are per-location, so a ten-client agency running flat-rate AI Employee reported around nine hundred seventy dollars a month in AI fees alone. Treat that as reported. The takeaway is that the true cost of a branded AI front office in GoHighLevel is the four hundred ninety-seven dollar plan plus a per-location AI fee for every client plus usage, before you have earned a dollar.",
+    },
+    {
+      h2: "What that gate costs a small or new agency",
+      body:
+        "For an established agency with a full roster, four hundred ninety-seven dollars a month spread across many clients is defensible. For a small or new agency, the same gate is a wall. You are being asked to pay top-tier pricing at exactly the moment you have the fewest clients to spread it across. If you have three clients, the plan alone is a large slice of your revenue, and that is before the per-location AI fees that grow with each client you add.\n\nThe deeper problem is that the gate changes what you can even try. A new agency wants to sign a first client, deliver something genuinely branded and impressive, and use that win to sign the next. If the branded portal only exists at four hundred ninety-seven a month, you either front that cost on a hope, or you launch with an unbranded sub-account that undercuts the whole software-company pitch you were trying to make. Either way, the gate is shaping your business around the platform's pricing rather than around your clients.\n\nThis is the never-taxes idea applied to getting started. You should not have to buy the most expensive plan to look professional to your first client, and you should not have a per-location fee climbing before you have the revenue to carry it. The features that make you look like a real software vendor, the portal and the domain and the branding, are not exotic. They are table stakes for the pitch. Gating them behind the top tier taxes the exact agencies that most need them to grow: the small and the new.",
+    },
+    {
+      h2: "The flat alternative",
+      body:
+        "The flat model unbundles the branding from the price. On SeldonFrame, the branded client portal and custom domains are included at twenty-nine dollars a month. They are not a top-tier feature. The client logs into a portal with your brand, at a domain that is yours, with your logo, and the platform underneath stays invisible, all on the flat price. There is no four hundred ninety-seven dollar plan standing between you and looking like a software company to your first client.\n\nUnderneath the branding, the front office is the whole point. The AI receptionist is the product, included, answering across voice, chat, and SMS. The website, CRM, booking, and reviews are included at the same flat price. Workspaces are unlimited and the first one is free forever, so you can build and demo a real branded client environment before you have spent anything. There is no per-location AI seat to buy, because the AI runs on your own AI keys and your own Twilio at raw provider cost. That means the smart parts of the front office do not carry a per-client platform fee that climbs as you grow, which is exactly the line that hurts on the per-location model.\n\nThe honest way to say it is that the flat model moves the money. Instead of paying a high plan plus per-location AI fees to unlock branding, you pay a small flat fee for the orchestration and run the AI and telephony on accounts you own. The branding your client sees is the same or better. The cost you subtract from your resale price is far smaller and does not grow with your roster. And because the keys and numbers are yours, the work stays portable rather than locked to one vendor's billing. You keep the margin, and you keep your options.",
+    },
+    {
+      h2: "Setup, and where GoHighLevel is still stronger",
+      body:
+        "Setup on the flat model is deliberately fast. A full client workspace, with the branded portal, the custom domain, the AI receptionist configured, the website up, and the CRM and booking wired in, comes out of a single conversation in about three minutes. You describe the client and the workspace is built. You are not assembling snapshots, configuring a metering system, or wiring a reselling flow before you can show a client anything. For a small agency signing clients one at a time, that speed is the difference between demoing today and demoing next week.\n\nThat said, GoHighLevel is genuinely more mature in two areas that matter, and it would be unfair not to say so. Its SaaS configurator is deeper. If you want granular control over building multiple pricing tiers, gating specific features into specific plans, and running a fully productized signup and billing flow, GoHighLevel has years of iteration behind that machine and it shows. And its snapshot and template marketplace is a real asset. You can drop in a mature, niche-specific configuration built and refined by other agencies and be running fast, with a library no newcomer can match on breadth.\n\nSo the recommendation is honest and specific. If your agency's edge is a finely tuned, multi-tier SaaS product built on the snapshot ecosystem, and the per-location AI math works for your client mix, the four hundred ninety-seven dollar plan buys you a mature machine and you should stay. If you are a small, new, or growth-stage agency and your goal is to give each client a genuinely branded AI front office, portal and domain and all, without paying a top-tier gate and a growing per-location fee to do it, the flat path gets you the client-facing result for twenty-nine dollars flat and keeps your margin intact as you scale. Choose on which problem is actually yours.",
+    },
+  ],
+  faq: [
+    {
+      q: "Do I need the $497 plan to white-label GoHighLevel?",
+      a: "For the full branded reselling experience, yes. White-labeling client sub-accounts under your own brand is SaaS Mode, which is the Agency Pro plan, reported at four hundred ninety-seven dollars a month. Rebilling usage with your own markup lives on that same top plan. Lower plans give you the platform, but not the branded client-facing reselling engine.",
+    },
+    {
+      q: "Can I white-label a CRM for clients cheaply?",
+      a: "Yes, on a flat-priced platform. SeldonFrame includes a branded client portal and custom domains at twenty-nine dollars a month, with unlimited workspaces and the first one free forever. The AI receptionist, website, CRM, booking, and reviews are included, and the AI runs on your own keys at raw provider cost, so there is no per-location fee climbing as you add clients.",
+    },
+    {
+      q: "What's included in SeldonFrame's white-label?",
+      a: "At twenty-nine dollars a month flat you get a branded client portal, custom domains, your logo carried through, and the full front office: an AI receptionist across voice, chat, and SMS, a website, CRM, booking, and reviews. Workspaces are unlimited, the first is free forever, and each full client workspace is built from one conversation in about three minutes.",
+    },
+  ],
+  sources: [
+    {
+      label: "GoHighLevel — Pricing",
+      url: "https://www.gohighlevel.com/pricing",
+    },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide",
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+  ],
+};

--- a/packages/crm/src/lib/seo/guides/why-agencies-leave-gohighlevel.ts
+++ b/packages/crm/src/lib/seo/guides/why-agencies-leave-gohighlevel.ts
@@ -1,0 +1,65 @@
+import type { Guide } from "./types";
+
+export const guide: Guide = {
+  slug: "why-agencies-leave-gohighlevel",
+  title: "10 Reasons Agencies Are Leaving GoHighLevel in 2026",
+  description:
+    "From per-location AI fees to markup locked behind the $497 plan, here are 10 reasons agencies switch off GoHighLevel and what they move to.",
+  targetKeyword: "why agencies leave gohighlevel",
+  intent: "commercial",
+  cluster: "gohighlevel",
+  relatedTool: "/tools/agency-margin-calculator",
+  relatedBest: "/alternative-to-gohighlevel",
+  dek: "GoHighLevel built a lot of agencies, and lately it is losing some of them too. The reasons cluster around cost, control, and complexity, and here are ten of them laid out plainly.",
+  sections: [
+    {
+      h2: "It starts with the AI and the fees that stack on it",
+      body: "The first reason is that AI is an add-on, priced per location. GoHighLevel's AI Employee is not part of the base plan. Reported pricing puts it around 50 dollars a month per location on the Growth option or around 97 dollars a month per location on the Unlimited option, or roughly 0.02 to 0.05 dollars per minute on usage. For an agency, the word location is the problem: every client you add multiplies the AI fee, so the feature clients most want to see becomes a line item that grows with your roster.\n\nThe second reason is that usage fees stack on top of that. Even after the add-on, the messages and minutes get billed. SMS is rebilled at around 0.0079 dollars per segment, email at around 0.675 dollars per thousand, and calls at around 0.014 dollars per minute, at cost. Voice AI is reported at roughly 0.163 dollars per minute in platform cost, commonly resold near 0.40 dollars per minute. None of these are outrageous alone, but they pile onto the subscription and the AI add-on until the true monthly cost of serving a client is a moving target you have to keep recalculating.\n\nThe third reason is that rebilling with markup is gated behind the top plan. On the 297-dollar Unlimited plan, usage is rebilled to clients without markup, which sounds fair until you realize it means you cannot mark it up to earn margin on it. The ability to rebill with a markup is reserved for the 497-dollar Agency Pro plan. So the pricing lever that would let you turn usage into profit is locked behind the most expensive tier, and agencies notice that the platform's economics are tilted toward the platform.",
+    },
+    {
+      h2: "You cannot bring your own key, and the learning curve is real",
+      body: "The fourth reason is that you cannot bring your own AI key. This one shows up clearly on GoHighLevel's own ideas board, where an open and upvoted request asks to let users connect their own OpenAI API keys. Because you cannot, you are locked into the platform's AI pricing and its margins instead of paying raw provider cost. For an agency running a lot of AI minutes across many clients, the difference between platform-priced AI and cost-priced AI is the difference between a thin margin and a healthy one, and right now that lever is not available.\n\nThe fifth reason is that the learning curve eats weeks. Independent guides report that it takes roughly one to three weeks to become functional in GoHighLevel, and longer to master. For an agency that is real payroll: someone has to learn the platform deeply enough to build and maintain client accounts, and that onboarding time is a cost before a single client is served. It also creates key-person risk, because the person who knows the system becomes hard to replace.\n\nThe sixth reason is the one that hurts most at scale: margins shrink as you add clients. Because the AI is priced per location and usage stacks on top, your cost of goods grows almost in step with your client count. One widely cited example describes a ten-client agency paying around 970 dollars a month in AI fees alone, reported, before the base subscription and before any other usage. Growth is supposed to improve your margins through leverage. When each new client brings its own recurring AI bill, growth can quietly do the opposite.",
+    },
+    {
+      h2: "The pricing is complex, and you are renting, not owning",
+      body: "The seventh reason is plan and pricing complexity. Between three base tiers at 97, 297, and 497 dollars a month, an AI add-on priced per location, usage rebilled at cost, markup gated to the top plan, and annual discounts worth roughly two months, simply knowing what a client will cost you to serve takes a spreadsheet. Complexity is a cost of its own. Every hour spent modeling the true margin on an account is an hour not spent winning or serving one, and pricing that opaque makes it easy to underprice a client by accident.\n\nThe eighth reason is that you are renting, not owning. Your funnels, your automations, your client accounts, and your workflows all live inside GoHighLevel, and they are portable only to the extent the platform allows. If prices change or the terms shift, you do not have a lot of leverage, because your entire operation is built on rails you do not control. Lock-in is comfortable right up until the moment you want to leave, and then it becomes the whole story. Agencies that have been burned by platform changes before are increasingly wary of building their business on ground they do not own.\n\nThe ninth reason is that you pay for funnel features many clients never use. GoHighLevel's funnel builder, templates, and snapshots are genuinely strong, but a large share of service-business clients, the plumbers, clinics, and cleaners of the world, never touch a funnel. They want the phone answered and jobs booked. When most of a client's plan is capability they will never open, the agency is either eating that cost or passing along a price the client struggles to justify, and either way the value story gets harder to tell.",
+    },
+    {
+      h2: "It can overwhelm small teams, and where agencies go instead",
+      body: "The tenth reason is that it can overwhelm small teams. A large all-in-one platform assumes you have the capacity to run all of it. A two- or three-person agency often does not, and the breadth becomes a burden rather than a benefit. Time goes into managing the tool instead of serving clients, and the features that justified the price sit unused because nobody has the hours to set them up. For a lean team, a simpler system that does the core job well can outproduce a powerful one that nobody has time to fully operate.\n\nWhere do these agencies go? Many move toward a flat-priced, AI-first front office like SeldonFrame. It is 29 dollars a month flat with unlimited workspaces and the first workspace free forever, so adding a client does not add a per-location AI fee, and the whitelabel AI receptionist, website, CRM, booking, reviews, client portal, and custom domain are all included rather than bolted on. It runs on your own AI keys and your own Twilio, so voice and messaging bill at raw provider cost with no platform markup, which is exactly the lever GoHighLevel does not give you. And a full client workspace comes together from one conversation in about three minutes, instead of weeks of setup.\n\nThat model flips the math that pushes agencies out. Costs stay flat as the roster grows, the AI is cost-priced rather than platform-priced, and you own and can port your work rather than renting it. For an agency whose clients are service businesses that mainly need leads answered and jobs booked, the value story becomes simple again: one booked job pays for the month, and margin improves with scale instead of eroding.",
+    },
+    {
+      h2: "A fair word on who should stay",
+      body: "None of this makes GoHighLevel a mistake. It made a lot of agencies successful, and for the right agency it is still the right tool. If your business is funnel-heavy, if you build and sell multi-step funnels, run large tagged email and SMS campaigns, and lean on templates and snapshots to launch offers fast, GoHighLevel's depth is hard to replace and its price is buying something real. The reasons above are reasons to leave only if the features driving the cost are features your clients do not use.\n\nThe honest test is what your clients actually need. If they need funnels and campaigns, stay, because that is where GoHighLevel wins and a front-office tool will not match it. Its automation depth, its reseller layer, and its large, active community are genuine strengths, and switching away from them to save money would be a false economy if you use them every day. The platform is not leaving the market, and for funnel-driven agencies it remains a strong choice.\n\nBut if your clients are service businesses that mainly need the phone answered and the calendar filled, the case for leaving gets strong. The per-location AI fees, the stacked usage, the markup gated behind the top plan, the missing bring-your-own-key option, and the funnel features nobody opens all add up to paying for scale and complexity you do not use. In that case a flat-priced, AI-first front office keeps your margins intact as you grow, and lets you spend your time serving clients instead of modeling their cost. Match the platform to the clients you actually serve, and the decision makes itself.",
+    },
+  ],
+  faq: [
+    {
+      q: "Why do agencies quit GoHighLevel?",
+      a: "The reasons cluster around cost, control, and complexity. AI is a per-location add-on, usage fees stack on top, and the ability to rebill usage with a markup is gated behind the 497-dollar plan. You cannot bring your own AI key, the learning curve is reported at one to three weeks, and margins shrink as you add clients, with one cited example putting a ten-client agency near 970 dollars a month in AI fees alone, reported. On top of that, you are renting rather than owning, and you often pay for funnel features many clients never use.",
+    },
+    {
+      q: "What do agencies switch to?",
+      a: "Many move to a flat-priced, AI-first front office like SeldonFrame. It is 29 dollars a month flat with unlimited workspaces and the first workspace free forever, so adding clients does not add per-location AI fees. The whitelabel AI receptionist, website, CRM, booking, reviews, and custom domains are included, it runs on your own AI keys and Twilio at raw provider cost, and a full client workspace is built from one conversation in about three minutes.",
+    },
+    {
+      q: "Is GoHighLevel worth it for a small agency?",
+      a: "It depends on what your clients need. If your work is funnel-heavy, running multi-step funnels and large email and SMS campaigns with templates and snapshots, GoHighLevel's depth is hard to beat and worth its price. If your clients are service businesses that mainly need leads answered and jobs booked, the per-location AI fees, stacked usage, and unused funnel features often make a flat-priced front office the better fit.",
+    },
+  ],
+  sources: [
+    { label: "GoHighLevel — Pricing", url: "https://www.gohighlevel.com/pricing" },
+    {
+      label: "HighLevel — Pricing & Billing: Wallets, Charges, Rebilling",
+      url: "https://help.gohighlevel.com/support/solutions/articles/155000001156-highlevel-pricing-guide",
+    },
+    {
+      label: "NetPartners — GoHighLevel Agency Pricing, Costs & Margins",
+      url: "https://netpartners.marketing/gohighlevel-agency-pricing-guide/",
+    },
+    {
+      label: "HighLevel Ideas — Let us use our own OpenAI API Keys",
+      url: "https://ideas.gohighlevel.com/conversation-ai/p/let-us-use-our-own-openai-api-keys",
+    },
+  ],
+};


### PR DESCRIPTION
## What
Adds an **18-article GoHighLevel-alternative content cluster** to the `/guides` engine — a new `gohighlevel` cluster positioning SeldonFrame as a GoHighLevel alternative across cost, comparison, decision, and how-to/migration intent. Data-only files (`src/lib/seo/guides/<slug>.ts`), inheriting the citable machinery (HTML + `.md` twin, Article/FAQPage JSON-LD, byline, sitemap/llms.txt, IndexNow) and the `guides.spec.ts` gate.

## The 18 articles
**Cost & pricing truth:** how-much-does-gohighlevel-cost · gohighlevel-pricing-plans-explained · hidden-gohighlevel-fees · is-gohighlevel-ai-employee-worth-it
**Alternatives & comparison:** best-gohighlevel-alternatives *(pillar)* · gohighlevel-vs-seldonframe · best-gohighlevel-alternative-for-solopreneurs · gohighlevel-vs-hubspot
**Reasons & decisions:** why-agencies-leave-gohighlevel · is-gohighlevel-worth-it-for-small-business · is-gohighlevel-hard-to-learn · do-i-need-gohighlevel
**How-to, migration & agency margin:** how-to-switch-from-gohighlevel · how-to-replace-gohighlevel · how-to-price-an-ai-receptionist-service · run-client-ai-on-your-own-keys · gohighlevel-saas-mode-vs-flat-pricing · white-label-ai-front-office-without-agency-pro

Formats span *how much · pricing tiers · 7 hidden fees · 10 reasons · is-it-worth-it · vs · do-I-need · how-do-I · how-to*.

## Principles
- **Fair pricing-tier comparisons**; every article concedes where GoHighLevel wins (funnels, snapshot library, deep email/SMS automation, community).
- **never-lies:** every GoHighLevel figure hedged and traced to a real `sources` entry (spec-enforced).
- **never-taxes framing:** flat \$29, AI included (not a per-location add-on), runs on your own keys at raw provider cost; BYO-key is the mechanism, not the headline.
- **Interlinking:** each funnels via one `relatedTool` (cost/margin/receptionist calculators) + one money page (`/alternative-to-gohighlevel`, `/gohighlevel-pricing`, `/best/*`); the cluster hub auto-groups them at `/guides`.

See `docs/strategy/2026-07-10-gohighlevel-alternative-cluster.md`.

## Gate
- `guides.spec.ts` — **366/366 green** (never-lies source check, markdown render, registry consistency)
- `next build` — **compiled successfully, 682/682 static pages** (up from 648)

🤖 Generated with [Claude Code](https://claude.com/claude-code)