### PR TITLE
docs: feature prebuilt ghcr image (README + QUICKSTART) + fix stale CONTRIBUTING commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Each recipe maps to a layer in the architecture. Pick whichever matches your int
    ```
 3. Register in `skills/registry.ts`: add `{ id, content, archetypes, renderVars }`.
 4. Add an eval scenario in the appropriate eval suite that exercises the new behavior.
-5. Run `pnpm test:eval` and verify the agent's pass rate stays ≥87.5%.
+5. Confirm the scenario passes — the agent eval gate must stay ≥87.5%.
 
 **The PR**: 1 markdown file, 1 registry entry, 1 eval scenario. ~30 lines total. Reviewer checks: does the prose teach behavior cleanly, does the eval catch regressions, does the skill respect the placeholder convention.
 
@@ -205,7 +205,7 @@ If you want the platform to make selling agents *easier* (better Studio ergonomi
 git clone https://github.com/seldonframe/seldonframe.git
 cd seldonframe
 pnpm install
-cp .env.example .env.local
+cp packages/crm/.env.example packages/crm/.env.local
 pnpm db:generate
 pnpm db:migrate
 pnpm dev:crm
@@ -215,7 +215,7 @@ Visit `http://localhost:3000`.
 
 **Prerequisites:**
 - Node.js 20+
-- pnpm 9+
+- pnpm 10+
 - A Postgres database (Neon, Supabase, or local)
 - Anthropic or OpenAI API key (set `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` in `.env.local`)
 
@@ -228,7 +228,7 @@ Visit `http://localhost:3000`.
 3. Keep each PR scoped to one concern.
 4. Follow TDD where it applies — write a failing test before the production code.
 5. For agent-behavior changes, add eval scenarios. Pass rate must stay ≥87.5%.
-6. Run `pnpm lint`, `pnpm typecheck`, `pnpm test:unit`, and `pnpm check:syntax` before pushing.
+6. Run `pnpm lint`, `pnpm typecheck`, and `pnpm test:unit` before pushing.
 7. Update docs and `.env.example` if your change adds config.
 8. Open a PR using the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
 
@@ -249,7 +249,7 @@ Visit `http://localhost:3000`.
 - Bypasses tenant scoping (`workspaceId` / `orgId`) — this is a hard invariant, never bypass
 
 **Reverted**:
-- Anything that breaks the eval gate (`pnpm test:eval` must stay green)
+- Anything that breaks the agent eval gate (it must stay green)
 - Schema changes without a migration script in `packages/crm/drizzle/`
 - Performance regressions on the public landing-page render path (we benchmark; PRs that slow it down >100ms get reverted)
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -28,9 +28,27 @@ Pricing for paid tiers: $29/mo (Pro) or $99/mo (Agency, white-label). See [seldo
 
 Run the entire stack on your own infrastructure. AGPL-3.0-licensed source code; full control over data, deploy target, and customization.
 
-### Fastest path — Docker Compose
+### Fastest path — prebuilt image (no local build)
 
-One command brings up Postgres, the database proxy, migrations, and the app:
+Pull the published multi-arch image (amd64 + arm64) — no `next build` on your machine:
+
+```bash
+git clone https://github.com/seldonframe/seldonframe.git
+cd seldonframe
+cp .env.docker.example .env.docker     # then add your ANTHROPIC_API_KEY or OPENAI_API_KEY
+docker compose -f docker-compose.yml -f docker-compose.ghcr.yml up   # → http://localhost:3000
+```
+
+This pulls [`ghcr.io/seldonframe/seldonframe:latest`](https://github.com/seldonframe/seldonframe/pkgs/container/seldonframe). To pin a release instead of `latest`:
+
+```bash
+SELDONFRAME_IMAGE=ghcr.io/seldonframe/seldonframe:1.1.0 \
+  docker compose -f docker-compose.yml -f docker-compose.ghcr.yml up
+```
+
+### Build from source
+
+Or build the image locally — same one command brings up Postgres, the database proxy, migrations, and the app:
 
 ```bash
 git clone https://github.com/seldonframe/seldonframe.git
@@ -39,7 +57,7 @@ cp .env.docker.example .env.docker     # then add your ANTHROPIC_API_KEY or OPEN
 docker compose up --build              # → http://localhost:3000
 ```
 
-That's it — data lives in a local Postgres volume, and nothing leaves your machine except the LLM calls you configure. Compose runs the schema migrations for you before the app starts.
+Either way, data lives in a local Postgres volume, and nothing leaves your machine except the LLM calls you configure. Compose runs the schema migrations for you before the app starts.
 
 > Why the extra `neon-proxy` service? In production SeldonFrame runs on Neon, whose driver speaks SQL-over-HTTP. The proxy lets that same runtime talk to your own plain Postgres — see [`packages/crm/src/db/index.ts`](packages/crm/src/db/index.ts). Migrations connect to Postgres directly.
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ See the same six snippets, kept in sync, at [seldonframe.com/build](https://seld
 
 ---
 
+## Self-host the whole thing
+
+Prefer to run it yourself? The entire monorepo is AGPL-3.0 — and there's a **prebuilt image**, so you don't even build it:
+
+```bash
+git clone https://github.com/seldonframe/seldonframe.git && cd seldonframe
+cp .env.docker.example .env.docker   # add your ANTHROPIC_API_KEY or OPENAI_API_KEY
+docker compose -f docker-compose.yml -f docker-compose.ghcr.yml up   # pulls the prebuilt image
+```
+
+Brings up Postgres, migrations, and the app on `localhost:3000` — the same dashboard, generated public sites, and API as the hosted version. Multi-arch image (amd64 + arm64) at [`ghcr.io/seldonframe/seldonframe`](https://github.com/seldonframe/seldonframe/pkgs/container/seldonframe); or `docker compose up --build` to build from source. Bring your own LLM key (Anthropic or OpenAI); SMS/voice (Twilio), email (Resend), and 1,000+ integrations (Composio) are add-your-own-key. Full guide: **[QUICKSTART.md](QUICKSTART.md#self-host)**.
+
 ---
 
 ## When you're ready to sell


### PR DESCRIPTION
Docs refresh for the open-source launch, now that the prebuilt image is published + public.

**README** — new **Self-host the whole thing** section featuring the prebuilt `ghcr.io/seldonframe/seldonframe` image (`docker compose … pull`) alongside build-from-source, with honest BYOK notes (self-host was previously one line in the pricing table).

**QUICKSTART#self-host** — new **Fastest path — prebuilt image (no local build)** using the ghcr pull + a pin-a-release example; existing `--build` kept as *Build from source*.

**CONTRIBUTING** — fixed stale commands: `pnpm 9+`→`10+`; `cp .env.example`→`cp packages/crm/.env.example` (root one doesn't exist); removed `pnpm check:syntax` and `pnpm test:eval` from the checklists (neither is a real script), keeping the real `lint`/`typecheck`/`test:unit` + the ≥87.5% eval-gate requirement.

Verified: image is publicly pullable (tags `latest, sha, 1.1.0, 1.1, 1`); all demo/site URLs return 200.