### PR TITLE
fix(ci): green main — clock-rotted booking specs, block-emit drift, throw-contract violations

### DIFF
--- a/docs/learnings/2026-07-10-clock-rotted-test-fixtures.md
+++ b/docs/learnings/2026-07-10-clock-rotted-test-fixtures.md
@@ -1,0 +1,44 @@
+# Clock-rotted test fixtures — frozen dates + a real-clock cutoff
+
+## The problem, in one line
+Booking-availability unit specs failed "identically on certain days" on main
+CI with no code change — every slot-expecting assertion red, every
+empty-expecting assertion green.
+
+## The approach
+1. Read the failing spec first. The fixtures were FROZEN calendar dates
+   (2026-07-01…2026-07-06) — that alone is not a bug.
+2. Grep the code under test for `new Date()` / `Date.now` — found
+   `generateCandidateSlots(policy, dayISO, new Date())` at three call sites
+   in `packages/crm/src/lib/agents/tools.ts`, and the policy filter drops any
+   slot earlier than `now + leadTimeHours` (leadTimeHours default 0 still
+   drops PAST slots).
+3. Diagnosis: the moment the real calendar passed the fixture dates, all
+   fixture slots became "in the past" and were filtered. The failure pattern
+   (slots-expected fail, empty-expected pass) confirms it without running
+   anything.
+4. Fix at the seam the file already advertises: the tool takes an optional
+   `deps` object ("DI over module mocking" — stated in the spec header). Add
+   `now?: () => Date` to the deps type, default `() => new Date()`
+   (production byte-identical), use it at all three call sites.
+5. In the spec, pin `const FROZEN_NOW = () => new Date("2026-06-28...")` —
+   a date BEFORE every fixture — and pass it in every deps object.
+6. Reproduce the failure before the spec change (the deps.now addition is
+   inert until a test passes it), then verify 7/7 green.
+
+## Judgment calls
+- Did NOT use `node:test` `mock.timers` to freeze the global Date: the repo's
+  stated convention is dependency injection over global/module mocking, and
+  the pure function (`generateCandidateSlots`) already took an injected `now`
+  — only the tool layer hardwired the clock. Extend the seam, don't mock.
+- Did NOT make fixtures relative to the real clock ("next Friday from now"):
+  that keeps tests day-dependent (walk-horizon and weekday assertions shift
+  meaning) and makes failures irreproducible. Frozen fixtures + frozen clock
+  is strictly more deterministic.
+- Kept `FROZEN_NOW` a shared const with a comment naming the rot mechanism,
+  so the next fixture added to the file gets pinned by default.
+
+## The reusable rule, one line
+A test that mixes frozen calendar fixtures with code reading the real clock
+is a time bomb — always inject the clock through the existing deps seam and
+pin it earlier than every fixture date.

--- a/docs/learnings/2026-07-10-gates-masking-gates.md
+++ b/docs/learnings/2026-07-10-gates-masking-gates.md
@@ -1,0 +1,47 @@
+# Fail-fast gates mask the gates behind them — always re-run the WHOLE chain after a fix
+
+## The problem, in one line
+Fixing the reported main-CI failures was not enough: two more layers of real
+drift were hiding behind them, each only visible after the layer above it
+went green.
+
+## The approach
+1. Layer 1 (reported): unit tests failed → CI job stopped → the later
+   `pnpm emit:blocks:check` and `pnpm emit:event-registry:check` steps of the
+   SAME job never ran. Both had real drift (a booking status added 2026-06-11
+   was never re-emitted into BLOCK.md / event-registry.json).
+2. Layer 2 (inside one gate): the block-codegen checker `process.exit(1)`s on
+   the FIRST parse failure. An unparseable SKILL.md (fat skill with no
+   `props`) killed the run before it ever compared the `hero` block — whose
+   generated file had real drift (a hand-edited enum missing a value the
+   runtime actually sets, i.e. a live validation bug).
+3. Method that surfaced all of it: after fixing the named failures, run every
+   CI step locally in the workflow's order (read `.github/workflows/ci.yml`
+   for the step list) — not just the tests that were reported red.
+4. On Windows, distinguish real drift from line-ending phantoms: run the
+   emitter in WRITE mode, then ask `git diff` (git normalizes CRLF). Emitters
+   that string-compare their output to a CRLF checkout report 100% "drift"
+   locally; only the files git still shows changed are real.
+5. Prove the fix introduces nothing: full-suite delta vs main tip
+   (`git stash` → run → `git stash pop` → diff the sorted failing-test
+   lists). Verdict here: 0 new, 10 fixed, 98 identical pre-existing
+   env-dependent failures.
+
+## Judgment calls
+- Did NOT "fix" the 9 all-blocks BLOCK.md drift reports — git showed only 2
+  files with real content changes; the rest were CRLF artifacts that CI's LF
+  checkout never sees. Committing them would have been pure churn.
+- Did NOT restructure the emitter to continue-past-parse-errors: tempting
+  ("one bad block shouldn't hide the rest") but out of scope for a green-main
+  fix — noted instead of done (Minimal Impact).
+- Judged local suite health by DELTA against main tip on the same machine,
+  not by absolute green — this repo has a known env-dependent local failure
+  baseline (DB/network-bound specs).
+- Beware `cmd | tail` for verification: the pipeline's exit code is tail's,
+  not the runner's. The first "exit 0" was a lie; rerun with the output
+  redirected to a file and echo the real `$?`.
+
+## The reusable rule, one line
+A red gate is also a blindfold: after fixing what it reported, re-run the
+entire gate chain in CI order locally — and judge "drift" by `git diff`,
+"green" by the real exit code, and suite health by delta vs main.

--- a/packages/core/src/events/event-registry.json
+++ b/packages/core/src/events/event-registry.json
@@ -270,6 +270,10 @@
           "rawType": "string | null",
           "nullable": true
         },
+        "phone?": {
+          "rawType": "string",
+          "nullable": false
+        },
         "conversationId": {
           "rawType": "string | null",
           "nullable": true

--- a/packages/crm/src/app/(dashboard)/settings/features/actions.ts
+++ b/packages/crm/src/app/(dashboard)/settings/features/actions.ts
@@ -22,10 +22,16 @@ export async function toggleModuleAction(formData: FormData): Promise<void> {
   await assertWritable();
 
   const orgId = await getOrgId();
-  if (!orgId) throw new Error("Unauthorized");
+  // Missing org = expired/absent session — the v1.7.3 bug class if thrown
+  // (cascades to "This page couldn't load"). Redirect like every dashboard page.
+  if (!orgId) redirect("/login");
 
   const parsedModuleId = moduleIdSchema.safeParse(formData.get("moduleId"));
   if (!parsedModuleId.success) {
+    // contract:throw-ok: tamper guard — the rendered form only ever submits
+    // ids from MODULE_IDS via a hidden input; this branch is unreachable
+    // without hand-crafting the POST, and a forged request deserves a loud
+    // failure, not a silent pass.
     throw new Error("Invalid module id");
   }
   const moduleId = parsedModuleId.data;

--- a/packages/crm/src/blocks/caldiy-booking.block.md
+++ b/packages/crm/src/blocks/caldiy-booking.block.md
@@ -246,7 +246,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
             "scheduled",
             "completed",
             "cancelled",
-            "no_show"
+            "no_show",
+            "blocked"
           ]
         },
         "from": {
@@ -314,7 +315,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
                   "scheduled",
                   "completed",
                   "cancelled",
-                  "no_show"
+                  "no_show",
+                  "blocked"
                 ]
               },
               "startsAt": {
@@ -526,7 +528,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
                     "scheduled",
                     "completed",
                     "cancelled",
-                    "no_show"
+                    "no_show",
+                    "blocked"
                   ]
                 },
                 "startsAt": {
@@ -762,7 +765,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
                     "scheduled",
                     "completed",
                     "cancelled",
-                    "no_show"
+                    "no_show",
+                    "blocked"
                   ]
                 },
                 "startsAt": {
@@ -962,7 +966,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
                 "scheduled",
                 "completed",
                 "cancelled",
-                "no_show"
+                "no_show",
+                "blocked"
               ]
             },
             "startsAt": {
@@ -1179,7 +1184,8 @@ compose_with: [crm, formbricks-intake, email, sms, payments, automation, brain-v
                 "scheduled",
                 "completed",
                 "cancelled",
-                "no_show"
+                "no_show",
+                "blocked"
               ]
             },
             "startsAt": {

--- a/packages/crm/src/blocks/cinematic-landing/SKILL.md
+++ b/packages/crm/src/blocks/cinematic-landing/SKILL.md
@@ -3,6 +3,10 @@ name: cinematic-landing
 version: 1.0.0
 description: Dark cinematic landing system — looping Pexels MP4 background + liquid-glass UI + Instrument Serif italic typography + Framer Motion choreography. Auto-applied to agency + cinematic-aspirational (coaching, medspa, wellness, luxury) archetypes during create_full_workspace. The marketplace-forkable "fat skill" that captures the entire Aura / Velorah / Aethera / Asme aesthetic family.
 surface: landing-aesthetic
+# Fat skill — an aesthetic layer, not a props-schema block. No flat props
+# to codegen (the v1.12 opt-out, same as composite); runtime primitives
+# live in components/landing/cinematic/.
+codegen: false
 applies_to:
   - hero
   # Phase 2 will extend to: about, services, testimonials, pricing, cta

--- a/packages/crm/src/blocks/hero/__generated__/block.ts
+++ b/packages/crm/src/blocks/hero/__generated__/block.ts
@@ -25,21 +25,8 @@ export const PropsSchema = z.object({
   "background_image_query": z.string().min(2),
   "background_video_query": z.string().min(2).optional(),
   "shiny_word": z.string().min(2).max(30).optional(),
-  "variant": z.enum(["split-image-right", "full-bleed", "founder-portrait"] as const).optional(),
-  // v1.44.0 — template id from hero-templates/registry.ts. When set, the
-  // public renderer dispatches to HERO_TEMPLATES[template] (cinematic-aura,
-  // viktor-light, velorah-editorial, nexora-light, securify-bold,
-  // stellar-tabs-white). Absent → renderer falls back to the legacy
-  // variant system. Hand-edited extension; matches the SKILL.md schema
-  // and will roundtrip through the next `pnpm blocks:emit` cleanly.
-  "template": z.enum([
-    "cinematic-aura",
-    "viktor-light",
-    "velorah-editorial",
-    "nexora-light",
-    "securify-bold",
-    "stellar-tabs-white",
-  ] as const).optional()
+  "variant": z.enum(["split-image-right", "full-bleed", "founder-portrait", "cinematic-aura"] as const).optional(),
+  "template": z.enum(["cinematic-aura", "viktor-light", "velorah-editorial", "nexora-light", "securify-bold", "stellar-tabs-white"] as const).optional()
 });
 
 export type Props = z.infer<typeof PropsSchema>;

--- a/packages/crm/src/lib/agents/tools.ts
+++ b/packages/crm/src/lib/agents/tools.ts
@@ -348,6 +348,10 @@ export type LookUpAvailabilityDeps = {
     },
   ) => CalendarBackend;
   listSlots?: NativeBackendListSlots;
+  /** Clock seam for the lead-time cutoff in generateCandidateSlots. Tests pin
+   *  a frozen date so frozen fixtures never slide into the past; production
+   *  passes nothing and gets the real clock. */
+  now?: () => Date;
 };
 
 export const lookUpAvailability: AgentTool<
@@ -387,6 +391,7 @@ export const lookUpAvailability: AgentTool<
   },
   execute: async (input, ctx, deps: LookUpAvailabilityDeps = {}) => {
     const listSlots = deps.listSlots ?? ((a) => listPublicBookingSlotsAction(a));
+    const now = deps.now ?? (() => new Date());
     // ── booking-mode branch (ICP-3, deployed agents only) ──
     // Workspace/operator agents never set ctx.booking → mode is 'native' and the
     // existing availability chain below runs byte-for-byte unchanged. A deployed
@@ -465,7 +470,7 @@ export const lookUpAvailability: AgentTool<
           )
             .toISOString()
             .slice(0, 10);
-          const dayCandidates = generateCandidateSlots(policy, dayISO, new Date());
+          const dayCandidates = generateCandidateSlots(policy, dayISO, now());
           if (dayCandidates.length === 0) continue; // off-policy weekday / all past
 
           // Prefer the explicit free-windows surface (P1); fall back to deriving
@@ -573,7 +578,7 @@ export const lookUpAvailability: AgentTool<
         // that day (weekday window + duration cadence + lead time).
         if (!hasPolicy) return result.slots;
         const dayCandidates = new Set(
-          generateCandidateSlots(policy, dayISO, new Date()),
+          generateCandidateSlots(policy, dayISO, now()),
         );
         return result.slots.filter((iso) => dayCandidates.has(iso));
       },
@@ -591,7 +596,7 @@ export const lookUpAvailability: AgentTool<
     // booking config (the action returned empty everywhere) should still offer
     // its policy window for the requested day — the candidates, capped at
     // maxPerDay. Workspace agents skip this (they have no policy window to offer).
-    const fallbackCandidates = generateCandidateSlots(policy, input.date, new Date());
+    const fallbackCandidates = generateCandidateSlots(policy, input.date, now());
     if (
       hasPolicy &&
       slots.length === 0 &&

--- a/packages/crm/src/lib/auth/config.ts
+++ b/packages/crm/src/lib/auth/config.ts
@@ -194,6 +194,9 @@ if (resendApiKey) {
 
         if (!response.ok) {
           const detail = await response.text().catch(() => "<no-body>");
+          // contract:throw-ok: NextAuth catches provider errors and routes to
+          // its error page. Swallowing here would show "check your inbox" for
+          // an email that was never sent — the never-lies violation.
           throw new Error(
             `Failed to send sign-in email (${response.status}): ${detail.slice(0, 200)}`,
           );

--- a/packages/crm/src/lib/billing/start-checkout.ts
+++ b/packages/crm/src/lib/billing/start-checkout.ts
@@ -56,10 +56,15 @@ export async function startCheckout(input: StartCheckoutInput): Promise<StartChe
     | null;
 
   if (!response.ok) {
+    // contract:throw-ok: browser-side helper — the sole caller
+    // (upgrade-modal's upgrade()) try/catches and renders the message
+    // via setError; the throw IS the structured error channel here.
     throw new Error(payload?.error ?? `checkout failed: ${response.status}`);
   }
 
   if (!payload?.url) {
+    // contract:throw-ok: same as above — caught by upgrade-modal and
+    // rendered as an inline error state.
     throw new Error("checkout response missing url");
   }
 

--- a/packages/crm/tests/unit/agents/booking/booking-policy-tools.spec.ts
+++ b/packages/crm/tests/unit/agents/booking/booking-policy-tools.spec.ts
@@ -29,6 +29,13 @@ import { resolveBookingPolicy } from "../../../../src/lib/agents/booking/booking
 // 2026-07-01 is a Wednesday → weekday 3.
 const TEST_DATE = "2026-07-01";
 
+// Frozen clock injected via deps.now. generateCandidateSlots drops any slot
+// earlier than now + leadTimeHours, so a real-clock `now` makes these frozen
+// fixtures rot: the suite started failing the moment the calendar passed the
+// fixture dates (broke main CI 2026-07-10). Always keep FROZEN_NOW before
+// every fixture date above/below.
+const FROZEN_NOW = () => new Date("2026-06-28T00:00:00.000Z");
+
 /** A book_external ctx whose policy is 09:00–11:00, 60-min, Wed-only, UTC.
  *  Candidates for TEST_DATE: 09:00 and 10:00 (11:00 wouldn't fit a 60-min slot). */
 function ctxWithPolicy(
@@ -74,6 +81,7 @@ describe("look_up_availability honors the booking policy window ∩ free/busy", 
         backendWithWindows([{ start: `${TEST_DATE}T10:00:00.000Z`, end: `${TEST_DATE}T11:00:00.000Z` }]),
       // not reached on the book_external happy path, but provide a safe default
       listSlots: async () => ({ slots: [], durationMinutes: 60 }),
+      now: FROZEN_NOW,
     };
     const res = (await lookUpAvailability.execute(
       { date: TEST_DATE },
@@ -96,6 +104,7 @@ describe("look_up_availability honors the booking policy window ∩ free/busy", 
       resolveBackend: () =>
         backendWithWindows([{ start: `${TEST_DATE}T00:00:00.000Z`, end: `${TEST_DATE}T23:59:59.000Z` }]),
       listSlots: async () => ({ slots: [], durationMinutes: 60 }),
+      now: FROZEN_NOW,
     };
     const res = (await lookUpAvailability.execute(
       { date: TEST_DATE },
@@ -112,6 +121,7 @@ describe("look_up_availability honors the booking policy window ∩ free/busy", 
       resolveBackend: () =>
         backendWithWindows([{ start: `${TEST_DATE}T09:00:00.000Z`, end: `${TEST_DATE}T11:00:00.000Z` }]),
       listSlots: async () => ({ slots: [], durationMinutes: 60 }),
+      now: FROZEN_NOW,
     };
     const res = (await lookUpAvailability.execute(
       { date: TEST_DATE },
@@ -183,6 +193,7 @@ describe("look_up_availability walks forward across days (book_external)", () =>
       ],
     }),
     listSlots: async () => ({ slots: [], durationMinutes: 60 }),
+    now: FROZEN_NOW,
   };
 
   test("an in-policy Friday returns same-day slots (all on the Friday)", async () => {


### PR DESCRIPTION
## Why

Main's unit-tests CI job has been red: the booking-availability specs failed on three consecutive runs (and on unrelated PRs), plus two more main-only failures (block-codegen staleness, uncaught-throw contract). This PR makes main green again.

## Root causes & fixes

### 1. Booking-availability specs — fixtures rotted past the real clock
Not weekday-dependence: `look_up_availability` hardwired `new Date()` into its three `generateCandidateSlots` call sites, and the policy filter drops any slot earlier than `now + leadTimeHours`. The spec's frozen fixtures (2026-07-01…07-06) slid into the past, so every slot-expecting assertion failed while the empty-expectation tests kept passing — exactly the observed pattern.

**Fix (per the spec's own DI-over-mocking convention):** `LookUpAvailabilityDeps` gains optional `now?: () => Date` (production default = real clock, behavior unchanged); the spec pins `FROZEN_NOW` = 2026-06-28, before every fixture.

### 2. Block-codegen staleness — a parse failure masking real drift
`cinematic-landing`'s SKILL.md (fat skill, `surface: landing-aesthetic`, no flat props) was unparseable by the emitter, which `process.exit(1)`s — failing the gate and hiding real drift behind it. It now declares `codegen: false` (the v1.12 opt-out, same as composite).

The unmasked drift was real: `hero/__generated__/block.ts` had been hand-edited in v1.44.0 (against the DO-NOT-EDIT header) and its `variant` enum was missing `"cinematic-aura"` — a value SKILL.md declares and `enforceArchetypeOnHero` actually sets, i.e. the stale schema rejected a value the runtime produces. Regenerated from the frontmatter.

### 3. Throw contract — 5 violations
- `settings/features` action: missing orgId (expired session) → `redirect("/login")` (the v1.7.3 bug class if thrown); invalid-module-id stays as an annotated tamper guard.
- `auth/config` verification email: annotated — NextAuth catches provider errors; swallowing would lie "check your inbox" for an unsent email.
- `billing/start-checkout` ×2: annotated — browser helper whose sole caller (upgrade-modal) catches into `setError`.

### 4. Bonus: drift in the post-test CI gates
`pnpm emit:blocks:check` + `pnpm emit:event-registry:check` run *after* `pnpm test:unit`, so the unit failures were masking their drift: the `blocked` booking status (1ccc62bdc, June 11) and an optional `phone` field were never re-emitted into `caldiy-booking.block.md` / `event-registry.json`. Regenerated — this also fixes the two event-registry unit specs failing on main.

## Verification

- The 3 originally-failing specs reproduced at main tip, now pass (booking spec 7/7).
- `pnpm blocks:emit:check`, `pnpm emit:blocks:check`, `pnpm emit:event-registry:check`, migration-journal check: all pass.
- `tsc --noEmit`: pass.
- Full unit-suite delta vs main tip (same machine): **0 new failures, 10 fixed** (98 remaining local failures are byte-identical to main's pre-existing env-dependent baseline — DB/network-bound specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)