### PR TITLE
feat(self-host): one-command Docker Compose (Postgres + Neon proxy + app)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Keep the build context lean without dropping anything the app reads at
+# build or runtime. Conservative on purpose — only node_modules, build
+# output, VCS, and secrets are excluded.
+**/node_modules
+**/.next
+**/dist
+**/.turbo
+**/coverage
+.git
+**/*.log
+**/.env
+**/.env.*
+!**/.env.example
+.DS_Store

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,24 @@
+# SeldonFrame self-host env — copy to .env.docker and fill in your LLM key.
+#
+#   cp .env.docker.example .env.docker
+#
+# DATABASE_URL, NEON_LOCAL_HOST and NEXT_PUBLIC_APP_URL are set by
+# docker-compose.yml, so you don't need them here. The two secrets below are
+# pre-generated for local use — regenerate for anything internet-facing with:
+#   openssl rand -hex 32
+
+# --- required ---
+AUTH_SECRET=463d8b66816c731ac9d138a2d84f9a607c08da8ef1c2fc61816373a547fbb0be
+NEXTAUTH_SECRET=463d8b66816c731ac9d138a2d84f9a607c08da8ef1c2fc61816373a547fbb0be
+ENCRYPTION_KEY=d893b306f06aadbca7edabda86e059b252f8be78c47fb93070f5757afaa532fe
+
+# --- bring your own LLM key (set at least one) ---
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# --- optional integrations (add as you need them) ---
+# RESEND_API_KEY=            # transactional email
+# TWILIO_ACCOUNT_SID=        # SMS / voice
+# TWILIO_AUTH_TOKEN=
+# STRIPE_SECRET_KEY=         # payments
+# BLOB_READ_WRITE_TOKEN=     # image uploads (Vercel Blob); optional locally

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,9 @@
 # report on Windows. The underlying fix is keeping these generated
 # files at LF wherever they live.
 packages/core/src/events/event-registry.json eol=lf
+
+# Shell scripts must stay LF or they break bash — notably inside the
+# Docker self-host build, where a Windows `core.autocrlf=true` checkout
+# would otherwise ship CRLF scripts into the Linux image and fail
+# `next build` with `$'\r': command not found`. eol=lf overrides autocrlf.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ dist/agent-servers/
 
 .vercel
 .env*.local
+
+# Docker self-host: ship the example, never the filled-in secrets
+!.env.docker.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ RUN corepack enable
 WORKDIR /app
 
 COPY . .
+# A Windows clone (core.autocrlf) checks shell scripts out as CRLF, which
+# breaks bash inside the Linux build. Normalize them so the image builds the
+# same on any host OS. (node_modules is not in the context — see .dockerignore.)
+RUN find . -name '*.sh' -type f -exec sed -i 's/\r$//' {} +
 RUN pnpm install --frozen-lockfile
 
 # `next build` should not need real secrets — pages are dynamic/authed. The

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# SeldonFrame — self-host image for the CRM app (dashboard + public sites + API).
+# Build context is the repo root (the app is a pnpm workspace at packages/crm).
+#
+#   docker compose up            # recommended — brings up Postgres + Neon proxy + this app
+#   docker build -t seldonframe .   # image only
+#
+# Two stages: `builder` installs the full workspace and runs `next build`;
+# `runner` carries the built app + node_modules (drizzle-kit lives here too, so
+# the compose `migrate` service can reuse this image). We copy the whole /app
+# tree between stages so pnpm's relative workspace symlinks stay intact.
+
+# ---------- builder ----------
+FROM node:22-bookworm-slim AS builder
+ENV PNPM_HOME=/pnpm PATH=/pnpm:$PATH NEXT_TELEMETRY_DISABLED=1
+RUN corepack enable
+WORKDIR /app
+
+COPY . .
+RUN pnpm install --frozen-lockfile
+
+# `next build` should not need real secrets — pages are dynamic/authed. The
+# placeholders keep any module-load-time env reads happy; NEON_LOCAL_HOST is
+# deliberately unset so the build path matches production (plain neon-http).
+ENV DATABASE_URL=postgres://build:build@127.0.0.1:5432/build \
+    AUTH_SECRET=build-only-not-a-real-secret \
+    NEXTAUTH_SECRET=build-only-not-a-real-secret \
+    ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
+    NEXT_PUBLIC_APP_URL=http://localhost:3000
+RUN pnpm --filter @seldonframe/crm build
+
+# ---------- runner ----------
+FROM node:22-bookworm-slim AS runner
+ENV NODE_ENV=production PNPM_HOME=/pnpm PATH=/pnpm:$PATH \
+    NEXT_TELEMETRY_DISABLED=1 PORT=3000
+RUN corepack enable
+WORKDIR /app
+
+# curl for the compose healthcheck; tini for correct signal handling.
+RUN apt-get update && apt-get install -y --no-install-recommends curl tini \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app ./
+
+EXPOSE 3000
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["pnpm", "--filter", "@seldonframe/crm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ ENV NODE_ENV=production PNPM_HOME=/pnpm PATH=/pnpm:$PATH \
 RUN corepack enable
 WORKDIR /app
 
-# curl for the compose healthcheck; tini for correct signal handling.
-RUN apt-get update && apt-get install -y --no-install-recommends curl tini \
+# curl for the healthcheck; tini for signal handling; psql for the
+# self-host schema apply (scripts/docker-migrate.sh).
+RUN apt-get update && apt-get install -y --no-install-recommends curl tini postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app ./

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -28,14 +28,31 @@ Pricing for paid tiers: $29/mo (Pro) or $99/mo (Agency, white-label). See [seldo
 
 Run the entire stack on your own infrastructure. AGPL-3.0-licensed source code; full control over data, deploy target, and customization.
 
-### Prerequisites
+### Fastest path — Docker Compose
+
+One command brings up Postgres, the database proxy, migrations, and the app:
+
+```bash
+git clone https://github.com/seldonframe/seldonframe.git
+cd seldonframe
+cp .env.docker.example .env.docker     # then add your ANTHROPIC_API_KEY or OPENAI_API_KEY
+docker compose up --build              # → http://localhost:3000
+```
+
+That's it — data lives in a local Postgres volume, and nothing leaves your machine except the LLM calls you configure. Compose runs the schema migrations for you before the app starts.
+
+> Why the extra `neon-proxy` service? In production SeldonFrame runs on Neon, whose driver speaks SQL-over-HTTP. The proxy lets that same runtime talk to your own plain Postgres — see [`packages/crm/src/db/index.ts`](packages/crm/src/db/index.ts). Migrations connect to Postgres directly.
+
+### Manual path — run from source
+
+#### Prerequisites
 
 - Node.js 20+
 - pnpm 10+
 - Postgres 15+ (Neon, Supabase, or local)
 - Anthropic or OpenAI API key
 
-### Setup
+#### Setup
 
 ```bash
 git clone https://github.com/seldonframe/seldonframe.git
@@ -63,20 +80,20 @@ TWILIO_ACCOUNT_SID=...          # SMS
 STRIPE_SECRET_KEY=...           # payments
 ```
 
-### Database
+#### Database
 
 ```bash
 pnpm db:generate
 pnpm db:migrate
 ```
 
-### Run
+#### Run
 
 ```bash
 pnpm dev:crm                    # → http://localhost:3000
 ```
 
-### Build (for production deploy)
+#### Build (for production deploy)
 
 ```bash
 pnpm build

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Your builder hub is **[seldonframe.com/build](https://seldonframe.com/build)** �
 
 | | |
 |---|---|
-| **Self-host** | $0 — AGPL-3.0, the entire monorepo |
+| **Self-host** | $0 — AGPL-3.0, the entire monorepo · [`docker compose up`](QUICKSTART.md#self-host) and you're running |
 | **Hosted — first workspace** | Free forever, no card |
 | **Hosted — unlimited workspaces** | $29/mo flat (white-label + voice included) |
 | **Your AI tokens** | Bring your own key — we never mark up usage |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,91 @@
+# SeldonFrame — self-host the whole stack with one command:
+#
+#   cp .env.docker.example .env.docker   # then add your LLM key
+#   docker compose up --build
+#   # → http://localhost:3000
+#
+# Three services:
+#   postgres    plain Postgres 16 — your data lives here.
+#   neon-proxy  translates the Neon serverless driver's SQL-over-HTTP into
+#               ordinary Postgres, so the app's neon-http runtime works
+#               against your own database (see src/db/index.ts).
+#   migrate     runs drizzle migrations once, then exits.
+#   app         the Next.js app (dashboard + generated public sites + API).
+#
+# Everything is bring-your-own-key: no data leaves your machine except the
+# LLM calls you configure.
+
+name: seldonframe
+
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: seldon
+      POSTGRES_PASSWORD: seldon
+      POSTGRES_DB: seldonframe
+    # wal_level=logical is what the Neon proxy expects in front of Postgres.
+    command: ["postgres", "-c", "wal_level=logical"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U seldon -d seldonframe"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  neon-proxy:
+    image: ghcr.io/timowilhelm/local-neon-http-proxy:main
+    restart: unless-stopped
+    environment:
+      PG_CONNECTION_STRING: postgres://seldon:seldon@postgres:5432/seldonframe
+    ports:
+      - "4444:4444"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  migrate:
+    build:
+      context: .
+    image: seldonframe-app
+    command: ["pnpm", "db:migrate"]
+    env_file: .env.docker
+    environment:
+      DATABASE_URL: postgres://seldon:seldon@postgres:5432/seldonframe
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  app:
+    build:
+      context: .
+    image: seldonframe-app
+    restart: unless-stopped
+    env_file: .env.docker
+    environment:
+      # Migrations speak plain Postgres to `postgres`; the runtime speaks
+      # neon-http, redirected to the proxy by NEON_LOCAL_HOST (src/db/index.ts).
+      DATABASE_URL: postgres://seldon:seldon@postgres:5432/seldonframe
+      NEON_LOCAL_HOST: neon-proxy
+      NEON_LOCAL_PORT: "4444"
+      NEXT_PUBLIC_APP_URL: http://localhost:3000
+      PORT: "3000"
+    ports:
+      - "3000:3000"
+    depends_on:
+      neon-proxy:
+        condition: service_started
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:3000/api/version || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 40s
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,10 @@ services:
     build:
       context: .
     image: seldonframe-app
-    command: ["pnpm", "db:migrate"]
-    env_file: .env.docker
+    # Applies the current schema to a fresh DB over a plain Postgres
+    # connection (drizzle-kit's Neon driver can't reach local Postgres).
+    # Idempotent — skips if the schema already exists.
+    command: ["sh", "scripts/docker-migrate.sh"]
     environment:
       DATABASE_URL: postgres://seldon:seldon@postgres:5432/seldonframe
     depends_on:

--- a/packages/crm/src/db/index.ts
+++ b/packages/crm/src/db/index.ts
@@ -1,10 +1,24 @@
-import { neon } from "@neondatabase/serverless";
+import { neon, neonConfig } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import * as schema from "./schema";
 
 const databaseUrl =
   process.env.DATABASE_URL ??
   "postgresql://user:pass@localhost:5432/seldon_frame?sslmode=require";
+
+// Self-hosting escape hatch. In production SeldonFrame runs on Neon, whose
+// serverless driver speaks SQL-over-HTTPS to `<host>/sql`. A self-hoster
+// pointing DATABASE_URL at a plain Postgres has no such endpoint — so the
+// docker-compose stack runs the Neon local HTTP proxy in front of Postgres,
+// and this block redirects the driver's fetch to it. Gated on NEON_LOCAL_HOST:
+// unset in production, so prod behaviour is byte-identical.
+if (process.env.NEON_LOCAL_HOST) {
+  const host = process.env.NEON_LOCAL_HOST;
+  const port = process.env.NEON_LOCAL_PORT ?? "4444";
+  neonConfig.fetchEndpoint = `http://${host}:${port}/sql`;
+  neonConfig.useSecureWebSocket = false;
+  neonConfig.poolQueryViaFetch = true;
+}
 
 const sql = neon(databaseUrl);
 

--- a/scripts/docker-migrate.sh
+++ b/scripts/docker-migrate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Self-host schema provisioning for docker-compose.
+#
+# Why not `drizzle-kit migrate`? Two reasons:
+#   1. drizzle-kit bundles the Neon serverless driver, which only talks to a
+#      remote Neon endpoint over WebSocket — it can't reach a local Postgres.
+#   2. 44 of the repo's migrations were applied to production out-of-band and
+#      are absent from the journal, so a journal-based migrator leaves a fresh
+#      database missing schema.
+#
+# So we apply the CURRENT schema directly instead: `drizzle-kit export` emits
+# the full DDL offline (no driver, no journal), and psql loads it over a plain
+# TCP connection. Idempotent — if the schema is already present, do nothing.
+set -e
+cd packages/crm
+
+: "${DATABASE_URL:?DATABASE_URL is required}"
+
+if [ "$(psql "$DATABASE_URL" -tAc "SELECT to_regclass('public.organizations') IS NOT NULL")" = "t" ]; then
+  echo "[docker-migrate] schema already present — nothing to do."
+  exit 0
+fi
+
+echo "[docker-migrate] fresh database — applying current schema…"
+node_modules/.bin/drizzle-kit export --dialect=postgresql --schema=./src/db/schema/index.ts > /tmp/schema.sql
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/schema.sql
+echo "[docker-migrate] applied $(grep -c 'CREATE TABLE' /tmp/schema.sql) tables."


### PR DESCRIPTION
Closes the r/selfhosted gap flagged before the Reddit launch. The whole stack now runs with:

```bash
cp .env.docker.example .env.docker   # add your ANTHROPIC_API_KEY or OPENAI_API_KEY
docker compose up --build            # → http://localhost:3000
```

## What's here
- **Dockerfile** — two-stage build (`next build` → `next start`); the image doubles as the migrate runner (drizzle-kit + psql ship in it).
- **docker-compose.yml** — `postgres` + `neon-proxy` + one-shot `migrate` + `app`, with healthchecks and ordered startup.
- **src/db/index.ts** — env-gated self-host shim. In prod the neon-http driver talks to Neon; when `NEON_LOCAL_HOST` is set it redirects the driver's fetch to the local Neon HTTP proxy in front of plain Postgres. **Unset in production → byte-identical prod behaviour.**
- **scripts/docker-migrate.sh** — provisions a fresh DB by `drizzle-kit export` → `psql` (see 'Two real bugs' below).
- `.env.docker.example` (+ .gitignore negation so the example ships but filled-in secrets never do), `.dockerignore`, QUICKSTART + README self-host sections.

## Two real bugs this surfaced (both fixed here)
1. **Windows CRLF** — a Windows clone (`core.autocrlf`) checks `*.sh` out as CRLF; bash in the Linux build then dies with `$'\r': command not found`. Fixed in the Dockerfile (strip CR) **and** `.gitattributes` (`*.sh eol=lf`).
2. **drizzle-kit can't reach local Postgres** — `drizzle-kit migrate` bundles the Neon serverless (WebSocket) driver, so it can't talk to a plain Postgres; and 44/93 migrations are out-of-band anyway, so a journal replay under-provisions a fresh DB. So `docker-migrate.sh` applies the **current** schema instead: `drizzle-kit export` (offline DDL, no driver) → `psql`. Idempotent via a `to_regclass` sentinel.

## Verified end-to-end (real `docker compose up --build` on this machine)
- migrate applied **110 tables**; `information_schema` confirms 110
- neon-http `select 1` round-trips through the proxy to plain Postgres (real rows)
- `/api/version` **200**, `/login` **200** and renders the real UI, DB-backed `/w/<missing>` returns **404-not-500**
- **zero error lines** in the app logs

## Caveats (documented, not blockers)
- Durable workflows (`@workflow/next`, e.g. the post-booking reminder) target the Vercel workflow runtime — that one feature won't fire under self-host; the app boots and serves fine without it.
- Image is ~2.8 GB (full `next start`, not standalone-traced) — fine for a reference self-host; slimming is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)