### PR TITLE
Design-switch re-skins /w + prebuilt ghcr image + log cleanup

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,74 @@
+# Publishes the self-host Docker image to GHCR so operators can
+# `docker compose up` WITHOUT a local build. Triggers on a published
+# GitHub release (tag the app, cut a release) and on manual dispatch.
+#
+# The image is multi-arch (amd64 + arm64) and pushed to
+# ghcr.io/seldonframe/seldonframe tagged :latest, :sha-<gitsha>, and the
+# release semver (e.g. :1.4.2, :1.4, :1). Auth uses the built-in
+# GITHUB_TOKEN — no PAT, no stored secret.
+#
+# ONE-TIME REPO SETUP (owner):
+#   Settings → Actions → General → Workflow permissions → allow
+#     GITHUB_TOKEN read/write (the job `permissions:` block below requests
+#     packages:write, but the repo must permit it or the first push 403s).
+#   After the first push, the package appears under the org's Packages;
+#     set its visibility to Public so anonymous `docker pull` works.
+#
+# NOTE (arm64): the linux/arm64 image is built under QEMU emulation on the
+# amd64 runner, which runs a full `next build`. This is slow and can OOM/
+# time out. If it proves flaky, either drop `linux/arm64` from `platforms`
+# or split into a native arm64 runner (ubuntu-24.04-arm) + manifest merge.
+name: publish-image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,0 +1,20 @@
+# Opt-in override: pull the prebuilt image from GHCR instead of building
+# locally. Use it alongside the base compose file:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.ghcr.yml pull
+#   docker compose -f docker-compose.yml -f docker-compose.ghcr.yml up
+#
+# Pin a release instead of :latest by setting SELDONFRAME_IMAGE, e.g.
+#   SELDONFRAME_IMAGE=ghcr.io/seldonframe/seldonframe:1.4.2 docker compose ...
+#
+# `pull_policy: always` makes compose fetch the registry image rather than
+# fall back to building the local `build:` section inherited from the base
+# file. Both the migrate and app services share the one image (migrate runs
+# scripts/docker-migrate.sh out of it), so both are overridden here.
+services:
+  migrate:
+    image: ${SELDONFRAME_IMAGE:-ghcr.io/seldonframe/seldonframe:latest}
+    pull_policy: always
+  app:
+    image: ${SELDONFRAME_IMAGE:-ghcr.io/seldonframe/seldonframe:latest}
+    pull_policy: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@
 #
 # Everything is bring-your-own-key: no data leaves your machine except the
 # LLM calls you configure.
+#
+# Prefer a prebuilt image (no local `next build`)? Add the GHCR override:
+#   docker compose -f docker-compose.yml -f docker-compose.ghcr.yml up
 
 name: seldonframe
 

--- a/packages/crm/src/lib/theme/normalize-theme.ts
+++ b/packages/crm/src/lib/theme/normalize-theme.ts
@@ -39,6 +39,20 @@ export function normalizeTheme(raw: unknown): OrgTheme {
   // merge produced. Absent/non-string input omits the field entirely (matches
   // every other optional OrgTheme field's "absent → not customized" default).
   const customizedAt = typeof value.customizedAt === "string" ? value.customizedAt : undefined;
+  // v1.56.0 — carry the aesthetic-archetype fields through untouched. These are
+  // the operator's live "design" choice (set by setArchetypeForOrg when they
+  // switch design on /ready). normalizeTheme previously dropped them, so the
+  // public /w landing read `undefined` and fell back to the FROZEN archetype
+  // baked at generation time — i.e. "Change design" was a silent no-op. We
+  // pass the id through permissively (any string) because the sole consumer
+  // (app/(public)/w/[slug]/page.tsx) already guards with `... in ARCHETYPES`
+  // before using it, so an unknown value can never reach the renderer.
+  const aestheticArchetype =
+    typeof value.aestheticArchetype === "string"
+      ? (value.aestheticArchetype as OrgTheme["aestheticArchetype"])
+      : undefined;
+  const aestheticArchetypeChoice =
+    typeof value.aestheticArchetypeChoice === "string" ? value.aestheticArchetypeChoice : undefined;
 
   return {
     primaryColor,
@@ -47,6 +61,8 @@ export function normalizeTheme(raw: unknown): OrgTheme {
     mode,
     borderRadius,
     logoUrl,
+    ...(aestheticArchetype !== undefined ? { aestheticArchetype } : {}),
+    ...(aestheticArchetypeChoice !== undefined ? { aestheticArchetypeChoice } : {}),
     ...(customizedAt !== undefined ? { customizedAt } : {}),
   };
 }

--- a/packages/crm/src/lib/workspace/create-full.ts
+++ b/packages/crm/src/lib/workspace/create-full.ts
@@ -536,12 +536,11 @@ export async function createFullWorkspace(
   // primitives, just operator-orchestrated instead of server-orchestrated.
   //
   // See: docs/superpowers/specs/2026-05-15-ops-stack-only-workspace-creation-design.md
-  console.warn(
-    JSON.stringify({
-      event: "landing_page_skipped_default",
-      workspace_id: createResult.orgId,
-    }),
-  );
+  // NOTE: no "landing_page_skipped_default" log here. It used to fire
+  // UNCONDITIONALLY on every successful build (a v1.55.0 vestige of the removed
+  // enhanceLandingForWorkspace step) and actively misled log-based diagnosis —
+  // it reads as "the landing was skipped" when in fact the real landing is
+  // generated downstream (R1 landing step / operator SKILL), not skipped.
 
   // v1.37.0 — Step 12.8: STAMP google_place_url on soul for audit trail.
   // Cheap O(1) write; if the operator ever wants to re-sync from the


### PR DESCRIPTION
Two independent fixes — the "safe" half of a two-part effort. PR-2 (separate) is the world-class image work: source-URL image import + Pexels/Unsplash fill.

## 1. "Change design" now actually re-skins the public site
**Root cause:** `normalizeTheme()` whitelisted its return object and silently dropped `aestheticArchetype` / `aestheticArchetypeChoice`. So `/w/[slug]` always read `undefined` for the live archetype and rendered the one **frozen at generation time** — making the picker on `/clients/[slug]/ready` a visual no-op. (The `archetype_theme_applied … overwrote_legacy_defaults:false` log was a red herring from a different code path, `applyArchetypeThemeToOrg`.)

**Fix:** carry the two fields through `normalizeTheme` (permissive pass-through; the `/w` consumer already guards with `… in ARCHETYPES` before use). One file: `packages/crm/src/lib/theme/normalize-theme.ts`.

Also removes the unconditional `landing_page_skipped_default` log — a v1.55.0 vestige that fires on **every successful build** and actively misled this diagnosis (it reads as "landing skipped" when the real landing is generated downstream).

## 2. Prebuilt multi-arch image on ghcr.io (self-host)
- `.github/workflows/publish-image.yml` — builds & pushes `linux/amd64,linux/arm64` to `ghcr.io/seldonframe/seldonframe` on **release** + **manual dispatch**, tagged `:latest` / `:sha-…` / semver. `GITHUB_TOKEN` auth, gha build cache.
- `docker-compose.ghcr.yml` — opt-in override so operators pull the image instead of running a local `next build`.
- Base `docker-compose.yml` gains a one-line discoverability pointer.

⚠️ **One-time repo setup before the first publish works:**
- Settings → Actions → General → Workflow permissions must allow **read/write** (`packages:write`) — otherwise the first push 403s.
- After the first publish, set the ghcr package visibility to **Public** so anonymous `docker pull` / `docker compose up` works without login.
- arm64 builds under QEMU emulation (slow, can OOM/timeout on the default runner). If it proves flaky, drop `linux/arm64` from `platforms` or split to a native `ubuntu-24.04-arm` runner + manifest merge.

## Verify
- Full verify-build gate (tsc + check:use-server + unit-tests + migration-journal + emit-drift) run via the independent `verify-runner` — **verdict pending; will post here.**
- CI (`ci.yml`) on this PR runs install + migration-journal + unit tests + two drift-detectors. Note `ci.yml` does **not** run tsc — verify-runner covers the type check.

## Not in this PR
- The stale `claude-sonnet-4-20250514` model-id default (≈15 files) — its own blast radius, tracked separately.
- PR-2: world-class images (source-URL scrape via HTML/og:image + logo + Pexels-first/Unsplash-with-credit fill).

🚦 **Please don't merge until I confirm the verify-runner verdict is green.**
