### PR TITLE
feat(landing): two-path rebuild — agent marquee, how-it-works, chatbox

### DIFF
--- a/packages/crm/src/components/landing/marketing-agent-marquee.tsx
+++ b/packages/crm/src/components/landing/marketing-agent-marquee.tsx
@@ -1,0 +1,144 @@
+// packages/crm/src/components/landing/marketing-agent-marquee.tsx
+//
+// The two on-ramps, made concrete (2026-07-13). SeldonFrame builds an agent
+// two ways, and this section shows the catalog for each as a scrolling
+// marquee:
+//   • Path A — DESCRIBE it → SF generates. Agents you want but don't have and
+//     can't record because they don't exist yet (voice receptionist,
+//     speed-to-lead, review requester…).
+//   • Path B — RECORD it → SF compiles. Agents that replace a workflow you
+//     already do by hand or badly automate (inbox triage, a Sheets lead log,
+//     a scraper→CRM…).
+//
+// Rides the vendored Marquee (components/ui/marquee.tsx); each row pauses on
+// hover. Dark-slab styling (this section is buildStack/dark-only). Chips are
+// plain DOM + lucide icons — SSR-visible, reduced-motion just stops the CSS
+// marquee (no per-item JS).
+
+"use client";
+
+import {
+  Archive,
+  BarChart3,
+  BellRing,
+  Building2,
+  CalendarCheck,
+  CalendarClock,
+  ClipboardCheck,
+  Database,
+  FileSignature,
+  FileText,
+  Inbox,
+  MessageSquare,
+  Moon,
+  PhoneOff,
+  Phone,
+  PieChart,
+  Plug,
+  Receipt,
+  Repeat,
+  RotateCcw,
+  Star,
+  Table,
+  Truck,
+  UserCheck,
+  UserPlus,
+  Zap,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Marquee } from "@/components/ui/marquee";
+
+type Agent = { name: string; vertical: string; icon: LucideIcon };
+
+// Path A — describe it, SF generates it (customer-facing, real-time).
+const DESCRIBE: Agent[] = [
+  { name: "Voice receptionist", vertical: "for an HVAC company", icon: Phone },
+  { name: "Speed-to-lead texter", vertical: "for a roofing company", icon: Zap },
+  { name: "Missed-call text-back", vertical: "for a med spa", icon: PhoneOff },
+  { name: "Review requester", vertical: "for a dental practice", icon: Star },
+  { name: "Win-back agent", vertical: "for a gym", icon: RotateCcw },
+  { name: "Website chat concierge", vertical: "for a law firm", icon: MessageSquare },
+  { name: "After-hours answering", vertical: "for a plumber", icon: Moon },
+  { name: "Quote responder", vertical: "for a landscaper", icon: FileText },
+  { name: "No-show reducer", vertical: "for a salon", icon: BellRing },
+  { name: "Waitlist filler", vertical: "for a clinic", icon: CalendarClock },
+];
+
+// Path B — record it, SF compiles it (back-office ops you do by hand).
+const RECORD: Agent[] = [
+  { name: "Inbox triage & drafts", vertical: "for a real-estate team", icon: Inbox },
+  { name: "Inbox organizer", vertical: "label · archive · zero-inbox", icon: Archive },
+  { name: "Google Sheets lead log", vertical: "new lead → enriched row", icon: Table },
+  { name: "Scheduling assistant", vertical: "reads the thread, books it", icon: CalendarCheck },
+  { name: "Lead scraper → CRM", vertical: "for an agency", icon: Database },
+  { name: "Invoice processor", vertical: "attachment → accounting", icon: Receipt },
+  { name: "CRM updater", vertical: "call outcome → the contact", icon: UserCheck },
+  { name: "Proposal drafter", vertical: "template + CRM data", icon: FileSignature },
+  { name: "Weekly report builder", vertical: "the numbers → a digest", icon: BarChart3 },
+  { name: "Content repurposer", vertical: "one call → posts + summary", icon: Repeat },
+  { name: "Order-status updater", vertical: "supplier emails → tracker", icon: Truck },
+  { name: "Onboarding form filler", vertical: "intake → filled docs", icon: ClipboardCheck },
+  { name: "White-label receptionist", vertical: "one per client, your brand", icon: Building2 },
+  { name: "Client onboarding agent", vertical: "for an agency", icon: UserPlus },
+  { name: "Agency reporting agent", vertical: "per-client → branded report", icon: PieChart },
+  { name: "MCP-endpoint agent", vertical: "rentable by other LLMs", icon: Plug },
+];
+
+function AgentChip({ agent }: { agent: Agent }) {
+  const Icon = agent.icon;
+  return (
+    <div className="flex w-[248px] shrink-0 items-center gap-3 rounded-[13px] border border-[rgba(255,255,255,.10)] bg-[#243830] px-4 py-3">
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-[9px] bg-[rgba(52,211,153,.12)] text-[#34D399]">
+        <Icon className="size-[18px]" aria-hidden />
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-[13.5px] font-[600] leading-tight text-[#F6F2EA]">
+          {agent.name}
+        </span>
+        <span className="block truncate text-[12px] leading-tight text-[rgba(246,242,234,.6)]">
+          {agent.vertical}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+function RowLabel({ kicker, children }: { kicker: string; children: React.ReactNode }) {
+  return (
+    <p className="mb-2 flex items-center gap-2 text-[12px] font-[600] text-[rgba(246,242,234,.85)]">
+      <span className="rounded-full bg-[rgba(52,211,153,.14)] px-2 py-0.5 text-[10.5px] font-[700] uppercase tracking-[0.06em] text-[#34D399]">
+        {kicker}
+      </span>
+      {children}
+    </p>
+  );
+}
+
+export function MarketingAgentMarquee() {
+  return (
+    <div className="relative mt-10 flex flex-col gap-6">
+      <div>
+        <RowLabel kicker="Describe it">Agents you&apos;re missing — SF builds them from a sentence</RowLabel>
+        <Marquee pauseOnHover className="[--duration:52s] [--gap:0.9rem] py-0">
+          {DESCRIBE.map((a) => (
+            <AgentChip key={a.name} agent={a} />
+          ))}
+        </Marquee>
+      </div>
+
+      <div>
+        <RowLabel kicker="Record it">Workflows you do by hand — SF compiles them from one recording</RowLabel>
+        <Marquee reverse pauseOnHover className="[--duration:64s] [--gap:0.9rem] py-0">
+          {RECORD.map((a) => (
+            <AgentChip key={a.name} agent={a} />
+          ))}
+        </Marquee>
+      </div>
+
+      {/* Edge fades so the rows dissolve into the slab instead of hard-cutting. */}
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-[#1F2B24] to-transparent" aria-hidden />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-[#1F2B24] to-transparent" aria-hidden />
+    </div>
+  );
+}

--- a/packages/crm/src/components/landing/marketing-build-steps.tsx
+++ b/packages/crm/src/components/landing/marketing-build-steps.tsx
@@ -26,51 +26,46 @@ import { IntegrationBeam } from "@/components/landing/integration-beam";
 // Shared spring-ish ease used everywhere (the brief's cubic-bezier).
 const EASE = [0.22, 1, 0.36, 1] as const;
 
-type Step = {
-  num: string;
-  title: string;
+// Two on-ramps. Path A: describe the agent you're MISSING → SF generates it.
+// Path B: record the workflow you already DO → SF compiles it.
+type Path = {
+  kicker: string;
+  arrow: string;
+  title: ReactNode;
   body: string;
+  steps: readonly string[];
   mock: ReactNode;
-  /** Optional extra figure rendered below the mock (step 3's outward-integration beam). */
   figure?: ReactNode;
 };
 
-const STEPS: readonly Step[] = [
+const PATHS: readonly Path[] = [
   {
-    num: "1",
-    title: "Paste a URL — or describe the business.",
-    body: "Your website, or a quick description of your business. We build from either.",
+    kicker: "Describe it",
+    arrow: "we generate it",
+    title: (
+      <>
+        You know what you want.{" "}
+        <em className="font-[Newsreader,Georgia,serif] font-normal not-italic">Describe it.</em>
+      </>
+    ),
+    body: "For the agents you don't have yet — a voice receptionist, speed-to-lead, a review requester. Paste your website or describe the business; SF generates the whole front office and wires the agent in.",
+    steps: ["Paste a URL or describe the business", "Watch it build — site, booking, CRM, agent", "Go live on your domain"],
     mock: <ScanMock />,
-  },
-  {
-    num: "2",
-    title: "Watch it spin up in 3 minutes.",
-    body: "The build runs live — website, booking, intake, CRM, and a 24/7 AI agent that answers across voice, SMS, chat, and email. Everything wired together.",
-    mock: (
-      <ArriveMock
-        rows={[
-          "Website live",
-          "Booking page live",
-          "AI receptionist trained",
-          "CRM ready",
-        ]}
-      />
-    ),
-  },
-  {
-    num: "3",
-    title: "Go live and let it run.",
-    body: "Your site, booking, and AI agent go live on your own domain — answering customers and booking jobs while you work. You own all of it.",
-    mock: (
-      <ArriveMock
-        rows={[
-          { label: "Custom domain connected", emphasis: true },
-          "Answering customers 24/7",
-          "You own everything",
-        ]}
-      />
-    ),
     figure: <IntegrationBeam />,
+  },
+  {
+    kicker: "Record it",
+    arrow: "we compile it",
+    title: (
+      <>
+        You already do the work.{" "}
+        <em className="font-[Newsreader,Georgia,serif] font-normal not-italic">Record it.</em>
+      </>
+    ),
+    body: "For the workflows you run by hand — inbox triage, a Google-Sheets lead log, a scraper → CRM. Screen-record yourself doing it once; SF watches, asks about what it missed, and compiles a working agent.",
+    steps: ["Screen-record the workflow once", "Answer what the recording didn't show", "Get a tested agent you can switch on"],
+    mock: <RecordMock />,
+    figure: <RecordFigure />,
   },
 ];
 
@@ -83,53 +78,59 @@ export function MarketingBuildSteps() {
     >
       <div className="mx-auto max-w-[1120px]">
         {/* Section head */}
-        <div className="max-w-[600px]">
+        <div className="mx-auto max-w-[680px] text-center">
           <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#059669]">
             <span className="h-px w-4 bg-[#059669] opacity-50" aria-hidden />
             How it works
           </div>
           <h2 className="mt-3.5 text-[clamp(27px,4.2vw,42px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#221D17]">
-            Paste a URL.{" "}
+            Two ways in.{" "}
             <em className="font-[Newsreader,Georgia,serif] font-normal not-italic">
-              Done in 3 minutes.
+              Both live in minutes.
             </em>
           </h2>
-          <p className="mt-4 max-w-[54ch] text-[clamp(15.5px,1.9vw,18px)] leading-[1.55] text-[#6E665A]">
-            Your whole front office — website, booking, CRM, and a 24/7 AI agent — built
-            from a single link and ready for customers. No code, no setup fee, no waiting.
-          </p>
-
-          {/* "What you need" beat — BYOK as a qualifier, not a barrier. */}
-          <p className="mt-5 inline-flex max-w-[60ch] items-start gap-2 rounded-[12px] border border-[rgba(34,29,23,.10)] bg-[#FFFDFA] px-4 py-3 text-[13.5px] leading-[1.5] text-[#6E665A] shadow-[0_1px_2px_rgba(34,29,23,.05)]">
-            <span className="mt-0.5 inline-block size-1.5 shrink-0 rounded-full bg-[#059669]" aria-hidden />
-            <span>
-              <strong className="font-[600] text-[#221D17]">All you need:</strong> a URL, and an AI key you probably
-              already have (ChatGPT, Claude, or Gemini). We show you how to connect it in 30 seconds.
-            </span>
+          <p className="mx-auto mt-4 max-w-[60ch] text-[clamp(15.5px,1.9vw,18px)] leading-[1.55] text-[#6E665A]">
+            Describe the agent you&apos;re missing and SF generates it — or record the workflow
+            you already do by hand and SF compiles it. All you need is a URL (or a recording) and
+            an AI key you probably already have.
           </p>
         </div>
 
-        {/* Step cards */}
-        <div className="mt-12 grid grid-cols-1 gap-4 min-[900px]:grid-cols-3 min-[900px]:gap-5">
-          {STEPS.map((step) => (
+        {/* Two path cards */}
+        <div className="mt-12 grid grid-cols-1 gap-5 min-[900px]:grid-cols-2">
+          {PATHS.map((path) => (
             <div
-              key={step.num}
-              className="relative flex flex-col gap-4 overflow-hidden rounded-[18px] border border-[rgba(34,29,23,.08)] bg-[#FFFDFA] p-6 shadow-[0_1px_2px_rgba(34,29,23,.05),0_10px_30px_rgba(34,29,23,.07)]"
+              key={path.kicker}
+              className="relative flex flex-col gap-4 overflow-hidden rounded-[20px] border border-[rgba(34,29,23,.08)] bg-[#FFFDFA] p-7 shadow-[0_1px_2px_rgba(34,29,23,.05),0_10px_30px_rgba(34,29,23,.07)]"
             >
-              {/* Newsreader italic step number */}
-              <span className="font-[Newsreader,Georgia,serif] text-2xl italic text-[#059669]">
-                {step.num}
-              </span>
-              <h3 className="m-0 text-[16px] font-[600] leading-tight tracking-[-0.01em] text-[#221D17]">
-                {step.title}
+              {/* Path badge */}
+              <div className="flex items-center gap-2">
+                <span className="rounded-full bg-[rgba(5,150,105,.1)] px-2.5 py-1 text-[11px] font-[700] uppercase tracking-[0.06em] text-[#059669]">
+                  {path.kicker}
+                </span>
+                <span className="text-[12px] font-[500] text-[#9A9183]">→ {path.arrow}</span>
+              </div>
+
+              <h3 className="m-0 text-[clamp(19px,2.4vw,23px)] font-[500] leading-[1.12] tracking-[-0.02em] text-[#221D17]">
+                {path.title}
               </h3>
-              <p className="m-0 text-[13.5px] leading-[1.5] text-[#6E665A]">{step.body}</p>
+              <p className="m-0 max-w-[46ch] text-[14px] leading-[1.55] text-[#6E665A]">{path.body}</p>
 
-              {/* Animated build log */}
-              <div className="mt-auto">{step.mock}</div>
+              {/* Three mini-steps */}
+              <ol className="m-0 flex flex-col gap-2 p-0">
+                {path.steps.map((s, i) => (
+                  <li key={s} className="flex items-center gap-2.5 text-[13px] text-[#221D17]">
+                    <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[rgba(5,150,105,.1)] text-[11px] font-[700] text-[#059669]">
+                      {i + 1}
+                    </span>
+                    {s}
+                  </li>
+                ))}
+              </ol>
 
-              {/* Optional figure (step 3: outward-integration beam) */}
-              {step.figure ? <div className="mt-1">{step.figure}</div> : null}
+              {/* Animated mock */}
+              <div className="mt-2">{path.mock}</div>
+              {path.figure ? <div className="mt-2">{path.figure}</div> : null}
             </div>
           ))}
         </div>
@@ -298,63 +299,104 @@ function ScanMock() {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
-   STEPS 2 & 3 — Arrive: done-rows slide in from the left, staggered, each with
-   a green-dot pulse on arrival, then settle. Reusable for both cards.
+   RECORD — the Path-B mock: REC (red, pulsing) → reads frames + narration →
+   compiles → agent ready. Same LogFrame + step-clock idiom as ScanMock.
    ════════════════════════════════════════════════════════════════════════ */
 
-type ArriveRow = string | { label: string; emphasis?: boolean };
-
-function normalizeRow(row: ArriveRow): { label: string; emphasis: boolean } {
-  return typeof row === "string" ? { label: row, emphasis: false } : { label: row.label, emphasis: !!row.emphasis };
-}
-
-function ArriveMock({ rows }: { rows: readonly ArriveRow[] }) {
+// 0 idle → 1 recording → 2 compiling (dot blinks) → 3 compiled (done) → 4 hold
+function RecordMock() {
   const reduce = useReducedMotion() ?? false;
   const [ref, inView] = useInViewRef<HTMLDivElement>();
-  // One tick per row arrival (~700ms apart → close to the ~200ms-stagger feel
-  // once you account for each row's own slide), then a hold before resetting.
-  const HOLD = 2;
-  const steps = rows.length + HOLD;
-  const step = useStepClock(steps, 700, inView, reduce);
+  const step = useStepClock(5, 1100, inView, reduce);
+
+  const recording = reduce || step >= 1;
+  const compiling = !reduce && step === 2;
+  const compiled = reduce || step >= 3;
 
   return (
     <LogFrame innerRef={ref}>
-      {rows.map((raw, i) => {
-        const { label, emphasis } = normalizeRow(raw);
-        const visible = reduce || step >= i;
-        // The row "just arrived" on the exact tick it appears → pulse the dot.
-        const justArrived = !reduce && step === i;
-        return (
-          <motion.div
-            key={label}
-            initial={false}
-            animate={{ opacity: visible ? 1 : 0, x: visible ? 0 : -10 }}
-            transition={{ duration: 0.34, ease: EASE }}
-            className="flex items-center gap-2"
-          >
-            <motion.span
-              className="flex size-1.5 shrink-0 items-center justify-center"
-              animate={justArrived ? { scale: [1, 1.5, 1] } : { scale: 1 }}
-              transition={{ duration: 0.45, ease: EASE }}
-            >
-              <StatusDot tone={visible ? "done" : "idle"} />
-            </motion.span>
-            <span className={`flex-1 ${visible ? "text-[#221D17]" : ""}`}>{label}</span>
-            {emphasis ? (
-              <motion.span
-                aria-hidden
-                className="shrink-0 text-[#059669]"
-                initial={false}
-                animate={{ opacity: visible ? 1 : 0, scale: visible ? 1 : 0.6 }}
-                transition={{ duration: 0.32, ease: EASE, delay: justArrived ? 0.12 : 0 }}
-              >
-                <LinkCheck className="size-3.5" />
-              </motion.span>
-            ) : null}
-          </motion.div>
-        );
-      })}
+      {/* recording row — red dot pulses while capturing */}
+      <div className="flex items-center gap-2">
+        <motion.span
+          className="size-1.5 shrink-0 rounded-sm bg-[#E5484D]"
+          animate={recording && !reduce ? { opacity: [1, 0.35, 1] } : { opacity: recording ? 1 : 0.4 }}
+          transition={{ duration: 1.2, repeat: recording && !reduce ? Infinity : 0, ease: "easeInOut" }}
+          aria-hidden
+        />
+        <span className={`flex-1 ${recording ? "text-[#221D17]" : ""}`}>
+          {recording ? "REC — capturing your workflow" : "Ready to record"}
+        </span>
+      </div>
+
+      {/* reading → compiled */}
+      <motion.div
+        className="flex items-center gap-2"
+        animate={{ opacity: recording ? 1 : 0.35 }}
+        transition={{ duration: 0.3, ease: EASE }}
+      >
+        <StatusDot tone={compiled ? "done" : compiling ? "active" : "idle"} />
+        <span className={`flex-1 ${compiled ? "text-[#221D17]" : ""}`}>
+          {compiled ? "Steps + tools compiled" : "Reading frames + narration…"}
+        </span>
+      </motion.div>
+
+      {/* agent ready */}
+      <motion.div
+        className="flex items-center gap-2"
+        animate={{ opacity: compiled ? 1 : 0.35 }}
+        transition={{ duration: 0.3, ease: EASE }}
+      >
+        <StatusDot tone={compiled ? "done" : "idle"} />
+        <span className={`flex-1 ${compiled ? "text-[#221D17]" : ""}`}>
+          {compiled ? "Agent ready to test" : "Agent"}
+        </span>
+      </motion.div>
     </LogFrame>
+  );
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   RECORD figure — the Path-B counterpart to the IntegrationBeam box: a small
+   "screen recording → compiled agent" still, so both path cards carry equal
+   visual weight.
+   ════════════════════════════════════════════════════════════════════════ */
+
+function RecordFigure() {
+  const CAPTURED = [
+    "Opened Gmail, read the thread",
+    "Labeled + archived 4 messages",
+    "Logged the lead to the sheet",
+  ];
+  return (
+    <div className="flex min-h-[220px] w-full flex-col justify-between overflow-hidden rounded-[10px] border border-[rgba(34,29,23,.08)] bg-[#F6F2EA] p-5">
+      {/* window chrome + REC badge */}
+      <div className="flex items-center justify-between">
+        <span className="flex gap-1.5" aria-hidden>
+          <span className="size-2 rounded-full bg-[#E5484D]/70" />
+          <span className="size-2 rounded-full bg-[#FEBC2E]/70" />
+          <span className="size-2 rounded-full bg-[#28C840]/70" />
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-[rgba(229,72,77,.1)] px-2 py-0.5 text-[10.5px] font-[700] uppercase tracking-[0.06em] text-[#E5484D]">
+          <span className="size-1.5 rounded-full bg-[#E5484D]" /> REC 0:14
+        </span>
+      </div>
+
+      {/* captured steps */}
+      <div className="flex flex-col gap-1.5 font-mono text-[11.5px] text-[#6E665A]">
+        {CAPTURED.map((c) => (
+          <div key={c} className="flex items-center gap-2">
+            <span className="size-1.5 shrink-0 rounded-sm bg-[#059669]" aria-hidden />
+            <span className="truncate">{c}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* compiled result */}
+      <div className="flex items-center gap-2 rounded-[9px] border border-[rgba(5,150,105,.28)] bg-[rgba(5,150,105,.06)] px-3 py-2">
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-[#059669] text-[11px] font-[800] text-[#FFFDFA]" aria-hidden>✓</span>
+        <span className="text-[12.5px] font-[600] text-[#221D17]">Inbox-triage agent — compiled, ready to test</span>
+      </div>
+    </div>
   );
 }
 
@@ -375,20 +417,5 @@ function TypedText({ text, animate }: { text: string; animate: boolean }) {
     >
       {text}
     </motion.span>
-  );
-}
-
-/** Tiny link + check cue for the custom-domain emphasis row. */
-function LinkCheck({ className = "" }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
-      <path
-        d="M9 17H7A5 5 0 0 1 7 7h2m6 0h2a5 5 0 0 1 1.5 9.75M9 12h6"
-        stroke="#059669"
-        strokeWidth={2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
   );
 }

--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -31,7 +31,6 @@ import { MarketingAgentOrbit } from "@/components/landing/marketing-agent-orbit"
 import { FlickerGrid } from "@/components/landing/flicker-grid";
 import { MarketingDemoMarquee } from "@/components/landing/marketing-demo-marquee";
 import { heroSubmitTarget } from "@/components/landing/hero-submit-target";
-import { HeroModeSwitch } from "@/components/landing/landing-mode";
 import { BorderBeam } from "@/components/ui/border-beam";
 
 // Re-exported for callers that only need the pure routing decision (e.g.
@@ -337,12 +336,6 @@ export function MarketingHero({
             borderWidth={1}
           />
         )}
-        {/* Mode switch: build vs record (Task 9). Null when the flag is
-            off — the form is byte-identical to today. */}
-        <div className="mx-2 mt-2">
-          <HeroModeSwitch />
-        </div>
-
         {/* Tabs */}
         <div
           role="tablist"
@@ -379,8 +372,9 @@ export function MarketingHero({
           </button>
         </div>
 
-        {/* URL pane */}
-        <div className={`px-4 pt-3.5 ${tab === "url" ? "block" : "hidden"}`}>
+        {/* URL pane — terminal-style prompt prefix */}
+        <div className={`items-center gap-2.5 px-4 pt-3.5 ${tab === "url" ? "flex" : "hidden"}`}>
+          <span className="select-none font-mono text-[16px] font-[600] text-[#059669]" aria-hidden>&gt;</span>
           <input
             ref={urlRef}
             type="text"
@@ -431,6 +425,16 @@ export function MarketingHero({
           </button>
         </div>
       </form>
+
+      {/* The second on-ramp, at the point of action: record instead of describe. */}
+      <a
+        href="/record"
+        className="group mt-3.5 inline-flex items-center gap-2 text-[13.5px] font-[500] text-[#6E665A] transition-colors hover:text-[#059669]"
+      >
+        <span className="size-[7px] rounded-full bg-[#E5484D]" aria-hidden />
+        or <span className="font-[600] text-[#221D17] group-hover:text-[#059669]">record a workflow</span> you already do
+        <ArrowRight size={13} className="transition-transform group-hover:translate-x-0.5" aria-hidden />
+      </a>
       </div>
       </div>
 

--- a/packages/crm/src/components/landing/marketing-modules.tsx
+++ b/packages/crm/src/components/landing/marketing-modules.tsx
@@ -27,17 +27,13 @@ import { motion, useInView, useReducedMotion } from "framer-motion";
 import {
   Calendar,
   FileText,
-  Mail,
   MessageSquare,
   Phone,
-  Plug,
-  Send,
-  Smartphone,
   Star,
   Users,
 } from "lucide-react";
 import { BentoGrid, BentoCard } from "@/components/ui/magic/bento-grid";
-import { OrbitingCircles } from "@/components/ui/magic/orbiting-circles";
+import { MarketingAgentMarquee } from "@/components/landing/marketing-agent-marquee";
 
 // Shared spring-ish ease used everywhere (the brief's cubic-bezier).
 const EASE = [0.22, 1, 0.36, 1] as const;
@@ -81,38 +77,6 @@ const FEATURES = [
   },
 ] as const;
 
-const AGENTS = [
-  "Speed-to-Lead",
-  "Review Agent",
-  "Reactivation Agent",
-  "Quote Agent",
-  "Follow-up Agent",
-] as const;
-
-// The 6 SURFACES an SF agent can run on (CLAUDE.md §1b — distinct from the
-// 6 build-time PRIMITIVES). Powers the "any agent on any surface" orbit
-// figure below — used by MarketingAgents only.
-const SURFACES = [
-  { label: "Voice", icon: Phone },
-  { label: "web-chat", icon: MessageSquare },
-  { label: "SMS", icon: Smartphone },
-  { label: "Email", icon: Mail },
-  { label: "DM", icon: Send },
-  { label: "MCP", full: "MCP-endpoint", icon: Plug },
-] as const;
-
-// Real tools the agents act through (Composio-bound), mirroring the top-hero
-// orbit. Inner ring = first 4, outer ring = rest.
-const AGENT_TOOLS = [
-  { src: "/brand/integrations/gmail.svg", alt: "Gmail" },
-  { src: "/brand/integrations/google-calendar.svg", alt: "Google Calendar" },
-  { src: "/brand/integrations/stripe.svg", alt: "Stripe" },
-  { src: "/brand/integrations/slack.svg", alt: "Slack" },
-  { src: "/brand/integrations/hubspot.svg", alt: "HubSpot" },
-  { src: "/brand/integrations/notion.svg", alt: "Notion" },
-  { src: "/brand/integrations/google-sheets.svg", alt: "Google Sheets" },
-  { src: "/brand/integrations/instagram.svg", alt: "Instagram" },
-] as const;
 
 export function MarketingModules() {
   return (
@@ -175,110 +139,42 @@ export function MarketingAgents() {
     <section
       id="agents"
       aria-label="Hire agents"
-      className="border-t border-[rgba(34,29,23,.08)] bg-[#1F2B24] px-5 py-20 md:px-8 md:py-28 lg:px-12"
+      className="overflow-hidden border-t border-[rgba(34,29,23,.08)] bg-[#1F2B24] px-5 py-20 md:px-8 md:py-28 lg:px-12"
     >
       <div className="mx-auto max-w-[1120px]">
-        <div className="grid gap-10 lg:grid-cols-[1fr_260px] lg:items-center lg:gap-14">
-          <div>
-            {/* Section head */}
-            <div className="max-w-[640px]">
-              <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[rgba(52, 211, 153,.9)]">
-                <span className="h-px w-4 bg-[rgba(52, 211, 153,.5)]" aria-hidden />
-                Hire agents
-              </div>
-              <h2 className="mt-3.5 text-[clamp(27px,4.2vw,42px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#F6F2EA]">
-                Hire agents.
-              </h2>
-              <p className="mt-4 max-w-[60ch] text-[clamp(15.5px,1.9vw,18px)] leading-[1.55] text-[rgba(246,242,234,.78)]">
-                Add no-code AI agents to do the work — answer every call, text back missed calls,
-                request 5-star reviews, reply to DMs and email, win back cold leads. Start from a
-                template or build your own in plain English.{" "}
-                <strong className="font-[500] text-[#FFFDFA]">A 24/7 worker for pennies — not an employee or an agency.</strong>
-              </p>
-            </div>
-
-            {/* Agent chips */}
-            <div className="mt-7 flex flex-wrap gap-2">
-              {AGENTS.map((name) => (
-                <span
-                  key={name}
-                  className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,.12)] bg-[rgba(255,255,255,.06)] px-3 py-1.5 text-[12.5px] font-[500] text-[rgba(246,242,234,.88)]"
-                >
-                  <span className="size-1.5 shrink-0 rounded-full bg-[#34d399] shadow-[0_0_0_3px_rgba(52, 211, 153,.22)]" aria-hidden />
-                  {name}
-                </span>
-              ))}
-              <span className="inline-flex items-center rounded-full border border-dashed border-[rgba(255,255,255,.14)] bg-transparent px-3 py-1.5 font-sans text-[11px] tracking-[0.04em] text-[rgba(246,242,234,.45)]">
-                + more shipping monthly
-              </span>
-            </div>
-
-            {/* CTAs — browse the marketplace, or build a custom agent in the Studio */}
-            <div className="mt-8 flex flex-wrap gap-3">
-              <Link
-                href="/marketplace"
-                className="inline-flex items-center gap-2 rounded-full bg-[#F6F2EA] px-5 py-3 text-[14px] font-[600] text-[#1F2B24] transition-transform hover:-translate-y-px"
-              >
-                Browse the agent marketplace →
-              </Link>
-              <Link
-                href="/build"
-                className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,255,255,.22)] bg-transparent px-5 py-3 text-[14px] font-[500] text-[rgba(246,242,234,.9)] transition-colors hover:border-[rgba(255,255,255,.4)]"
-              >
-                Or build your own in the Studio →
-              </Link>
-            </div>
+        {/* Section head — the two on-ramps */}
+        <div className="mx-auto max-w-[680px] text-center">
+          <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[rgba(52, 211, 153,.9)]">
+            <span className="h-px w-4 bg-[rgba(52, 211, 153,.5)]" aria-hidden />
+            Hire agents
           </div>
+          <h2 className="mt-3.5 text-[clamp(27px,4.2vw,42px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#F6F2EA]">
+            Two ways to build an agent.
+          </h2>
+          <p className="mx-auto mt-4 max-w-[58ch] text-[clamp(15.5px,1.9vw,18px)] leading-[1.55] text-[rgba(246,242,234,.78)]">
+            <strong className="font-[500] text-[#FFFDFA]">Describe what you&apos;re missing</strong> and SF generates it,
+            or <strong className="font-[500] text-[#FFFDFA]">record what you already do</strong> and SF compiles it. Either
+            way you get a 24/7 worker for pennies — not an employee or an agency.
+          </p>
+        </div>
 
-          {/* Lead figure — one agent, working across your real tools, mirroring
-              the top-hero orbit (real logos, not abstract chips). The 6 SF
-              surfaces (CLAUDE.md §1b) are preserved as the caption below so the
-              "any agent on any surface" claim survives the visual swap. */}
-          <div className="flex flex-col items-center gap-4">
-            <div
-              className="relative mx-auto size-[290px] shrink-0"
-              aria-label="One agent, working across your tools: Gmail, Google Calendar, Stripe, Slack, HubSpot, Notion, Google Sheets, and 1,000 more via Composio"
-            >
-              <div className="absolute left-1/2 top-1/2 z-10 flex size-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-[18px] bg-[#34d399] shadow-[0_0_0_8px_rgba(52, 211, 153,.14)]">
-                {/* eslint-disable-next-line @next/next/no-img-element -- static brand asset */}
-                <img src="/brand/seldonframe-icon.svg" alt="SeldonFrame agent" width={30} height={30} className="block" />
-              </div>
-              <OrbitingCircles
-                radius={78}
-                duration={22}
-                iconSize={42}
-                path={false}
-                className="border border-[rgba(255,255,255,.16)] bg-[#FFFDFA]"
-              >
-                {AGENT_TOOLS.slice(0, 4).map((t) => (
-                  // eslint-disable-next-line @next/next/no-img-element -- static vendored SVG
-                  <img key={t.src} src={t.src} alt={t.alt} width={22} height={22} className="block" />
-                ))}
-              </OrbitingCircles>
-              <OrbitingCircles
-                radius={128}
-                duration={30}
-                reverse
-                iconSize={44}
-                path={false}
-                className="border border-[rgba(255,255,255,.16)] bg-[#FFFDFA]"
-              >
-                {AGENT_TOOLS.slice(4).map((t) => (
-                  // eslint-disable-next-line @next/next/no-img-element -- static vendored SVG
-                  <img key={t.src} src={t.src} alt={t.alt} width={23} height={23} className="block" />
-                ))}
-              </OrbitingCircles>
-            </div>
-            <p className="max-w-[240px] text-center text-[12px] leading-[1.5] text-[rgba(246,242,234,.6)]">
-              on{" "}
-              {SURFACES.map((s, i) => (
-                <span key={s.label}>
-                  {i > 0 && " · "}
-                  <span className="text-[rgba(246,242,234,.85)]">{s.label}</span>
-                </span>
-              ))}
-            </p>
-          </div>
+        {/* The two catalogs, scrolling */}
+        <MarketingAgentMarquee />
+
+        {/* CTAs */}
+        <div className="mt-10 flex flex-wrap justify-center gap-3">
+          <Link
+            href="/marketplace"
+            className="inline-flex items-center gap-2 rounded-full bg-[#F6F2EA] px-5 py-3 text-[14px] font-[600] text-[#1F2B24] transition-transform hover:-translate-y-px"
+          >
+            Browse the agent marketplace →
+          </Link>
+          <Link
+            href="/build"
+            className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,255,255,.22)] bg-transparent px-5 py-3 text-[14px] font-[500] text-[rgba(246,242,234,.9)] transition-colors hover:border-[rgba(255,255,255,.4)]"
+          >
+            Or build your own in the Studio →
+          </Link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
The **two on-ramps** (describe → generate / record → compile) made concrete across the landing, per your direction. First of the landing PRs; record-in-dashboard deferred as agreed.

## Hire agents → a two-row agent marquee
The surface orbit is replaced by a scrolling **catalog of ~26 real agents** (`marketing-agent-marquee.tsx`), split into the two paths:
- **Describe it** row — voice receptionist · speed-to-lead · missed-call text-back · review requester · win-back · website chat · quote responder …
- **Record it** row — inbox triage · inbox organizer · Sheets lead log · scheduling assistant · scraper→CRM · invoice processor · white-label receptionist · agency reporting · MCP-endpoint …

Heading is now **"Two ways to build an agent."** Each chip = icon + agent + vertical, edge-faded, pause-on-hover.

## How it works → two path cards
"**You know what you want. Describe it.**" / "**You already do the work. Record it.**" — each with a badge (→ we generate it / → we compile it), 3 steps, an animated mock, and a figure. The Record card gets a **screen-recording → compiled-agent** figure that mirrors the Describe card's integration beam, so the cards carry equal weight (fixes the empty-card imbalance you flagged; the integration-beam logos you liked stay).

## Chatbox
- Terminal-style **`>` prompt** on the URL input.
- The redundant **"From a recording" mode-switch row is removed** — demoted to one clean tab row (Paste a URL / Describe the business).
- An explicit **"or record a workflow you already do →"** link now carries the record path to `/record`.

## Verification
Rendered every section on a dev server (screenshots): both marquee rows scroll, both how-it-works cards balanced with animated mocks, chatbox one clean row with the record link. `tsc` clean on touched files; `landing-mode-shell` 6/6, `marketing-hero-target` 2/2.

## Notes
- Deferred (your call): **"wired together" mockups** polish — waiting until you see the green live.
- Next feature PR (deferred): **record-to-agent inside the dashboard** for logged-in users.
- ⏳ Eyeball the preview on mobile (marquee chip widths + the two-column how-it-works stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)