### PR TITLE
fix(ai): sweep deprecated claude-sonnet-4-20250514 default → claude-sonnet-4-5-20250929

### DIFF
--- a/packages/crm/src/app/api/v1/public/analyze-url/route.ts
+++ b/packages/crm/src/app/api/v1/public/analyze-url/route.ts
@@ -7,6 +7,7 @@ import { demoApiBlockedResponse, isDemoReadonly } from "@/lib/demo/server";
 import { fetchPublicUrlSafe, SsrfBlockedError } from "@/lib/security/ssrf-guard";
 import { checkRateLimit } from "@/lib/utils/rate-limit";
 import { withUrlExtractionCache } from "@/lib/web-build/cached-extraction";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
 type DetectedTool = { name: string; slug: string; icon: string; autoConnect: boolean };
 
@@ -318,7 +319,7 @@ async function extractBusinessData(markdown: string, url: string): Promise<Extra
 
   try {
     const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: DEFAULT_SONNET_MODEL,
       max_tokens: 2048,
       system: [
         { type: "text", text: EXTRACTION_SYSTEM_STATIC, cache_control: { type: "ephemeral" } },

--- a/packages/crm/src/lib/ai/generate-block.ts
+++ b/packages/crm/src/lib/ai/generate-block.ts
@@ -1,12 +1,13 @@
 import { getAnthropicClient } from "@/lib/ai/client";
 import { assembleBlockContext } from "@/lib/ai/context";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 import { validateMigrationSQL } from "@/lib/db/migration-safety";
 import { generateMarketplaceBlockCodeFromBlockMd, type GeneratedBlockCode } from "@/lib/marketplace/actions";
 import { db } from "@/db";
 import { marketplaceBlocks } from "@/db/schema";
 import { and, desc, eq, ilike, or } from "drizzle-orm";
 
-const SELDON_MODEL = process.env.SELDON_MODEL?.trim() || "claude-sonnet-4-20250514";
+const SELDON_MODEL = process.env.SELDON_MODEL?.trim() || DEFAULT_SONNET_MODEL;
 
 export type ClarifyingQuestion = {
   id: string;

--- a/packages/crm/src/lib/ai/models.ts
+++ b/packages/crm/src/lib/ai/models.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared default Anthropic model ids for Seldon's internal generation calls
+ * (Seldon-It, block generation, soul compiler, soul wiki, public URL analysis).
+ *
+ * WHY THIS EXISTS: `claude-sonnet-4-20250514` (Sonnet 4) was copy-pasted as the
+ * hardcoded default across ~10 call sites. It is now deprecated and 404s in
+ * production (`personality_generator_model_fallback` fires on it). Centralizing
+ * the default here means the next model retirement is a one-line change, not
+ * another repo-wide sweep.
+ *
+ * `claude-sonnet-4-5-20250929` (Sonnet 4.5) is the current GA Sonnet — the same
+ * id the personality generator falls back to and the agent runtime defaults to.
+ * It is in the same pre-4.6 API family as Sonnet 4, so this is a true drop-in
+ * (identical thinking / sampling / token surface — no request-shape changes).
+ *
+ * Call sites keep their own env override (`SELDON_MODEL`, `SOUL_COMPILER_MODEL`,
+ * `ANTHROPIC_MODEL`); this constant only supplies the fallback default.
+ */
+export const DEFAULT_SONNET_MODEL = "claude-sonnet-4-5-20250929";

--- a/packages/crm/src/lib/ai/seldon-actions.ts
+++ b/packages/crm/src/lib/ai/seldon-actions.ts
@@ -8,6 +8,7 @@ import { getCurrentUser, getOrgId } from "@/lib/auth/helpers";
 import { canSeldonIt, resolvePlanFromPlanId } from "@/lib/billing/entitlements";
 import { assertWritable } from "@/lib/demo/server";
 import { getAIClient, getSeldonUsageStats, recordSeldonUsage } from "@/lib/ai/client";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 import { exportWorkspaceAsAgentAction } from "@/lib/ai/export-workspace-as-agent";
 import { writeEvent } from "@/lib/brain";
 import { buildProgressiveBrainContext } from "@/lib/brain-manifest";
@@ -175,7 +176,7 @@ function toSeldonErrorMessage(cause: unknown) {
   }
 
   if (normalized.includes("model") || normalized.includes("not found")) {
-    return "Seldon It model configuration failed. Check SELDON_MODEL (expected claude-sonnet-4-20250514).";
+    return "Seldon It model configuration failed. Check that SELDON_MODEL is a valid Anthropic model id (default claude-sonnet-4-5-20250929).";
   }
 
   if (
@@ -1303,7 +1304,7 @@ export async function runSeldonItAction(_prev: SeldonRunState, formData: FormDat
     const systemPrompt = buildSystemPrompt(soul, integrations, wikiContent);
 
     const response = await aiResolution.client.messages.create({
-      model: process.env.SELDON_MODEL?.trim() || "claude-sonnet-4-20250514",
+      model: process.env.SELDON_MODEL?.trim() || DEFAULT_SONNET_MODEL,
       max_tokens: 4096,
       system: systemPrompt,
       messages: [

--- a/packages/crm/src/lib/frameworks/actions.ts
+++ b/packages/crm/src/lib/frameworks/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { organizations } from "@/db/schema";
 import { getAIClient, recordSeldonUsage } from "@/lib/ai/client";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 import { getCurrentUser, getOrgId } from "@/lib/auth/helpers";
 import type { FrameworkConfig } from "@/lib/soul/install";
 
@@ -512,7 +513,7 @@ Business name: ${businessName || "Not provided"}`;
 
   try {
     const response = await aiResolution.client.messages.create({
-      model: process.env.SELDON_MODEL?.trim() || "claude-sonnet-4-20250514",
+      model: process.env.SELDON_MODEL?.trim() || DEFAULT_SONNET_MODEL,
       max_tokens: 2200,
       temperature: 0.4,
       messages: [{ role: "user", content: prompt }],
@@ -530,7 +531,7 @@ Business name: ${businessName || "Not provided"}`;
       orgId,
       userId: user.id,
       mode: aiResolution.mode,
-      model: process.env.SELDON_MODEL?.trim() || "claude-sonnet-4-20250514",
+      model: process.env.SELDON_MODEL?.trim() || DEFAULT_SONNET_MODEL,
     });
 
     await saveFrameworkToLibrary({ orgId, framework });

--- a/packages/crm/src/lib/soul-compiler/anthropic.ts
+++ b/packages/crm/src/lib/soul-compiler/anthropic.ts
@@ -1,8 +1,9 @@
 import Anthropic from "@anthropic-ai/sdk";
 import { ZodError } from "zod";
 import { routingResultSchema, soulV4Schema, type RoutingResult, type SoulV4 } from "@/lib/soul-compiler/schema";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
-const DEFAULT_MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || "claude-sonnet-4-20250514";
+const DEFAULT_MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || DEFAULT_SONNET_MODEL;
 const ROUTING_MAX_TOKENS = 1200;
 const EXTRACTION_MAX_TOKENS = 6000;
 

--- a/packages/crm/src/lib/soul-compiler/faq-extractor.ts
+++ b/packages/crm/src/lib/soul-compiler/faq-extractor.ts
@@ -3,13 +3,14 @@ import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
 import { createByokAnthropicClient } from "./anthropic";
 import { readSkillPack } from "@/lib/skill-packs/reader";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
 const SKILL_PACK_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "skills/faq-extraction.md"
 );
 
-const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || "claude-sonnet-4-20250514";
+const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || DEFAULT_SONNET_MODEL;
 const MAX_TOKENS = 4000;
 
 // XML tag patterns we strip from extracted Q&A content. Defense-in-depth

--- a/packages/crm/src/lib/soul-compiler/faq-synthesizer.ts
+++ b/packages/crm/src/lib/soul-compiler/faq-synthesizer.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
 import { createByokAnthropicClient } from "./anthropic";
 import { readSkillPack } from "@/lib/skill-packs/reader";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 import type { SoulV4 } from "./schema";
 
 const SKILL_PACK_PATH = path.join(
@@ -10,7 +11,7 @@ const SKILL_PACK_PATH = path.join(
   "skills/faq-synthesis.md"
 );
 
-const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || "claude-sonnet-4-20250514";
+const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || DEFAULT_SONNET_MODEL;
 const MAX_TOKENS = 4000;
 
 export type SynthesizedFaq = {

--- a/packages/crm/src/lib/soul-compiler/sitemap-priority.ts
+++ b/packages/crm/src/lib/soul-compiler/sitemap-priority.ts
@@ -3,13 +3,14 @@ import { fileURLToPath } from "node:url";
 import Anthropic from "@anthropic-ai/sdk";
 import { createByokAnthropicClient } from "./anthropic";
 import { readSkillPack } from "@/lib/skill-packs/reader";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
 const SKILL_PACK_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "skills/sitemap-priority.md"
 );
 
-const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || "claude-sonnet-4-20250514";
+const MODEL = process.env.SOUL_COMPILER_MODEL?.trim() || DEFAULT_SONNET_MODEL;
 const MAX_TOKENS = 2000;
 const DEFAULT_LIMIT = 10;
 

--- a/packages/crm/src/lib/soul-wiki/SOUL_WIKI_HANDOFF.md
+++ b/packages/crm/src/lib/soul-wiki/SOUL_WIKI_HANDOFF.md
@@ -57,8 +57,8 @@ This runbook covers Soul Wiki ingestion, compilation, retrieval, onboarding auto
 
 ## AI/Env Requirements
 - `ANTHROPIC_API_KEY` is required for compile/query behavior.
-- Default model currently used in Soul Wiki compile/query paths:
-  - `claude-sonnet-4-20250514`
+- Default model currently used in Soul Wiki compile/query paths (from `DEFAULT_SONNET_MODEL` in `src/lib/ai/models.ts`):
+  - `claude-sonnet-4-5-20250929`
 
 ## Safety and Failure Behavior
 - Demo mode write guards are active on write routes/actions.

--- a/packages/crm/src/lib/soul-wiki/compile.ts
+++ b/packages/crm/src/lib/soul-wiki/compile.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { and, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { organizations, soulSources, soulWiki } from "@/db/schema";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
 type WikiCategory = {
   slug: string;
@@ -121,7 +122,7 @@ async function compileArticle(client: Anthropic, category: WikiCategory, rawBund
   const soulRecord = soul && typeof soul === "object" ? (soul as Record<string, unknown>) : null;
 
   const response = await client.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: DEFAULT_SONNET_MODEL,
     max_tokens: 4096,
     system: `You are a business knowledge compiler. Your job is to read raw source material about a business and compile a specific wiki article from it.
 
@@ -192,7 +193,7 @@ export async function incrementalCompile(orgId: string, newSourceId: string) {
     const existing = existingArticles.find((article) => article.slug === category.slug) as WikiRow | undefined;
 
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: DEFAULT_SONNET_MODEL,
       max_tokens: 4096,
       system: `You are a wiki editor. You have an existing article and new source material. Update the article if the new material adds relevant information. If nothing new is relevant, return the existing article unchanged.
 

--- a/packages/crm/src/lib/soul-wiki/query.ts
+++ b/packages/crm/src/lib/soul-wiki/query.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { soulWiki } from "@/db/schema";
+import { DEFAULT_SONNET_MODEL } from "@/lib/ai/models";
 
 function getAnthropicClient() {
   const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
@@ -36,7 +37,7 @@ export async function querySoulWiki(orgId: string, userPrompt: string, maxTokens
 
   try {
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: DEFAULT_SONNET_MODEL,
       max_tokens: maxTokens,
       system:
         "You are a knowledge retriever. Given a user prompt and a wiki, extract ONLY the sections relevant to fulfilling the prompt. Return relevant content as-is, preserving wording. Do not summarize or paraphrase.",


### PR DESCRIPTION
## Problem

`claude-sonnet-4-20250514` (Sonnet 4) is **deprecated and 404s in production**. Confirmed in prod logs: the personality generator's `personality_generator_model_fallback` fires *from* `claude-sonnet-4-20250514` → `claude-sonnet-4-5-20250929`, reason `404 ... model: claude-sonnet-4-20250514`.

It was copy-pasted as the hardcoded default in **10 production call sites**. Only one file in the whole codebase (`personality-generator.ts`) has a 404-retry fallback chain — the other **10 paths call the Anthropic SDK directly with no fallback**, so they 404 outright whenever the model id doesn't resolve:

| Feature | Files |
|---|---|
| Soul compiler | `soul-compiler/{anthropic,faq-extractor,faq-synthesizer,sitemap-priority}.ts` |
| Soul wiki | `soul-wiki/{compile,query}.ts` |
| Seldon-It copilot | `ai/seldon-actions.ts`, `ai/generate-block.ts` |
| Framework generation | `frameworks/actions.ts` (×2) |
| Public URL analysis | `app/api/v1/public/analyze-url/route.ts` |

## Fix

- **New shared constant** `DEFAULT_SONNET_MODEL = "claude-sonnet-4-5-20250929"` in `packages/crm/src/lib/ai/models.ts` (a leaf module — no imports, zero circular-dep risk).
- **Swept all 10 live defaults** to reference it. Kept each site's existing env-override pattern (`SELDON_MODEL`, `SOUL_COMPILER_MODEL`) — only the fallback default string changed.
- Updated the two stale text refs: the "model configuration failed" error message in `seldon-actions.ts`, and the "Default model currently used" line in `soul-wiki/SOUL_WIKI_HANDOFF.md`.

### Why `claude-sonnet-4-5-20250929` and not `claude-sonnet-5`

This is a **bug fix, not a model upgrade**. `claude-sonnet-4-5-20250929` is the codebase's own established "current GA Sonnet":
- it's the personality generator's proven fallback target (the one prod logs show working),
- it's the default in the agent runtime (`stateless-turn.ts`, `runtime.ts`, `voice-profile/build-deps.ts`, `agent-templates/actions.ts`),
- `web-onboarding/web-fetch-extractor.ts` already did exactly this swap and documents it as *"current GA Sonnet, used elsewhere in the agent runtime."*

Critically, it's in the **same pre-4.6 API family** as Sonnet 4, so this is a true drop-in — identical `thinking`/sampling/token surface, no request-shape changes. Verified against the `/claude-api` model catalog (Sonnet 4.5 = Active).

Moving to `claude-sonnet-5` would be a *separate, larger migration* (adaptive-thinking-on-by-default, non-default sampling-param rejection, ~30% tokenizer shift) — out of scope for a 404 fix, flagged below as an optional follow-up.

## ⚠️ Action needed from Max (this PR alone may not fully fix prod)

1. **Check Vercel env vars.** The prod fallback log implies `ANTHROPIC_MODEL` is currently **set to `claude-sonnet-4-20250514`** in Vercel (that's why the personality generator's *primary* — `ANTHROPIC_MODEL || claude-opus-4-7` — 404'd from the stale id). If `ANTHROPIC_MODEL` / `SELDON_MODEL` / `SOUL_COMPILER_MODEL` are set to the stale id, **the env override still wins over these code defaults** and those paths keep 404ing. This code change only protects the *unset* case. Please update/unset those env vars to a valid model. (I can't read Vercel env from here — the Vercel connector needs auth.)

2. **Founder-call confirmation.** `docs/superpowers/plans/2026-07-04-win-ladder-seldonchat.md:14` records a decision to pin the Seldon-It copilot to `claude-sonnet-4-20250514` *"exactly (founder call)"*. That id now 404s, so the pin is no longer viable regardless; 4.5 is the closest current GA Sonnet. Please confirm 4.5 is acceptable for the copilot.

## Left intentionally unchanged

- `web-onboarding/web-fetch-extractor.ts:23` — an **accurate historical fix-note** (documents the same swap already done there). Editing it would erase useful history.
- `docs/superpowers/{specs,plans}/*` (5 dated files) — **archival planning records** of past sprints. Editing them to change a model id would falsify the historical record. (These are why a repo-wide grep for the old id is not empty after this PR.)

## Verification (`/verify-build` gate)

- ✅ **use-server hygiene** — clean (imports into the two `"use server"` files added no non-async exports).
- ✅ **Unit tests** — soul-compiler suites 35/35; ai + personality + extraction suites 85/85; `antifragility-model-bump` integration test self-skips (DB/flag-gated). No test pins the stale id.
- ✅ **tsc** — full-package typecheck yields **0 new errors**. It reports 10 errors, but a stash-delta run confirms `origin/main` produces the **identical** 10 — all pre-existing and unrelated (the verify worktree's node_modules is older than `origin/main`, so posthog/qrcode/markdown-to-jsx resolve as "Cannot find module", plus pre-existing composio/copilot type-shape errors). None are in files this PR touches.
- ✅ **Regression grep** — no forbidden booking/messaging/email/sms paths touched.
- n/a **Migration journal** — no migrations in this change.
- ⏳ **Live smoke** — deferred (branch not deployed). Recommend smoking one soul-compiler path (`/api/v1/public/analyze-url` or a workspace compile) and one soul-wiki compile/query on the preview or post-merge, confirming no 404 model error in logs.

## Follow-ups (optional, separate PRs)

- Consider giving the 10 no-fallback paths the same `callAnthropicWithModelFallback`-style resilience the personality generator has, so a *future* model retirement degrades gracefully instead of 404ing.
- Consider a deliberate migration to `claude-sonnet-5` (handle the 4.6+ breaking changes) if you want the newer model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
