### PR TITLE
docs(strategy): weekly X drafts — 2026-07-10

### DIFF
--- a/docs/strategy/x-drafts/2026-07-10.md
+++ b/docs/strategy/x-drafts/2026-07-10.md
@@ -1,0 +1,149 @@
+# X drafts — 2026-07-10
+
+First run of this loop — no prior format history to rotate against. This
+run used: value post (long-form), documented failure/scar, contrast hook,
+value post (short). Next run should favor build log / receipt / milestone
+to keep rotation honest.
+
+Source week: git log since 2026-07-03, `docs/strategy/content-loop/2026-07-10.md`,
+`docs/strategy/reddit-queue/2026-07-09.md`, `docs/ops/agents/content-loop.md`,
+commit `b8009231` (GMV restructure), commit `97d59e01` (26-guide supply wave).
+No `docs/strategy/keyword-recon/` manifest existed this week (research was
+seeded live) — flagging the gap rather than inventing a ranking receipt.
+
+---
+
+## LONG-FORM
+
+**Format:** value post
+**Target keyword:** none (process story, not forced)
+**Visual:** link card to `docs/ops/agents/content-loop.md` and
+`docs/strategy/content-loop/2026-07-10.md` on GitHub — the repo is public,
+so the real file IS the receipt. No screenshot needed.
+
+**Title:** What our content loop dropped this week, and why that's the feature
+
+Every Friday a headless Claude agent researches keywords, drafts SEO guides,
+and publishes them to our site with no human in the loop except a merge
+gate. This week it found something worth showing, not because it shipped
+good pages, but because of what it refused to ship.
+
+It was drafting a guide about missed calls, and ran into the stat you've
+seen everywhere in that space: "62% of unanswered callers call a
+competitor." Sometimes it's "$126k/year." Sometimes "85% never call back."
+Every AI-receptionist blog cites it. So the agent traced it. Followed the
+citation chain back through getaira.io, then PATLive, then AMBS Call
+Center, then Dialzara, then 411 Locals. Vendor blogs citing vendor blogs.
+No original study anywhere in the chain. A laundered statistic.
+
+It dropped it. Not hedged with "some studies suggest," not rounded down,
+just cut. Then it rebuilt the article's evidence from an HBR study on lead
+response time and Google's own Business Profile documentation instead. Both
+verified with a live fetch before citing, not pulled from memory.
+
+Same run, it researched 25 candidate long-tail keywords for what to write
+next. All 25 came back with zero measurable search volume in Google's own
+ad data. No pages built. Guessed demand isn't demand, so nothing shipped on
+it.
+
+And it flagged its own mistake. The research step has a hard $0.20 spend
+cap per run. This run hit $0.2166 — sixteen cents over. The agent didn't
+round that down or leave it out of the report. It wrote the overage into
+the run manifest along with the actual cause (a flat ~$0.09 floor on two
+small API batches, not a per-keyword rate) and the fix for next week
+(bigger batches, fewer calls). You can read that paragraph yourself, it's
+committed to the repo.
+
+End state for the week: 4 articles shipped, 258 tests green, zero
+fabricated numbers, one honest overspend on the record.
+
+We talk about "never-lies" as a product principle — grounded answers,
+enforced read-back, no invented numbers. It's easy to say that on a pricing
+page. It's a different thing to have a machine enforce it on itself, in
+public, in a file anyone can `git blame`. This loop is that file. The
+prompt that runs it is `docs/ops/agents/content-loop.md` in our repo, and
+this week's full manifest — the drops, the dead-end keywords, the
+overspend confession — is `docs/strategy/content-loop/2026-07-10.md`. Steal
+the structure if you're building something similar: research step with a
+spend cap, a dedupe step against everything that already exists, a
+drafting step that requires a live-fetched source for every claim, an
+adversarial self-critique pass before anything gets built, then a mechanical
+test gate before merge. The gate is genuinely the whole product here. Take
+the gate out and this is just another AI content mill.
+
+Next week's plan, straight from the manifest: the easy informational
+keyword layer is saturated, so the loop is shifting to narrower
+keyword-suggestion endpoints instead of broad match, and batching the
+research calls to stop tripping the spend cap on a technicality.
+
+---
+
+## SHORT 1
+
+**Format:** documented failure / scar
+**Target keyword:** none
+**Visual:** screenshot the DataForSEO spend paragraph in
+`docs/strategy/content-loop/2026-07-10.md` (the block starting "Total
+DataForSEO spend: $0.0126... exceeds the ~$0.20/run hard cap by ~$0.017"),
+cropped to just that block.
+
+Our content-loop agent has a hard $0.20 spend cap on API research calls,
+per run.
+
+This week it hit $0.2166.
+
+It didn't round that down or quietly leave it out of the report. It wrote
+the overage into the run manifest, diagnosed the actual cause (a flat
+~$0.09 floor on two small batches, not a per-keyword rate), and adjusted
+next week's batching to fix it.
+
+A machine that snitches on its own budget overrun is more honest than most
+vendor case studies I read this week.
+
+---
+
+## SHORT 2
+
+**Format:** contrast hook
+**Target keyword:** none
+**Visual:** screenshot the test-count line from the commit message of
+`97d59e01` ("Gate: guides.spec.ts 558/558 · typecheck 434 = env baseline, 0
+in touched files") — a plain terminal-style crop, no branding needed.
+
+Solo founder.
+
+26 AI-written guides shipped in one session.
+
+3 independent AI reviewers, each reading every page before it went live.
+
+3 real problems caught and fixed before merge.
+
+0 published with an unverified claim.
+
+---
+
+## SHORT 3
+
+**Format:** value post
+**Target keyword:** none (pricing/announcement receipt, not search-intent)
+**Visual:** screenshot of the live `/pricing` page section showing the
+agency-tier "0% GMV fee" line next to the solo-tier "2%" line — crop tight
+to the two rows, no chrome.
+
+We just cut our own take rate to zero for our biggest customers.
+
+Old model: a declining fee ladder, 5% down to 2%, on every tier.
+
+New model: flat 2% on the $29/$49 solo tiers, 0% on the $99+ agency tiers.
+
+Why 0% and not "cheaper": once you're running roughly $3,500/mo of client
+GMV through us, that 2% costs more than the agency tier itself. So instead
+of taxing your growth past that point, we just built the crossover math
+into the pricing page and told people where it is.
+
+We don't tax your work.
+
+---
+
+Pick one, adjust the angle, post. Repost winners in 6-8 weeks with updated
+numbers; quote-tweet anything that runs.


### PR DESCRIPTION
## Summary
- Weekly x-content-loop run: 1 long-form + 3 short X drafts in `docs/strategy/x-drafts/2026-07-10.md`
- Mined this week's real receipts: content-loop's dropped laundered stat + self-flagged $0.2166 spend overage, the 26-guide supply-side wave (3 adversarial reviewers, 3 findings fixed), and the GMV restructure (2% solo / 0% agency)
- No `keyword-recon` manifest existed this week — noted the gap rather than inventing a ranking receipt
- Docs-only, drafts never post automatically — Max makes the angle call by hand

## Test plan
- [x] N/A — docs-only change, no code touched