### PR TITLE
fix(web-onboarding): contact-page fallback + honest extraction_failed surface

### DIFF
--- a/docs/superpowers/plans/2026-07-14-extraction-failed-honesty-and-contact-fallback.md
+++ b/docs/superpowers/plans/2026-07-14-extraction-failed-honesty-and-contact-fallback.md
@@ -1,0 +1,101 @@
+# Plan — extraction-failed honesty + contact-page fallback
+
+Spec: `docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-contact-fallback-design.md`
+Worktree: `.claude/worktrees/extraction-fallback` · branch `feature/extraction-contact-fallback` (off `origin/main` @ `5a739dad9`)
+
+Commit per task. TDD: write/extend the spec file first, watch it fail, implement, watch it pass.
+Regression set: `node --test --import tsx` over `packages/crm/tests/unit/web-onboarding/*.spec.ts*` + `packages/crm/tests/unit/web-build-stream-route.spec.ts`.
+
+## Task 1 — `contact-page-candidates.ts` (pure helper + spec)
+
+New: `packages/crm/src/lib/web-onboarding/contact-page-candidates.ts`
+New: `packages/crm/tests/unit/web-onboarding/contact-page-candidates.spec.ts`
+
+```ts
+export function findContactPageCandidates(markdown: string, baseUrl: string): string[]
+```
+
+Rules (from spec): harvest `[text](href)` links; resolve relative hrefs against
+baseUrl; same-hostname only; pathname match
+`/(contact|about|location|visit|find[-_]?us)/i`; rank contact-matching paths
+before about/other; dedupe on origin+pathname; exclude baseUrl's own
+origin+pathname; cap 2; when zero matches return
+`[origin + "/contact", origin + "/contact-us"]`. Invalid baseUrl → `[]`
+(defensive; callers pass a vetted URL). No IO. ~60-80 LOC prod.
+
+## Task 2 — fallback inside `markdown-extractor.ts` (+ spec extensions)
+
+Edit: `packages/crm/src/lib/web-onboarding/markdown-extractor.ts`
+Edit: `packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts`
+
+- Extract existing steps 2+3 (Anthropic call w/ error mapping + pickText +
+  parseExtraction + logging) into `runExtractionOnce({ client, model, md, url, attempt })`
+  returning `ExtractedBusinessFacts` or throwing the same WebFetchErrors.
+  Add `attempt` to the two warn-log payloads; keep every other field.
+- Main flow: attempt 1 on homepage MD. Catch ONLY
+  `WebFetchError` with reason `extraction_failed` thrown by the parse/empty-text
+  path of attempt 1 (Anthropic 401/402/429/internal rethrow immediately — use a
+  narrow flag from runExtractionOnce, e.g. it throws a `ParseFailed` marker
+  subclass or returns a discriminated result, implementer's choice, keep it
+  simple).
+- Fallback: `findContactPageCandidates(homepageMd, scrape.finalUrl)` → up to 2
+  `firecrawlScrape` calls via `Promise.allSettled` (reuse
+  `params.firecrawlClient` seam); skip failures; log
+  `markdown_extractor_contact_fallback` `{ url, candidates, scraped_ok }`
+  (console.warn JSON, house style).
+- If ≥1 ok: attempt 2 on
+  `homepageMd + candidates.map(c => "\n\n--- Additional page: " + c.url + " ---\n" + c.md.slice(0, 20_000)).join("")`.
+- Success (either attempt) → fall through to the EXISTING image-harvest block
+  unchanged (it reads the homepage `scrape`), return facts.
+- Both attempts failed / no candidates ok → throw
+  `WebFetchError("extraction_failed", "The model returned no usable JSON.")`
+  exactly as today.
+- Tests per spec §Tests (4 new cases; keep the existing 5 green; mock
+  firecrawlClient.scrape resolves different MD per URL).
+
+## Task 3 — honest 422 message in the orchestrator (+ spec extension)
+
+Edit: `packages/crm/src/lib/web-onboarding/run-create-from-url.ts` (step-5 catch)
+Edit: `packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts`
+
+```ts
+const reason = (err as { reason?: string }).reason ?? "extraction_failed";
+sse.error(422, reason === "extraction_failed"
+  ? { reason, message: "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead." }
+  : { reason });
+```
+
+Test: extraction_failed 422 frame contains `"message"`; a different reason
+(e.g. `anthropic_unauthorized`) contains no message.
+
+## Task 4 — `/try` error panel honesty
+
+Edit: `packages/crm/src/app/(public)/try/try-client.tsx`
+
+- Error listener: parse `reason` (`data as { code?; reason?; message? }`),
+  add `const [extractionFailed, setExtractionFailed] = useState(false)`.
+- Render (error panel, `phase === "error"`):
+  - `rateLimited` branch unchanged.
+  - `extractionFailed` branch: message text; row with
+    "Try a different URL" button → `reset()` (secondary style:
+    `rounded-[11px] border border-[rgba(34,29,23,.16)] bg-[#FFFDFA] …`) and
+    "Describe your business instead" link → `/signup` (primary style:
+    `rounded-[11px] bg-[#1F2B24] text-[#FFFDFA] …` — match main's forest
+    tokens, NOT the stale #00897B).
+  - else: existing Try again button.
+- `reset()` already clears state; keep `url` in the input so "Try a different
+  URL" lets them edit.
+- No new spec file (no DOM harness for this component today); tsc covers types.
+
+## Task 5 — docs commit hygiene
+
+Spec + plan committed as the first commit (already staged before Task 1).
+File-header comment in try-client.tsx: update the "URL builds only" doc note
+if touched lines make it stale. CHANGELOG not used in this repo — skip.
+
+## Verify
+
+`verify-runner` in this worktree: unit tests + `tsc --noEmit` (stash-delta
+method per memory: judge by delta vs baseline, junctioned node_modules from
+guardian) + check-use-server + migration-journal (no-op — no migrations) +
+regression grep. Then GATE 2 (Max merges).

--- a/docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-contact-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-contact-fallback-design.md
@@ -1,0 +1,146 @@
+# Extraction-failed honesty + contact-page fallback — design
+
+**Date:** 2026-07-14 · **Branch:** `feature/extraction-contact-fallback` · **Status:** approved (Max, in-chat 2026-07-14)
+
+## Problem (observed in prod, Vercel log export 2026-07-14)
+
+`seldonframe.com/try?url=https://medspabybeautybar.com/` failed twice with
+`markdown_extractor_parse_failed … text_preview: {"_error": "extraction_failed"}`.
+
+Ground truth (verified by fetching the site): the homepage has business name,
+city/state (footer), and services — but **no phone number anywhere** (no `tel:`
+links, no phone-shaped digits; the site runs CleanTalk contact obfuscation and
+the number lives on its `/contact` page). `phone` is one of the six REQUIRED
+extraction fields, so Opus correctly obeyed extraction-prompt rule 4
+("NEVER invent → emit `{"_error": "extraction_failed"}`").
+
+Two product defects fall out:
+
+1. **Dishonest UI.** `run-create-from-url.ts` step 5 emits
+   `sse.error(422, { reason: "extraction_failed" })` with no `message`, so
+   `/try`'s error listener falls back to *"Something broke on our end. Give it
+   another try."* + a **Try again** button. The condition is permanent for that
+   URL — retrying can never succeed and burns the visitor's 3-builds/24h rate
+   limit. This violates never-lies at the exact moment we're selling it.
+2. **Single-page scrape misses contact pages.** Facts that live on `/contact`
+   or `/about` are invisible, so a whole class of legitimate SMB sites can't
+   build.
+
+## Fix 1 — honest `extraction_failed` surface
+
+- `run-create-from-url.ts` step-5 catch: when the mapped `reason` is
+  `"extraction_failed"`, include a `message` in the 422 SSE error body:
+
+  > "We read that site but couldn't find the basics we need — a business name,
+  > location, and phone number. Try a different URL, or describe your business
+  > instead."
+
+  Other reasons (`anthropic_unauthorized`, `credits_exhausted`,
+  `internal_error`) are untouched (Minimal Impact). `run-create-from-paste.ts`
+  untouched (different failure semantics, out of scope).
+- `try-client.tsx` error listener: also parse `reason` from the SSE error
+  payload. When `reason === "extraction_failed"`:
+  - show the server `message` (fallback to equivalent local copy),
+  - **hide "Try again"** (futile); instead render two actions styled with the
+    current forest tokens (`#1F2B24`, `rounded-[11px]`):
+    - **"Try a different URL"** → `reset()` (back to idle with the input),
+    - **"Describe your business instead"** → link to `/signup` (the paste/
+      describe build path is authed-only today — documented deviation in the
+      file header; we are NOT creating a public paste route).
+  - all other errors keep today's behavior (rate-limited → signup CTA;
+    generic → Try again).
+- `/clients/new` (`clients-new-form.tsx`) already shows honest copy for
+  extraction_failed — untouched.
+
+## Fix 2 — contact-page fallback in the extractor
+
+Seam: `packages/crm/src/lib/web-onboarding/markdown-extractor.ts`
+(`extractBusinessFactsFromUrl`) so BOTH routes (public `/try` + authed
+`/clients/new`) benefit with zero route changes.
+
+New pure helper `packages/crm/src/lib/web-onboarding/contact-page-candidates.ts`:
+
+```
+findContactPageCandidates(markdown: string, baseUrl: string): string[]
+```
+
+- Harvest markdown links (`[text](href)`, absolute or relative), resolve
+  against `baseUrl`.
+- Keep **same-host only** (exact hostname match — the base URL was already
+  SSRF-vetted at the route boundary; same-host paths can't change the target).
+- Keep links whose pathname matches `/(contact|about|location|visit|find[-_]?us)/i`.
+- Rank: contact > about > everything else; dedupe on origin+pathname (strip
+  query/hash); exclude the base page itself; **cap at 2**.
+- If zero candidates found, fall back to guesses
+  `[origin + "/contact", origin + "/contact-us"]` (Firecrawl failure on a 404
+  guess is handled gracefully below).
+
+`markdown-extractor.ts` flow change (behavior on main, which already includes
+the PR #70/#71 image-harvest merge, is preserved):
+
+1. Scrape homepage (unchanged, including html/ogImage/favicon capture).
+2. Refactor the Anthropic call + error mapping + parse into an internal
+   `runExtractionOnce(md)` helper (pure refactor of existing code — the
+   401/402/429 mapping and the `markdown_extractor_parse_failed` /
+   `markdown_extractor_empty_text` logging keep their exact shapes, with an
+   added `attempt` field).
+3. On FIRST parse failure (`parseExtraction` not ok — covers both the
+   `_error` sentinel and malformed JSON; NOT Anthropic API errors, which
+   throw immediately as today):
+   - `findContactPageCandidates(homepageMd, finalUrl)`,
+   - scrape up to 2 candidates via `firecrawlScrape` (`Promise.allSettled`;
+     a failed/thin candidate is skipped, never fatal),
+   - log `markdown_extractor_contact_fallback`
+     `{ url, candidates, scraped_ok }`,
+   - if ≥1 candidate scraped ok: re-run `runExtractionOnce` ONCE on
+     `homepageMd + "\n\n--- Additional page: <url> ---\n" + candidateMd`
+     (each candidate MD truncated to 20 000 chars),
+   - if the second attempt succeeds → continue to the image-harvest block
+     exactly as today (harvest still reads the HOMEPAGE scrape's html —
+     contact-page image harvest is out of scope).
+4. If no candidate scraped ok, or the second attempt also fails → throw
+   `WebFetchError("extraction_failed", …)` as today.
+
+Cost ceiling: worst case +2 Firecrawl scrapes + 1 Opus call, only on the
+previously-dead extraction-failure path. Success results are already cached
+per-URL on the public route (`withUrlExtractionCache` — failures are never
+cached, verified).
+
+## Tests (node:test + tsx, DI seams already exist)
+
+- `contact-page-candidates.spec.ts` (new, pure): absolute/relative resolution,
+  cross-host exclusion, ranking, dedupe, cap 2, self-exclusion, guess
+  fallback.
+- `markdown-extractor.spec.ts` (extend, mocked Firecrawl + Anthropic):
+  1. first attempt `_error` → candidate scraped → second attempt succeeds →
+     facts returned; second LLM message contains both MDs; Firecrawl called
+     with the candidate URL.
+  2. fallback also fails → `WebFetchError(extraction_failed)`; LLM called
+     exactly twice.
+  3. no candidates in MD + guess scrapes fail → throws; LLM called once.
+  4. Anthropic 401 on first attempt → NO fallback (immediate
+     `anthropic_unauthorized`).
+  5. existing 5 tests keep passing unchanged.
+- `route-create-from-url.spec.ts` (extend): extraction_failed 422 event now
+  carries `message` + `reason`.
+- `try-client` error-panel states are covered by eyeball + the existing
+  clients-new-form patterns; no new DOM spec (the component has no spec today
+  and the logic delta is a conditional render).
+
+## Out of scope (explicitly)
+
+- Public anonymous paste/describe route.
+- `run-create-from-paste.ts` message copy.
+- Contact-page image harvesting.
+- Firecrawl-level caching behavior (their default scrape cache may serve the
+  same content on quick retries — orthogonal).
+
+## Verification
+
+- `/verify-build` via `verify-runner` in this worktree (unit tests + tsc +
+  check-use-server + migration-journal + regression grep). No migrations, no
+  new deps, no env changes.
+- Post-merge live smoke: rebuild `https://medspabybeautybar.com/` on /try —
+  expect either a successful build (phone found on /contact) or the honest
+  message with the two CTAs. This is the staging-verified claim (L-06);
+  everything before it is code-correct only.

--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -87,6 +87,12 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
   const [done, setDone] = useState<DoneData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [rateLimited, setRateLimited] = useState(false);
+  // 2026-07-14 — extraction-failed honesty fix. extraction_failed is a
+  // PERMANENT condition for that URL (the site genuinely has no phone/name/
+  // location we could find) — "Try again" would just fail identically and
+  // burn the visitor's rate limit. See run-create-from-url.ts's step-5 catch
+  // for the server-side `message` this reads.
+  const [extractionFailed, setExtractionFailed] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const autoSubmittedRef = useRef(false);
 
@@ -133,7 +139,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
 
     es.addEventListener("error", (raw) => {
       const payload = (raw as MessageEvent).data;
-      let data: { code?: string; message?: string } = {};
+      let data: { code?: string; reason?: string; message?: string } = {};
       try {
         if (typeof payload === "string" && payload.length > 0) {
           data = JSON.parse(payload);
@@ -143,8 +149,15 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       }
       es.close();
       setEventSource(null);
+      const isExtractionFailed = data.reason === "extraction_failed";
       setRateLimited(data.code === "rate_limited");
-      setError(data.message ?? "Something broke on our end. Give it another try.");
+      setExtractionFailed(isExtractionFailed);
+      setError(
+        data.message ??
+          (isExtractionFailed
+            ? "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."
+            : "Something broke on our end. Give it another try."),
+      );
       setPhase("error");
     });
   }
@@ -168,6 +181,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
     setDone(null);
     setError(null);
     setRateLimited(false);
+    setExtractionFailed(false);
     setBuildInput(null);
   }
 
@@ -321,6 +335,28 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                   >
                     Sign up to keep building
                   </a>
+                ) : extractionFailed ? (
+                  // extraction_failed is a permanent condition for this URL —
+                  // no "Try again" (it would just fail identically). Offer
+                  // the two honest paths instead: pick a different URL, or
+                  // sign up to describe the business instead (the anonymous
+                  // paste/describe path isn't public — see the file-header
+                  // deviation note).
+                  <div className="mt-3 flex flex-wrap items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={reset}
+                      className="rounded-[11px] border border-[rgba(34,29,23,.16)] bg-[#FFFDFA] px-4 py-2 text-[13.5px] font-[500] text-[#221D17]"
+                    >
+                      Try a different URL
+                    </button>
+                    <a
+                      href="/signup"
+                      className="inline-flex items-center gap-1.5 rounded-[11px] bg-[#1F2B24] px-4 py-2 text-[13.5px] font-[600] text-[#FFFDFA]"
+                    >
+                      Describe your business instead
+                    </a>
+                  </div>
                 ) : (
                   <button
                     type="button"

--- a/packages/crm/src/lib/web-onboarding/contact-page-candidates.ts
+++ b/packages/crm/src/lib/web-onboarding/contact-page-candidates.ts
@@ -1,0 +1,82 @@
+// packages/crm/src/lib/web-onboarding/contact-page-candidates.ts
+//
+// Pure helper (no IO) used by markdown-extractor.ts's contact-page fallback
+// (see docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-
+// contact-fallback-design.md). When the homepage scrape is missing a
+// required extraction field (most commonly `phone`, obfuscated by tools
+// like CleanTalk and moved to a dedicated page), we harvest same-host
+// "contact-shaped" links from the homepage Markdown so the extractor can
+// retry against them.
+//
+// Same-host only: the base URL was already SSRF-vetted at the route
+// boundary (validateCreateFromUrlInput), so a same-host path can't change
+// the effective target — no additional vetting needed here.
+
+const CONTACT_PATH_RE = /(contact|about|location|visit|find[-_]?us)/i;
+const CONTACT_RANK_RE = /contact/i;
+const ABOUT_RANK_RE = /about/i;
+
+// [text](href) — the only markdown link shape Firecrawl emits.
+const MD_LINK_RE = /\[[^\]]*\]\(([^)\s]+)\)/g;
+
+function rankOf(pathname: string): number {
+  if (CONTACT_RANK_RE.test(pathname)) return 0;
+  if (ABOUT_RANK_RE.test(pathname)) return 1;
+  return 2;
+}
+
+/**
+ * Harvest same-host, contact-shaped page links from a scraped homepage's
+ * Markdown, ranked contact > about > everything else, deduped on
+ * origin+pathname, capped at 2. Falls back to `[origin + "/contact",
+ * origin + "/contact-us"]` guesses when zero candidates are found in the
+ * Markdown (the extractor's caller scrapes these gracefully — a 404 guess
+ * is simply skipped, never fatal).
+ */
+export function findContactPageCandidates(markdown: string, baseUrl: string): string[] {
+  let base: URL;
+  try {
+    base = new URL(baseUrl);
+  } catch {
+    return [];
+  }
+
+  const baseKey = base.origin + base.pathname.replace(/\/+$/, "") || base.origin;
+
+  type Candidate = { url: string; key: string; rank: number };
+  const candidates: Candidate[] = [];
+  const seen = new Set<string>();
+
+  let match: RegExpExecArray | null;
+  MD_LINK_RE.lastIndex = 0;
+  while ((match = MD_LINK_RE.exec(markdown)) !== null) {
+    const href = match[1];
+    let resolved: URL;
+    try {
+      resolved = new URL(href, base);
+    } catch {
+      continue;
+    }
+    if (resolved.hostname !== base.hostname) continue;
+    if (!CONTACT_PATH_RE.test(resolved.pathname)) continue;
+
+    const normalizedPath = resolved.pathname.replace(/\/+$/, "") || "/";
+    const key = resolved.origin + normalizedPath;
+    const selfKey = baseKey.replace(/\/+$/, "") || base.origin;
+    if (key === selfKey) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    candidates.push({
+      url: resolved.origin + normalizedPath,
+      key,
+      rank: rankOf(resolved.pathname),
+    });
+  }
+
+  candidates.sort((a, b) => a.rank - b.rank);
+  const top = candidates.slice(0, 2).map((c) => c.url);
+  if (top.length > 0) return top;
+
+  return [`${base.origin}/contact`, `${base.origin}/contact-us`];
+}

--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -42,6 +42,7 @@ import { parseExtraction } from "./extraction-parser";
 import { firecrawlScrape, type ScrapeDeps } from "./firecrawl-scrape";
 import { harvestImagesFromHtml } from "./html-image-harvester";
 import { WebFetchError, type WebFetchErrorReason } from "./web-fetch-extractor";
+import { findContactPageCandidates } from "./contact-page-candidates";
 
 // Re-export the error type so callers can import it from either path
 // during the cutover period without breaking.
@@ -89,6 +90,126 @@ function pickText(content: Array<AnthropicContentBlock>): string {
     .map((part) => (part.type === "text" ? part.text ?? "" : ""))
     .join("\n")
     .trim();
+}
+
+// Contact-page fallback (2026-07-14): each additional candidate page's MD is
+// truncated to this many chars before being appended to the retry prompt —
+// keeps the combined message bounded even if a /contact page is unusually
+// large (it's supplementary context, not the primary document).
+const CANDIDATE_MD_MAX_CHARS = 20_000;
+
+// Up to 2 Firecrawl scrapes of contact-shaped candidate pages, only on the
+// previously-dead extraction-failure path.
+const MAX_CONTACT_FALLBACK_CANDIDATES = 2;
+
+/**
+ * One Anthropic extraction call: system + user-message-with-MD -> parsed
+ * JSON. Pure refactor of the original steps 2+3 — same error mapping, same
+ * log event names/fields, with an added `attempt` field on the two warn
+ * logs so a contact-page-fallback retry (attempt 2) is distinguishable from
+ * the first pass in Vercel logs.
+ */
+async function runExtractionOnce(args: {
+  client: AnthropicLike;
+  model: string;
+  md: string;
+  url: string;
+  attempt: number;
+}): Promise<ExtractedBusinessFacts> {
+  const { client, model, md, url, attempt } = args;
+
+  let response: { content: Array<AnthropicContentBlock>; stop_reason?: string };
+  try {
+    response = await client.messages.create({
+      model,
+      max_tokens: MAX_TOKENS,
+      // Static across every call for this deployment (same SYSTEM_PROMPT
+      // string every time) — hoisted into a cached `system` array entry
+      // per the enhance-blocks.ts:722-748 pattern. Only the per-request
+      // Markdown + URL stay in the uncached user message.
+      system: [
+        { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: `${EXTRACTION_INSTRUCTIONS_MD}\n\nURL: ${url}\n\nPage content (Markdown):\n${md}`,
+        },
+      ],
+    });
+  } catch (err: unknown) {
+    const status = (err as { status?: number } | null)?.status;
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      JSON.stringify({
+        event: "markdown_extractor_anthropic_error",
+        url,
+        model,
+        status: status ?? null,
+        message: message.slice(0, 500),
+      }),
+    );
+    if (status === 401 || status === 403) {
+      throw new WebFetchError(
+        "anthropic_unauthorized",
+        "Anthropic rejected the BYOK key.",
+        err,
+      );
+    }
+    if (status === 402 || status === 429) {
+      throw new WebFetchError(
+        "credits_exhausted",
+        "BYOK Anthropic key has no remaining credits.",
+        err,
+      );
+    }
+    throw new WebFetchError(
+      "internal_error",
+      err instanceof Error ? err.message : "Anthropic SDK call failed.",
+      err,
+    );
+  }
+
+  const text = pickText(response.content);
+  if (!text) {
+    console.warn(
+      JSON.stringify({
+        event: "markdown_extractor_empty_text",
+        url,
+        model,
+        attempt,
+        stop_reason: response.stop_reason ?? null,
+        content_types: response.content.map((b) => b.type),
+      }),
+    );
+    throw new WebFetchError(
+      "extraction_failed",
+      "LLM returned no text content block.",
+    );
+  }
+
+  const parsed = parseExtraction(text);
+  if (!parsed.ok) {
+    console.warn(
+      JSON.stringify({
+        event: "markdown_extractor_parse_failed",
+        url,
+        model,
+        attempt,
+        // stop_reason="max_tokens" + a large text_len ⇒ truncation (raise
+        // MAX_TOKENS); "end_turn" with valid-looking text ⇒ malformed JSON.
+        stop_reason: response.stop_reason ?? null,
+        text_len: text.length,
+        text_preview: text.slice(0, 500),
+      }),
+    );
+    throw new WebFetchError(
+      "extraction_failed",
+      "The model returned no usable JSON.",
+    );
+  }
+
+  return parsed.data;
 }
 
 /**
@@ -142,99 +263,92 @@ export async function extractBusinessFactsFromUrl(params: {
 
   const md = scrape.markdown;
 
-  // Step 2: Anthropic call — NO TOOLS, NO web_fetch. Just system +
-  // user-message-with-MD -> JSON response.
-  let response: { content: Array<AnthropicContentBlock>; stop_reason?: string };
+  // Step 2: attempt 1 — Anthropic call — NO TOOLS, NO web_fetch. Just
+  // system + user-message-with-MD -> JSON response.
+  let facts: ExtractedBusinessFacts;
   try {
-    response = await client.messages.create({
-      model: modelInUse,
-      max_tokens: MAX_TOKENS,
-      // Static across every call for this deployment (same SYSTEM_PROMPT
-      // string every time) — hoisted into a cached `system` array entry
-      // per the enhance-blocks.ts:722-748 pattern. Only the per-request
-      // Markdown + URL stay in the uncached user message.
-      system: [
-        { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
-      ],
-      messages: [
-        {
-          role: "user",
-          content: `${EXTRACTION_INSTRUCTIONS_MD}\n\nURL: ${params.url}\n\nPage content (Markdown):\n${md}`,
-        },
-      ],
-    });
+    facts = await runExtractionOnce({ client, model: modelInUse, md, url: params.url, attempt: 1 });
   } catch (err: unknown) {
-    const status = (err as { status?: number } | null)?.status;
-    const message = err instanceof Error ? err.message : String(err);
-    console.error(
-      JSON.stringify({
-        event: "markdown_extractor_anthropic_error",
-        url: params.url,
-        model: modelInUse,
-        status: status ?? null,
-        message: message.slice(0, 500),
-      }),
-    );
-    if (status === 401 || status === 403) {
-      throw new WebFetchError(
-        "anthropic_unauthorized",
-        "Anthropic rejected the BYOK key.",
-        err,
-      );
+    // Only a parse/empty-text failure (reason "extraction_failed") is
+    // retryable via the contact-page fallback below. Anthropic API errors
+    // (anthropic_unauthorized / credits_exhausted / internal_error) rethrow
+    // immediately — a bad key or exhausted credits won't be fixed by
+    // scraping a different page.
+    if (!(err instanceof WebFetchError) || err.reason !== "extraction_failed") {
+      throw err;
     }
-    if (status === 402 || status === 429) {
-      throw new WebFetchError(
-        "credits_exhausted",
-        "BYOK Anthropic key has no remaining credits.",
-        err,
-      );
-    }
-    throw new WebFetchError(
-      "internal_error",
-      err instanceof Error ? err.message : "Anthropic SDK call failed.",
-      err,
-    );
-  }
 
-  // Step 3: extract and parse the JSON text.
-  const text = pickText(response.content);
-  if (!text) {
+    // Step 2b: contact-page fallback. Homepage extraction failed to parse
+    // (most commonly a required field like `phone` living on a /contact
+    // page the homepage never surfaced). Harvest up to 2 same-host
+    // contact-shaped candidates and retry once with their MD appended.
+    const candidates = findContactPageCandidates(md, scrape.finalUrl).slice(
+      0,
+      MAX_CONTACT_FALLBACK_CANDIDATES,
+    );
+
+    const scrapeResults = await Promise.allSettled(
+      candidates.map((candidateUrl) =>
+        firecrawlScrape(candidateUrl, { firecrawlClient: params.firecrawlClient }).then(
+          (result) => ({ candidateUrl, result }),
+        ),
+      ),
+    );
+
+    const scrapedOk: Array<{ url: string; md: string }> = [];
+    for (const settled of scrapeResults) {
+      if (settled.status !== "fulfilled") continue;
+      const { candidateUrl, result } = settled.value;
+      if (result.ok) {
+        scrapedOk.push({ url: candidateUrl, md: result.markdown });
+      }
+    }
+
     console.warn(
       JSON.stringify({
-        event: "markdown_extractor_empty_text",
+        event: "markdown_extractor_contact_fallback",
         url: params.url,
-        model: modelInUse,
-        stop_reason: response.stop_reason ?? null,
-        content_types: response.content.map((b) => b.type),
+        candidates,
+        scraped_ok: scrapedOk.map((c) => c.url),
       }),
     );
-    throw new WebFetchError(
-      "extraction_failed",
-      "LLM returned no text content block.",
-    );
-  }
 
-  const parsed = parseExtraction(text);
-  if (!parsed.ok) {
-    console.warn(
-      JSON.stringify({
-        event: "markdown_extractor_parse_failed",
-        url: params.url,
+    if (scrapedOk.length === 0) {
+      // No candidate scraped ok — nothing new to retry with. Surface the
+      // same extraction_failed error as before.
+      throw new WebFetchError(
+        "extraction_failed",
+        "The model returned no usable JSON.",
+      );
+    }
+
+    const combinedMd =
+      md +
+      scrapedOk
+        .map(
+          (c) =>
+            `\n\n--- Additional page: ${c.url} ---\n${c.md.slice(0, CANDIDATE_MD_MAX_CHARS)}`,
+        )
+        .join("");
+
+    try {
+      facts = await runExtractionOnce({
+        client,
         model: modelInUse,
-        // stop_reason="max_tokens" + a large text_len ⇒ truncation (raise
-        // MAX_TOKENS); "end_turn" with valid-looking text ⇒ malformed JSON.
-        stop_reason: response.stop_reason ?? null,
-        text_len: text.length,
-        text_preview: text.slice(0, 500),
-      }),
-    );
-    throw new WebFetchError(
-      "extraction_failed",
-      "The model returned no usable JSON.",
-    );
+        md: combinedMd,
+        url: params.url,
+        attempt: 2,
+      });
+    } catch {
+      // Second attempt also failed (parse failure OR an Anthropic API
+      // error) — either way, surface the standard extraction_failed error
+      // as today rather than a fallback-specific reason.
+      throw new WebFetchError(
+        "extraction_failed",
+        "The model returned no usable JSON.",
+      );
+    }
   }
-
-  const facts = parsed.data;
 
   // Deterministically enrich with images harvested straight from the page
   // HTML. Firecrawl markdown only carries ![](...) images; the real hero /

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -257,7 +257,24 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         facts = await input.deps.extractBusinessFactsFromUrl({ url: validation.url, byokKey: extraction.key });
       } catch (err: unknown) {
         const reason = (err as { reason?: string }).reason ?? "extraction_failed";
-        sse.error(422, { reason });
+        // 2026-07-14 — extraction-failed honesty fix. extraction_failed is a
+        // PERMANENT condition for that URL (no phone/name/location found
+        // anywhere on the site) — retrying can never succeed. Without a
+        // `message`, the UI falls back to "Something broke on our end. Give
+        // it another try." and shows a Try again button, which burns the
+        // visitor's rate limit on a build that will fail identically every
+        // time. Other reasons (anthropic_unauthorized, credits_exhausted,
+        // internal_error) are untouched — those ARE sometimes transient.
+        sse.error(
+          422,
+          reason === "extraction_failed"
+            ? {
+                reason,
+                message:
+                  "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
+              }
+            : { reason },
+        );
         sse.close();
         return;
       }

--- a/packages/crm/tests/unit/web-onboarding/contact-page-candidates.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/contact-page-candidates.spec.ts
@@ -1,0 +1,93 @@
+// packages/crm/tests/unit/web-onboarding/contact-page-candidates.spec.ts
+//
+// Pure helper — no IO. Harvests markdown links off a scraped homepage and
+// ranks candidate "contact-shaped" pages (contact/about/location/visit/
+// find-us) so the extractor can retry extraction against them when the
+// homepage alone is missing a required field (e.g. phone lives on /contact
+// behind CleanTalk obfuscation). See
+// docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-contact-fallback-design.md.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { findContactPageCandidates } from "../../../src/lib/web-onboarding/contact-page-candidates";
+
+describe("findContactPageCandidates", () => {
+  test("resolves absolute and relative hrefs against baseUrl", () => {
+    const md =
+      "[Contact us](/contact)\n" +
+      "[About](https://acme.com/about)\n" +
+      "[Home](/)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.deepEqual(result, ["https://acme.com/contact", "https://acme.com/about"]);
+  });
+
+  test("excludes cross-host links even if the pathname matches", () => {
+    const md =
+      "[Contact us](https://otherhost.com/contact)\n" +
+      "[About](/about)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.deepEqual(result, ["https://acme.com/about"]);
+  });
+
+  test("ranks contact-matching paths before about/other", () => {
+    const md =
+      "[About us](/about)\n" +
+      "[Visit us](/visit)\n" +
+      "[Contact](/contact)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.equal(result[0], "https://acme.com/contact");
+  });
+
+  test("dedupes on origin+pathname (strips query/hash)", () => {
+    const md =
+      "[Contact](/contact)\n" +
+      "[Contact again](/contact?utm=1)\n" +
+      "[Contact anchor](/contact#form)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.deepEqual(result, ["https://acme.com/contact"]);
+  });
+
+  test("excludes the base page itself (falls through to guess fallback when it was the only match)", () => {
+    const md = "[Contact us](https://acme.com/contact-us)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/contact-us");
+    // The only in-page match was the base page itself, so it's excluded and
+    // zero real candidates remain — per spec this falls back to the guesses.
+    assert.deepEqual(result, ["https://acme.com/contact", "https://acme.com/contact-us"]);
+  });
+
+  test("excludes the base page itself while keeping a distinct sibling candidate", () => {
+    const md = "[Contact us](https://acme.com/contact-us)\n[About](/about)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/contact-us");
+    assert.deepEqual(result, ["https://acme.com/about"]);
+  });
+
+  test("caps at 2 candidates", () => {
+    const md =
+      "[Contact](/contact)\n" +
+      "[About](/about)\n" +
+      "[Location](/location)\n" +
+      "[Visit us](/visit-us)\n" +
+      "[Find us](/find-us)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.equal(result.length, 2);
+  });
+
+  test("falls back to guesses when zero matches found", () => {
+    const md = "[Home](/)\n[Services](/services)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.deepEqual(result, ["https://acme.com/contact", "https://acme.com/contact-us"]);
+  });
+
+  test("invalid baseUrl returns []", () => {
+    const md = "[Contact](/contact)\n";
+    const result = findContactPageCandidates(md, "not-a-url");
+    assert.deepEqual(result, []);
+  });
+
+  test("matches find-us and find_us variants (case-insensitive)", () => {
+    const md = "[Find Us](/Find-Us)\n";
+    const result = findContactPageCandidates(md, "https://acme.com/");
+    assert.deepEqual(result, ["https://acme.com/Find-Us"]);
+  });
+});

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -196,3 +196,189 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     );
   });
 });
+
+// 2026-07-14 — Contact-page fallback (extraction-failed honesty + contact
+// fallback design). When the first extraction attempt fails to parse (the
+// `_error` sentinel or malformed JSON — the common case is a required field
+// like `phone` living on a /contact page the homepage scrape never saw), the
+// extractor retries once against the homepage MD + up to 2 same-host
+// contact-shaped candidate pages before giving up.
+describe("extractBusinessFactsFromUrl — contact-page fallback", () => {
+  const HOMEPAGE_MARKDOWN =
+    SAMPLE_MARKDOWN.replace("Phone: (602) 555-0100  \n", "") +
+    "\n\n[Contact us](/contact)\n[About](/about)\n";
+
+  const CONTACT_MARKDOWN =
+    "# Contact Acme Plumbing\n\n" +
+    "Phone: (602) 555-0100\n" +
+    "Email: hello@acme-plumbing.com\n\n" +
+    "123 Main St, Phoenix, AZ 85001. Call us any time, 24/7 emergency service " +
+    "available. We serve the greater Phoenix metro area.\n";
+
+  const validFacts = {
+    business_name: "Acme Plumbing",
+    city: "Phoenix",
+    state: "AZ",
+    phone: "(602) 555-0100",
+    services: ["Drain cleaning", "Water heater repair"],
+    business_description: "Family-owned plumbing serving Phoenix since 1998.",
+  };
+
+  test("first attempt _error -> candidate scraped -> second attempt succeeds -> facts returned; second LLM message contains both MDs; Firecrawl called with the candidate URL", async () => {
+    const scrapedUrls: string[] = [];
+    const firecrawl = makeFakeFirecrawl(async (url) => {
+      scrapedUrls.push(url);
+      if (url === "https://acme.com/") {
+        return {
+          markdown: HOMEPAGE_MARKDOWN,
+          metadata: { sourceURL: "https://acme.com/", statusCode: 200 },
+        };
+      }
+      if (url === "https://acme.com/contact") {
+        return {
+          markdown: CONTACT_MARKDOWN,
+          metadata: { sourceURL: "https://acme.com/contact", statusCode: 200 },
+        };
+      }
+      throw new Error("unexpected scrape URL: " + url);
+    });
+
+    let call = 0;
+    const calls: Array<Record<string, unknown>> = [];
+    const client = {
+      messages: {
+        create: async (params: Record<string, unknown>) => {
+          calls.push(params);
+          call += 1;
+          if (call === 1) {
+            return { content: [{ type: "text", text: JSON.stringify({ _error: "extraction_failed" }) }] };
+          }
+          return { content: [{ type: "text", text: JSON.stringify(validFacts) }] };
+        },
+      },
+    } as unknown;
+
+    const result = await extractBusinessFactsFromUrl({
+      url: "https://acme.com/",
+      byokKey: "sk-ant-test",
+      firecrawlClient: firecrawl,
+      anthropicClient: client,
+    });
+
+    assert.equal(result.business_name, "Acme Plumbing");
+    assert.equal(calls.length, 2, "LLM called exactly twice");
+    assert.ok(
+      scrapedUrls.includes("https://acme.com/contact"),
+      "Firecrawl must be called with the candidate URL",
+    );
+
+    const secondUserMsg = (calls[1].messages as Array<{ content: string }>)[0]?.content ?? "";
+    assert.ok(secondUserMsg.includes("Acme Plumbing"), "second message contains homepage MD");
+    assert.ok(secondUserMsg.includes("Contact Acme Plumbing"), "second message contains candidate MD");
+    assert.ok(secondUserMsg.includes("https://acme.com/contact"), "second message labels the candidate URL");
+  });
+
+  test("fallback also fails -> WebFetchError(extraction_failed); LLM called exactly twice", async () => {
+    const firecrawl = makeFakeFirecrawl(async (url) => {
+      if (url === "https://acme.com/") {
+        return {
+          markdown: HOMEPAGE_MARKDOWN,
+          metadata: { sourceURL: "https://acme.com/", statusCode: 200 },
+        };
+      }
+      if (url === "https://acme.com/contact") {
+        return {
+          markdown: CONTACT_MARKDOWN,
+          metadata: { sourceURL: "https://acme.com/contact", statusCode: 200 },
+        };
+      }
+      throw new Error("unexpected scrape URL: " + url);
+    });
+
+    let call = 0;
+    const calls: Array<Record<string, unknown>> = [];
+    const client = {
+      messages: {
+        create: async (params: Record<string, unknown>) => {
+          calls.push(params);
+          call += 1;
+          return { content: [{ type: "text", text: JSON.stringify({ _error: "extraction_failed" }) }] };
+        },
+      },
+    } as unknown;
+
+    await assert.rejects(
+      () =>
+        extractBusinessFactsFromUrl({
+          url: "https://acme.com/",
+          byokKey: "sk-ant-test",
+          firecrawlClient: firecrawl,
+          anthropicClient: client,
+        }),
+      (err: unknown) => err instanceof WebFetchError && err.reason === "extraction_failed",
+    );
+    assert.equal(calls.length, 2, "LLM called exactly twice (attempt 1 + fallback attempt)");
+  });
+
+  test("no candidates in MD + guess scrapes fail -> throws; LLM called once", async () => {
+    const NO_LINKS_MARKDOWN = SAMPLE_MARKDOWN.replace("Phone: (602) 555-0100  \n", "");
+    const firecrawl = makeFakeFirecrawl(async (url) => {
+      if (url === "https://acme.com/") {
+        return {
+          markdown: NO_LINKS_MARKDOWN,
+          metadata: { sourceURL: "https://acme.com/", statusCode: 200 },
+        };
+      }
+      // Guess fallback URLs (/contact, /contact-us) both fail to scrape.
+      throw new Error("404 not found");
+    });
+
+    let call = 0;
+    const calls: Array<Record<string, unknown>> = [];
+    const client = {
+      messages: {
+        create: async (params: Record<string, unknown>) => {
+          calls.push(params);
+          call += 1;
+          return { content: [{ type: "text", text: JSON.stringify({ _error: "extraction_failed" }) }] };
+        },
+      },
+    } as unknown;
+
+    await assert.rejects(
+      () =>
+        extractBusinessFactsFromUrl({
+          url: "https://acme.com/",
+          byokKey: "sk-ant-test",
+          firecrawlClient: firecrawl,
+          anthropicClient: client,
+        }),
+      (err: unknown) => err instanceof WebFetchError && err.reason === "extraction_failed",
+    );
+    assert.equal(calls.length, 1, "LLM called exactly once — no successfully-scraped candidate to retry with");
+  });
+
+  test("Anthropic 401 on first attempt -> NO fallback (immediate anthropic_unauthorized)", async () => {
+    let scrapeCalls = 0;
+    const firecrawl = makeFakeFirecrawl(async (url) => {
+      scrapeCalls += 1;
+      return {
+        markdown: HOMEPAGE_MARKDOWN,
+        metadata: { sourceURL: url, statusCode: 200 },
+      };
+    });
+    const client = makeThrowingAnthropic(401, "unauthorized");
+
+    await assert.rejects(
+      () =>
+        extractBusinessFactsFromUrl({
+          url: "https://acme.com/",
+          byokKey: "sk-ant-bad",
+          firecrawlClient: firecrawl,
+          anthropicClient: client,
+        }),
+      (err: unknown) => err instanceof WebFetchError && err.reason === "anthropic_unauthorized",
+    );
+    assert.equal(scrapeCalls, 1, "only the homepage scrape happens — no contact-page fallback scrape");
+  });
+});

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -202,6 +202,26 @@ describe("runCreateFromUrl", () => {
     const text = await readAll(sse.stream);
     assert.match(text, /event: error\n.*"code":422.*extraction_failed/);
   });
+
+  // 2026-07-14 — extraction-failed honesty fix. The extraction_failed 422
+  // is a PERMANENT condition for that URL (no phone/name/location found on
+  // the site at all) — retrying is futile, so the SSE payload must carry an
+  // honest `message` the client can show instead of "Something broke on our
+  // end. Give it another try." Other reasons are untouched.
+  test("extraction_failed 422 carries a `message` explaining what's missing", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad output"); (e as any).reason = "extraction_failed"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"extraction_failed".*"message":"/);
+  });
+
+  test("a different reason (e.g. anthropic_unauthorized) carries no `message`", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad key"); (e as any).reason = "anthropic_unauthorized"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"anthropic_unauthorized"/);
+    assert.ok(!text.includes('"message"'), "non-extraction_failed reasons must not carry a message");
+  });
 });
 
 // 2026-06-23 — Deploy-CTA → instantiate-the-clicked-agent wiring. The


### PR DESCRIPTION
## Why
Prod failure 2026-07-14: `/try` on medspabybeautybar.com died with `markdown_extractor_parse_failed` — the homepage has NO phone number (CleanTalk obfuscation; it lives on /contact), `phone` is a REQUIRED extraction field, so Opus correctly refused per the never-invent rule. The visitor then saw the dishonest "Something broke on our end / Try again" (retry can never succeed and burns the 3/24h rate limit).

## What
1. **Contact-page fallback** (shared extractor — both /try and /clients/new benefit): on a required-fields refusal, harvest same-host contact/about links from the homepage markdown (guess /contact + /contact-us when none), scrape up to 2 via Firecrawl, re-run extraction ONCE on combined markdown (candidates truncated at 20k chars). Anthropic auth/credit errors never trigger the fallback. Worst case +2 scrapes +1 LLM call, only on the previously-dead path.
2. **Honest 422**: `extraction_failed` SSE error now carries a real `message`.
3. **/try error panel**: replaces dead-end "Try again" with "Try a different URL" + "Describe your business instead" (→ /signup).

## Verification
- verify-runner: PASS — 86/86 unit tests, tsc delta 0, use-server clean, no migrations, regression grep clean.
- reviewer: SHIP — same-host SSRF contract adversarially verified (protocol-relative / userinfo / backslash / homograph vectors all rejected); image-harvest + error mapping preserved; new tests pin call counts and trigger conditions.
- Post-deploy smoke: rebuild medspabybeautybar.com on /try → expect fallback rescue or the honest two-button panel.

Spec: docs/superpowers/specs/2026-07-14-extraction-failed-honesty-and-contact-fallback-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)