### PR TITLE
World-class images (3): Blob re-host the client's captured images

### DIFF
--- a/packages/crm/src/lib/landing/r1-payload-generator.ts
+++ b/packages/crm/src/lib/landing/r1-payload-generator.ts
@@ -24,6 +24,7 @@ import {
   resolveServicePhoto,
   type ServicePhoto,
 } from "./service-photo-resolver";
+import { resolveExternalMedia } from "@/lib/media/resolve-url";
 
 // Prefer a smaller model for payload generation — the prompt is highly
 // structured (JSON schema is fully specified), so Haiku is sufficient
@@ -141,6 +142,101 @@ export function pickHeroPhotoFromFacts(
   return { src: pick.src, alt: (pick.alt ?? "").trim() };
 }
 
+// ── Blob re-host (part 3) ─────────────────────────────────────────────────────
+
+/** Replace a source image URL with a permanent Blob URL. Returns the original
+ *  URL on any failure — re-hosting is best-effort and never blocks the build. */
+export type RehostImageFn = (url: string) => Promise<string>;
+
+// Hosts we NEVER re-host: already-permanent Blob storage, and the stock CDNs
+// (Unsplash/Pexels) which are hotlink-friendly by their own API terms.
+const BLOB_HOST_RE = /\.blob\.vercel-storage\.com$/i;
+const STOCK_HOST_RE = /(?:^|\.)(?:unsplash\.com|pexels\.com)$/i;
+
+/**
+ * Only the CLIENT's OWN scraped images get re-hosted — not stock, not
+ * already-Blob URLs. Exported for unit testing.
+ */
+export function isRehostableSourceUrl(url: string | null | undefined): url is string {
+  if (typeof url !== "string" || !url.trim()) return false;
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+  if (BLOB_HOST_RE.test(u.host)) return false; // already permanent
+  if (STOCK_HOST_RE.test(u.host)) return false; // stock CDN — hotlink-friendly
+  return true;
+}
+
+const REHOST_TIMEOUT_MS = 8000;
+
+/** Production re-host: SSRF-guarded fetch → Blob put (resolveExternalMedia),
+ *  bounded by a timeout, degrading to the original URL on any failure. */
+const defaultRehostImage: RehostImageFn = async (url) => {
+  try {
+    const result = await Promise.race([
+      resolveExternalMedia(url, "image"),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), REHOST_TIMEOUT_MS)),
+    ]);
+    if (result && result.ok) return result.url;
+  } catch {
+    // fall through to the original URL
+  }
+  return url;
+};
+
+/**
+ * Re-host the client's own captured images used in the payload (hero photo,
+ * service photos, logo) to permanent Blob URLs. Mutates the payload in place.
+ * Stock/Blob URLs are skipped (isRehostableSourceUrl). Best-effort per image.
+ * Exported for unit testing. Returns counts for observability.
+ */
+export async function rehostCapturedImages(
+  payload: R1LandingPayload,
+  rehostFn: RehostImageFn,
+): Promise<{ attempted: number; rehosted: number }> {
+  const targets = new Set<string>();
+  if (isRehostableSourceUrl(payload.hero.heroImage?.src)) {
+    targets.add(payload.hero.heroImage.src);
+  }
+  for (const service of payload.services.services) {
+    if (isRehostableSourceUrl(service.photo?.src)) targets.add(service.photo.src);
+  }
+  if (isRehostableSourceUrl(payload.logo)) targets.add(payload.logo);
+
+  if (targets.size === 0) return { attempted: 0, rehosted: 0 };
+
+  const pairs = await Promise.all(
+    [...targets].map(async (u) => [u, await rehostFn(u)] as const),
+  );
+  const map = new Map(pairs);
+  let rehosted = 0;
+  const swap = (src: string): string => {
+    const next = map.get(src);
+    if (next && next !== src) {
+      rehosted++;
+      return next;
+    }
+    return src;
+  };
+
+  if (payload.hero.heroImage && isRehostableSourceUrl(payload.hero.heroImage.src)) {
+    payload.hero.heroImage.src = swap(payload.hero.heroImage.src);
+  }
+  for (const service of payload.services.services) {
+    if (service.photo && isRehostableSourceUrl(service.photo.src)) {
+      service.photo.src = swap(service.photo.src);
+    }
+  }
+  if (isRehostableSourceUrl(payload.logo)) {
+    payload.logo = swap(payload.logo);
+  }
+  return { attempted: targets.size, rehosted };
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /**
@@ -163,6 +259,11 @@ export async function generateR1Payload(args: {
    * Defaults to the real resolveServicePhoto (which may call Unsplash).
    */
   resolveServicePhotoFn?: ResolveServicePhotoFn;
+  /**
+   * Test seam — inject a fake image re-host fn to keep tests offline.
+   * Defaults to the real Blob re-host (resolveExternalMedia).
+   */
+  rehostImageFn?: RehostImageFn;
 }): Promise<R1LandingPayload> {
   const client = (args.anthropicClient ??
     new Anthropic({ apiKey: args.byokKey })) as AnthropicLike;
@@ -360,6 +461,29 @@ export async function generateR1Payload(args: {
       logo_present: !!args.facts.logo,
     }),
   );
+
+  // Blob re-host the client's OWN captured images (hero/service/logo) → permanent
+  // URLs, so the public site never depends on a hotlink that can 403/expire.
+  // Stock (Unsplash/Pexels) + already-Blob URLs are skipped. Best-effort — a
+  // failed re-host keeps the original URL; workspace creation never blocks.
+  try {
+    const { attempted, rehosted } = await rehostCapturedImages(
+      parsed,
+      args.rehostImageFn ?? defaultRehostImage,
+    );
+    if (attempted > 0) {
+      console.warn(
+        JSON.stringify({
+          event: "landing_images_rehosted",
+          business_name: args.facts.business_name,
+          attempted,
+          rehosted,
+        }),
+      );
+    }
+  } catch {
+    // Re-hosting must never block the build.
+  }
 
   return parsed;
 }

--- a/packages/crm/tests/unit/landing/r1-rehost.spec.ts
+++ b/packages/crm/tests/unit/landing/r1-rehost.spec.ts
@@ -1,0 +1,110 @@
+// Blob re-host of the client's captured images (world-class images, part 3).
+//
+// Re-hosting makes the client's OWN scraped photos/logo permanent (Blob) so the
+// public site never depends on a hotlink that can 403/expire. Stock (Unsplash/
+// Pexels) URLs are hotlink-friendly by their API terms and are left as-is;
+// already-Blob URLs are skipped. Best-effort — a failed re-host keeps the
+// original URL so workspace creation never blocks.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isRehostableSourceUrl,
+  rehostCapturedImages,
+} from "../../../src/lib/landing/r1-payload-generator";
+import type { R1LandingPayload } from "../../../src/lib/landing/r1-payload-prompt";
+
+describe("isRehostableSourceUrl", () => {
+  test("true for the client's own https CDN image", () => {
+    assert.equal(isRehostableSourceUrl("https://www.dallasheatingac.com/img/hero.webp"), true);
+  });
+  test("false for stock CDNs (Unsplash / Pexels)", () => {
+    assert.equal(isRehostableSourceUrl("https://images.unsplash.com/photo-123"), false);
+    assert.equal(isRehostableSourceUrl("https://images.pexels.com/photos/1/x.jpg"), false);
+    assert.equal(isRehostableSourceUrl("https://unsplash.com/x"), false);
+  });
+  test("false for already-Blob URLs", () => {
+    assert.equal(
+      isRehostableSourceUrl("https://abc123.public.blob.vercel-storage.com/media/external/x.jpg"),
+      false,
+    );
+  });
+  test("false for empty / null / non-http", () => {
+    assert.equal(isRehostableSourceUrl(""), false);
+    assert.equal(isRehostableSourceUrl(null), false);
+    assert.equal(isRehostableSourceUrl(undefined), false);
+    assert.equal(isRehostableSourceUrl("data:image/png;base64,xx"), false);
+  });
+});
+
+function samplePayload(): R1LandingPayload {
+  return {
+    hero: {
+      archetype: "bold-urgency",
+      businessName: "X",
+      tagline: "t",
+      subhead: "s",
+      primaryCTA: { label: "a", href: "/book" },
+      trustBadges: [],
+      heroImage: { src: "https://client.com/hero.jpg", alt: "h" },
+    },
+    services: {
+      archetype: "bold-urgency",
+      heading: "H",
+      services: [
+        { id: "s1", name: "A", description: "d", photo: { src: "https://client.com/a.jpg", alt: "a" } },
+        { id: "s2", name: "B", description: "d", photo: { src: "https://images.unsplash.com/photo-9", alt: "b" } },
+      ],
+    },
+    testimonials: { archetype: "bold-urgency", heading: "H", testimonials: [] },
+    faq: { archetype: "bold-urgency", heading: "H", items: [] },
+    footer: { archetype: "bold-urgency", businessName: "X", phone: "1" },
+    logo: "https://client.com/logo.png",
+  };
+}
+
+describe("rehostCapturedImages", () => {
+  test("re-hosts only the client's own images (hero, scraped service, logo), never stock", async () => {
+    const seen: string[] = [];
+    const fake = async (u: string) => {
+      seen.push(u);
+      return `https://abc.public.blob.vercel-storage.com/media/external/${encodeURIComponent(u).slice(-16)}.jpg`;
+    };
+    const p = samplePayload();
+    const { attempted, rehosted } = await rehostCapturedImages(p, fake);
+
+    assert.equal(attempted, 3); // hero + service A + logo; Unsplash service B skipped
+    assert.equal(rehosted, 3);
+    assert.match(p.hero.heroImage!.src, /blob\.vercel-storage\.com/);
+    assert.match(p.services.services[0].photo!.src, /blob\.vercel-storage\.com/);
+    assert.equal(p.services.services[1].photo!.src, "https://images.unsplash.com/photo-9"); // untouched
+    assert.match(p.logo!, /blob\.vercel-storage\.com/);
+    assert.ok(!seen.some((u) => u.includes("unsplash")), "stock URL must never be re-hosted");
+  });
+
+  test("keeps the original URL when re-host fails (graceful degrade)", async () => {
+    const fake = async (u: string) => u; // simulate failure → returns original
+    const p = samplePayload();
+    const { attempted, rehosted } = await rehostCapturedImages(p, fake);
+    assert.equal(attempted, 3);
+    assert.equal(rehosted, 0);
+    assert.equal(p.hero.heroImage!.src, "https://client.com/hero.jpg");
+    assert.equal(p.logo, "https://client.com/logo.png");
+  });
+
+  test("no-op when there are no client images to re-host", async () => {
+    const p = samplePayload();
+    p.hero.heroImage = { src: "https://images.unsplash.com/photo-1", alt: "" };
+    p.services.services = [];
+    delete p.logo;
+    let called = 0;
+    const fake = async (u: string) => {
+      called++;
+      return u;
+    };
+    const { attempted } = await rehostCapturedImages(p, fake);
+    assert.equal(attempted, 0);
+    assert.equal(called, 0);
+  });
+});


### PR DESCRIPTION
**Part 3 of the world-class image work** (parts 1+2 = #70/#71, merged). Makes the client's OWN captured images permanent.

## What
The scraped hero / service / logo images were hotlinked straight to the client's CDN — subject to 403 / expiry / rot. This re-hosts them to Vercel Blob via the existing SSRF-guarded `resolveExternalMedia` (its first real caller), in the generator post-process, for **used images only** (no orphan uploads).
- Stock (Unsplash/Pexels) + already-Blob URLs are skipped (`isRehostableSourceUrl`) — stock CDNs are hotlink-friendly by their own API terms.
- Best-effort per image: 8s timeout, graceful degrade to the original URL, wrapped so re-hosting **never blocks** workspace creation.
- DI seam (`rehostImageFn`) keeps tests fully offline.

## Verify
- 8 new unit tests: host filtering (client vs stock vs Blob vs junk), the re-host swap, graceful degrade on failure, and the no-op-when-no-client-images path.
- `tsc` clean (only the pre-existing `copilot/turn/route.ts:315`).
- Full unit suite: **regression delta 0** (81 pre-existing failures unchanged), +8 new passing.

## Remaining — the final piece (its own PR, scoped)
**Pexels-first fill + Unsplash attribution render.** The deepest remaining change: a Pexels resolver matching the existing Unsplash resolver's quality (query broadening, scenery rejection, archetype fallback) + threading `ResolvedUnsplashImage.attribution` through resolver → payload → the R1 hero component to render the credit. Per the product decision, Pexels-first minimizes Unsplash (no attribution needed) and the residual Unsplash fallback renders a photographer credit. Left for a focused pass rather than rushed at the tail of this batch.
