### PR TITLE
World-class images (2): render the client's captured logo in the nav

### DIFF
--- a/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
+++ b/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
@@ -174,6 +174,7 @@ export default async function PublicSPage({ params }: PageProps) {
             servicePages={navServices}
             homeHref="/"
             cta={payload.nav?.cta}
+            logoUrl={payload.logo}
           />
           <ServicePageTemplate
             archetype={payload.hero.archetype}
@@ -234,6 +235,7 @@ export default async function PublicSPage({ params }: PageProps) {
             servicePages={navServices}
             homeHref="/"
             cta={payload.nav?.cta}
+            logoUrl={payload.logo}
           />
           {payload.emergency && <EmergencyStrip {...payload.emergency} />}
           <Hero {...payload.hero} orgSlug={orgSlug} leadForm={payload.leadForm} />

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -261,6 +261,7 @@ export default async function WorkspaceLandingPage({ params }: PageProps) {
         servicePages={navServices}
         homeHref={homeHref}
         cta={payload.nav?.cta}
+        logoUrl={payload.logo}
       />
       {payload.emergency && <EmergencyStrip {...payload.emergency} />}
       <Hero {...payload.hero} orgSlug={slug} leadForm={payload.leadForm} />

--- a/packages/crm/src/app/(public)/w/[slug]/services/[service]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/services/[service]/page.tsx
@@ -100,6 +100,7 @@ export default async function WorkspaceServicePage({ params }: PageProps) {
         servicePages={navServices}
         homeHref={homeHref}
         cta={payload.nav?.cta}
+        logoUrl={payload.logo}
       />
       <ServicePageTemplate
         archetype={payload.hero.archetype}

--- a/packages/crm/src/components/landing-r1/chrome/navbar.tsx
+++ b/packages/crm/src/components/landing-r1/chrome/navbar.tsx
@@ -88,6 +88,10 @@ export type NavbarProps = {
   /** Primary booking CTA rendered in the right actions area. When omitted (legacy
    *  payloads without nav.cta) the button is not rendered — no regression. */
   cta?: { label: string; href: string };
+  /** The client's own logo (captured from their site during URL onboarding).
+   *  When present, replaces the text wordmark in the brand slot. Omitted →
+   *  wordmark (unchanged legacy behavior). */
+  logoUrl?: string;
 };
 
 export function Navbar({
@@ -99,6 +103,7 @@ export function Navbar({
   servicePages,
   homeHref = "/",
   cta,
+  logoUrl,
 }: NavbarProps) {
   if (ARCHETYPES_WITHOUT_NAVBAR.includes(archetype)) return null;
 
@@ -121,9 +126,16 @@ export function Navbar({
       <div className="sf-navbar-inner">
         {/* Left: wordmark + optional service-area tagline */}
         <div className="sf-navbar-brand">
-          <a className="sf-navbar-wordmark" href={homeHref} aria-label={`${businessName} — home`}>
-            {businessName.toUpperCase()}
-          </a>
+          {logoUrl ? (
+            <a className="sf-navbar-logo-link" href={homeHref} aria-label={`${businessName} — home`}>
+              {/* eslint-disable-next-line @next/next/no-img-element -- the client's own logo lives on an arbitrary operator CDN; next/image can't be pre-configured for every host. */}
+              <img className="sf-navbar-logo" src={logoUrl} alt={businessName} />
+            </a>
+          ) : (
+            <a className="sf-navbar-wordmark" href={homeHref} aria-label={`${businessName} — home`}>
+              {businessName.toUpperCase()}
+            </a>
+          )}
           {areaLine && (
             <span className="sf-navbar-area" aria-hidden>
               {areaLine}
@@ -267,6 +279,21 @@ export function Navbar({
         }
         .sf-navbar-wordmark:hover {
           color: var(--primary);
+        }
+        .sf-navbar-logo-link {
+          display: inline-flex;
+          align-items: center;
+          text-decoration: none;
+        }
+        .sf-navbar-logo {
+          height: 30px;
+          width: auto;
+          max-width: 180px;
+          object-fit: contain;
+          display: block;
+        }
+        @media (min-width: 1024px) {
+          .sf-navbar-logo { height: 34px; }
         }
         .sf-navbar-area {
           font-family: var(--font-body);

--- a/packages/crm/src/lib/landing/r1-payload-generator.ts
+++ b/packages/crm/src/lib/landing/r1-payload-generator.ts
@@ -243,6 +243,12 @@ export async function generateR1Payload(args: {
     );
   }
 
+  // Thread the client's own captured logo (part 1) onto the payload so the
+  // nav renders their real brand mark instead of a text wordmark.
+  if (typeof args.facts.logo === "string" && args.facts.logo.trim()) {
+    parsed.logo = args.facts.logo.trim();
+  }
+
   // ── Photo post-process ─────────────────────────────────────────────────────
   // After the payload is validated, enrich each service with an HD photo.
   // Infer the vertical from facts (same source as classifyArchetype in the

--- a/packages/crm/src/lib/landing/r1-payload-prompt.ts
+++ b/packages/crm/src/lib/landing/r1-payload-prompt.ts
@@ -198,6 +198,10 @@ export type R1LandingPayload = {
   testimonials: R1TestimonialsSection;
   faq: R1FaqSection;
   footer: R1FooterSection;
+  /** The client's own logo, captured from their site during URL onboarding
+   *  (html-image-harvester). Optional — absent on paste/manual builds.
+   *  Rendered in the nav brand slot in place of the text wordmark. */
+  logo?: string;
   emergency?: R1EmergencySection;
   sticky?: R1StickySection;
   /** Speed-to-Lead bottom section (optional). */

--- a/packages/crm/tests/unit/landing/navbar-logo.spec.tsx
+++ b/packages/crm/tests/unit/landing/navbar-logo.spec.tsx
@@ -1,0 +1,37 @@
+// Navbar brand-slot logo rendering (world-class images, part 2).
+//
+// When the client's own logo is captured from their site (html-image-harvester
+// → facts.logo → R1 payload.logo → Navbar logoUrl), the nav renders their real
+// brand mark instead of the uppercase text wordmark. Absent logoUrl keeps the
+// legacy wordmark behavior unchanged.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import { Navbar } from "../../../src/components/landing-r1/chrome/navbar";
+
+const base = {
+  archetype: "bold-urgency" as const,
+  businessName: "Dallas Heating",
+  phone: "972-423-0012",
+};
+
+describe("Navbar logo", () => {
+  test("renders the client logo <img> in place of the wordmark when logoUrl is set", () => {
+    const html = renderToString(<Navbar {...base} logoUrl="https://cdn.x.com/logo.svg" />);
+    assert.match(html, /class="sf-navbar-logo"/);
+    assert.match(html, /src="https:\/\/cdn\.x\.com\/logo\.svg"/);
+    assert.match(html, /alt="Dallas Heating"/);
+    // The uppercase text wordmark must NOT render when a logo is shown.
+    assert.doesNotMatch(html, /DALLAS HEATING</);
+  });
+
+  test("falls back to the text wordmark when no logoUrl", () => {
+    const html = renderToString(<Navbar {...base} />);
+    assert.match(html, /DALLAS HEATING/);
+    assert.doesNotMatch(html, /sf-navbar-logo"/);
+  });
+});


### PR DESCRIPTION
**Part 2 of the world-class image work** (part 1 = #70, capture + hero-use, merged). Renders the client's OWN logo — captured in part 1 — in the R1 nav, replacing the generic uppercase text wordmark.

## What
- `facts.logo` (captured by the html-image-harvester in part 1) → threaded onto the R1 payload (`payload.logo`, set in `generateR1Payload`) → rendered in the navbar brand slot across **all three R1 surfaces**: `/w/[slug]`, subdomain `/s/[orgSlug]`, and service pages.
- Absent logo (paste / manual builds) → unchanged text wordmark. No regression.
- External https logo via a plain `<img>` — the logo lives on an arbitrary operator CDN, so next/image can't be pre-configured per host. Harvester is https-only, so no mixed content.

## Verify
- 2 navbar render tests: logo `<img>` shown in place of the wordmark when `logoUrl` is set; wordmark fallback when absent.
- `tsc` clean (only the pre-existing `copilot/turn/route.ts:315`).
- Full unit suite: **regression delta 0** (81 pre-existing failures unchanged, +2 new passing tests).

## Remaining — part 3 (its own PR)
- **Pexels-first / Unsplash-with-credit** fill for slots the source site doesn't cover (per the product decision) + **render the Unsplash attribution** that's currently computed-then-dropped (`ResolvedUnsplashImage.attribution`).
- **Blob re-host** captured images — permanence, recover http-only sources, hotlink-rot / SSRF hardening (the harvester is https-only today as the interim safety measure).

⚠️ Taste note: a transparent SVG logo on a dark-`--bg` navbar may need per-archetype handling; most R1 navbars use a light `--bg`, so flagged rather than gated.
