### PR TITLE
feat(seo): supply-side follow-ups — /sell hub + discoverability + listing hardening

### DIFF
--- a/docs/ops/agents/vendor-rate-refresh.md
+++ b/docs/ops/agents/vendor-rate-refresh.md
@@ -1,0 +1,30 @@
+# vendor-rate-refresh — quarterly supply-side vendor-rate verification (headless agent prompt)
+
+Runs the 1st of each quarter (Jan/Apr/Jul/Oct), 09:30. Invocation: `claude -p "$(cat docs/ops/agents/vendor-rate-refresh.md)"` from the repo root. Sibling of `seo-price-refresh.md` (monthly, demand-side registries) — this one covers the vendor rates and platform-fee claims quoted inside the `sell-agents` guide cluster, which are all published with "as of this writing" hedges that rot.
+
+---
+
+You are refreshing the vendor-rate facts inside SeldonFrame's supply-side (`sell-agents` cluster) guides. Repo root = the current working directory. Work on a FRESH branch off origin/main; never push main directly.
+
+Objective: every vendor rate, platform fee, and price anchor quoted in the sell-agents guides either matches the vendor's live page or gets re-hedged/updated — the builder-facing pages must never lie about someone else's pricing.
+
+Steps:
+1. `git fetch origin`, create branch `chore/vendor-rate-refresh-YYYY-QN` off origin/main.
+2. Build the claim inventory: grep the sell-agents guides for dollar/percent claims —
+   `grep -n "\$[0-9]\|% \|per minute\|per MTok\|/mo" packages/crm/src/lib/seo/guides/*.ts` filtered to guides whose `cluster` is `"sell-agents"` (list them via `guidesInCluster` in `packages/crm/src/lib/seo/guides/index.ts`). The known heavy files: `ai-marketplace-fees-compared.ts`, `voice-ai-reseller-programs.ts`, `white-label-ai-agents.ts`, `what-is-byok-ai.ts`, `how-much-to-charge-for-an-ai-agent.ts`, `ai-agent-statistics.ts`, plus the Ruby/Twilio anchors scattered across the build-and-sell guides.
+3. Verify each claim against the vendor's own live page (the guide's `sources` array carries the URL). The canonical set as of 2026-07:
+   - https://www.twilio.com/en-us/voice/pricing/us and /sms/pricing/us
+   - https://www.ruby.com/pricing/
+   - https://platform.claude.com/docs/en/about-claude/pricing
+   - https://www.gohighlevel.com/pricing (incl. the AI Employee add-on)
+   - https://stammer.ai/pricing · https://synthflow.ai/pricing · https://vapi.ai/pricing · https://www.retellai.com/pricing
+   - Apple Small Business Program + Google Play service-fee pages (the fee anchors in ai-marketplace-fees-compared)
+   - https://www.brightlocal.com/research/local-consumer-review-survey/ (survey-year figures)
+   - Status-only checks (terms were "not publicly disclosed" at publish — confirm that's still true, or upgrade with a citation if they published): GPT Store payouts (use en.wikipedia.org/wiki/GPT_Store; openai.com 403s) · creator.poe.com · AWS Marketplace AI Agents · Salesforce AgentExchange.
+4. Where a rate/fee/figure changed: update the guide prose (keep the writing style — plain paragraphs, hedges like "as of this writing" stay), and update the `sources` entry if the vendor moved the page. If a vendor page stops resolving, WIDEN the hedge (e.g. "previously published at…, page no longer public") — never keep a dead claim bare. If a previously-undisclosed program published terms, add the citation rather than paraphrasing from memory.
+5. Also re-check the SF-side anchors those pages quote ($29/mo flat · GMV 5→3→2%) against `CLAUDE.md` §1b — if SF pricing changed, STOP and report loudly instead of editing (that's a Max decision, not a refresh).
+6. Run the gate from `packages/crm`: `npx tsx --test tests/unit/seo/guides.spec.ts` — all green.
+7. Commit with a table of changes (vendor | claim | old | new | source URL) in the commit body, push the branch, and print: which rates drifted, which guides are affected, and the branch name — DO NOT merge to main; Max merges.
+8. If NOTHING drifted: print "all sell-agents vendor rates verified current, no changes" and do not create a branch.
+
+Constraints: never-lies is absolute — when unsure, keep or widen the old hedge; never strengthen a claim. Known fetch blocks (don't burn budget): bls.gov, Upwork/Fiverr help pages, openai.com, gartner.com (403), mckinsey.com (timeouts). Keep total web fetches under ~30. Do not spawn sub-agents for fetching.

--- a/docs/strategy/x-drafts/2026-07-10.md
+++ b/docs/strategy/x-drafts/2026-07-10.md
@@ -145,5 +145,102 @@ We don't tax your work.
 
 ---
 
+<!-- Appended by the PM supply-side-waves session (same day, separate from the weekly loop above). -->
+
+## SHORT 4 — scar (no keyword) [PM session: supply-side waves]
+Vault patterns applied: self-surprise (#10) inverted, anti-income-porn honesty (#11)
+
+> My reviewer agent accused my writer agent of fabricating a statistic today.
+>
+> "97% of consumers read reviews, 85% influenced by positive ones, 2026 survey —
+> classic hallucination fingerprint. BLOCKING."
+>
+> So I pulled up the primary source myself. Every number was on the page,
+> literally, including the year. The writer had fetched it live before citing it.
+> The checker was the one guessing.
+>
+> Kept the reviewer anyway. It caught two real problems in the same batch.
+> The fix wasn't fewer checks. It was: verify the verifier before you edit.
+
+CREATIVE — none. The post carries itself; a fake "transcript" screenshot would
+violate the no-imitated-captures rule.
+
+PASTE-READY:
+```
+My reviewer agent accused my writer agent of 𝗳𝗮𝗯𝗿𝗶𝗰𝗮𝘁𝗶𝗻𝗴 𝗮 𝘀𝘁𝗮𝘁𝗶𝘀𝘁𝗶𝗰 today.
+
+"97% of consumers read reviews, 85% influenced by positive ones, 2026 survey — classic hallucination fingerprint. BLOCKING."
+
+So I pulled up the primary source myself. Every number was on the page, literally, including the year. The writer had fetched it live before citing it. The checker was the one guessing.
+
+Kept the reviewer anyway. It caught two real problems in the same batch.
+
+The fix wasn't fewer checks. It was: verify the verifier before you edit.
+```
+
+---
+
+## SHORT 5 — value post (keyword: sell AI agents)
+Vault patterns applied: keyword-first (GSC hack), replace-the-tool frame (#4), negation triple (#2)
+
+> Sell AI agents — everyone writes content for the businesses BUYING them.
+> Almost nobody writes for the builders selling them.
+>
+> We looked at our own SEO estate today: 300+ pages for buyers, zero for sellers.
+> A marketplace with no supply-side content is a store with no vendor entrance.
+>
+> So we shipped the seller cluster: how to price an agent, where to sell it,
+> what marketplace fees actually are (mostly: not published), how to white-label
+> one build across many clients.
+>
+> Not growth hacks. Not income screenshots. Not "make $10k/mo with AI."
+> The sober version, every number traced to a primary source.
+>
+> If you build agents, it's all free: seldonframe.com/guides
+
+CREATIVE — CAPTURE (image 1): browser, light or dark to match your X theme,
+seldonframe.com/guides scrolled to the "Building & selling AI agents" cluster so
+the section heading + article list are visible. Crop to the cluster block only,
+no browser chrome. Plainness is the receipt.
+
+PASTE-READY:
+```
+Sell AI agents — everyone writes content for the businesses BUYING them. Almost nobody writes for the builders selling them.
+
+We looked at our own SEO estate today: 300+ pages for buyers, 𝘇𝗲𝗿𝗼 for sellers. A marketplace with no supply-side content is a store with no vendor entrance.
+
+So we shipped the seller cluster: how to price an agent, where to sell it, what marketplace fees actually are (mostly: not published), how to white-label one build across many clients.
+
+Not growth hacks. Not income screenshots. Not "make $10k/mo with AI." The sober version, every number traced to a primary source.
+
+If you build agents, it's all free: seldonframe.com/guides
+```
+
+---
+
+## SHORT 6 — contrast hook + receipt (no keyword)
+Vault patterns applied: contrast resolves in reader's head (#1, #9), never-lies close (#11)
+
+> Solo founder. 32 writer agents. 3 reviewer agents. 32 SEO guides live before
+> dinner.
+>
+> The case-studies section is still empty. Because we don't have case studies
+> yet, and we don't fake them.
+
+CREATIVE — CAPTURE (the receipt IS the post): terminal or GitHub, the merged PR
+list showing "feat(seo): supply-side content wave 1" + "feat(seo): supply-side
+waves 2-7 — 26 sell-agents guides" both MERGED today, timestamps visible. Crop
+tight. Alternative capture: the /guides hub cluster with the article count
+visible. One image only.
+
+PASTE-READY:
+```
+Solo founder. 32 writer agents. 3 reviewer agents. 𝟯𝟮 𝗦𝗘𝗢 𝗴𝘂𝗶𝗱𝗲𝘀 live before dinner.
+
+The case-studies section is still empty. Because we don't have case studies yet, and we don't fake them.
+```
+
+---
+
 Pick one, adjust the angle, post. Repost winners in 6-8 weeks with updated
 numbers; quote-tweet anything that runs.

--- a/packages/crm/src/app/(public)/agencies/page.tsx
+++ b/packages/crm/src/app/(public)/agencies/page.tsx
@@ -9,6 +9,7 @@
 // app/(marketing)/pricing-public/page.tsx.
 
 import type { Metadata } from "next";
+import Link from "next/link";
 import { MarketingNav } from "@/components/landing/marketing-nav";
 import { MarketingAgencyMath } from "@/components/landing/marketing-agency-math";
 import { MarketingFooter } from "@/components/landing/marketing-footer";
@@ -25,6 +26,37 @@ export default function AgenciesPage() {
       <MarketingNav />
       <main id="main-content" className="pt-[100px]">
         <MarketingAgencyMath />
+
+        {/* Guides for agency builders — cross-links into the supply-side content library. */}
+        <section aria-label="Guides for agency builders" className="border-t border-[rgba(34,29,23,.08)] px-5 py-16 md:px-8 lg:px-12">
+          <div className="mx-auto max-w-[1120px]">
+            <h2 className="text-[13px] font-[600] uppercase tracking-[0.09em] text-[rgba(34,29,23,.55)]">
+              Guides for agency builders
+            </h2>
+            <ul className="mt-4 flex flex-col flex-wrap gap-x-8 gap-y-2.5 md:flex-row">
+              <li>
+                <Link href="/sell" className="text-[14.5px] font-[600] text-[#00897B] underline-offset-4 hover:underline">
+                  Sell AI agents: the complete playbook
+                </Link>
+              </li>
+              <li>
+                <Link href="/guides/ai-agency-pricing-models" className="text-[14.5px] font-[600] text-[#00897B] underline-offset-4 hover:underline">
+                  AI agency pricing models
+                </Link>
+              </li>
+              <li>
+                <Link href="/guides/white-label-ai-agents" className="text-[14.5px] font-[600] text-[#00897B] underline-offset-4 hover:underline">
+                  White-label AI agents
+                </Link>
+              </li>
+              <li>
+                <Link href="/guides/what-to-include-in-an-ai-front-office-package" className="text-[14.5px] font-[600] text-[#00897B] underline-offset-4 hover:underline">
+                  What goes in an AI front-office package
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </section>
       </main>
       <MarketingFooter />
     </div>

--- a/packages/crm/src/app/(public)/marketplace/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/marketplace/[slug]/page.tsx
@@ -178,12 +178,26 @@ export default async function ListingDetailPage({ params, searchParams }: Listin
     author: { "@type": "Organization", name: agent.builder },
   };
 
+  // schema.org BreadcrumbList — Home → Marketplace → this listing. Helps
+  // search engines render the breadcrumb trail in results and gives LLMs a
+  // clean site-hierarchy signal alongside the SoftwareApplication JSON-LD.
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://www.seldonframe.com" },
+      { "@type": "ListItem", position: 2, name: "Marketplace", item: "https://www.seldonframe.com/marketplace" },
+      { "@type": "ListItem", position: 3, name: agent.name, item: `https://www.seldonframe.com/marketplace/${agent.slug}` },
+    ],
+  };
+
   return (
     <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans }}>
       <MarketplaceStyles />
       <MarkdownPointer href={`/marketplace/${agent.slug}.md`} />
       {/* GEO: structured data so LLMs + search engines can cite the listing. */}
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <MarketplaceNav active="browse" />
 
       <main className="sf-listing-main" style={{ maxWidth: 1100, margin: "0 auto", padding: "26px 32px 70px" }}>
@@ -465,6 +479,89 @@ export default async function ListingDetailPage({ params, searchParams }: Listin
                       — a stat-backed answer page you can deploy from in 60 seconds.
                     </p>
                   ) : null}
+                </div>
+              </div>
+            </section>
+
+            {/* cross-link — sell-agents guide cluster */}
+            <section style={sectionBorder}>
+              <h2 style={{ ...sectionH2, marginBottom: 4 }}>Selling agents like this one</h2>
+              <p style={{ margin: "0 0 18px", fontSize: 14.5, color: "rgba(34,29,23,0.55)" }}>
+                Guides for builders who want to list on the marketplace
+              </p>
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                {[
+                  { href: "/guides/how-to-make-money-selling-ai-agents", label: "How to make money selling AI agents" },
+                  { href: "/guides/how-much-to-charge-for-an-ai-agent", label: "How much to charge for an AI agent" },
+                  { href: "/guides/white-label-ai-agents", label: "White-label AI agents for agencies" },
+                ].map((g) => (
+                  <Link
+                    key={g.href}
+                    href={g.href}
+                    className="sf-link"
+                    style={{ display: "inline-flex", alignItems: "center", gap: 7, fontSize: 15, fontWeight: 600, color: MKT.green, textDecoration: "none" }}
+                  >
+                    <MarketplaceIcon name="backArrow" size={14} style={{ transform: "rotate(180deg)" }} />
+                    {g.label}
+                  </Link>
+                ))}
+              </div>
+            </section>
+
+            {/* "Sell yours" CTA row */}
+            <section style={{ padding: "26px 0 0" }}>
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  gap: 16,
+                  flexWrap: "wrap",
+                  background: "rgba(0,137,123,0.06)",
+                  border: "1px solid rgba(0,137,123,0.18)",
+                  borderRadius: 16,
+                  padding: "18px 22px",
+                }}
+              >
+                <p style={{ margin: 0, fontSize: 15.5, fontWeight: 600, color: MKT.ink }}>
+                  Built an agent worth selling? List it on the marketplace.
+                </p>
+                <div style={{ display: "flex", gap: 10, flex: "none" }}>
+                  <Link
+                    href="/marketplace/build"
+                    className="sf-btn"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      fontSize: 14.5,
+                      fontWeight: 650,
+                      color: "#fff",
+                      background: MKT.green,
+                      textDecoration: "none",
+                      padding: "10px 18px",
+                      borderRadius: 11,
+                    }}
+                  >
+                    Build an agent
+                  </Link>
+                  <Link
+                    href="/sell"
+                    className="sf-link"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      fontSize: 14.5,
+                      fontWeight: 650,
+                      color: MKT.ink,
+                      background: "#fff",
+                      border: "1px solid rgba(34,29,23,0.16)",
+                      textDecoration: "none",
+                      padding: "10px 18px",
+                      borderRadius: 11,
+                    }}
+                  >
+                    Learn how selling works
+                  </Link>
                 </div>
               </div>
             </section>

--- a/packages/crm/src/app/(public)/sell/page.tsx
+++ b/packages/crm/src/app/(public)/sell/page.tsx
@@ -1,0 +1,147 @@
+// /sell — the "sell AI agents" hub page. Targets the keyword "sell ai agents"
+// and fans out to the four ways SeldonFrame lets a builder monetize an agent
+// (direct, white-label, marketplace, MCP rental), each backed by its pillar
+// guide(s). The "complete builder's library" section is registry-driven
+// (guidesInCluster("sell-agents")) so it grows automatically as the content
+// loop adds guides to that cluster — no hardcoded list to maintain.
+
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { guidesInCluster } from "@/lib/seo/guides";
+
+export const metadata: Metadata = {
+  title: "Sell AI Agents: Direct, White-Label, Marketplace, or MCP | SeldonFrame",
+  description:
+    "Four ways to sell AI agents you build: direct to local businesses, white-label as an agency, list on the marketplace, or rent via MCP. Build once with SeldonFrame.",
+  alternates: { canonical: "/sell" },
+};
+
+type Path = {
+  n: string;
+  title: string;
+  body: string;
+  links: { href: string; label: string }[];
+};
+
+const PATHS: Path[] = [
+  {
+    n: "01",
+    title: "Sell direct to local businesses on retainer",
+    body: "Build an agent for a real business, deploy it into their own hosted workspace, and bill them a flat monthly retainer. No middleman, no revenue share — you keep the client relationship and the recurring revenue.",
+    links: [
+      { href: "/guides/how-to-make-money-selling-ai-agents", label: "How to make money selling AI agents" },
+      { href: "/guides/how-to-sell-ai-agents-to-local-businesses", label: "How to sell AI agents to local businesses" },
+    ],
+  },
+  {
+    n: "02",
+    title: "White-label across clients as an agency",
+    body: "Run unlimited client workspaces under your own brand for one flat $29/mo — no per-client license fee. Package the agent, the CRM, and the booking flow as your own AI front-office product.",
+    links: [
+      { href: "/guides/white-label-ai-agents", label: "White-label AI agents" },
+      { href: "/agencies", label: "For agencies" },
+    ],
+  },
+  {
+    n: "03",
+    title: "List it on the marketplace",
+    body: "Publish the agent you built to the SeldonFrame marketplace so other builders and businesses can find and install it. SeldonFrame only takes a cut (a GMV fee stepping down from 5% to 2%) when it's the sales channel.",
+    links: [
+      { href: "/marketplace/build", label: "Build to list" },
+      { href: "/guides/best-ai-agent-marketplaces", label: "Best AI agent marketplaces" },
+    ],
+  },
+  {
+    n: "04",
+    title: "Rent it out via MCP",
+    body: "Expose the agent as a rentable MCP endpoint so another builder or agent can call it programmatically and pay per use, without ever seeing your source. Owned and portable — no lock-in either direction.",
+    links: [
+      { href: "/guides/how-to-rent-out-an-ai-agent-via-mcp", label: "How to rent out an AI agent via MCP" },
+      { href: "/guides/what-is-an-mcp-marketplace", label: "What is an MCP marketplace" },
+    ],
+  },
+];
+
+export default function SellHubPage(): ReactElement {
+  const guides = guidesInCluster("sell-agents");
+
+  const collectionLd = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Sell AI Agents: Build Once, Sell It Four Ways",
+    description: metadata.description,
+    url: "https://www.seldonframe.com/sell",
+  };
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://www.seldonframe.com" },
+      { "@type": "ListItem", position: 2, name: "Sell AI agents", item: "https://www.seldonframe.com/sell" },
+    ],
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(collectionLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "40px 32px 70px", width: "100%" }}>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.12 }}>
+          Sell AI Agents: Build Once, Sell It Four Ways
+        </h1>
+        <p style={{ margin: "16px 0 0", fontSize: 18, lineHeight: 1.6, color: "rgba(34,29,23,0.78)", fontWeight: 500, maxWidth: 640 }}>
+          Build an agent. Sell it. Get paid. — direct to a client, white-labeled across an agency, listed on the marketplace, or rented out over MCP. Same agent, four ways to get paid.
+        </p>
+
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+          <Link href="/marketplace/build" className="sf-link" style={{ background: MKT.ink, color: "#F6F2EA", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none" }}>
+            Build free
+          </Link>
+          <Link href="/guides" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "11px 22px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+            Browse all guides
+          </Link>
+        </div>
+
+        <section style={{ marginTop: 44 }}>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))", gap: 18 }}>
+            {PATHS.map((p) => (
+              <div key={p.n} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 16, padding: "24px 26px", background: "rgba(255,255,255,0.6)" }}>
+                <div style={{ fontSize: 13, fontWeight: 800, letterSpacing: "0.06em", color: MKT.green }}>{p.n}</div>
+                <div style={{ marginTop: 6, fontSize: 19, fontWeight: 800, letterSpacing: "-0.01em" }}>{p.title}</div>
+                <p style={{ margin: "10px 0 16px", fontSize: 15, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }}>{p.body}</p>
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  {p.links.map((l) => (
+                    <Link key={l.href} href={l.href} className="sf-link" style={{ color: MKT.green, fontWeight: 700, fontSize: 14.5, textDecoration: "none" }}>
+                      {l.label} &rarr;
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section style={{ marginTop: 48 }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 23, fontWeight: 800, letterSpacing: "-0.02em" }}>The complete builder's library</h2>
+          <p style={{ margin: "0 0 18px", fontSize: 15, lineHeight: 1.6, color: "rgba(34,29,23,0.7)", maxWidth: 640 }}>
+            Every guide on building and selling AI agents, in one place.
+          </p>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 14 }}>
+            {guides.map((g) => (
+              <Link key={g.slug} href={`/guides/${g.slug}`} className="sf-link" style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 14, padding: "18px 20px", textDecoration: "none", color: MKT.ink, background: "rgba(255,255,255,0.55)", display: "block" }}>
+                <div style={{ fontSize: 16, fontWeight: 800, lineHeight: 1.3 }}>{g.title}</div>
+                <p style={{ margin: "8px 0 0", fontSize: 13.5, lineHeight: 1.55, color: "rgba(34,29,23,0.62)" }}>{g.description}</p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/llms.txt/route.ts
+++ b/packages/crm/src/app/llms.txt/route.ts
@@ -197,6 +197,7 @@ export async function GET(req: Request): Promise<Response> {
   lines.push("## Pages");
   lines.push("");
   lines.push(`- [Agent Marketplace](${base}/marketplace): browse and install vetted agents, or rent them over MCP.`);
+  lines.push(`- [Sell AI agents](${base}/sell): the four ways to sell an agent you build — direct, white-label, marketplace, or rent via MCP.`);
   lines.push(`- [AI agent library](${base}/ai-agents): every stat-backed agent answer page.`);
   lines.push(`- [Pricing](${base}/pricing): plans and what a workspace costs.`);
   lines.push(

--- a/packages/crm/src/app/sitemap.ts
+++ b/packages/crm/src/app/sitemap.ts
@@ -72,6 +72,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
+  // The sell-agents hub (targets "sell ai agents").
+  entries.push({
+    url: `${base}/sell`,
+    lastModified: now,
+    changeFrequency: "weekly",
+    priority: 0.8,
+  });
+
   // Marketplace browse + listings (so the cross-links resolve for crawlers).
   entries.push({
     url: `${base}/marketplace`,

--- a/packages/crm/src/components/landing/marketing-footer.tsx
+++ b/packages/crm/src/components/landing/marketing-footer.tsx
@@ -18,6 +18,7 @@ const COLUMNS: readonly Column[] = [
       { label: "Features", href: "#modules" },
       { label: "Pricing", href: "#pricing" },
       { label: "Marketplace", href: "/marketplace" },
+      { label: "Sell AI agents", href: "/sell" },
       { label: "For agencies", href: "/agencies" },
       { label: "Changelog", href: "https://github.com/seldonframe/crm/releases", external: true },
     ],
@@ -26,6 +27,7 @@ const COLUMNS: readonly Column[] = [
     heading: "Resources",
     links: [
       { label: "Docs", href: "/docs" },
+      { label: "Guides", href: "/guides" },
       { label: "MCP / Claude Code", href: "https://github.com/seldonframe/crm#claude-code-mcp", external: true },
       { label: "API", href: "/docs" },
       { label: "Live demos", href: "#demos" },

--- a/packages/crm/src/components/seo/guide-page.tsx
+++ b/packages/crm/src/components/seo/guide-page.tsx
@@ -91,6 +91,26 @@ export function GuidePage({ slug }: { slug: string }): ReactElement {
             </div>
           </div>
 
+          {/* Demand->supply cross-promo — only for the agency-heavy GoHighLevel cluster. */}
+          {g.cluster === "gohighlevel" && (
+            <div style={{ marginTop: 28, border: `1px solid ${MKT.ink10}`, borderRadius: 16, padding: "24px 26px", background: "rgba(255,255,255,0.6)" }}>
+              <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: "-0.01em" }}>Run an agency? Sell AI agents instead of renting software</div>
+              <p style={{ margin: "8px 0 16px", fontSize: 15, lineHeight: 1.6, color: "rgba(34,29,23,0.7)" }}>
+                Agencies reading GoHighLevel comparisons are often really pricing an agency stack. The other side of that
+                decision is selling AI agents to clients at a flat platform cost instead of per-sub-account fees — this
+                site's builder library covers pricing, white-labeling, and where to sell.
+              </p>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+                <Link href="/sell" className="sf-link" style={{ background: MKT.ink, color: "#F6F2EA", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none" }}>
+                  Selling AI agents: the guides
+                </Link>
+                <Link href="/guides/white-label-ai-agents" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "11px 22px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+                  White-label AI agents
+                </Link>
+              </div>
+            </div>
+          )}
+
           <section style={{ marginTop: 40 }}>
             <h2 style={{ margin: "0 0 14px", fontSize: 23, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
             {g.faq.map((f) => (

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -56,6 +56,16 @@ the primary-source-only stats page (survey-based pricing-data page needs data co
 (never-lies gates). Follow-ups queued in the strategy doc: /sell hub · marketplace-listing
 JSON-LD hardening · demand→supply cross-links · vendor-rate quarterly refresh.
 
+### Task — Supply-side follow-up slices (2026-07-10, Max-directed, branch feat/supply-follow-ups)
+
+Max: "do this" on the 4 queued slices + fix the discoverability gap (cluster not in footer/nav).
+
+- [ ] /sell hub page (kw "sell ai agents") + sitemap entry + footer links (Sell AI agents → /sell, Guides → /guides)
+- [ ] Marketplace listing hardening: BreadcrumbList JSON-LD + related sell-agents guides block + "Sell yours" CTA on /marketplace/[slug]
+- [ ] Demand→supply cross-link: cluster-keyed block in guide-page.tsx (gohighlevel cluster → /sell) + /agencies link into the cluster
+- [ ] Quarterly vendor-rate-refresh: docs/ops/agents/vendor-rate-refresh.md (copy seo-price-refresh pattern) + scheduled task
+- [ ] Gate: tsc delta + relevant specs + reviewer pass → PR → merge (authorized) → smoke + IndexNow /sell
+
 ### Task — Retainer sibling-recovery period narrowing (2026-07-08, money-review follow-up, worktree hungry-jang-c20e73)
 
 Fix from the autopay-console money review: `findOutstandingFailedForSubscriptionReal` matched ANY


### PR DESCRIPTION
The four queued follow-up slices from the supply-side plan, Max-directed.

## What
1. **/sell hub** targeting "sell ai agents": 4 monetization paths (direct / white-label / marketplace / rent-via-MCP) each linking its pillar guide, plus a registry-driven directory of the whole `sell-agents` cluster (auto-grows with future waves). CollectionPage + BreadcrumbList JSON-LD, canonical, sitemap + llms.txt.
2. **Discoverability fix**: footer now links **Sell AI agents → /sell** (Product) and **Guides → /guides** (Resources) — the 32-guide cluster previously had zero nav presence.
3. **Marketplace listing hardening** (/marketplace/[slug]): BreadcrumbList JSON-LD, a "Selling agents like this one" guides block, and a "Sell yours" CTA (→ /marketplace/build + /sell). Works for live and seed listings; no invented listing data.
4. **Demand→supply cross-links**: gohighlevel-cluster guides get a gated "Run an agency? Sell AI agents instead" block (→ /sell + white-label guide); /agencies gets a guides-for-agency-builders row.
5. **Quarterly vendor-rate-refresh**: `docs/ops/agents/vendor-rate-refresh.md` (sibling of seo-price-refresh — verify-or-rehedge every vendor rate quoted in the cluster, PR-only). Scheduled task registered locally, next run Oct 1.

## Gate
- Independent reviewer: **SHIP, 0 blocking**; both nits applied (GMV taper phrasing → canonical wording · agencies raw `<a>` → `next/link`)
- guides.spec.ts 558/558 · tsc: 0 errors in touched files (51 total = current baseline)
- RSC client-fn-from-server check: clean (reviewer verified imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)