### PR TITLE
fix(landing): normalize live archetype at the loader — design switch now re-skins the whole site

### DIFF
--- a/docs/superpowers/specs/2026-07-15-live-archetype-at-source-design.md
+++ b/docs/superpowers/specs/2026-07-15-live-archetype-at-source-design.md
@@ -1,0 +1,113 @@
+# Live archetype normalized at the source — design
+
+**Date:** 2026-07-15 · **Branch:** `fix/live-archetype-at-source` (off main @ `ea4bffd9d`) · **Status:** prod bug fix (Max report 2026-07-14 evening: design switch changes dashboard colors but not the public site)
+
+## Verified root cause (DB + live-HTML + code, all first-hand)
+
+Workspace `zen-flow-hydration` (org `33b746de-085c-4c6c-9575-6288d6ac2215`):
+
+- `organizations.theme.aestheticArchetype` = `cinematic-aspirational` — Max's
+  picker choice WROTE correctly (the picker/track detection is NOT the bug;
+  "Cinematic Luxe" = `cinematic-aspirational` in `design-picker/data.ts:51`).
+  `theme.primaryColor` = `#a08562` — why his dashboard went gold.
+- `landing_pages` r1 row: `blueprint_json.archetype` AND
+  `blueprint_json.payload.*.archetype` fields are frozen at build-time
+  `clinical-trust`.
+- Rendered HTML today:
+  - `/w/zen-flow-hydration`: MIXED — SiteShell/Navbar/Hero/Map/LeadForm render
+    `data-archetype="cinematic-aspirational"` (the v1.56.0 fix at
+    `w/[slug]/page.tsx:235-241` overrides `payload.hero.archetype`), but
+    ServicesGrid / Testimonials / FAQ / Footer / sticky-nav render
+    `data-archetype="clinical-trust"` — they read their OWN per-section
+    `archetype` fields from the payload, which nothing normalizes.
+  - Subdomain `zen-flow-hydration.app.seldonframe.com` (route
+    `(public)/s/[orgSlug]/[...slug]/page.tsx` — what the dashboard's "View
+    your website" opens): 100% frozen `clinical-trust` — this route has NO
+    live-theme normalization at all (it passes raw `payload.hero.archetype`
+    at lines 164-250).
+  - Both responses are `X-Vercel-Cache: MISS`, `no-store` — not a caching
+    issue.
+
+**One line:** the archetype is denormalized into many payload fields at
+generation time; only ONE render site normalizes only ONE of those fields
+from the live org theme, so a design switch re-skins part of /w and none of
+the subdomain.
+
+## Fix — normalize once, at the loader
+
+`loadLandingPayload` (`lib/landing/r1-save.ts:~102`) is the single source
+both public routes (and any other consumer) read. It already selects
+`organizations.theme` and returns `normalizeTheme(orgRow.theme)`.
+
+1. New pure helper `packages/crm/src/lib/landing/apply-live-archetype.ts`:
+
+   ```ts
+   export function applyLiveArchetype<T>(payload: T, live: AestheticArchetypeId): T
+   ```
+
+   Deep-walks the payload (plain JSON — objects/arrays only) and replaces the
+   value of every property named `archetype` whose current value is a string
+   key of `ARCHETYPES` (from `@/lib/workspace/aesthetic-archetypes`) with
+   `live`. Non-archetype-id values (unknown strings) are left untouched.
+   Returns a NEW object (no mutation of the input). Bounded recursion (payloads
+   are small JSON); no `any` leakage beyond the walk internals.
+
+2. In `loadLandingPayload`, after the payload row is read and before return:
+   when `theme.aestheticArchetype` is set AND `theme.aestheticArchetype in
+   ARCHETYPES` AND it differs from `blueprintJson.archetype`, return
+   `payload: applyLiveArchetype(payload, theme.aestheticArchetype)` and also
+   surface the live id as the returned top-level `archetype`. When the org
+   theme has no archetype (pre-1.54 workspaces), return the payload untouched
+   — the frozen value remains the fallback, exactly as today.
+
+3. `(public)/w/[slug]/page.tsx:227-241` — remove the now-redundant local
+   `liveArchetype` override block; replace with a one-line comment pointing
+   at the loader ("live-archetype normalization moved into loadLandingPayload
+   so ALL consumers + ALL payload sections re-skin — see
+   apply-live-archetype.ts"). The rest of the page is untouched (it keeps
+   reading `payload.hero.archetype`, which now arrives normalized).
+
+4. `(public)/s/[orgSlug]/[...slug]/page.tsx` — NO change needed for the
+   archetype (it reads the same loader). Do not add health-template rendering
+   here (separate gap, separate slice — see Out of scope).
+
+## Why this shape
+
+- Single seam: every render site — current and future (og-image, service
+  subpages, embeds) — inherits the fix; no per-route drift (this bug IS the
+  drift: v1.56.0 fixed one field on one route).
+- The org theme is the canonical user-intent store (the picker, the dashboard
+  card, and SeldonChat's update_design all write it via
+  setArchetypeForOrg/setLandingTemplateForOrg). The payload pin becomes what
+  it should be: a build-time fallback.
+
+## Out of scope (explicitly)
+
+- The /s route also never checks `theme.landingTemplate` (health templates
+  can't render on subdomains) — REAL gap, but zero current workspaces hit it
+  and it needs template-render plumbing in /s; filed as a follow-up task, not
+  this fix.
+- `theme.mode` propagation differences between routes.
+- Converging the frozen pin on payload re-save (harmless either way).
+
+## Tests
+
+- `tests/unit/landing/apply-live-archetype.spec.ts` (new, pure):
+  - replaces `archetype` at top level, in `hero`, in nested section objects,
+    and inside arrays (`servicePages[].sections[]`-shaped fixtures);
+  - leaves non-archetype-id strings and non-`archetype` keys untouched;
+  - returns a new object; input not mutated;
+  - no-ops when live id equals the frozen id everywhere.
+- `loadLandingPayload` has no DI seam for db — its integration is covered by
+  the pure-helper spec + tsc + the post-deploy live smoke (below). Existing
+  r1-save / w-page specs (if any reference the removed block) updated.
+
+## Verification
+
+- verify-runner six checks (no migrations/deps/env).
+- Post-deploy smoke (the REAL gate, on the exact broken workspace):
+  `https://zen-flow-hydration.app.seldonframe.com/` AND
+  `https://app.seldonframe.com/w/zen-flow-hydration` must render
+  `data-archetype="cinematic-aspirational"` on EVERY data-archetype
+  attribute (grep the HTML; zero `clinical-trust` attribute values), without
+  Max touching the picker again.

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -224,21 +224,8 @@ export default async function WorkspaceLandingPage({ params }: PageProps) {
     home: workspaceUrls.home,
   });
 
-  // Re-skin from the LIVE org theme, not the archetype frozen into the payload
-  // at generation time. The ready-page "Change design" picker writes
-  // theme.aestheticArchetype (+ theme.mode) via setArchetypeForOrg; without this
-  // override /w/[slug] would keep rendering the original archetype forever
-  // (palette + font + hero variant all derive from this id). Falls back to the
-  // baked value for workspaces whose theme has no archetype yet (pre-1.54).
-  // payload.hero.archetype feeds SiteShell + Navbar + Hero + Map + LeadForm, so
-  // normalizing it here re-skins the whole page uniformly.
-  const liveArchetype =
-    r1.theme?.aestheticArchetype && r1.theme.aestheticArchetype in ARCHETYPES
-      ? (r1.theme.aestheticArchetype as AestheticArchetypeId)
-      : payload.hero.archetype;
-  if (liveArchetype !== payload.hero.archetype) {
-    payload.hero = { ...payload.hero, archetype: liveArchetype };
-  }
+  // 2026-07-15 — live-archetype normalization moved into loadLandingPayload
+  // so ALL consumers + ALL payload sections re-skin — see apply-live-archetype.ts.
 
   const homeHref = `/w/${slug}`;
   const navServices = getServicePages(payload).map((p) => ({ slug: p.slug, name: p.name }));

--- a/packages/crm/src/lib/landing/apply-live-archetype.ts
+++ b/packages/crm/src/lib/landing/apply-live-archetype.ts
@@ -1,0 +1,57 @@
+// packages/crm/src/lib/landing/apply-live-archetype.ts
+//
+// 2026-07-15 — LIVE ARCHETYPE AT THE SOURCE
+//
+// The archetype id is denormalized into MANY payload fields at R1
+// generation time (top-level `archetype`, `hero.archetype`, and a per-section
+// `archetype` on every section object — ServicesGrid, Testimonials, FAQ,
+// Footer, sticky-nav, servicePages[].sections[], etc.). When the operator
+// switches the design via the picker, only `organizations.theme
+// .aestheticArchetype` is updated — the frozen payload fields are never
+// touched, so a design switch silently re-skins nothing (or, pre-fix, only
+// the one field a single render site happened to override locally).
+//
+// Fix: normalize ALL of them, once, at the loader (see r1-save.ts) via this
+// pure deep-walk helper, so every render site (current and future) inherits
+// the live theme uniformly instead of drifting field-by-field.
+//
+// This module is deliberately dependency-free (no db, no React) so it stays
+// trivially unit-testable and reusable from any consumer of the payload.
+
+import { ARCHETYPES } from "@/lib/workspace/aesthetic-archetypes";
+
+/**
+ * Deep-walks a plain-JSON payload (objects/arrays only — no class instances,
+ * Dates, Maps, etc., which the R1 payload never contains) and returns a NEW
+ * object where every property literally named `archetype` whose current
+ * string value is a valid key of `ARCHETYPES` has been replaced with `live`.
+ *
+ * - Non-`archetype` keys are left untouched, even when their value happens
+ *   to look like an archetype id.
+ * - `archetype` values that are NOT a recognized archetype id (unknown /
+ *   stale strings) are left untouched — we only ever replace known ids.
+ * - The input is not mutated; a structurally new object is returned.
+ */
+export function applyLiveArchetype<T>(payload: T, live: string): T {
+  return walk(payload, live) as T;
+}
+
+function walk(value: unknown, live: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => walk(item, live));
+  }
+
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (key === "archetype" && typeof val === "string" && val in ARCHETYPES) {
+        out[key] = live;
+      } else {
+        out[key] = walk(val, live);
+      }
+    }
+    return out;
+  }
+
+  return value;
+}

--- a/packages/crm/src/lib/landing/r1-save.ts
+++ b/packages/crm/src/lib/landing/r1-save.ts
@@ -24,6 +24,8 @@ import type { AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes"
 import type { R1LandingPayload } from "./r1-payload-prompt";
 import { normalizeTheme } from "@/lib/theme/normalize-theme";
 import type { OrgTheme } from "@/lib/theme/types";
+import { ARCHETYPES } from "@/lib/workspace/aesthetic-archetypes";
+import { applyLiveArchetype } from "./apply-live-archetype";
 
 const R1_SLUG = "r1";
 const R1_STATUS = "published"; // public immediately, no gate
@@ -166,10 +168,33 @@ export async function loadLandingPayload(workspaceSlug: string): Promise<{
   const bjson = row.blueprintJson as Record<string, unknown>;
   if (bjson["_r1"] !== true) return null;
 
-  const payload = bjson["payload"] as R1LandingPayload | undefined;
-  const archetype = bjson["archetype"] as AestheticArchetypeId | undefined;
+  const payloadRaw = bjson["payload"] as R1LandingPayload | undefined;
+  const archetypeRaw = bjson["archetype"] as AestheticArchetypeId | undefined;
 
-  if (!payload || !archetype) return null;
+  if (!payloadRaw || !archetypeRaw) return null;
+
+  // 2026-07-15 — LIVE ARCHETYPE AT THE SOURCE: the payload freezes the
+  // archetype into many fields at generation time (top-level + per-section),
+  // but the design picker / SeldonChat's update_design only ever write
+  // theme.aestheticArchetype. Normalize here, once, so EVERY consumer of
+  // loadLandingPayload (both public routes, and any future one) re-skins
+  // uniformly instead of relying on each render site to override its own
+  // field (that per-route drift was the bug — see
+  // docs/superpowers/specs/2026-07-15-live-archetype-at-source-design.md).
+  // The frozen payload value remains the fallback when the org theme has no
+  // archetype yet (pre-1.54 workspaces) or already matches — no-op either way.
+  const liveArchetype = theme.aestheticArchetype;
+  const hasLiveOverride =
+    typeof liveArchetype === "string" &&
+    liveArchetype in ARCHETYPES &&
+    liveArchetype !== archetypeRaw;
+
+  const payload = hasLiveOverride
+    ? applyLiveArchetype(payloadRaw, liveArchetype)
+    : payloadRaw;
+  const archetype = hasLiveOverride
+    ? (liveArchetype as AestheticArchetypeId)
+    : archetypeRaw;
 
   const seoRaw = (row.seo ?? {}) as Record<string, unknown>;
   return {

--- a/packages/crm/tests/unit/landing/apply-live-archetype.spec.ts
+++ b/packages/crm/tests/unit/landing/apply-live-archetype.spec.ts
@@ -1,0 +1,89 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { applyLiveArchetype } from "../../../src/lib/landing/apply-live-archetype";
+
+describe("applyLiveArchetype", () => {
+  test("replaces archetype at the top level", () => {
+    const input = { archetype: "clinical-trust", tagline: "hi" };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.archetype, "cinematic-aspirational");
+  });
+
+  test("replaces archetype nested inside hero", () => {
+    const input = {
+      hero: { archetype: "clinical-trust", headline: "Welcome" },
+    };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.hero.archetype, "cinematic-aspirational");
+    assert.equal(out.hero.headline, "Welcome");
+  });
+
+  test("replaces archetype in nested section objects", () => {
+    const input = {
+      sections: {
+        servicesGrid: { archetype: "clinical-trust", title: "Services" },
+        testimonials: { archetype: "clinical-trust", title: "Reviews" },
+      },
+    };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.sections.servicesGrid.archetype, "cinematic-aspirational");
+    assert.equal(out.sections.testimonials.archetype, "cinematic-aspirational");
+  });
+
+  test("replaces archetype inside arrays (servicePages[].sections[]-shaped)", () => {
+    const input = {
+      servicePages: [
+        {
+          slug: "roofing",
+          sections: [
+            { archetype: "clinical-trust", kind: "hero" },
+            { archetype: "clinical-trust", kind: "faq" },
+          ],
+        },
+        {
+          slug: "siding",
+          sections: [{ archetype: "clinical-trust", kind: "hero" }],
+        },
+      ],
+    };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.servicePages[0].sections[0].archetype, "cinematic-aspirational");
+    assert.equal(out.servicePages[0].sections[1].archetype, "cinematic-aspirational");
+    assert.equal(out.servicePages[1].sections[0].archetype, "cinematic-aspirational");
+  });
+
+  test("leaves non-archetype-id string values untouched", () => {
+    const input = { archetype: "not-a-real-archetype-id" };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.archetype, "not-a-real-archetype-id");
+  });
+
+  test("leaves non-archetype keys untouched even with a valid-id-looking string value", () => {
+    const input = { theme: "clinical-trust", archetype: "clinical-trust" };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.equal(out.theme, "clinical-trust");
+    assert.equal(out.archetype, "cinematic-aspirational");
+  });
+
+  test("returns a new object; does not mutate the input", () => {
+    const input = { archetype: "clinical-trust", hero: { archetype: "clinical-trust" } };
+    const out = applyLiveArchetype(input, "cinematic-aspirational");
+    assert.notEqual(out, input);
+    assert.equal(input.archetype, "clinical-trust");
+    assert.equal(input.hero.archetype, "clinical-trust");
+  });
+
+  test("no-ops when the live id equals the frozen id everywhere", () => {
+    const input = {
+      archetype: "clinical-trust",
+      hero: { archetype: "clinical-trust" },
+      sections: [{ archetype: "clinical-trust" }],
+    };
+    const out = applyLiveArchetype(input, "clinical-trust");
+    assert.equal(out.archetype, "clinical-trust");
+    assert.equal(out.hero.archetype, "clinical-trust");
+    assert.equal(out.sections[0].archetype, "clinical-trust");
+    assert.notEqual(out, input);
+  });
+});


### PR DESCRIPTION
## Why
Prod bug (Max, 2026-07-14): design switches wrote `organizations.theme.aestheticArchetype` correctly, but the archetype is FROZEN into many payload fields at build time (top-level + per-section). Only /w normalized only the hero field, so a switch partially re-skinned /w and did nothing on the subdomain (what "View your website" opens). Verified against workspace zen-flow-hydration: DB theme = cinematic-aspirational, rendered HTML = clinical-trust on all sections of the subdomain and on ServicesGrid/Testimonials/FAQ/Footer/sticky-nav of /w. Fresh MISS renders — not caching.

## What
1. `apply-live-archetype.ts` — pure deep-walk that replaces every payload property named `archetype` holding a valid archetype id with the live org-theme id (new object, input unmutated). 8 unit tests.
2. `loadLandingPayload` applies it once at the loader when the org theme has a valid archetype differing from the frozen pin — so BOTH public routes and every payload section re-skin. No-archetype workspaces are byte-identical.
3. Removed /w's now-redundant partial override (single source of truth).

## Verification
- verify-runner PASS: 204 tests (195 pass; 9 pre-existing failures identical on main; +8 new), tsc delta 0, use-server clean, no migrations, scoped 5-file diff, guard-condition spot-checks.
- reviewer SHIP: caller-by-caller blast-radius table — all read-modify-write payload flows (copilot field/media edits) use their own raw loader, so the frozen fallback is never overwritten; render-only callers inherit the fix.
- Post-deploy smoke (the real gate): both zen-flow-hydration URLs must render data-archetype="cinematic-aspirational" everywhere with no re-pick.

Spec: docs/superpowers/specs/2026-07-15-live-archetype-at-source-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)