### PR TITLE
chore: guides-rewrite closeout (task log + swarm learnings)

### DIFF
--- a/docs/learnings/2026-07-10-mass-content-rewrite-swarm.md
+++ b/docs/learnings/2026-07-10-mass-content-rewrite-swarm.md
@@ -1,0 +1,44 @@
+# Mass content rewrite via subagent swarm — the method that held (2026-07-10)
+
+Context: rewrote all 92 /guides pages (walls of text → diagrams + analogies + readable prose)
+in one day: engine PR (#55) then 90 parallel rewriters + 3 fact-drift reviewers (PR #56).
+Written for a weaker model executing this cold.
+
+## The architecture call that made it tractable
+Upgrade the ENGINE, not the pages. Markdown-lite in registry strings (valid markdown → the
+GEO twin needs zero changes), typed diagram primitives (flow/loop/compare/bars/stack) rendered
+by one shared component, callouts as a typed field, favicons derived from source URLs already
+in the data. 92 pages inherited visuals before a single article was rewritten.
+
+## Rules that prevented disasters at N=90
+1. **FACTS FROZEN as a named, repeated contract** in every prompt: numbers/hedges/quotes/
+   attributions/sources byte-identical in meaning. Rewriters may only restructure prose.
+2. **Shared spec file, tiny per-agent prompts.** One rewrite-spec.md in scratchpad; each of 90
+   prompts = 3 lines (file + cluster + diagram hint). Consistency comes from the spec + two
+   gold exemplars, not from prompt length.
+3. **Mechanical self-check in the spec**: compile the file via `npx tsx -e require(...)` and
+   print section/diagram/callout counts. Caught escaping errors at the writer, not the gate.
+4. **Fact-drift review = numeric fingerprints, not vibes.** Reviewers script a multiset diff of
+   number-ish tokens (old vs new per file) and investigate only deltas; sources arrays compared
+   byte-for-byte. 90 diffs reviewed rigorously for ~3 agents' effort.
+5. **Verify the verifier.** Across the day, reviewer flags were wrong ~40% of the time
+   (BrightLocal stats were real; "AppExchange is now AgentExchange" is Salesforce's own banner;
+   smoke agent's "no <strong>" grepped the RSC flight payload, not the HTML). Rule: re-verify a
+   flag against the primary source/page yourself BEFORE editing. The real catches (nested
+   markup, the $50→$970 "flat-rate" chart) were worth the whole gate.
+
+## Deploy-verification traps (cost us two false rounds)
+- **Sentinel must come from the NEW content, not the new template.** Polling for engine CSS
+  (`sfGd`) matched the PREVIOUS deploy (engine merged earlier). Poll for a content marker
+  (e.g. `<strong>` count > threshold) instead.
+- **Screenshot services capture the viewport, not the page.** microlink's default height hid
+  everything below the fold → two vision FAILs on pages that were fine. Fix: set
+  `viewport.height` to article height (5-9k px) and CHECK THE PNG DIMENSIONS before grading.
+- Google s2 favicons 301 → gstatic PNG; a bare curl says text/html — follow redirects before
+  declaring images broken.
+
+## Numbers
+90 rewrites ≈ 78k tokens each; 6 rounds of 12-16 parallel; 2 slugs were silently never
+dispatched (round lists drift — reconcile `git status` count against the roster BEFORE gating);
+spec suite (834 tests incl. markup-balance + JSON-LD-strip across all guides) caught the one
+nested-markup case the writers' self-checks missed.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -79,13 +79,22 @@ short paragraphs, 16-year-old reading level with "kind of like…" analogies —
 world-class standalone value. Architecture: engine upgrade (markdown-lite + typed diagram
 primitives + callouts + favicon logos) then batch rewrite of all 74 guides. Facts frozen.
 
-- [ ] PR A — engine: types (diagram/callout/markdown-lite) · guide-page.tsx inline renderer +
-      guide-diagrams.tsx SVG set (CSS-animated, reduced-motion safe) · sources-row favicons ·
-      FAQ JSON-LD markdown-strip · guide-markdown.ts twin degradation · spec-test extensions ·
-      2 exemplar guides upgraded · content-loop.md style contract
-- [ ] PR B — rewrite all 74 guides in batches (simplify, shorten, bold/italic, analogies,
-      1-2 diagrams each; facts/hedges/sources verbatim) + fact-drift reviewer gate per batch
-- [ ] Gates: guides.spec green · tsc delta · reviewer SHIP · merge · smoke + vision pass
+- [x] PR A (#55, MERGED): engine — markdown-lite React-node parser (guide-inline.ts pure module) ·
+      guide-diagrams.tsx (5 SVG primitives, CSS-animated, reduced-motion safe) · callout boxes ·
+      sources-row favicons · JSON-LD/meta strip · twin degradation · spec 834 tests · 2 exemplars ·
+      style contract in content-loop.md. Reviewer SHIP + 4 hardening fixes applied.
+- [x] PR B (#56, MERGED): ALL 90 remaining guides rewritten by parallel subagents (92 total incl.
+      exemplars). 3 fact-drift reviewers (numeric-fingerprint multisets + close reads): 90/90
+      sources byte-identical, 0 magnitude drift, 0 hedge drops; 1 blocking fixed (self-contradicting
+      seat-fee chart → consistent $97 series) + nested-markup + invented-quantity NITs fixed.
+- [x] Gates: guides.spec 834/834 · tsc 51=baseline · CI failure-diff = main's pre-existing red ·
+      live verify: <strong>/callouts/flow-SVGs/favicons confirmed in production HTML · vision pass
+      on full-page desktop+mobile captures (typography/diagrams/callouts/mobile all clean; smoke
+      agent's "no <strong>" claim disproven by direct curl — it grepped the RSC payload)
+
+**Review:** whole guide estate (92 pages) now renders diagrams, analogies, short readable prose;
+GEO surface (md twins) degrades everything to text; facts provably frozen. Future guides inherit
+the style via the content-loop contract.
 
 ### Task — Retainer sibling-recovery period narrowing (2026-07-08, money-review follow-up, worktree hungry-jang-c20e73)
 


### PR DESCRIPTION
Docs-only: tick the completed visual-rewrite checklist and add the extract-approach learnings note for the 90-guide swarm method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)