### PR TITLE
feat(dashboard): landing-design picker on the claimed-workspace home

### DIFF
--- a/docs/superpowers/plans/2026-07-14-dashboard-design-picker.md
+++ b/docs/superpowers/plans/2026-07-14-dashboard-design-picker.md
@@ -1,0 +1,83 @@
+# Plan — design picker on the claimed dashboard
+
+Spec: `docs/superpowers/specs/2026-07-14-dashboard-design-picker-design.md`
+Worktree: `.claude/worktrees/dashboard-design-picker` · branch `feature/dashboard-design-picker` (off `origin/main` @ `5a739dad9`)
+
+Commit per task. TDD where there's logic (Task 1); Tasks 2-3 are wiring
+covered by tsc + existing suites.
+Regression set: `node --test --import tsx` over the new spec +
+`tests/unit/web-onboarding/clients-new-form.spec.tsx` (touches nothing else,
+but run the full `tests/unit/design-picker/` dir if created) + spot-run any
+suite that imports from `components/clients/design-picker/`
+(grep first — likely none today).
+
+## Task 1 — `resolveDesignModuleProps` helper (+ spec)
+
+New: `packages/crm/src/components/clients/design-picker/resolve-module-props.ts`
+New: `packages/crm/tests/unit/design-picker/resolve-module-props.spec.ts`
+
+Lift the logic from `app/(dashboard)/clients/[slug]/ready/page.tsx:244-281`
+VERBATIM into a pure function (inputs `{ theme, soul, settings }`, returns
+`{ initialValue, autoResolvedId, autoReason, designs, sectionLabel, autoNote }`).
+Import the same deps the page uses today (`isLandingTemplateId`,
+`isHealthVertical`, `resolveHealthTemplate`, `classifyArchetypeFromSoul`,
+`ARCHETYPE_DESIGNS`, types). Server-safe: no "use client", no React.
+Spec cases per the design doc §Tests (health track via template id, health
+track via vertical, archetype track with persisted choice, archetype track
+falling back to soul classification, null theme/soul).
+
+## Task 2 — refactor ready page onto the helper + relocate the wrapper
+
+Edit: `app/(dashboard)/clients/[slug]/ready/page.tsx` — replace lines
+244-281 with a call to `resolveDesignModuleProps({ theme: workspace.theme,
+soul: workspace.soul, settings: workspace.settings })`; pass its fields to
+`<ReadyDesignPicker/>` exactly as before (prop names unchanged). Remove
+now-unused imports.
+
+Move: `app/(dashboard)/clients/[slug]/ready/ready-design-picker.tsx` →
+`packages/crm/src/components/clients/design-picker/ReadyDesignPicker.tsx`.
+Keep the file content identical EXCEPT the action import becomes
+`import { setLandingTemplateAction } from "@/app/(dashboard)/clients/[slug]/ready/actions";`
+Update the ready page's import. Delete the old file (no re-export shim —
+grep first for other importers; scout found none, verify with
+`grep -r "ready-design-picker" packages/crm/src`).
+
+Gate: `npx tsc --noEmit` delta 0 vs baseline; ready page renders the same
+props (pure refactor).
+
+## Task 3 — claimed-dashboard card
+
+Edit: `app/(dashboard)/dashboard/page.tsx`, inside the
+`isFreshClaimedWorkspace && activeWorkspace` branch (~682):
+
+- Add one scoped select inside this branch:
+  `db.select({ theme: organizations.theme, settings: organizations.settings }).from(organizations).where(eq(organizations.id, activeWorkspace.id)).limit(1)`
+  (match the file's existing query idiom; `soul` is already in scope).
+- `const designProps = resolveDesignModuleProps({ theme, soul, settings })`.
+- Render a card after the booking/intake/chatbot card row, matching that
+  branch's card idiom (same border/rounded/padding classes as the sibling
+  cards — read them and copy):
+
+  ```tsx
+  <ReadyDesignPicker
+    slug={activeWorkspace.slug}
+    initialValue={designProps.initialValue}
+    autoResolvedId={designProps.autoResolvedId}
+    autoReason={designProps.autoReason}
+    designs={designProps.designs}
+    sectionLabel={designProps.sectionLabel}
+    autoNote={designProps.autoNote}
+  />
+  ```
+
+  wrapped in the card container. No flag gate. Populated-dashboard branch
+  untouched.
+- Comment style: match the file's dated-comment idiom (one short comment
+  explaining why the select lives inside the branch — zero cost elsewhere).
+
+## Verify
+
+verify-runner in this worktree: new spec green, full unit regression delta 0,
+tsc delta 0 vs baseline, use-server check, no migrations, regression grep.
+Then GATE 2 (Max merges) + post-deploy smoke: /dashboard?claimed=1 shows the
+card; a style pick re-skins /w/<slug>.

--- a/docs/superpowers/specs/2026-07-14-dashboard-design-picker-design.md
+++ b/docs/superpowers/specs/2026-07-14-dashboard-design-picker-design.md
@@ -1,0 +1,108 @@
+# Design picker on the claimed dashboard — design
+
+**Date:** 2026-07-14 · **Branch:** `feature/dashboard-design-picker` · **Status:** approved (Max, in-chat 2026-07-14: "allow users to change their design model right on /dashboard?claimed=1 just like we do on /clients/<slug>/ready")
+
+## Problem
+
+A visitor who builds on /try and claims lands on `/dashboard?claimed=1` (the
+fresh-claimed hero branch of `app/(dashboard)/dashboard/page.tsx`). The
+"Change design" landing-design picker exists only on the agency-side ready
+page (`/clients/[slug]/ready`) — the claimed owner has no way to re-skin
+their site from their own dashboard short of asking SeldonChat.
+
+## Approach — reuse, don't rebuild (verified seam)
+
+Everything already exists and authorizes correctly:
+
+- `ReadyDesignPicker` (`app/(dashboard)/clients/[slug]/ready/ready-design-picker.tsx`)
+  is a self-contained client wrapper: optimistic value + `useTransition` +
+  `setLandingTemplateAction(slug, id)` + `<PickerStyles/>`. Its only coupling
+  to the ready page is the import path of the action.
+- `setLandingTemplateAction` (`app/(dashboard)/clients/[slug]/ready/actions.ts:135`)
+  gates on session + org ownership (`ownerId` / `parentUserId` / `orgMembers`).
+  A claimed owner (link-owner sets `ownerId` = user id) passes. It calls the
+  shared `setLandingTemplateForOrg` core (same one SeldonChat's
+  `update_design` tool uses), which handles both tracks (health templates vs
+  8 aesthetic archetypes) and revalidates `/w/[slug]`.
+- The ready page computes the picker's props (track detection + current
+  choice + auto-resolved id + options) inline at
+  `app/(dashboard)/clients/[slug]/ready/page.tsx:244-281`.
+
+### Changes
+
+1. **Extract the prop-derivation into a shared server-safe pure helper**
+   (second occurrence — extraction now justified per CLAUDE.md §3.1):
+   `packages/crm/src/components/clients/design-picker/resolve-module-props.ts`
+
+   ```ts
+   export function resolveDesignModuleProps(input: {
+     theme: unknown; soul: unknown; settings: unknown;
+   }): {
+     initialValue: DesignId;
+     autoResolvedId?: Exclude<DesignId, "auto">;
+     autoReason: string;
+     designs?: DesignTemplate[];
+     sectionLabel?: string;
+     autoNote?: string;
+   }
+   ```
+
+   Body = the exact logic currently at ready/page.tsx:244-281
+   (`isLandingTemplateId` / `isHealthVertical` / `resolveHealthTemplate` /
+   `classifyArchetypeFromSoul` / `ARCHETYPE_DESIGNS`). The ready page is
+   refactored to call it (pure refactor — identical rendered props).
+
+2. **Relocate the client wrapper to the shared picker folder** so both
+   surfaces import it:
+   `packages/crm/src/components/clients/design-picker/ReadyDesignPicker.tsx`
+   (moved from the ready route; the ready route re-exports or imports from
+   the new path). It keeps calling `setLandingTemplateAction` imported from
+   `app/(dashboard)/clients/[slug]/ready/actions.ts` — server actions are
+   module-scoped, importing across route folders is fine and avoids
+   duplicating the auth gate. NO new server action.
+
+3. **Dashboard surface** (`app/(dashboard)/dashboard/page.tsx`, fresh-claimed
+   branch only, the `isFreshClaimedWorkspace && activeWorkspace` block at
+   ~line 682): render a "Landing design" card using the shared wrapper.
+   - Data: `soul` is already loaded (used by agent picks). `theme` +
+     `settings` for the active workspace are NOT selected today → add ONE
+     scoped select (`organizations.theme`, `organizations.settings` where
+     `id = activeWorkspace.id`) inside the fresh-claimed branch only (zero
+     cost on every other dashboard render).
+   - Placement: a card following the booking/intake/chatbot card row in the
+     hero column (match the existing card idiom of that branch — border,
+     rounded, muted eyebrow). Keep it compact; the module already renders
+     its own thumbnail + "Change design" control.
+   - Pass `slug = activeWorkspace.slug`.
+   - NOT flag-gated (the picker is already live on ready + copilot; this is
+     a third surface of the same capability).
+   - The populated (non-fresh) dashboard branch is OUT OF SCOPE.
+
+## Non-goals
+
+- No new server action, no change to `setLandingTemplateForOrg` /
+  `setArchetypeForOrg`.
+- No change to the ready page's rendered behavior (refactor must be
+  invisible).
+- No design-picker on the populated dashboard or operator views (later if
+  wanted).
+
+## Tests
+
+- New: `tests/unit/design-picker/resolve-module-props.spec.ts` — pure helper:
+  health-track workspace (landingTemplate set / health vertical) returns
+  health defaults + choice; archetype-track returns `ARCHETYPE_DESIGNS`,
+  archetype choice/auto resolution from theme, fallback to
+  `classifyArchetypeFromSoul`; missing theme/soul → sane "auto" defaults.
+- Existing suites must stay green; the ready page refactor is covered by
+  tsc + the helper spec (the page has no dedicated spec today).
+- Visual: vision-verify is deferred to post-deploy eyeball (the card reuses
+  the existing module's styles); flag if `PickerStyles` mounts twice
+  anywhere (it must mount once per surface).
+
+## Verification
+
+`/verify-build` via verify-runner in this worktree (no migrations, no deps,
+no env). Post-deploy smoke: claimed dashboard shows the card; picking a
+style re-skins `/w/<slug>` (the #67 normalizeTheme/aestheticArchetype
+regression is already fixed on main — confirm it stays fixed by the smoke).

--- a/packages/crm/src/app/(dashboard)/clients/[slug]/ready/page.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/[slug]/ready/page.tsx
@@ -54,12 +54,10 @@ import { GenerateWebsiteButton } from "./generate-website-button";
 // the welcome email when the operator clicks "Maybe later" on step 3.
 import { dismissOnboardingAction } from "./actions";
 // 2026-06-03 — Health/wellness landing-design picker (ready-page swap).
-import { ReadyDesignPicker } from "./ready-design-picker";
-import { isLandingTemplateId } from "@/components/landing-templates/registry";
-import { isHealthVertical, resolveHealthTemplate } from "@/lib/landing/template-selection";
-import type { DesignId } from "@/components/clients/design-picker/types";
-import { ARCHETYPE_DESIGNS } from "@/components/clients/design-picker/data";
-import { classifyArchetypeFromSoul } from "@/lib/workspace/apply-archetype-theme";
+// 2026-07-14 — moved to the shared design-picker folder so the claimed
+// dashboard can reuse it too; prop derivation lives in resolveDesignModuleProps.
+import { ReadyDesignPicker } from "@/components/clients/design-picker/ReadyDesignPicker";
+import { resolveDesignModuleProps } from "@/components/clients/design-picker/resolve-module-props";
 
 export const dynamic = "force-dynamic";
 
@@ -241,44 +239,18 @@ export default async function WorkspaceReadyPage({ params, searchParams }: Ready
   // was already switchable via the SeldonChat copilot; this surfaces the same
   // capability as a click-to-apply picker. `value` is the operator's intent
   // ("auto" or an id); `autoResolvedId` is what Auto maps to for this workspace.
-  const wsTheme =
-    (workspace.theme as unknown as {
-      landingTemplate?: string;
-      landingTemplateChoice?: string;
-      aestheticArchetype?: string;
-      aestheticArchetypeChoice?: string;
-    } | null) ?? null;
-  const wsVertical = ((workspace.soul as unknown as { industry?: string } | null)?.industry ?? "").toString();
-  const currentTemplateId = wsTheme?.landingTemplate;
-  const onHealthTrack =
-    isLandingTemplateId(currentTemplateId) || isHealthVertical(wsVertical);
-
-  let designChoice: DesignId;
-  let designAutoResolved: Exclude<DesignId, "auto"> | undefined;
-  let designAutoReason: string;
-  let designOptions: typeof ARCHETYPE_DESIGNS | undefined;
-  let designSectionLabel: string | undefined;
-  let designAutoNote: string | undefined;
-
-  if (onHealthTrack) {
-    designChoice = (wsTheme?.landingTemplateChoice as DesignId | undefined) ?? "auto";
-    designAutoResolved = (
-      isLandingTemplateId(currentTemplateId)
-        ? currentTemplateId
-        : resolveHealthTemplate(wsVertical)
-    ) as Exclude<DesignId, "auto">;
-    designAutoReason = wsVertical ? `Auto-picked for ${wsVertical}` : "Auto-picked for this business";
-    // health options + copy = the picker defaults; leave undefined.
-  } else {
-    // Archetype track — trades/generic. Auto resolves via soul classification.
-    designChoice = (wsTheme?.aestheticArchetypeChoice as DesignId | undefined) ?? "auto";
-    designAutoResolved = (wsTheme?.aestheticArchetype ??
-      classifyArchetypeFromSoul(workspace.soul, workspace.settings)) as Exclude<DesignId, "auto">;
-    designAutoReason = wsVertical ? `Auto-picked for ${wsVertical}` : "Auto-picked for this business";
-    designOptions = ARCHETYPE_DESIGNS;
-    designSectionLabel = "Design styles";
-    designAutoNote = "Auto matches a style to your business. Pick any style to override it — your site re-skins instantly.";
-  }
+  const {
+    initialValue: designChoice,
+    autoResolvedId: designAutoResolved,
+    autoReason: designAutoReason,
+    designs: designOptions,
+    sectionLabel: designSectionLabel,
+    autoNote: designAutoNote,
+  } = resolveDesignModuleProps({
+    theme: workspace.theme,
+    soul: workspace.soul,
+    settings: workspace.settings,
+  });
 
   const publicBookingUrl = bookingTemplateRow
     ? `${APP_BASE}/book/${workspace.slug}/${bookingTemplateRow.slug}`

--- a/packages/crm/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/crm/src/app/(dashboard)/dashboard/page.tsx
@@ -61,6 +61,11 @@ import { ShareRow } from "@/components/activation/share-row";
 import { suggestAgentsForIndustry } from "@/lib/activation/suggest-agents";
 import { AgentPicks } from "@/components/activation/agent-picks";
 import { agentTemplates } from "@/db/schema/agent-templates";
+// 2026-07-14 — Landing-design picker card on the fresh-claimed hero. Same
+// module the ready page + SeldonChat copilot already surface; this is a
+// third surface of the same setLandingTemplateForOrg capability.
+import { ReadyDesignPicker } from "@/components/clients/design-picker/ReadyDesignPicker";
+import { resolveDesignModuleProps } from "@/components/clients/design-picker/resolve-module-props";
 
 /*
   Square UI class reference (source of truth):
@@ -700,6 +705,22 @@ export default async function DashboardPage({
       ? `${APP_BASE}/forms/${activeWorkspace.slug}/${activeIntakeForm.slug}`
       : null;
 
+    // 2026-07-14 — Landing-design picker card, fresh-claimed hero only.
+    // `theme`/`settings` aren't selected on the workspaceRows query above
+    // (only used here), so this scoped one-off select keeps every other
+    // dashboard render (populated view, operator sessions) at zero added
+    // cost. `soul` is already loaded above (getSoul()).
+    const [designRow] = await db
+      .select({ theme: organizations.theme, settings: organizations.settings })
+      .from(organizations)
+      .where(eq(organizations.id, activeWorkspace.id))
+      .limit(1);
+    const designProps = resolveDesignModuleProps({
+      theme: designRow?.theme ?? null,
+      soul,
+      settings: designRow?.settings ?? null,
+    });
+
     return (
       // Top-aligned, full-width — the (dashboard) layout column already pads
       // (px/py 4→8), so no extra padding or vertical centering here (the old
@@ -777,6 +798,27 @@ export default async function DashboardPage({
               </p>
             </a>
           </div>
+
+          {/* 2026-07-14 — Landing-design picker card. Reuses the same
+              module the ready page + SeldonChat copilot already surface
+              (setLandingTemplateForOrg) so a claimed owner can re-skin their
+              site without asking SeldonChat. */}
+          <section className="rounded-2xl border border-border/70 bg-card/40 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+              Landing design
+            </p>
+            <div className="mt-2">
+              <ReadyDesignPicker
+                slug={activeWorkspace.slug}
+                initialValue={designProps.initialValue}
+                autoResolvedId={designProps.autoResolvedId}
+                autoReason={designProps.autoReason}
+                designs={designProps.designs}
+                sectionLabel={designProps.sectionLabel}
+                autoNote={designProps.autoNote}
+              />
+            </div>
+          </section>
 
           {/* Tertiary link — keeps the agency-builder path discoverable
               for owners who also want to build workspaces for others. */}

--- a/packages/crm/src/components/clients/design-picker/ReadyDesignPicker.tsx
+++ b/packages/crm/src/components/clients/design-picker/ReadyDesignPicker.tsx
@@ -12,7 +12,7 @@ import { ReadyDesignModule } from "@/components/clients/design-picker/ReadyDesig
 import { PickerStyles } from "@/components/clients/design-picker/Styles";
 import type { DesignId, DesignTemplate } from "@/components/clients/design-picker/types";
 
-import { setLandingTemplateAction } from "./actions";
+import { setLandingTemplateAction } from "@/app/(dashboard)/clients/[slug]/ready/actions";
 
 type Props = {
   slug: string;

--- a/packages/crm/src/components/clients/design-picker/resolve-module-props.ts
+++ b/packages/crm/src/components/clients/design-picker/resolve-module-props.ts
@@ -1,0 +1,87 @@
+// SeldonFrame · landing-design picker — shared prop-derivation helper.
+//
+// 2026-07-14 — Lifted VERBATIM from the ready page's inline block
+// (app/(dashboard)/clients/[slug]/ready/page.tsx:244-281, comment dated
+// 2026-07-13) so a second surface (the claimed dashboard) can compute the
+// same picker props without duplicating the track-detection logic. Second
+// occurrence of this logic — extraction now justified per CLAUDE.md §3.1.
+//
+// Pure + server-safe: no "use client", no React, no DB/session access. The
+// caller (a server component / page) is responsible for loading
+// `theme`/`soul`/`settings` off the organizations row and passing them in.
+
+import { isLandingTemplateId } from "@/components/landing-templates/registry";
+import { isHealthVertical, resolveHealthTemplate } from "@/lib/landing/template-selection";
+import { classifyArchetypeFromSoul } from "@/lib/workspace/apply-archetype-theme";
+
+import { ARCHETYPE_DESIGNS } from "./data";
+import type { DesignId, DesignTemplate } from "./types";
+
+export type ResolveDesignModulePropsInput = {
+  theme: unknown;
+  soul: unknown;
+  settings: unknown;
+};
+
+export type ResolveDesignModulePropsResult = {
+  initialValue: DesignId;
+  autoResolvedId?: Exclude<DesignId, "auto">;
+  autoReason: string;
+  designs?: DesignTemplate[];
+  sectionLabel?: string;
+  autoNote?: string;
+};
+
+// Every workspace picks a design on one of two tracks:
+//   • health track   → the 5 premium landing templates (health verticals or a
+//                       workspace that already has a premium template applied)
+//   • archetype track → the 8 aesthetic archetypes (trades/generic verticals)
+// The archetype track re-skins the landing-r1 render (palette/font/hero).
+// `initialValue` is the operator's intent ("auto" or an id); `autoResolvedId`
+// is what Auto maps to for this workspace.
+export function resolveDesignModuleProps({
+  theme,
+  soul,
+  settings,
+}: ResolveDesignModulePropsInput): ResolveDesignModulePropsResult {
+  const wsTheme =
+    (theme as unknown as {
+      landingTemplate?: string;
+      landingTemplateChoice?: string;
+      aestheticArchetype?: string;
+      aestheticArchetypeChoice?: string;
+    } | null) ?? null;
+  const wsVertical = ((soul as unknown as { industry?: string } | null)?.industry ?? "").toString();
+  const currentTemplateId = wsTheme?.landingTemplate;
+  const onHealthTrack =
+    isLandingTemplateId(currentTemplateId) || isHealthVertical(wsVertical);
+
+  let initialValue: DesignId;
+  let autoResolvedId: Exclude<DesignId, "auto"> | undefined;
+  let autoReason: string;
+  let designs: DesignTemplate[] | undefined;
+  let sectionLabel: string | undefined;
+  let autoNote: string | undefined;
+
+  if (onHealthTrack) {
+    initialValue = (wsTheme?.landingTemplateChoice as DesignId | undefined) ?? "auto";
+    autoResolvedId = (
+      isLandingTemplateId(currentTemplateId)
+        ? currentTemplateId
+        : resolveHealthTemplate(wsVertical)
+    ) as Exclude<DesignId, "auto">;
+    autoReason = wsVertical ? `Auto-picked for ${wsVertical}` : "Auto-picked for this business";
+    // health options + copy = the picker defaults; leave undefined.
+  } else {
+    // Archetype track — trades/generic. Auto resolves via soul classification.
+    initialValue = (wsTheme?.aestheticArchetypeChoice as DesignId | undefined) ?? "auto";
+    autoResolvedId = (wsTheme?.aestheticArchetype ??
+      classifyArchetypeFromSoul(soul, settings)) as Exclude<DesignId, "auto">;
+    autoReason = wsVertical ? `Auto-picked for ${wsVertical}` : "Auto-picked for this business";
+    designs = ARCHETYPE_DESIGNS;
+    sectionLabel = "Design styles";
+    autoNote = "Auto matches a style to your business. Pick any style to override it — your site re-skins instantly.";
+  }
+
+  return { initialValue, autoResolvedId, autoReason, designs, sectionLabel, autoNote };
+}

--- a/packages/crm/tests/unit/design-picker/resolve-module-props.spec.ts
+++ b/packages/crm/tests/unit/design-picker/resolve-module-props.spec.ts
@@ -1,0 +1,84 @@
+// Unit tests for components/clients/design-picker/resolve-module-props.ts —
+// the pure prop-derivation helper shared by the ready page and the claimed
+// dashboard's design-picker card. Mirrors the ready page's inline logic
+// (lifted verbatim per docs/superpowers/plans/2026-07-14-dashboard-design-picker.md).
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveDesignModuleProps } from "@/components/clients/design-picker/resolve-module-props";
+import { ARCHETYPE_DESIGNS } from "@/components/clients/design-picker/data";
+
+describe("resolveDesignModuleProps", () => {
+  test("health track via persisted landingTemplate id", () => {
+    const result = resolveDesignModuleProps({
+      theme: { landingTemplate: "clinical-luxe", landingTemplateChoice: "clinical-luxe" },
+      soul: { industry: "chiropractic" },
+      settings: null,
+    });
+
+    assert.equal(result.initialValue, "clinical-luxe");
+    assert.equal(result.autoResolvedId, "clinical-luxe");
+    assert.equal(result.autoReason, "Auto-picked for chiropractic");
+    // health track leaves options/copy undefined (picker defaults).
+    assert.equal(result.designs, undefined);
+    assert.equal(result.sectionLabel, undefined);
+    assert.equal(result.autoNote, undefined);
+  });
+
+  test("health track via vertical (no template id yet, still auto)", () => {
+    const result = resolveDesignModuleProps({
+      theme: null,
+      soul: { industry: "med-spa" },
+      settings: null,
+    });
+
+    assert.equal(result.initialValue, "auto");
+    assert.equal(typeof result.autoResolvedId, "string");
+    assert.equal(result.autoReason, "Auto-picked for med-spa");
+    assert.equal(result.designs, undefined);
+  });
+
+  test("archetype track with a persisted choice", () => {
+    const result = resolveDesignModuleProps({
+      theme: {
+        aestheticArchetype: "bold-urgency",
+        aestheticArchetypeChoice: "bold-urgency",
+      },
+      soul: { industry: "plumbing" },
+      settings: null,
+    });
+
+    assert.equal(result.initialValue, "bold-urgency");
+    assert.equal(result.autoResolvedId, "bold-urgency");
+    assert.equal(result.autoReason, "Auto-picked for plumbing");
+    assert.deepEqual(result.designs, ARCHETYPE_DESIGNS);
+    assert.equal(result.sectionLabel, "Design styles");
+    assert.equal(
+      result.autoNote,
+      "Auto matches a style to your business. Pick any style to override it — your site re-skins instantly.",
+    );
+  });
+
+  test("archetype track falls back to soul classification when no persisted archetype", () => {
+    const result = resolveDesignModuleProps({
+      theme: null,
+      soul: { industry: "landscaping" },
+      settings: null,
+    });
+
+    assert.equal(result.initialValue, "auto");
+    assert.ok(result.autoResolvedId, "expected classifyArchetypeFromSoul to resolve something");
+    assert.deepEqual(result.designs, ARCHETYPE_DESIGNS);
+  });
+
+  test("null theme/soul/settings yields sane auto defaults on the archetype track", () => {
+    const result = resolveDesignModuleProps({ theme: null, soul: null, settings: null });
+
+    assert.equal(result.initialValue, "auto");
+    assert.ok(result.autoResolvedId, "classifyArchetypeFromSoul should still resolve a fallback archetype");
+    assert.equal(result.autoReason, "Auto-picked for this business");
+    assert.deepEqual(result.designs, ARCHETYPE_DESIGNS);
+    assert.equal(result.sectionLabel, "Design styles");
+  });
+});


### PR DESCRIPTION
## Why
A /try builder who claims lands on /dashboard?claimed=1 with no way to change their site's design — the picker only existed on the agency-side /clients/[slug]/ready page (Max, 2026-07-14: surface it on the claimed dashboard too).

## What
1. Extracted the ready page's picker prop-derivation (track detection health-templates vs 8 archetypes, auto-resolution) into a pure shared helper `resolve-module-props.ts` + 5-case spec. Byte-for-byte lift — reviewer confirmed zero behavioral drift.
2. Moved the `ReadyDesignPicker` client wrapper to the shared design-picker folder (git rename; single importer updated, no dangling refs).
3. New landing-design card on the fresh-claimed dashboard hero (matches sibling card idiom; one scoped theme/settings select inside that branch only). Reuses `setLandingTemplateAction` — same session + ownership gate, same `setLandingTemplateForOrg` core SeldonChat uses; public /w/[slug] revalidates instantly.

Populated-dashboard branch untouched. No new endpoint, flag, dep, or migration.

## Verification
- verify-runner: PASS — helper spec 5/5, tsc error set identical to baseline, use-server clean, no dangling imports of the old wrapper path, RSC boundary verified (server page renders the client component, never calls it).
- reviewer: SHIP across all 7 axes — refactor invisibility, RSC boundary, auth un-widened (foreign slug still fails the ownership gate), no PickerStyles double-mount, test quality pinned with concrete values.
- Post-deploy smoke: /dashboard?claimed=1 shows the card; a style pick re-skins /w/<slug>.

Spec: docs/superpowers/specs/2026-07-14-dashboard-design-picker-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)