### PR TITLE
World-class images (1/2): capture & use the client's own site photos

### DIFF
--- a/packages/crm/src/lib/landing/r1-payload-generator.ts
+++ b/packages/crm/src/lib/landing/r1-payload-generator.ts
@@ -122,6 +122,25 @@ export type ResolveServicePhotoFn = (input: {
   businessName: string;
 }) => Promise<ServicePhoto | null>;
 
+/**
+ * Pick the best real hero photo the pipeline captured from the source site.
+ * og:image + hero-classified images are merged into facts.photos FIRST (see
+ * markdown-extractor.ts / html-image-harvester.ts), so the first usable one is
+ * the intended hero. Returns null when the site had no scrapeable photo.
+ */
+export function pickHeroPhotoFromFacts(
+  facts: ExtractedBusinessFacts,
+): { src: string; alt: string } | null {
+  const photos = Array.isArray(facts.photos) ? facts.photos : [];
+  const usable = (src: string): boolean =>
+    /^https?:\/\//i.test(src) && !/\.svg(?:[?#]|$)/i.test(src);
+  const hero = photos.find((p) => p.section === "hero" && usable(p.src));
+  const any = photos.find((p) => usable(p.src));
+  const pick = hero ?? any;
+  if (!pick) return null;
+  return { src: pick.src, alt: (pick.alt ?? "").trim() };
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -275,31 +294,66 @@ export async function generateR1Payload(args: {
   // name). Real extracted hero photos are left untouched.
   const heroSrc = (parsed.hero.heroImage?.src ?? "").trim();
   const heroIsGenericFallback = !heroSrc || heroSrc.includes(GENERIC_HERO_PHOTO_ID);
+  let heroSource: "extracted" | "scraped" | "stock" = heroIsGenericFallback
+    ? "stock"
+    : "extracted";
   if (heroIsGenericFallback) {
-    try {
-      const resolved = await photoFn({
-        realSrc: null, // ignore the generic hardcoded URL — force the relevant fallback
-        realAlt: parsed.hero.heroImage?.alt ?? null,
-        // Empty serviceName → the resolver's `${serviceName} ${vertical}` query is
-        // just the vertical (e.g. "hvac"); when the vertical is unknown, the
-        // resolver falls to the archetype's curated fallbackImageQueries.
-        serviceName: "",
-        vertical,
-        archetype: args.archetype,
-        businessName: args.facts.business_name,
-      });
-      if (resolved?.src) {
-        parsed.hero.heroImage = {
-          src: resolved.src,
-          alt:
-            parsed.hero.heroImage?.alt ||
-            `${args.facts.business_name} — professional at work`,
-        };
+    // (2) Prefer the business's OWN captured photo before any stock image —
+    // world-class means the client's real hero shows, not a generic template.
+    const realHero = pickHeroPhotoFromFacts(args.facts);
+    if (realHero) {
+      parsed.hero.heroImage = {
+        src: realHero.src,
+        alt:
+          realHero.alt ||
+          parsed.hero.heroImage?.alt ||
+          `${args.facts.business_name} — hero`,
+      };
+      heroSource = "scraped";
+    } else {
+      // (3) No scrapeable photo — resolve a vertical/archetype-relevant HD stock
+      // image via the same resolver + DI seam the service cards use.
+      try {
+        const resolved = await photoFn({
+          realSrc: null, // ignore the generic hardcoded URL — force the relevant fallback
+          realAlt: parsed.hero.heroImage?.alt ?? null,
+          // Empty serviceName → the resolver's `${serviceName} ${vertical}` query is
+          // just the vertical (e.g. "hvac"); when the vertical is unknown, the
+          // resolver falls to the archetype's curated fallbackImageQueries.
+          serviceName: "",
+          vertical,
+          archetype: args.archetype,
+          businessName: args.facts.business_name,
+        });
+        if (resolved?.src) {
+          parsed.hero.heroImage = {
+            src: resolved.src,
+            alt:
+              parsed.hero.heroImage?.alt ||
+              `${args.facts.business_name} — professional at work`,
+          };
+        }
+      } catch {
+        // Network / rate-limit — keep the prompt's fallback rather than abort.
       }
-    } catch {
-      // Network / rate-limit — keep the prompt's fallback rather than abort.
     }
   }
+
+  // Observability — never let an all-stock result look silently "green".
+  // Records how the hero was sourced + how many of the client's own photos
+  // were available (CLAUDE.md §3.1 Optimistic-Path rule).
+  console.warn(
+    JSON.stringify({
+      event: "landing_images_sourced",
+      business_name: args.facts.business_name,
+      archetype: args.archetype,
+      photos_available: Array.isArray(args.facts.photos)
+        ? args.facts.photos.length
+        : 0,
+      hero_source: heroSource,
+      logo_present: !!args.facts.logo,
+    }),
+  );
 
   return parsed;
 }

--- a/packages/crm/src/lib/web-onboarding/extraction-prompt.ts
+++ b/packages/crm/src/lib/web-onboarding/extraction-prompt.ts
@@ -218,6 +218,12 @@ export type ExtractedBusinessFacts = {
   // only when the URL extraction found them on the original site. The
   // paste path always emits null/undefined for these. The R1 payload
   // generator prefers these over synthesis when present.
+
+  /** 2026-07-13 — the business's own logo, harvested from the source page
+   *  HTML (an <img> wordmark, else apple-touch-icon/favicon). URL path only;
+   *  the paste path leaves this undefined. Rendered in the R1 nav/footer. */
+  logo?: string | null;
+
   photos?: Array<{
     /** Absolute URL. */
     src: string;

--- a/packages/crm/src/lib/web-onboarding/firecrawl-scrape.ts
+++ b/packages/crm/src/lib/web-onboarding/firecrawl-scrape.ts
@@ -23,7 +23,19 @@ export type FirecrawlScrapeReason =
   | "rate_limited";
 
 export type FirecrawlScrapeResult =
-  | { ok: true; markdown: string; finalUrl: string; title?: string }
+  | {
+      ok: true;
+      markdown: string;
+      finalUrl: string;
+      title?: string;
+      /** Cleaned page HTML (requested alongside markdown) — the source the
+       *  image harvester reads. May be absent if the SDK returns MD only. */
+      html?: string;
+      /** og:image from page metadata — the strongest hero candidate. */
+      ogImage?: string;
+      /** Site favicon / touch-icon — a last-resort logo candidate. */
+      favicon?: string;
+    }
   | { ok: false; reason: FirecrawlScrapeReason; detail?: string };
 
 /**
@@ -64,12 +76,15 @@ const WAIT_FOR_MS = 2500;
  */
 type DocumentLike = {
   markdown?: string;
+  html?: string;
   metadata?: {
     sourceURL?: string;
     url?: string;
     title?: string;
     statusCode?: number;
     error?: string;
+    ogImage?: string;
+    favicon?: string;
   };
 };
 
@@ -112,7 +127,9 @@ export async function firecrawlScrape(
   let doc: DocumentLike;
   try {
     doc = (await client.scrape(url, {
-      formats: ["markdown"],
+      // markdown for the LLM extractor; html so the image harvester can pull
+      // the real hero/gallery/logo images that markdown structurally omits.
+      formats: ["markdown", "html"],
       // Keep header/footer/nav — business facts (phone, address, hours,
       // "Family-owned since 1998") frequently live there, not in <main>.
       onlyMainContent: false,
@@ -202,5 +219,8 @@ export async function firecrawlScrape(
     // defaulting to the input URL.
     finalUrl: doc.metadata?.sourceURL ?? doc.metadata?.url ?? url,
     title: doc.metadata?.title,
+    html: typeof doc.html === "string" ? doc.html : undefined,
+    ogImage: doc.metadata?.ogImage,
+    favicon: doc.metadata?.favicon,
   };
 }

--- a/packages/crm/src/lib/web-onboarding/html-image-harvester.ts
+++ b/packages/crm/src/lib/web-onboarding/html-image-harvester.ts
@@ -1,0 +1,202 @@
+// packages/crm/src/lib/web-onboarding/html-image-harvester.ts
+//
+// Dependency-free image harvester for scraped HTML.
+//
+// WHY: Firecrawl markdown only carries `![](url)` images. Real trades /
+// marketing sites serve their hero + gallery as CSS `background-image`,
+// `<picture>`/`srcset`, or lazy `data-src`, and the logo + `og:image` live in
+// `<head>` — none of which reach the markdown. So URL-built workspaces fell
+// back to generic stock even when the source site was full of real photos.
+// This harvester pulls the actual image URLs straight out of the HTML so the
+// client's OWN photos win.
+//
+// WHY REGEX, NOT A DOM PARSER: jsdom is a devDependency (tests only) and far
+// too heavy to bundle into the create-from-url serverless route. We only need
+// to pluck attribute values out of a bounded, Firecrawl-cleaned HTML string —
+// a handful of targeted regexes do that reliably and testably, with zero deps.
+
+export type ImageSection =
+  | "hero"
+  | "services"
+  | "gallery"
+  | "testimonial"
+  | "about"
+  | "other";
+
+export type HarvestedImage = {
+  /** Absolute http(s) URL. */
+  src: string;
+  alt: string;
+  section: ImageSection;
+};
+
+export type HarvestResult = {
+  images: HarvestedImage[];
+  /** Best logo candidate (a real <img> wordmark or apple-touch-icon), else null. */
+  logo: string | null;
+  /** og:image if present — the strongest hero candidate. */
+  ogImage: string | null;
+};
+
+// Hard cap so a photo-wall page can't blow up the payload; downstream caps
+// again at 12.
+const MAX_IMAGES = 20;
+
+// Obvious non-photo assets: data/blob URIs, tracking pixels, sprites, spacers.
+const JUNK_URL_RE =
+  /^(?:data|blob|javascript):|\/(?:sprite|spacer|pixel|blank|tracking)[\/.]|1x1|spacer\.gif|pixel\.(?:gif|png)/i;
+// SVGs are almost always logos/icons/illustrations, not photos — keep them out
+// of `images` (a scraped SVG may still be used as the logo candidate).
+const SVG_RE = /\.svg(?:[?#]|$)/i;
+
+/** Resolve a candidate URL to an absolute http(s) URL, or null if unusable. */
+function resolveAbs(candidate: string, baseUrl: string): string | null {
+  const raw = candidate?.trim();
+  if (!raw) return null;
+  if (JUNK_URL_RE.test(raw)) return null;
+  try {
+    // Handles relative, root-relative, and protocol-relative (//cdn/x.jpg).
+    const u = new URL(raw, baseUrl);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read one HTML attribute value off a tag string. The negative lookbehind
+ * `(?<![-\w])` prevents `src` from matching inside `data-src`, `srcset` from
+ * matching inside `data-srcset`, etc.
+ */
+function getAttr(tag: string, name: string): string | null {
+  const re = new RegExp(
+    `(?<![-\\w])${name}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s>]+))`,
+    "i",
+  );
+  const m = tag.match(re);
+  if (!m) return null;
+  return (m[2] ?? m[3] ?? m[4] ?? "").trim() || null;
+}
+
+/** Pick the highest-resolution URL out of a `srcset` value. */
+function largestFromSrcset(srcset: string): string | null {
+  const entries = srcset
+    .split(",")
+    .map((e) => e.trim())
+    .filter(Boolean);
+  let best: { url: string; weight: number } | null = null;
+  for (const entry of entries) {
+    const [url, descriptor] = entry.split(/\s+/, 2);
+    if (!url) continue;
+    let weight = 0;
+    if (descriptor) {
+      const w = descriptor.match(/(\d+)w/);
+      const x = descriptor.match(/([\d.]+)x/);
+      if (w) weight = parseInt(w[1], 10);
+      else if (x) weight = parseFloat(x[1]) * 1000; // rank 2x above any 1x
+    }
+    if (!best || weight >= best.weight) best = { url, weight };
+  }
+  return best?.url ?? null;
+}
+
+function classify(hint: string): ImageSection {
+  const h = hint.toLowerCase();
+  if (/hero|banner|masthead|jumbotron|slide/.test(h)) return "hero";
+  if (/gallery|project|portfolio|work|before|after/.test(h)) return "gallery";
+  if (/team|about|staff|owner|founder/.test(h)) return "about";
+  if (/review|testimonial|client/.test(h)) return "testimonial";
+  if (/service/.test(h)) return "services";
+  return "other";
+}
+
+function isLogoHint(hint: string): boolean {
+  return /\blogo\b|wordmark|brand-?mark/i.test(hint);
+}
+
+/**
+ * Pull image URLs out of a page's HTML. Never throws; returns empty result
+ * on non-string / empty input.
+ */
+export function harvestImagesFromHtml(html: string, baseUrl: string): HarvestResult {
+  if (!html || typeof html !== "string") {
+    return { images: [], logo: null, ogImage: null };
+  }
+
+  const seen = new Set<string>(); // dedup key = origin + pathname
+  const images: HarvestedImage[] = [];
+  let logo: string | null = null;
+  let ogImage: string | null = null;
+
+  const imageKey = (abs: string): string => {
+    try {
+      const u = new URL(abs);
+      return u.origin + u.pathname;
+    } catch {
+      return abs;
+    }
+  };
+
+  const pushImage = (rawUrl: string | null, hint: string, alt: string): void => {
+    if (images.length >= MAX_IMAGES) return;
+    const abs = resolveAbs(rawUrl ?? "", baseUrl);
+    if (!abs) return;
+    if (SVG_RE.test(abs)) return; // logo/icon, not a photo
+    const key = imageKey(abs);
+    if (seen.has(key)) return;
+    seen.add(key);
+    images.push({ src: abs, alt: (alt ?? "").trim(), section: classify(hint) });
+  };
+
+  // 0. og:image — the strongest hero candidate.
+  const og = html.match(/<meta[^>]+property=["']og:image(?::url)?["'][^>]*>/i);
+  if (og) {
+    ogImage = resolveAbs(getAttr(og[0], "content") ?? "", baseUrl);
+  }
+
+  // 1. <img> tags.
+  for (const m of html.matchAll(/<img\b[^>]*>/gi)) {
+    const tag = m[0];
+    const alt = getAttr(tag, "alt") ?? "";
+    const cls = getAttr(tag, "class") ?? "";
+    const id = getAttr(tag, "id") ?? "";
+    const srcset = getAttr(tag, "srcset") ?? getAttr(tag, "data-srcset");
+    const src =
+      (srcset ? largestFromSrcset(srcset) : null) ??
+      getAttr(tag, "src") ??
+      getAttr(tag, "data-src") ??
+      getAttr(tag, "data-lazy-src") ??
+      getAttr(tag, "data-original");
+    const hint = `${alt} ${cls} ${id} ${src ?? ""}`;
+    if (isLogoHint(hint)) {
+      // Logos are never photos. Remember the first one as the logo candidate.
+      if (!logo) logo = resolveAbs(src ?? "", baseUrl);
+      continue;
+    }
+    pushImage(src, hint, alt);
+  }
+
+  // 2. <source srcset> inside <picture>.
+  for (const m of html.matchAll(/<source\b[^>]*>/gi)) {
+    const srcset = getAttr(m[0], "srcset") ?? getAttr(m[0], "data-srcset");
+    if (srcset) pushImage(largestFromSrcset(srcset), srcset, "");
+  }
+
+  // 3. CSS background-image: url(...) — inline styles + <style> blocks.
+  for (const m of html.matchAll(
+    /background-image\s*:\s*url\((['"]?)([^'")]+)\1\)/gi,
+  )) {
+    pushImage(m[2], "hero background", "");
+  }
+
+  // 4. Logo fallback: apple-touch-icon / icon <link> when no <img> logo found.
+  if (!logo) {
+    const link = html.match(
+      /<link[^>]+rel=["'](?:apple-touch-icon|icon|shortcut icon)["'][^>]*>/i,
+    );
+    if (link) logo = resolveAbs(getAttr(link[0], "href") ?? "", baseUrl);
+  }
+
+  return { images, logo, ogImage };
+}

--- a/packages/crm/src/lib/web-onboarding/html-image-harvester.ts
+++ b/packages/crm/src/lib/web-onboarding/html-image-harvester.ts
@@ -57,7 +57,10 @@ function resolveAbs(candidate: string, baseUrl: string): string | null {
   try {
     // Handles relative, root-relative, and protocol-relative (//cdn/x.jpg).
     const u = new URL(raw, baseUrl);
-    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    // https ONLY — an http image on the https public /w page is blocked as
+    // mixed content and renders broken. (A future Blob re-host step can fetch
+    // http sources server-side and re-serve them over https.)
+    if (u.protocol !== "https:") return null;
     return u.toString();
   } catch {
     return null;

--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -40,6 +40,7 @@ import {
 } from "./extraction-prompt";
 import { parseExtraction } from "./extraction-parser";
 import { firecrawlScrape, type ScrapeDeps } from "./firecrawl-scrape";
+import { harvestImagesFromHtml } from "./html-image-harvester";
 import { WebFetchError, type WebFetchErrorReason } from "./web-fetch-extractor";
 
 // Re-export the error type so callers can import it from either path
@@ -233,5 +234,56 @@ export async function extractBusinessFactsFromUrl(params: {
     );
   }
 
-  return parsed.data;
+  const facts = parsed.data;
+
+  // Deterministically enrich with images harvested straight from the page
+  // HTML. Firecrawl markdown only carries ![](...) images; the real hero /
+  // gallery photos live in CSS background / srcset / lazy attrs and the logo
+  // + og:image live in <head>. We merge these ourselves rather than trusting
+  // the LLM to surface them from markdown (which it structurally cannot).
+  if (scrape.html || scrape.ogImage) {
+    const harvest = harvestImagesFromHtml(scrape.html ?? "", scrape.finalUrl);
+    facts.logo = harvest.logo ?? scrape.favicon ?? facts.logo ?? null;
+
+    const keyOf = (src: string): string => {
+      try {
+        const u = new URL(src);
+        return u.origin + u.pathname;
+      } catch {
+        return src;
+      }
+    };
+    const existing = Array.isArray(facts.photos) ? facts.photos : [];
+    const seen = new Set(existing.map((p) => keyOf(p.src)));
+    const additions: NonNullable<ExtractedBusinessFacts["photos"]> = [];
+
+    // og:image first — the strongest hero candidate.
+    const ogSrc = scrape.ogImage ?? harvest.ogImage;
+    if (ogSrc && !seen.has(keyOf(ogSrc))) {
+      additions.push({ src: ogSrc, alt: "", section: "hero" });
+      seen.add(keyOf(ogSrc));
+    }
+    for (const img of harvest.images) {
+      const k = keyOf(img.src);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      additions.push({ src: img.src, alt: img.alt, section: img.section });
+    }
+
+    // Real source photos go FIRST so the R1 generator prefers them over stock.
+    facts.photos = [...additions, ...existing].slice(0, 12);
+
+    console.warn(
+      JSON.stringify({
+        event: "source_images_harvested",
+        url: params.url,
+        from_html: harvest.images.length,
+        og_image: !!ogSrc,
+        logo: !!facts.logo,
+        total_photos: facts.photos.length,
+      }),
+    );
+  }
+
+  return facts;
 }

--- a/packages/crm/tests/unit/landing/r1-hero-photo.spec.ts
+++ b/packages/crm/tests/unit/landing/r1-hero-photo.spec.ts
@@ -1,0 +1,53 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { pickHeroPhotoFromFacts } from "../../../src/lib/landing/r1-payload-generator";
+import type { ExtractedBusinessFacts } from "../../../src/lib/web-onboarding/extraction-prompt";
+
+const base: ExtractedBusinessFacts = {
+  business_name: "Dallas Heating and Air",
+  city: "Dallas",
+  state: "TX",
+  phone: "972-423-0012",
+  services: ["AC repair"],
+  business_description: "HVAC.",
+};
+
+test("prefers a hero-classified captured photo over other sections", () => {
+  const facts: ExtractedBusinessFacts = {
+    ...base,
+    photos: [
+      { src: "https://x.com/service.jpg", section: "services" },
+      { src: "https://x.com/hero.jpg", section: "hero" },
+    ],
+  };
+  assert.equal(pickHeroPhotoFromFacts(facts)?.src, "https://x.com/hero.jpg");
+});
+
+test("falls back to the first usable photo when none are hero-classified", () => {
+  const facts: ExtractedBusinessFacts = {
+    ...base,
+    photos: [
+      { src: "https://x.com/a.jpg", section: "gallery" },
+      { src: "https://x.com/b.jpg", section: "about" },
+    ],
+  };
+  assert.equal(pickHeroPhotoFromFacts(facts)?.src, "https://x.com/a.jpg");
+});
+
+test("skips svg/non-http candidates", () => {
+  const facts: ExtractedBusinessFacts = {
+    ...base,
+    photos: [
+      { src: "https://x.com/logo.svg", section: "hero" },
+      { src: "https://x.com/real.jpg", section: "gallery" },
+    ],
+  };
+  assert.equal(pickHeroPhotoFromFacts(facts)?.src, "https://x.com/real.jpg");
+});
+
+test("returns null when the site had no scrapeable photo", () => {
+  assert.equal(pickHeroPhotoFromFacts(base), null);
+  assert.equal(pickHeroPhotoFromFacts({ ...base, photos: [] }), null);
+  assert.equal(pickHeroPhotoFromFacts({ ...base, photos: null }), null);
+});

--- a/packages/crm/tests/unit/web-onboarding/firecrawl-scrape.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/firecrawl-scrape.spec.ts
@@ -62,11 +62,36 @@ describe("firecrawlScrape", () => {
       assert.equal(result.finalUrl, "https://acme-plumbing.com/");
       assert.equal(result.title, "Acme Plumbing | Phoenix, AZ");
     }
-    // Confirm we asked for markdown format + kept onlyMainContent off.
+    // Confirm we asked for markdown + html formats and kept onlyMainContent off.
     assert.equal(calls.length, 1);
     const opts = calls[0]?.opts as { formats?: string[]; onlyMainContent?: boolean } | undefined;
-    assert.deepEqual(opts?.formats, ["markdown"]);
+    assert.deepEqual(opts?.formats, ["markdown", "html"]);
     assert.equal(opts?.onlyMainContent, false);
+  });
+
+  test("surfaces html + og:image + favicon for the image harvester", async () => {
+    const { client } = makeFakeClient(async () => ({
+      markdown: SAMPLE_MARKDOWN,
+      html: '<html><body><img src="/hero.jpg" alt="hero"></body></html>',
+      metadata: {
+        sourceURL: "https://acme-plumbing.com/",
+        title: "Acme",
+        statusCode: 200,
+        ogImage: "https://cdn.acme.com/og.jpg",
+        favicon: "https://acme-plumbing.com/favicon.ico",
+      },
+    }));
+
+    const result = await firecrawlScrape("https://acme-plumbing.com", {
+      firecrawlClient: client,
+    });
+
+    assert.equal(result.ok, true);
+    if (result.ok) {
+      assert.match(result.html ?? "", /hero\.jpg/);
+      assert.equal(result.ogImage, "https://cdn.acme.com/og.jpg");
+      assert.equal(result.favicon, "https://acme-plumbing.com/favicon.ico");
+    }
   });
 
   test("SDK throws -> reason: fetch_failed with detail from error message", async () => {

--- a/packages/crm/tests/unit/web-onboarding/html-image-harvester.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/html-image-harvester.spec.ts
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { harvestImagesFromHtml } from "../../../src/lib/web-onboarding/html-image-harvester";
+
+const BASE = "https://dallasheatingac.com/";
+
+test("resolves a root-relative <img src> to an absolute URL", () => {
+  const r = harvestImagesFromHtml('<img src="/photos/ac-unit.jpg" alt="AC unit">', BASE);
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://dallasheatingac.com/photos/ac-unit.jpg");
+  assert.equal(r.images[0].alt, "AC unit");
+});
+
+test("captures lazy-loaded data-src when src is a placeholder-less img", () => {
+  const r = harvestImagesFromHtml('<img data-src="https://cdn.x.com/hero.jpg" class="lazy">', BASE);
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://cdn.x.com/hero.jpg");
+});
+
+test("does NOT mistake data-src for src (attribute-boundary)", () => {
+  // A real srcset should win; ensure getAttr('src') isn't matching 'data-src'.
+  const r = harvestImagesFromHtml('<img data-src="https://cdn.x.com/real.jpg">', BASE);
+  assert.equal(r.images[0].src, "https://cdn.x.com/real.jpg");
+});
+
+test("picks the largest candidate from srcset", () => {
+  const html =
+    '<img srcset="/s/small.jpg 300w, /s/mid.jpg 768w, /s/big.jpg 1600w" alt="job">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.images[0].src, "https://dallasheatingac.com/s/big.jpg");
+});
+
+test("extracts CSS background-image url()", () => {
+  const html = '<div class="hero" style="background-image:url(\'/img/masthead.jpg\')"></div>';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://dallasheatingac.com/img/masthead.jpg");
+  assert.equal(r.images[0].section, "hero");
+});
+
+test("resolves protocol-relative //cdn URLs to https", () => {
+  const r = harvestImagesFromHtml('<img src="//cdn.x.com/a.jpg">', BASE);
+  assert.equal(r.images[0].src, "https://cdn.x.com/a.jpg");
+});
+
+test("captures og:image as a hero candidate (regardless of attr order)", () => {
+  const html = '<meta content="https://cdn.x.com/og.jpg" property="og:image">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.ogImage, "https://cdn.x.com/og.jpg");
+});
+
+test("detects the logo from an <img> and does not list it as a photo", () => {
+  const html =
+    '<img src="/assets/site-logo.png" alt="Dallas Heating Logo"><img src="/p/tech.jpg" alt="tech">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.logo, "https://dallasheatingac.com/assets/site-logo.png");
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://dallasheatingac.com/p/tech.jpg");
+});
+
+test("falls back to apple-touch-icon for the logo when no <img> logo exists", () => {
+  const html = '<link rel="apple-touch-icon" href="/icons/touch.png"><img src="/p/x.jpg">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.logo, "https://dallasheatingac.com/icons/touch.png");
+});
+
+test("rejects data: URIs, tracking pixels, and SVGs from photos", () => {
+  const html = [
+    '<img src="data:image/gif;base64,R0lGOD">',
+    '<img src="/img/1x1.png">',
+    '<img src="/img/tracking/pixel.gif">',
+    '<img src="/img/logo-sprite.svg">',
+    '<img src="/img/real-photo.jpg">',
+  ].join("");
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://dallasheatingac.com/img/real-photo.jpg");
+});
+
+test("dedupes the same image path ignoring the query string", () => {
+  const html =
+    '<img src="/p/hero.jpg?w=400"><img src="/p/hero.jpg?w=1600"><img src="/p/other.jpg">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.images.length, 2);
+});
+
+test("classifies by alt/class hints", () => {
+  const html =
+    '<img src="/a.jpg" class="gallery-item"><img src="/b.jpg" alt="Our team photo">';
+  const r = harvestImagesFromHtml(html, BASE);
+  const bySrc = Object.fromEntries(r.images.map((i) => [i.src.split("/").pop(), i.section]));
+  assert.equal(bySrc["a.jpg"], "gallery");
+  assert.equal(bySrc["b.jpg"], "about");
+});
+
+test("never throws on empty / non-string input", () => {
+  assert.deepEqual(harvestImagesFromHtml("", BASE), { images: [], logo: null, ogImage: null });
+  // @ts-expect-error — exercising the runtime guard
+  assert.deepEqual(harvestImagesFromHtml(undefined, BASE), { images: [], logo: null, ogImage: null });
+});

--- a/packages/crm/tests/unit/web-onboarding/html-image-harvester.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/html-image-harvester.spec.ts
@@ -78,6 +78,14 @@ test("rejects data: URIs, tracking pixels, and SVGs from photos", () => {
   assert.equal(r.images[0].src, "https://dallasheatingac.com/img/real-photo.jpg");
 });
 
+test("drops absolute http:// URLs (mixed-content safety)", () => {
+  const html =
+    '<img src="http://old.example.com/a.jpg"><img src="https://ok.example.com/b.jpg">';
+  const r = harvestImagesFromHtml(html, BASE);
+  assert.equal(r.images.length, 1);
+  assert.equal(r.images[0].src, "https://ok.example.com/b.jpg");
+});
+
 test("dedupes the same image path ignoring the query string", () => {
   const html =
     '<img src="/p/hero.jpg?w=400"><img src="/p/hero.jpg?w=1600"><img src="/p/other.jpg">';


### PR DESCRIPTION
**Part 1 of the world-class image work.** Fixes the core bug behind "no images from the source URL": URL-built workspaces showed generic stock even when the source site was full of real photos.

## Root cause
Firecrawl was scraping `formats: ["markdown"]` only. Markdown carries just `![](url)` images — real hero/gallery photos live in CSS `background-image` / `srcset` / lazy `data-src`, and the logo + `og:image` live in `<head>`. None reached the extractor → `facts.photos` came back empty → the generator fell back to Unsplash for the hero and every card. (`landing_page_skipped_default` was a red herring — the landing *is* generated; it just had no source images to use.)

## What this does
1. **Capture** — `html-image-harvester.ts` (new, zero-dependency regex; jsdom is dev-only and too heavy for the serverless route). Request `formats:[markdown,html]`, surface `og:image`/`favicon`, harvest `<img>`/`srcset`/`data-src`/`background-image` + the logo, and **merge deterministically** into `facts.photos`/`facts.logo` (real photos first) — not dependent on the LLM finding them in markdown.
2. **Use** — `r1-payload-generator.ts`: the hero now prefers the client's OWN captured photo (og:image / hero-classified) over stock. Adds a `landing_images_sourced` event (`hero_source: extracted|scraped|stock`, `photos_available`, `logo_present`) so an all-stock result is never silently "green" (CLAUDE.md §3.1).
3. **https-only** capture — an http image on the https `/w` page is blocked as mixed content; Blob re-hosting of http sources is part 2.

## Verify
- **Real-site smoke on dallasheatingac.com** (HTTP 200, 164 KB HTML): the harvester found the logo (`logo-header.svg`), the og:image hero (`hero-bg.webp`), and **20 real photos** — HVAC job photos, team, gallery, service images. Exactly the imagery that was missing before.
- **18 new unit tests** (harvester 14, hero-pick 4) + updated scrape-contract test. `tsc` clean (only the pre-existing `copilot/turn/route.ts:315` error remains).
- Full unit suite: **net regression delta 0** — the ~81 pre-existing failures are #68-rebrand landing-component specs, untouched here.

## Follow-up (part 2 — NOT in this PR)
- **Pexels-first / Unsplash-with-credit** fill (per the product decision) + render the Unsplash attribution that's currently computed-then-dropped.
- Render the captured **logo** in the R1 nav/footer.
- **Blob re-host** captured images (permanence, recover http sources, hotlink-rot / SSRF hardening).

CI (`ci.yml`) runs install + unit tests + drift on this PR; `tsc` verified locally (ci.yml has no tsc step).
