### PR TITLE
feat(demo-scenes): recordable animation stage for product videos (dev-only)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-demo-scenes.md
+++ b/docs/superpowers/plans/2026-07-14-demo-scenes.md
@@ -1,0 +1,75 @@
+# Plan — demo scenes (recordable animation stage)
+
+Spec: `docs/superpowers/specs/2026-07-14-demo-scenes-design.md`
+Worktree: `.claude/worktrees/demo-scenes` · branch `feature/demo-scenes` (off main @ `e5bd50728`)
+
+Commit per task. Before Task 1: read `app/(dev)/motion-lab/page.tsx` +
+`motion-lab-client.tsx` fully (gating, CSS imports, metadata idiom) and skim
+`components/ui/animated-list.tsx`, `components/ui/magic/animated-beam.tsx`,
+`components/ui/magic/terminal.tsx`, `components/ui/number-ticker.tsx`,
+`components/landing/edit-by-chat-demo.tsx` — copy their conventions
+(forceStatic / reduced-motion idiom, token usage) rather than inventing.
+
+## Task 1 — registry + routes (+ registry spec, TDD)
+
+- `components/demo-scenes/registry.ts` — `DEMO_SCENES: { id, title, blurb }[]`
+  + `getDemoScene(id)`. Component lookup lives in a separate
+  `components/demo-scenes/scene-components.tsx` map (client) so the registry
+  itself stays server-safe for the spec.
+- `tests/unit/demo-scenes/registry.spec.ts` — unique kebab-case ids, every
+  registry entry has non-empty title/blurb, `getDemoScene("nope")` → null,
+  the component map covers exactly the registry ids.
+- `app/(dev)/demo-scenes/page.tsx` — flag gate (same strict `SF_MOTION_LAB`
+  check as motion-lab), noindex metadata, route-level CSS imports, index
+  cards linking to `/demo-scenes/<id>`.
+- `app/(dev)/demo-scenes/[scene]/page.tsx` — same gate + noindex;
+  `notFound()` on unknown id; renders `<SceneStage>` (client) with the id.
+- `components/demo-scenes/scene-stage.tsx` — full-viewport stage host:
+  100svh, token background, `key`-bump Restart, `?loop=1` sync, light/dark
+  via `data-mode="record"` on the stage root, controls cluster bottom-right
+  that fades after 3s idle (mousemove resets). Placeholder scene body for
+  this commit (Task 2+ fill the scenes) — but ship ONE trivial scene inline
+  so the route is demonstrably working (e.g. stat-payoff early).
+
+## Task 2 — list + beam + ticker scenes
+
+- `booking-cascade.tsx` (AnimatedList; toast-style cards, vendored icons via
+  next/image or plain img from /brand/integrations/, 1.2s stagger, loop with
+  hold+fade reset)
+- `calendar-connected.tsx` (AnimatedBeam between Seldon mark and
+  google-calendar.svg; "Connected" spring pill; booking card slide-in; pulse)
+- `stat-payoff.tsx` (4 NumberTickers + AnimatedShinyText sub-line; loop
+  re-counts via key bump on an interval when loop is on)
+
+## Task 3 — chat + phone + confetti + terminal scenes
+
+- `grounded-chat.tsx` — phase machine per edit-by-chat-demo's idiom (typing →
+  message → reply → confirm → hold → reset). Bubbles: customer light card /
+  agent forest bubble, larger type (video-legible at 1080p).
+- `sms-phone.tsx` — pure-CSS phone frame + arriving iMessage-style bubble +
+  subtle shake keyframe. No deps.
+- `live-confetti.tsx` — headline + ~48 span particles; particle transforms
+  from a module-level seeded array (deterministic, no Math.random in render).
+- `docker-terminal.tsx` — Terminal + TypingAnimation + AnimatedSpan lines per
+  the spec copy.
+- Register all seven in the registry + component map (spec updated in the
+  same commit — the "component map covers registry" test forces this).
+
+## Task 4 — reduced-motion + SSR pass
+
+Sweep every scene: `prefers-reduced-motion` settles to final frame (use the
+same hook/idiom the existing magic components use — grep for how
+animated-shiny-text / flicker-grid gate motion); no window/document at module
+scope; no Math.random()/Date.now() in render paths. Add whatever the sweep
+finds to the scenes; re-run registry spec + tsc.
+
+## Verify
+
+- `node --test --import tsx tests/unit/demo-scenes/registry.spec.ts`
+- tsc delta 0 vs baseline (record baseline BEFORE first change; no git stash)
+- `bash scripts/check-use-server.sh src`
+- No migrations, no new deps (git diff package.json must be empty)
+- grep: no route.ts touched, nothing outside `(dev)/demo-scenes`,
+  `components/demo-scenes/`, `tests/unit/demo-scenes/`, docs.
+
+Then verify-runner (independent) + one reviewer pass + GATE 2 (Max merges).

--- a/docs/superpowers/specs/2026-07-14-demo-scenes-design.md
+++ b/docs/superpowers/specs/2026-07-14-demo-scenes-design.md
@@ -1,0 +1,110 @@
+# Demo scenes — recordable animation stage for product videos
+
+**Date:** 2026-07-14 · **Branch:** `feature/demo-scenes` (off main @ `e5bd50728`) · **Status:** approved (Max, in-chat: "can you build SVG animations like chatbox convo and calendar booking notification using animated-list … and whatever UI animation you think would enhance the demo")
+
+## Purpose
+
+Max is producing demo videos. Screen capture stays the ground truth for the
+product wows (never-lies: animations must never fake the product), but
+stylized animated INSERTS compress the beats screen recording is bad at:
+off-screen notifications, invisible "connected" plumbing, stat payoffs,
+intros/outros, and X-post creatives (GENERATED-vs-CAPTURE rule: these read
+as clearly stylized, never as fake screenshots).
+
+Deliverable: full-viewport, loopable, brand-tokened scenes Max can screen-
+record at any resolution — hosted on a dev-only route, reusing the motion
+stack already on main.
+
+## Verified foundation (scouted on main — reuse, don't rebuild)
+
+- `components/ui/animated-list.tsx` (staggered spring list, looping)
+- `components/ui/magic/animated-beam.tsx` (ref-to-ref gradient beam)
+- `components/ui/magic/terminal.tsx` (+ `TypingAnimation`, `AnimatedSpan`)
+- `components/ui/number-ticker.tsx`
+- `components/landing/edit-by-chat-demo.tsx` (chat-phase pattern to adapt, not import)
+- `/brand/integrations/*.svg` (google-calendar, gmail, stripe, hubspot, …) + `/brand/models/*.svg` + the Seldon mark
+- `(dev)/motion-lab` conventions: `SF_MOTION_LAB=1` strict flag, `robots: { index:false, follow:false }`, route-level imports of `landing-theme.css` + `motion-tokens.css`, dark flip via `.lp-root[data-mode="record"]`
+- Tokens: cream `#F6F2EA` / card `#FFFDFA` / forest `#1F2B24`; dark bg `#14110D` / card `#1F1A15`; `--motion-*` durations/easings; every scene honors `prefers-reduced-motion`
+- `framer-motion` + `motion` both installed — new code uses `motion/react`
+
+## Route design
+
+`app/(dev)/demo-scenes/page.tsx` — index listing scene cards (name, one-line
+use, link) — and `app/(dev)/demo-scenes/[scene]/page.tsx` — ONE scene
+rendered full-viewport (100svh, no chrome except a small bottom-right
+control cluster that auto-hides: Restart · Loop on/off · Light/Dark).
+Same gating idiom as motion-lab: `SF_MOTION_LAB` strict check → 404 when
+off; `robots: { index: false, follow: false }`; route-level CSS imports
+(landing-theme.css + motion-tokens.css — the tsx-has-no-CSS-loader gotcha).
+Unknown `[scene]` → `notFound()`. Server page resolves the scene id from a
+static registry and renders the matching client component.
+
+Controls detail: "Restart" remounts the scene via a `key` bump; "Loop"
+persists in a query param (`?loop=1`) so a recording session can deep-link;
+mode flip toggles `data-mode="record"` on the stage root (reuses the
+existing token flip). Controls fade to opacity 0 after 3s idle (mousemove
+resets) so they never appear in a recording.
+
+## The seven scenes (`components/demo-scenes/*.tsx`, all "use client", all props-defaulted)
+
+1. **`booking-cascade`** — AnimatedList notification stack, product-toast
+   styled cards w/ vendored icons: "📅 New booking — Sarah M · Tue 2:30 PM"
+   (google-calendar.svg) → "SMS confirmation sent to Sarah" → "Contact added
+   to CRM" → "Review request queued for Wednesday". ~1.2s stagger, loop with
+   a clean 1.5s hold + fade-reset. THE money-loop B-roll.
+2. **`calendar-connected`** — two nodes (Seldon mark ↔ google-calendar.svg)
+   joined by AnimatedBeam; after the beam settles, a "Connected" pill pops
+   (spring scale), then a small booking-event card slides in beneath the
+   calendar node and a dot pulse travels the beam. Loop.
+3. **`grounded-chat`** — chat playback (adapt the EditByChatDemo phase
+   machine, chat panel only, bigger type for video): typing indicator →
+   customer: "Do you do Saturday appointments?" → agent grounded reply
+   ("Yes — we're open Saturday 9–2. Want me to book you in?") → customer:
+   "Yes, 10am" → agent booking-confirmation bubble w/ calendar chip. Loop
+   with hold.
+4. **`stat-payoff`** — one row, four NumberTickers with labels: 1 URL →
+   1 website · 1 AI chatbot · 1 CRM · 1 booking page; sub-line
+   "one booked job pays for it" in AnimatedShinyText. Loop = re-count.
+5. **`sms-phone`** — CSS-only phone frame (rounded slab, notch, status bar —
+   NO new dependency, ~60 LOC of divs) with an iMessage-style bubble
+   sliding in: "You're booked for Tue 2:30 PM with Zen Flow Hydration —
+   reply R to reschedule." Subtle haptic-style shake on arrival. Loop.
+6. **`live-confetti`** — "zen-flow-hydration.app.seldonframe.com is live."
+   headline + a ~48-particle CSS confetti burst (absolutely-positioned
+   spans, randomized via a seeded array module-side — NO Math.random in
+   render to keep SSR happy, NO canvas-confetti dep). Loop.
+7. **`docker-terminal`** — Terminal component: types
+   `docker compose up -d`, staggered success lines (pull → db → migrations
+   → "✔ SeldonFrame running on http://localhost:3000"), ends with a blinking
+   cursor. For the self-host/open-source video. Loop.
+
+Scene registry: `components/demo-scenes/registry.ts` — `{ id, title, blurb,
+Component }[]`, imported by both route files (single source of truth).
+
+## Constraints
+
+- **No new dependencies** (worktree junction; also keeps the page zero-cost).
+- Every scene: `prefers-reduced-motion` → settle to final frame instantly
+  (same idiom as existing components); SSR-safe (no window at module scope);
+  no `Math.random()`/`Date.now()` at render (hydration + lint).
+- Copy uses the real demo workspace vocabulary (Zen Flow Hydration) — reads
+  as product-true, styled as insert.
+- Nothing on public routes; no proxy/middleware changes; no flags added
+  (reuse `SF_MOTION_LAB`).
+
+## Tests
+
+- `tests/unit/demo-scenes/registry.spec.ts` — registry ids unique, kebab-case,
+  every entry has Component + title; index/`[scene]` resolve helpers return
+  null for unknown ids.
+- Scene components are motion-visual — covered by tsc + the motion-lab-style
+  eyeball (vision-verify optional post-deploy; primary consumer is Max
+  recording locally). No renderToString specs for framer components (matches
+  existing repo practice for magic/*).
+
+## Verification
+
+verify-runner (six checks; no migrations/deps/env). GATE 2 = Max. Post-merge:
+Max sets `SF_MOTION_LAB=1` locally (or it's already set from the motion-lab
+work), opens `/demo-scenes`, records. Post-deploy nothing is publicly
+reachable without the flag.

--- a/packages/crm/src/app/(dev)/demo-scenes/[scene]/page.tsx
+++ b/packages/crm/src/app/(dev)/demo-scenes/[scene]/page.tsx
@@ -1,0 +1,41 @@
+// packages/crm/src/app/(dev)/demo-scenes/[scene]/page.tsx
+//
+// DEV-ONLY single-scene stage, rendered full-viewport for screen recording.
+// Same gating idiom as /motion-lab (SF_MOTION_LAB=1 strict-"1", reused from
+// motion-lab/gate.ts) + noindex/nofollow. Unknown [scene] -> notFound().
+// The server page only resolves the scene id from the static registry;
+// SceneStage (client) owns all the interactive stage chrome.
+
+import "@/components/landing/landing-theme.css";
+import "@/components/motion/motion-tokens.css";
+
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { isMotionLabOn } from "../../motion-lab/gate";
+import { getDemoScene } from "@/components/demo-scenes/registry";
+import { SceneStage } from "@/components/demo-scenes/scene-stage";
+
+export const metadata: Metadata = {
+  title: "Demo scene (dev only)",
+  robots: { index: false, follow: false },
+};
+
+export default async function DemoScenePage({
+  params,
+}: {
+  params: Promise<{ scene: string }>;
+}) {
+  if (!isMotionLabOn({ SF_MOTION_LAB: process.env.SF_MOTION_LAB })) notFound();
+
+  const { scene: sceneId } = await params;
+  const scene = getDemoScene(sceneId);
+  if (!scene) notFound();
+
+  return (
+    <Suspense fallback={null}>
+      <SceneStage scene={scene} />
+    </Suspense>
+  );
+}

--- a/packages/crm/src/app/(dev)/demo-scenes/page.tsx
+++ b/packages/crm/src/app/(dev)/demo-scenes/page.tsx
@@ -1,0 +1,75 @@
+// packages/crm/src/app/(dev)/demo-scenes/page.tsx
+//
+// DEV-ONLY index of every recordable demo scene (spec
+// docs/superpowers/specs/2026-07-14-demo-scenes-design.md). Same gating
+// idiom as the sibling /motion-lab route: SF_MOTION_LAB=1 strict-"1"
+// (reused from motion-lab/gate.ts, not duplicated) -> 404s in prod unless
+// the flag is explicitly on; noindex/nofollow even when reachable.
+
+import "@/components/landing/landing-theme.css";
+import "@/components/motion/motion-tokens.css";
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+import { isMotionLabOn } from "../motion-lab/gate";
+import { DEMO_SCENES } from "@/components/demo-scenes/registry";
+
+export const metadata: Metadata = {
+  title: "Demo scenes (dev only)",
+  robots: { index: false, follow: false },
+};
+
+export default function DemoScenesIndexPage() {
+  if (!isMotionLabOn({ SF_MOTION_LAB: process.env.SF_MOTION_LAB })) notFound();
+
+  return (
+    <div
+      className="lp-root"
+      style={{
+        minHeight: "100vh",
+        background: "var(--lp-bg)",
+        color: "var(--lp-ink)",
+        padding: 32,
+      }}
+    >
+      <header style={{ marginBottom: 24 }}>
+        <h1 style={{ margin: 0, fontSize: 24 }}>Demo scenes (dev only)</h1>
+        <p style={{ margin: "8px 0 0", fontSize: 14, color: "var(--lp-body)" }}>
+          Full-viewport, loopable, brand-tokened scenes for product video B-roll.
+          Not indexed, not linked from marketing.
+        </p>
+      </header>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gap: 16,
+        }}
+      >
+        {DEMO_SCENES.map((scene) => (
+          <Link
+            key={scene.id}
+            href={`/demo-scenes/${scene.id}`}
+            style={{
+              display: "block",
+              padding: 16,
+              borderRadius: 12,
+              border: "1px solid var(--lp-border, rgba(34,29,23,.14))",
+              background: "var(--lp-card)",
+              color: "var(--lp-ink)",
+              textDecoration: "none",
+            }}
+          >
+            <h2 style={{ margin: 0, fontSize: 16 }}>{scene.title}</h2>
+            <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--lp-body)" }}>
+              {scene.blurb}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/booking-cascade.tsx
+++ b/packages/crm/src/components/demo-scenes/booking-cascade.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/booking-cascade.tsx
+//
+// Scene 1 (spec): the money-loop B-roll — a staggered stack of product-toast
+// cards showing the automation cascade a real booking triggers. Built on the
+// existing AnimatedList (components/ui/animated-list.tsx), which has no
+// internal reduced-motion guard (per the motion-lab comment on
+// AnimatedListDemo) — so this scene owns its own reduced-motion branch that
+// renders every card statically, and owns its own loop (AnimatedList itself
+// only plays forward once; the loop is a hold-then-remount cycle here).
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+import { AnimatedList } from "@/components/ui/animated-list";
+
+interface CascadeItem {
+  id: string;
+  icon?: string;
+  emoji?: string;
+  text: string;
+}
+
+const ITEMS: CascadeItem[] = [
+  {
+    id: "booking",
+    icon: "/brand/integrations/google-calendar.svg",
+    text: "New booking — Sarah M · Tue 2:30 PM",
+  },
+  {
+    id: "sms",
+    icon: "/brand/integrations/twilio.svg",
+    text: "SMS confirmation sent to Sarah",
+  },
+  {
+    id: "crm",
+    icon: "/brand/seldon-mark.svg",
+    text: "Contact added to CRM",
+  },
+  {
+    id: "review",
+    emoji: "⭐",
+    text: "Review request queued for Wednesday",
+  },
+];
+
+const STAGGER_MS = 1200;
+const HOLD_MS = 1500;
+const FADE_MS = 400;
+
+function CascadeCard({ item }: { item: CascadeItem }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        width: "min(88vw, 460px)",
+        padding: "14px 18px",
+        borderRadius: 14,
+        background: "var(--lp-card)",
+        border: "1px solid var(--lp-border, rgba(34,29,23,.12))",
+        boxShadow: "0 12px 32px rgba(20,17,13,.12)",
+      }}
+    >
+      <span
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 32,
+          height: 32,
+          borderRadius: 9,
+          background: "var(--lp-bg-alt, rgba(34,29,23,.06))",
+          flexShrink: 0,
+          fontSize: 16,
+        }}
+      >
+        {item.icon ? (
+          // eslint-disable-next-line @next/next/no-img-element -- static vendored brand icon
+          <img src={item.icon} alt="" width={18} height={18} />
+        ) : (
+          item.emoji
+        )}
+      </span>
+      <span style={{ fontSize: "clamp(14px, 1.4vw, 18px)", color: "var(--lp-ink)" }}>
+        {item.text}
+      </span>
+    </div>
+  );
+}
+
+export function BookingCascadeScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [cycle, setCycle] = useState(0);
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (reducedMotion || !loop) return undefined;
+    const totalMs = STAGGER_MS * ITEMS.length + HOLD_MS;
+    const hideTimer = setTimeout(() => setVisible(false), totalMs);
+    const resetTimer = setTimeout(() => {
+      setCycle((c) => c + 1);
+      setVisible(true);
+    }, totalMs + FADE_MS);
+    return () => {
+      clearTimeout(hideTimer);
+      clearTimeout(resetTimer);
+    };
+  }, [cycle, reducedMotion, loop]);
+
+  if (reducedMotion) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 16 }}>
+        {ITEMS.map((item) => (
+          <CascadeCard key={item.id} item={item} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ opacity: visible ? 1 : 0, transition: `opacity ${FADE_MS}ms ease` }}>
+      <AnimatedList key={cycle} delay={STAGGER_MS} className="w-full">
+        {ITEMS.map((item) => (
+          <CascadeCard key={item.id} item={item} />
+        ))}
+      </AnimatedList>
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/calendar-connected.tsx
+++ b/packages/crm/src/components/demo-scenes/calendar-connected.tsx
@@ -49,11 +49,21 @@ export function CalendarConnectedScene({ loop = true }: { loop?: boolean }) {
   const toRef = useRef<HTMLDivElement>(null);
 
   const [cycle, setCycle] = useState(0);
-  const [connected, setConnected] = useState(reducedMotion);
-  const [cardIn, setCardIn] = useState(reducedMotion);
+  const [connected, setConnected] = useState(false);
+  const [cardIn, setCardIn] = useState(false);
 
+  // reducedMotion resolves asynchronously (motion's useReducedMotion reads
+  // matchMedia in an effect, after hydration) — so it must be re-checked on
+  // every dependency change, not just baked into a useState initializer
+  // that only runs once at mount. Without this, a user whose OS preference
+  // flips true after mount would be stuck on the bare beam forever (state
+  // seeded false, and the early return below never sets it true).
   useEffect(() => {
-    if (reducedMotion) return undefined;
+    if (reducedMotion) {
+      setConnected(true);
+      setCardIn(true);
+      return undefined;
+    }
     const t1 = setTimeout(() => setConnected(true), CONNECT_AT_MS);
     const t2 = setTimeout(() => setCardIn(true), CARD_AT_MS);
     let t3: ReturnType<typeof setTimeout> | undefined;

--- a/packages/crm/src/components/demo-scenes/calendar-connected.tsx
+++ b/packages/crm/src/components/demo-scenes/calendar-connected.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/calendar-connected.tsx
+//
+// Scene 2 (spec): the invisible-plumbing beat — Seldon <-> Google Calendar
+// joined by AnimatedBeam, a spring-pop "Connected" pill, a booking-event
+// card sliding in beneath the calendar node, and a pulse dot travelling the
+// beam. AnimatedBeam already has a complete reduced-motion branch
+// (forceStatic), so this scene forwards useReducedMotion into it and skips
+// its own extra motion (pulse dot, pill spring) in that branch too.
+
+import { useEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+
+import { AnimatedBeam } from "@/components/ui/magic/animated-beam";
+
+const CYCLE_MS = 6000;
+const CONNECT_AT_MS = 1400;
+const CARD_AT_MS = 1900;
+
+function Node({ src, label }: { src: string; label: string }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 8 }}>
+      <div
+        style={{
+          width: 64,
+          height: 64,
+          borderRadius: "50%",
+          background: "var(--lp-card)",
+          border: "1px solid var(--lp-border, rgba(34,29,23,.14))",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: "0 8px 24px rgba(20,17,13,.10)",
+        }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element -- static vendored brand icon */}
+        <img src={src} alt="" width={32} height={32} />
+      </div>
+      <span style={{ fontSize: 13, color: "var(--lp-body)" }}>{label}</span>
+    </div>
+  );
+}
+
+export function CalendarConnectedScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fromRef = useRef<HTMLDivElement>(null);
+  const toRef = useRef<HTMLDivElement>(null);
+
+  const [cycle, setCycle] = useState(0);
+  const [connected, setConnected] = useState(reducedMotion);
+  const [cardIn, setCardIn] = useState(reducedMotion);
+
+  useEffect(() => {
+    if (reducedMotion) return undefined;
+    const t1 = setTimeout(() => setConnected(true), CONNECT_AT_MS);
+    const t2 = setTimeout(() => setCardIn(true), CARD_AT_MS);
+    let t3: ReturnType<typeof setTimeout> | undefined;
+    if (loop) {
+      t3 = setTimeout(() => {
+        setConnected(false);
+        setCardIn(false);
+        setCycle((c) => c + 1);
+      }, CYCLE_MS);
+    }
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      if (t3) clearTimeout(t3);
+    };
+  }, [cycle, reducedMotion, loop]);
+
+  return (
+    <div
+      key={cycle}
+      style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 40 }}
+    >
+      <div
+        ref={containerRef}
+        style={{
+          position: "relative",
+          width: "min(70vw, 360px)",
+          height: 100,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <div ref={fromRef}>
+          <Node src="/brand/seldon-mark.svg" label="Seldon" />
+        </div>
+        <div ref={toRef}>
+          <Node src="/brand/integrations/google-calendar.svg" label="Google Calendar" />
+        </div>
+        <AnimatedBeam
+          containerRef={containerRef}
+          fromRef={fromRef}
+          toRef={toRef}
+          forceStatic={reducedMotion}
+        />
+        {!reducedMotion && connected && (
+          <motion.span
+            aria-hidden
+            initial={{ left: "10%" }}
+            animate={{ left: "90%" }}
+            transition={{ duration: 1.6, repeat: Infinity, ease: "linear" }}
+            style={{
+              position: "absolute",
+              top: "50%",
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: "var(--lp-accent)",
+              transform: "translate(-50%, -50%)",
+            }}
+          />
+        )}
+      </div>
+
+      {connected && (
+        <motion.div
+          initial={reducedMotion ? false : { opacity: 0, scale: 0.6 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ type: "spring", stiffness: 320, damping: 22 }}
+          style={{
+            padding: "6px 14px",
+            borderRadius: 999,
+            fontSize: 13,
+            fontWeight: 600,
+            background: "var(--lp-accent-soft, rgba(31,43,36,.09))",
+            color: "var(--lp-accent)",
+          }}
+        >
+          ✓ Connected
+        </motion.div>
+      )}
+
+      {cardIn && (
+        <motion.div
+          initial={reducedMotion ? false : { opacity: 0, y: -12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            padding: "12px 18px",
+            borderRadius: 12,
+            background: "var(--lp-card)",
+            border: "1px solid var(--lp-border, rgba(34,29,23,.12))",
+            fontSize: 14,
+            color: "var(--lp-ink)",
+          }}
+        >
+          📅 Tue 2:30 PM — Sarah M synced to Google Calendar
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/docker-terminal.tsx
+++ b/packages/crm/src/components/demo-scenes/docker-terminal.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/docker-terminal.tsx
+//
+// Scene 7 (spec): for the self-host/open-source video. Reuses the vendored
+// Terminal + TypingAnimation + AnimatedSpan trio exactly as the /motion-lab
+// TerminalDemo does — Terminal's own `sequence` prop already staggers the
+// lines (each AnimatedSpan waits for the previous item to finish before it
+// starts), so this scene just supplies the copy and forwards
+// forceStatic={reducedMotion} into every child, plus a blinking cursor at
+// the end.
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+import { Terminal, TypingAnimation, AnimatedSpan } from "@/components/ui/magic/terminal";
+
+const CYCLE_MS = 7000;
+
+export function DockerTerminalScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion || !loop) return undefined;
+    const timer = setInterval(() => setCycle((c) => c + 1), CYCLE_MS);
+    return () => clearInterval(timer);
+  }, [reducedMotion, loop]);
+
+  return (
+    <div style={{ width: "min(90vw, 640px)" }}>
+      <style>{`
+        @keyframes demo-scene-cursor-blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+        @media (prefers-reduced-motion: reduce) {
+          .demo-scene-cursor { animation: none !important; opacity: 1 !important; }
+        }
+      `}</style>
+      <Terminal key={cycle} className="w-full text-[15px]">
+        <TypingAnimation forceStatic={reducedMotion} className="text-[15px]">
+          $ docker compose up -d
+        </TypingAnimation>
+        <AnimatedSpan forceStatic={reducedMotion} delay={600} className="text-[15px] text-emerald-400">
+          ✔ Pulling seldonframe/seldonframe:latest
+        </AnimatedSpan>
+        <AnimatedSpan forceStatic={reducedMotion} delay={900} className="text-[15px] text-emerald-400">
+          ✔ Starting Postgres
+        </AnimatedSpan>
+        <AnimatedSpan forceStatic={reducedMotion} delay={900} className="text-[15px] text-emerald-400">
+          ✔ Running migrations
+        </AnimatedSpan>
+        <AnimatedSpan forceStatic={reducedMotion} delay={900} className="text-[15px] font-semibold text-emerald-400">
+          ✔ SeldonFrame running on http://localhost:3000
+        </AnimatedSpan>
+        <div style={{ display: "flex", alignItems: "center", gap: 2, marginTop: 4 }}>
+          <span className="text-[15px]" style={{ color: "var(--lp-body, #9A9183)" }}>
+            $
+          </span>
+          <span
+            className="demo-scene-cursor"
+            style={{
+              display: "inline-block",
+              width: 8,
+              height: 16,
+              background: "var(--lp-body, #9A9183)",
+              animation: reducedMotion ? "none" : "demo-scene-cursor-blink 1s step-end infinite",
+            }}
+          />
+        </div>
+      </Terminal>
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/grounded-chat.tsx
+++ b/packages/crm/src/components/demo-scenes/grounded-chat.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/grounded-chat.tsx
+//
+// Scene 3 (spec): a chat playback proving the "never-lies" grounded reply +
+// booking confirmation loop. Adapts the phase-machine idiom from
+// components/landing/edit-by-chat-demo.tsx (a `step` counter driving a
+// setTimeout chain) rather than importing that component directly — this
+// scene is chat-panel only, full-viewport, bigger type for 1080p video.
+// Bubbles: customer = light card, agent = forest bubble.
+
+import { useEffect, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+
+const EASE = [0.22, 1, 0.36, 1] as const;
+
+type Step =
+  | { kind: "typing-customer" }
+  | { kind: "msg-customer"; text: string }
+  | { kind: "typing-agent" }
+  | { kind: "msg-agent"; text: string }
+  | { kind: "confirm"; text: string }
+  | { kind: "hold" };
+
+const STEPS: { step: Step; ms: number }[] = [
+  { step: { kind: "typing-customer" }, ms: 900 },
+  { step: { kind: "msg-customer", text: "Do you do Saturday appointments?" }, ms: 700 },
+  { step: { kind: "typing-agent" }, ms: 900 },
+  {
+    step: { kind: "msg-agent", text: "Yes — we're open Saturday 9–2. Want me to book you in?" },
+    ms: 1500,
+  },
+  { step: { kind: "typing-customer" }, ms: 700 },
+  { step: { kind: "msg-customer", text: "Yes, 10am" }, ms: 600 },
+  { step: { kind: "typing-agent" }, ms: 800 },
+  { step: { kind: "confirm", text: "Booked — Saturday 10:00 AM. See you then!" }, ms: 2600 },
+];
+
+function TypingDots() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 5,
+        padding: "14px 16px",
+        borderRadius: 16,
+        borderBottomLeftRadius: 4,
+        background: "var(--lp-card)",
+        border: "1px solid var(--lp-border, rgba(34,29,23,.12))",
+        width: "fit-content",
+      }}
+    >
+      {[0, 1, 2].map((dot) => (
+        <span
+          key={dot}
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            background: "var(--lp-faint)",
+            animation: "demo-scene-typing-dot 1s ease-in-out infinite",
+            animationDelay: `${dot * 0.15}s`,
+          }}
+        />
+      ))}
+      <style>{`@keyframes demo-scene-typing-dot { 0%, 60%, 100% { opacity: .3; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }`}</style>
+    </div>
+  );
+}
+
+function Bubble({ from, children }: { from: "customer" | "agent"; children: React.ReactNode }) {
+  const isAgent = from === "agent";
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, ease: EASE }}
+      style={{
+        alignSelf: isAgent ? "flex-start" : "flex-end",
+        maxWidth: "min(80vw, 520px)",
+        padding: "16px 20px",
+        borderRadius: 18,
+        borderBottomLeftRadius: isAgent ? 4 : 18,
+        borderBottomRightRadius: isAgent ? 18 : 4,
+        background: isAgent ? "var(--lp-accent)" : "var(--lp-card)",
+        color: isAgent ? "var(--lp-on-accent, #F6F2EA)" : "var(--lp-ink)",
+        border: isAgent ? "none" : "1px solid var(--lp-border, rgba(34,29,23,.12))",
+        fontSize: "clamp(16px, 1.8vw, 22px)",
+        lineHeight: 1.4,
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+const CALENDAR_CHIP = (
+  <span
+    style={{
+      display: "inline-flex",
+      alignItems: "center",
+      gap: 6,
+      marginTop: 10,
+      padding: "6px 12px",
+      borderRadius: 999,
+      background: "rgba(246,242,234,.16)",
+      fontSize: "0.7em",
+      fontWeight: 600,
+    }}
+  >
+    {/* eslint-disable-next-line @next/next/no-img-element -- static vendored brand icon */}
+    <img src="/brand/integrations/google-calendar.svg" alt="" width={14} height={14} />
+    Sat, 10:00 AM
+  </span>
+);
+
+export function GroundedChatScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [index, setIndex] = useState(0);
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion) return undefined;
+    if (index >= STEPS.length) {
+      if (!loop) return undefined;
+      const resetTimer = setTimeout(() => {
+        setIndex(0);
+        setCycle((c) => c + 1);
+      }, 300);
+      return () => clearTimeout(resetTimer);
+    }
+    const timer = setTimeout(() => setIndex((n) => n + 1), STEPS[index].ms);
+    return () => clearTimeout(timer);
+  }, [index, reducedMotion, loop]);
+
+  const visible = reducedMotion ? STEPS.map((s) => s.step) : STEPS.slice(0, index).map((s) => s.step);
+  const current = reducedMotion ? null : index < STEPS.length ? STEPS[index].step : null;
+
+  return (
+    <div
+      key={cycle}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        width: "min(90vw, 560px)",
+        padding: 24,
+      }}
+    >
+      {visible
+        .filter((s) => s.kind === "msg-customer" || s.kind === "msg-agent" || s.kind === "confirm")
+        .map((s, i) => {
+          if (s.kind === "msg-customer") return <Bubble key={`c-${i}`} from="customer">{s.text}</Bubble>;
+          if (s.kind === "msg-agent") return <Bubble key={`a-${i}`} from="agent">{s.text}</Bubble>;
+          return (
+            <Bubble key={`x-${i}`} from="agent">
+              {s.text}
+              <br />
+              {CALENDAR_CHIP}
+            </Bubble>
+          );
+        })}
+      {!reducedMotion && current?.kind === "typing-customer" && (
+        <div style={{ alignSelf: "flex-end" }}>
+          <TypingDots />
+        </div>
+      )}
+      {!reducedMotion && current?.kind === "typing-agent" && (
+        <div style={{ alignSelf: "flex-start" }}>
+          <TypingDots />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/live-confetti.tsx
+++ b/packages/crm/src/components/demo-scenes/live-confetti.tsx
@@ -29,14 +29,20 @@ interface Particle {
 }
 
 // Deterministic — computed once at module load from index math only, so
-// this is safe to reuse verbatim on the server and the client.
+// this is safe to reuse verbatim on the server and the client. The trig
+// results are rounded to 2 decimals: Math.cos/sin are NOT guaranteed
+// bit-identical across JS engines (Node vs browser differ in the last ulp),
+// and an unrounded value serialized into the --tx/--ty style strings caused
+// a real hydration mismatch at the 15th decimal in dev.
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
 const PARTICLES: Particle[] = Array.from({ length: PARTICLE_COUNT }, (_, i) => {
   const angleRad = ((i * GOLDEN_ANGLE) % 360) * (Math.PI / 180);
   const distance = 18 + ((i * 53) % 55); // 18-73
   return {
     id: i,
-    txVw: Math.cos(angleRad) * distance * 0.55,
-    tyVh: Math.sin(angleRad) * distance * 0.35 + 22, // downward bias, confetti falls
+    txVw: round2(Math.cos(angleRad) * distance * 0.55),
+    tyVh: round2(Math.sin(angleRad) * distance * 0.35 + 22), // downward bias, confetti falls
     rotateDeg: (i * 47) % 360,
     delayMs: (i % 12) * 35,
     sizePx: 6 + (i % 4) * 2,

--- a/packages/crm/src/components/demo-scenes/live-confetti.tsx
+++ b/packages/crm/src/components/demo-scenes/live-confetti.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/live-confetti.tsx
+//
+// Scene 6 (spec): "<slug>.app.seldonframe.com is live." headline + a
+// ~48-particle CSS confetti burst. Particle transforms come from a
+// module-level deterministic formula (golden-angle spread + index-derived
+// distance/delay/size/color) — NOT Math.random() — so server and client
+// render the identical particle set and there's no hydration mismatch, and
+// no canvas-confetti dependency.
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+const HEADLINE = "zen-flow-hydration.app.seldonframe.com is live.";
+
+const PARTICLE_COUNT = 48;
+const COLORS = ["#1F2B24", "#F6F2EA", "#D9C9A3", "#7C8B7A", "#B7AE9C"];
+const GOLDEN_ANGLE = 137.508;
+
+interface Particle {
+  id: number;
+  txVw: number;
+  tyVh: number;
+  rotateDeg: number;
+  delayMs: number;
+  sizePx: number;
+  color: string;
+}
+
+// Deterministic — computed once at module load from index math only, so
+// this is safe to reuse verbatim on the server and the client.
+const PARTICLES: Particle[] = Array.from({ length: PARTICLE_COUNT }, (_, i) => {
+  const angleRad = ((i * GOLDEN_ANGLE) % 360) * (Math.PI / 180);
+  const distance = 18 + ((i * 53) % 55); // 18-73
+  return {
+    id: i,
+    txVw: Math.cos(angleRad) * distance * 0.55,
+    tyVh: Math.sin(angleRad) * distance * 0.35 + 22, // downward bias, confetti falls
+    rotateDeg: (i * 47) % 360,
+    delayMs: (i % 12) * 35,
+    sizePx: 6 + (i % 4) * 2,
+    color: COLORS[i % COLORS.length],
+  };
+});
+
+const CYCLE_MS = 4200;
+
+export function LiveConfettiScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion || !loop) return undefined;
+    const timer = setInterval(() => setCycle((c) => c + 1), CYCLE_MS);
+    return () => clearInterval(timer);
+  }, [reducedMotion, loop]);
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: "100%",
+        height: "100%",
+      }}
+    >
+      <style>{`
+        @keyframes demo-scene-confetti-burst {
+          0% { transform: translate(0, 0) rotate(0deg); opacity: 1; }
+          100% { transform: translate(var(--tx), var(--ty)) rotate(var(--rot)); opacity: 0; }
+        }
+      `}</style>
+
+      {!reducedMotion && (
+        <div
+          key={cycle}
+          aria-hidden
+          style={{ position: "absolute", inset: 0, pointerEvents: "none" }}
+        >
+          {PARTICLES.map((p) => (
+            <span
+              key={p.id}
+              style={
+                {
+                  position: "absolute",
+                  top: "50%",
+                  left: "50%",
+                  width: p.sizePx,
+                  height: p.sizePx * 0.4,
+                  background: p.color,
+                  borderRadius: 2,
+                  "--tx": `${p.txVw}vw`,
+                  "--ty": `${p.tyVh}vh`,
+                  "--rot": `${p.rotateDeg}deg`,
+                  animation: `demo-scene-confetti-burst 1400ms ease-out ${p.delayMs}ms both`,
+                } as React.CSSProperties
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      <h1
+        style={{
+          margin: 0,
+          textAlign: "center",
+          fontSize: "clamp(26px, 4vw, 46px)",
+          fontWeight: 700,
+          color: "var(--lp-ink)",
+          padding: "0 24px",
+        }}
+      >
+        {HEADLINE}
+      </h1>
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/registry.ts
+++ b/packages/crm/src/components/demo-scenes/registry.ts
@@ -1,0 +1,30 @@
+// packages/crm/src/components/demo-scenes/registry.ts
+//
+// Static metadata for every demo scene (spec "The seven scenes"). This file
+// stays server-safe (no "use client", no framer-motion import) so both the
+// index page (server component) and the registry spec (node:test, no DOM)
+// can import it directly. Component lookup — which DOES need "use client"
+// because the scenes are framer-motion islands — lives in the sibling
+// scene-components.tsx map, keyed by the same ids.
+//
+// Registry grows scene-by-scene across the build tasks; the "component map
+// covers exactly the registry ids" invariant (registry.spec.ts) keeps the
+// two files honest at every commit, not just the final one.
+
+export interface DemoSceneMeta {
+  id: string;
+  title: string;
+  blurb: string;
+}
+
+export const DEMO_SCENES: DemoSceneMeta[] = [
+  {
+    id: "stat-payoff",
+    title: "Stat payoff",
+    blurb: "One URL, four counted wins, and the pricing anchor line.",
+  },
+];
+
+export function getDemoScene(id: string): DemoSceneMeta | null {
+  return DEMO_SCENES.find((scene) => scene.id === id) ?? null;
+}

--- a/packages/crm/src/components/demo-scenes/registry.ts
+++ b/packages/crm/src/components/demo-scenes/registry.ts
@@ -19,6 +19,16 @@ export interface DemoSceneMeta {
 
 export const DEMO_SCENES: DemoSceneMeta[] = [
   {
+    id: "booking-cascade",
+    title: "Booking cascade",
+    blurb: "The money-loop B-roll: booking → SMS → CRM → review, staggered.",
+  },
+  {
+    id: "calendar-connected",
+    title: "Calendar connected",
+    blurb: "Seldon and Google Calendar joined by a beam, then a booking synced.",
+  },
+  {
     id: "stat-payoff",
     title: "Stat payoff",
     blurb: "One URL, four counted wins, and the pricing anchor line.",

--- a/packages/crm/src/components/demo-scenes/registry.ts
+++ b/packages/crm/src/components/demo-scenes/registry.ts
@@ -33,6 +33,26 @@ export const DEMO_SCENES: DemoSceneMeta[] = [
     title: "Stat payoff",
     blurb: "One URL, four counted wins, and the pricing anchor line.",
   },
+  {
+    id: "grounded-chat",
+    title: "Grounded chat",
+    blurb: "A grounded reply and a real booking confirmation, played back.",
+  },
+  {
+    id: "sms-phone",
+    title: "SMS phone",
+    blurb: "A booking-confirmation text arriving on a CSS-only phone frame.",
+  },
+  {
+    id: "live-confetti",
+    title: "Live confetti",
+    blurb: "The workspace-is-live headline with a confetti burst.",
+  },
+  {
+    id: "docker-terminal",
+    title: "Docker terminal",
+    blurb: "docker compose up -d, staggered to SeldonFrame running locally.",
+  },
 ];
 
 export function getDemoScene(id: string): DemoSceneMeta | null {

--- a/packages/crm/src/components/demo-scenes/scene-components.tsx
+++ b/packages/crm/src/components/demo-scenes/scene-components.tsx
@@ -14,6 +14,10 @@ import { DEMO_SCENES } from "./registry";
 import { StatPayoffScene } from "./stat-payoff";
 import { BookingCascadeScene } from "./booking-cascade";
 import { CalendarConnectedScene } from "./calendar-connected";
+import { GroundedChatScene } from "./grounded-chat";
+import { SmsPhoneScene } from "./sms-phone";
+import { LiveConfettiScene } from "./live-confetti";
+import { DockerTerminalScene } from "./docker-terminal";
 
 // Every scene component accepts the same `loop` prop — whether it re-plays
 // once it reaches its resting frame, or holds there (see scene-stage.tsx's
@@ -24,6 +28,10 @@ export const SCENE_COMPONENTS: Record<string, DemoSceneComponent> = {
   "booking-cascade": BookingCascadeScene,
   "calendar-connected": CalendarConnectedScene,
   "stat-payoff": StatPayoffScene,
+  "grounded-chat": GroundedChatScene,
+  "sms-phone": SmsPhoneScene,
+  "live-confetti": LiveConfettiScene,
+  "docker-terminal": DockerTerminalScene,
 };
 
 export function getSceneComponent(id: string): DemoSceneComponent | null {

--- a/packages/crm/src/components/demo-scenes/scene-components.tsx
+++ b/packages/crm/src/components/demo-scenes/scene-components.tsx
@@ -12,12 +12,21 @@ import type { ComponentType } from "react";
 
 import { DEMO_SCENES } from "./registry";
 import { StatPayoffScene } from "./stat-payoff";
+import { BookingCascadeScene } from "./booking-cascade";
+import { CalendarConnectedScene } from "./calendar-connected";
 
-export const SCENE_COMPONENTS: Record<string, ComponentType> = {
+// Every scene component accepts the same `loop` prop — whether it re-plays
+// once it reaches its resting frame, or holds there (see scene-stage.tsx's
+// ?loop=1 control).
+export type DemoSceneComponent = ComponentType<{ loop?: boolean }>;
+
+export const SCENE_COMPONENTS: Record<string, DemoSceneComponent> = {
+  "booking-cascade": BookingCascadeScene,
+  "calendar-connected": CalendarConnectedScene,
   "stat-payoff": StatPayoffScene,
 };
 
-export function getSceneComponent(id: string): ComponentType | null {
+export function getSceneComponent(id: string): DemoSceneComponent | null {
   return SCENE_COMPONENTS[id] ?? null;
 }
 

--- a/packages/crm/src/components/demo-scenes/scene-components.tsx
+++ b/packages/crm/src/components/demo-scenes/scene-components.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/scene-components.tsx
+//
+// Client-side component map, keyed by the same ids as registry.ts's
+// DEMO_SCENES. Split out from the registry so registry.ts stays importable
+// under node:test (no framer-motion / "use client" island in that module
+// graph). registry.spec.ts asserts this map's key set is EXACTLY the
+// registry's id set — no orphan scenes, no unregistered components.
+
+import type { ComponentType } from "react";
+
+import { DEMO_SCENES } from "./registry";
+import { StatPayoffScene } from "./stat-payoff";
+
+export const SCENE_COMPONENTS: Record<string, ComponentType> = {
+  "stat-payoff": StatPayoffScene,
+};
+
+export function getSceneComponent(id: string): ComponentType | null {
+  return SCENE_COMPONENTS[id] ?? null;
+}
+
+// Dev-time invariant (not a test — those live in registry.spec.ts): every
+// registry id must resolve to a component and vice versa.
+if (process.env.NODE_ENV !== "production") {
+  const registryIds = new Set(DEMO_SCENES.map((scene) => scene.id));
+  const mapIds = new Set(Object.keys(SCENE_COMPONENTS));
+  for (const id of registryIds) {
+    if (!mapIds.has(id)) {
+      // eslint-disable-next-line no-console -- dev-only sanity guard
+      console.warn(`[demo-scenes] registry id "${id}" has no component in SCENE_COMPONENTS`);
+    }
+  }
+}

--- a/packages/crm/src/components/demo-scenes/scene-stage.tsx
+++ b/packages/crm/src/components/demo-scenes/scene-stage.tsx
@@ -83,7 +83,7 @@ export function SceneStage({ scene }: { scene: DemoSceneMeta }) {
           justifyContent: "center",
         }}
       >
-        {Component ? <Component key={loop ? "loop" : "once"} /> : null}
+        {Component ? <Component loop={loop} /> : null}
       </div>
 
       <div

--- a/packages/crm/src/components/demo-scenes/scene-stage.tsx
+++ b/packages/crm/src/components/demo-scenes/scene-stage.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/scene-stage.tsx
+//
+// Full-viewport stage host for one demo scene (spec "Route design"). Reused
+// by app/(dev)/demo-scenes/[scene]/page.tsx. 100svh, token background via
+// .lp-root (the same landing-theme.css tokens motion-lab reuses), a small
+// bottom-right control cluster (Restart · Loop · Light/Dark) that fades to
+// opacity 0 after 3s idle so it never leaks into a recording.
+//
+//  - Restart: bumps a `key` on the scene wrapper, remounting the scene so
+//    every internal phase machine / AnimatedList / etc. replays from zero.
+//  - Loop: persisted in the `?loop=1` query param (via router.replace, no
+//    scroll reset) so a recording session can deep-link a looping scene.
+//    Passed down to the scene component as a prop so scenes that only
+//    replay when instructed (e.g. counters) can honor it; scenes that loop
+//    unconditionally by construction (AnimatedList, Terminal) ignore it.
+//  - Light/Dark: toggles data-mode="record" on the .lp-root wrapper, the
+//    same dark-flip idiom the landing + motion-lab use.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { getSceneComponent } from "./scene-components";
+import type { DemoSceneMeta } from "./registry";
+
+const IDLE_HIDE_MS = 3000;
+
+export function SceneStage({ scene }: { scene: DemoSceneMeta }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const loop = searchParams.get("loop") === "1";
+
+  const [restartKey, setRestartKey] = useState(0);
+  const [dark, setDark] = useState(false);
+  const [controlsVisible, setControlsVisible] = useState(true);
+  const idleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetIdleTimer = useCallback(() => {
+    setControlsVisible(true);
+    if (idleTimer.current) clearTimeout(idleTimer.current);
+    idleTimer.current = setTimeout(() => setControlsVisible(false), IDLE_HIDE_MS);
+  }, []);
+
+  useEffect(() => {
+    resetIdleTimer();
+    return () => {
+      if (idleTimer.current) clearTimeout(idleTimer.current);
+    };
+  }, [resetIdleTimer]);
+
+  const toggleLoop = useCallback(() => {
+    const next = new URLSearchParams(searchParams.toString());
+    if (loop) next.delete("loop");
+    else next.set("loop", "1");
+    const query = next.toString();
+    router.replace(query ? `?${query}` : "?", { scroll: false });
+  }, [loop, router, searchParams]);
+
+  const Component = getSceneComponent(scene.id);
+
+  return (
+    <div
+      className="lp-root"
+      data-mode={dark ? "record" : undefined}
+      onMouseMove={resetIdleTimer}
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100svh",
+        background: "var(--lp-bg)",
+        color: "var(--lp-ink)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        key={restartKey}
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        {Component ? <Component key={loop ? "loop" : "once"} /> : null}
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          right: 16,
+          bottom: 16,
+          display: "flex",
+          gap: 8,
+          padding: "8px 10px",
+          borderRadius: 10,
+          background: "var(--lp-card)",
+          border: "1px solid var(--lp-border, rgba(34,29,23,.14))",
+          opacity: controlsVisible ? 1 : 0,
+          transition: "opacity 240ms ease",
+          pointerEvents: controlsVisible ? "auto" : "none",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setRestartKey((n) => n + 1)}
+          style={controlButtonStyle}
+        >
+          Restart
+        </button>
+        <button type="button" onClick={toggleLoop} style={controlButtonStyle}>
+          Loop {loop ? "on" : "off"}
+        </button>
+        <button type="button" onClick={() => setDark((d) => !d)} style={controlButtonStyle}>
+          {dark ? "Dark" : "Light"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const controlButtonStyle: React.CSSProperties = {
+  fontSize: 12,
+  padding: "6px 10px",
+  borderRadius: 6,
+  border: "1px solid var(--lp-border, rgba(34,29,23,.14))",
+  background: "transparent",
+  color: "var(--lp-ink)",
+  cursor: "pointer",
+};

--- a/packages/crm/src/components/demo-scenes/sms-phone.tsx
+++ b/packages/crm/src/components/demo-scenes/sms-phone.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/sms-phone.tsx
+//
+// Scene 5 (spec): a pure-CSS phone frame (rounded slab, notch, status bar —
+// no new dependency, ~60 LOC of divs) with an iMessage-style bubble sliding
+// in, plus a subtle haptic-style shake on arrival. No framer-motion needed
+// for the frame itself; the bubble entrance + shake are plain CSS
+// @keyframes gated by prefers-reduced-motion (same idiom motion-tokens.css
+// uses: the reduced-motion media query zeroes durations, it doesn't try to
+// remove the animation property).
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+const MESSAGE =
+  "You're booked for Tue 2:30 PM with Zen Flow Hydration — reply R to reschedule.";
+
+const CYCLE_MS = 4500;
+
+export function SmsPhoneScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion || !loop) return undefined;
+    const timer = setInterval(() => setCycle((c) => c + 1), CYCLE_MS);
+    return () => clearInterval(timer);
+  }, [reducedMotion, loop]);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+      }}
+    >
+      <style>{`
+        @keyframes demo-scene-sms-slide-in {
+          0% { opacity: 0; transform: translateY(16px) scale(.96); }
+          100% { opacity: 1; transform: translateY(0) scale(1); }
+        }
+        @keyframes demo-scene-sms-shake {
+          0%, 100% { transform: translateX(0); }
+          20% { transform: translateX(-3px); }
+          40% { transform: translateX(3px); }
+          60% { transform: translateX(-2px); }
+          80% { transform: translateX(2px); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .demo-scene-sms-bubble { animation: none !important; opacity: 1 !important; transform: none !important; }
+        }
+      `}</style>
+
+      {/* Phone slab */}
+      <div
+        style={{
+          width: 300,
+          height: 620,
+          borderRadius: 44,
+          background: "#14110D",
+          border: "10px solid #14110D",
+          boxShadow: "0 24px 60px rgba(0,0,0,.35)",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Notch */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: 130,
+            height: 26,
+            borderBottomLeftRadius: 16,
+            borderBottomRightRadius: 16,
+            background: "#14110D",
+            zIndex: 2,
+          }}
+        />
+        {/* Status bar */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            padding: "14px 22px 4px",
+            fontSize: 13,
+            fontWeight: 600,
+            color: "#F6F2EA",
+          }}
+        >
+          <span>9:41</span>
+          <span>📶 🔋</span>
+        </div>
+
+        {/* Screen body */}
+        <div
+          style={{
+            height: "100%",
+            background: "#221D17",
+            padding: "48px 16px 16px",
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "flex-end",
+          }}
+        >
+          <div
+            key={cycle}
+            className="demo-scene-sms-bubble"
+            style={{
+              maxWidth: "84%",
+              padding: "12px 16px",
+              borderRadius: 20,
+              borderBottomLeftRadius: 6,
+              background: "#3A3A3C",
+              color: "#F6F2EA",
+              fontSize: 15,
+              lineHeight: 1.4,
+              animation: reducedMotion
+                ? "none"
+                : "demo-scene-sms-slide-in 500ms ease-out both, demo-scene-sms-shake 400ms ease-in-out 520ms 1",
+            }}
+          >
+            {MESSAGE}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/demo-scenes/sms-phone.tsx
+++ b/packages/crm/src/components/demo-scenes/sms-phone.tsx
@@ -54,7 +54,9 @@ export function SmsPhoneScene({ loop = true }: { loop?: boolean }) {
         }
       `}</style>
 
-      {/* Phone slab */}
+      {/* Phone slab — flex column so the screen body gets exactly the space
+          below the status bar; a plain height:100% here overflowed the slab
+          by the status-bar height and clipped the bubble's last line. */}
       <div
         style={{
           width: 300,
@@ -65,6 +67,8 @@ export function SmsPhoneScene({ loop = true }: { loop?: boolean }) {
           boxShadow: "0 24px 60px rgba(0,0,0,.35)",
           position: "relative",
           overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
         {/* Notch */}
@@ -97,17 +101,33 @@ export function SmsPhoneScene({ loop = true }: { loop?: boolean }) {
           <span>📶 🔋</span>
         </div>
 
-        {/* Screen body */}
+        {/* Screen body — flex:1 fills the slab below the status bar exactly */}
         <div
           style={{
-            height: "100%",
+            flex: 1,
+            minHeight: 0,
             background: "#221D17",
-            padding: "48px 16px 16px",
+            padding: "20px 16px 40px",
             display: "flex",
             flexDirection: "column",
             justifyContent: "flex-end",
           }}
         >
+          {/* Sender header — reads like a real Messages thread on camera */}
+          <div
+            style={{
+              position: "absolute",
+              top: 52,
+              left: 0,
+              right: 0,
+              textAlign: "center",
+              fontSize: 12.5,
+              letterSpacing: "0.02em",
+              color: "rgba(246,242,234,.55)",
+            }}
+          >
+            Zen Flow Hydration
+          </div>
           <div
             key={cycle}
             className="demo-scene-sms-bubble"

--- a/packages/crm/src/components/demo-scenes/stat-payoff.tsx
+++ b/packages/crm/src/components/demo-scenes/stat-payoff.tsx
@@ -3,12 +3,42 @@
 // packages/crm/src/components/demo-scenes/stat-payoff.tsx
 //
 // Scene 4 (spec): one row, four counted wins, "one booked job pays for it"
-// as the anchor line. This is the trivial first cut that ships with the
-// route in Task 1 — just enough real content to prove /demo-scenes/[scene]
-// works end to end. Task 2 upgrades this file to the full NumberTicker +
-// AnimatedShinyText treatment.
+// as the anchor line in AnimatedShinyText. NumberTicker already has no
+// internal reduced-motion guard, so it always plays its spring count —
+// that's fine for a short single count-up, but for the loop we key-bump on
+// an interval to re-trigger it (only when not reduced-motion and loop is
+// on); reduced-motion renders the settled numbers directly instead of
+// mounting NumberTicker at all.
 
-export function StatPayoffScene() {
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "motion/react";
+
+import { NumberTicker } from "@/components/ui/number-ticker";
+import { AnimatedShinyText } from "@/components/ui/magic/animated-shiny-text";
+
+// Spec: "one row, four NumberTickers with labels: 1 URL → 1 website ·
+// 1 AI chatbot · 1 CRM · 1 booking page" — "1 URL" is the static lead-in,
+// the arrow introduces the four counted outcomes.
+const LEAD_IN = "1 URL";
+const STATS = [
+  { value: 1, label: "website" },
+  { value: 1, label: "AI chatbot" },
+  { value: 1, label: "CRM" },
+  { value: 1, label: "booking page" },
+] as const;
+
+const RECOUNT_MS = 5000;
+
+export function StatPayoffScene({ loop = true }: { loop?: boolean }) {
+  const reducedMotion = Boolean(useReducedMotion());
+  const [cycle, setCycle] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion || !loop) return undefined;
+    const timer = setInterval(() => setCycle((c) => c + 1), RECOUNT_MS);
+    return () => clearInterval(timer);
+  }, [reducedMotion, loop]);
+
   return (
     <div
       style={{
@@ -16,16 +46,71 @@ export function StatPayoffScene() {
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: 16,
+        gap: 28,
         textAlign: "center",
+        padding: 24,
       }}
     >
-      <h1 style={{ margin: 0, fontSize: "clamp(28px, 4vw, 48px)", color: "var(--lp-ink)" }}>
-        1 URL → 1 website · 1 AI chatbot · 1 CRM · 1 booking page
-      </h1>
-      <p style={{ margin: 0, fontSize: "clamp(16px, 2vw, 22px)", color: "var(--lp-body)" }}>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "baseline",
+          justifyContent: "center",
+          gap: "clamp(10px, 2vw, 24px)",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "clamp(28px, 4.4vw, 56px)",
+            fontWeight: 700,
+            color: "var(--lp-ink)",
+          }}
+        >
+          {LEAD_IN} →
+        </span>
+        {STATS.map((stat, index) => (
+          <div key={stat.label} style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+            {index > 0 && (
+              <span style={{ fontSize: "clamp(20px, 2.4vw, 32px)", color: "var(--lp-faint)" }}>
+                ·
+              </span>
+            )}
+            {reducedMotion ? (
+              <span
+                style={{
+                  fontSize: "clamp(28px, 4.4vw, 56px)",
+                  fontWeight: 700,
+                  color: "var(--lp-ink)",
+                }}
+              >
+                {stat.value}
+              </span>
+            ) : (
+              <NumberTicker
+                key={cycle}
+                value={stat.value}
+                style={{
+                  fontSize: "clamp(28px, 4.4vw, 56px)",
+                  fontWeight: 700,
+                  color: "var(--lp-ink)",
+                }}
+              />
+            )}
+            <span style={{ fontSize: "clamp(14px, 1.6vw, 20px)", color: "var(--lp-body)" }}>
+              {stat.label}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <AnimatedShinyText
+        base="var(--lp-body)"
+        shine="var(--lp-ink)"
+        className="text-[clamp(16px,2vw,22px)] font-semibold"
+      >
         one booked job pays for it
-      </p>
+      </AnimatedShinyText>
     </div>
   );
 }

--- a/packages/crm/src/components/demo-scenes/stat-payoff.tsx
+++ b/packages/crm/src/components/demo-scenes/stat-payoff.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+// packages/crm/src/components/demo-scenes/stat-payoff.tsx
+//
+// Scene 4 (spec): one row, four counted wins, "one booked job pays for it"
+// as the anchor line. This is the trivial first cut that ships with the
+// route in Task 1 — just enough real content to prove /demo-scenes/[scene]
+// works end to end. Task 2 upgrades this file to the full NumberTicker +
+// AnimatedShinyText treatment.
+
+export function StatPayoffScene() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 16,
+        textAlign: "center",
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: "clamp(28px, 4vw, 48px)", color: "var(--lp-ink)" }}>
+        1 URL → 1 website · 1 AI chatbot · 1 CRM · 1 booking page
+      </h1>
+      <p style={{ margin: 0, fontSize: "clamp(16px, 2vw, 22px)", color: "var(--lp-body)" }}>
+        one booked job pays for it
+      </p>
+    </div>
+  );
+}

--- a/packages/crm/tests/unit/demo-scenes/registry.spec.ts
+++ b/packages/crm/tests/unit/demo-scenes/registry.spec.ts
@@ -1,0 +1,78 @@
+// Tests for the demo-scenes registry (spec
+// docs/superpowers/specs/2026-07-14-demo-scenes-design.md, plan Task 1).
+//
+// Invariants:
+//   1. Every id is unique
+//   2. Every id is kebab-case
+//   3. Every entry has a non-empty title + blurb
+//   4. getDemoScene("nope") -> null
+//   5. getDemoScene(<real id>) -> the matching entry
+//   6. The component map (scene-components.tsx) covers EXACTLY the
+//      registry's id set — no missing components, no orphan components.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { DEMO_SCENES, getDemoScene } from "../../../src/components/demo-scenes/registry";
+import { SCENE_COMPONENTS } from "../../../src/components/demo-scenes/scene-components";
+
+const KEBAB_CASE = /^[a-z]+(-[a-z]+)*$/;
+
+describe("DEMO_SCENES registry", () => {
+  test("every id is unique", () => {
+    const ids = DEMO_SCENES.map((scene) => scene.id);
+    assert.equal(new Set(ids).size, ids.length, "duplicate scene id found");
+  });
+
+  test("every id is kebab-case", () => {
+    for (const scene of DEMO_SCENES) {
+      assert.match(scene.id, KEBAB_CASE, `"${scene.id}" is not kebab-case`);
+    }
+  });
+
+  test("every entry has a non-empty title and blurb", () => {
+    for (const scene of DEMO_SCENES) {
+      assert.ok(scene.title.trim().length > 0, `${scene.id} has an empty title`);
+      assert.ok(scene.blurb.trim().length > 0, `${scene.id} has an empty blurb`);
+    }
+  });
+
+  test("at least one scene is registered", () => {
+    assert.ok(DEMO_SCENES.length > 0, "registry must not be empty");
+  });
+});
+
+describe("getDemoScene", () => {
+  test("returns null for an unknown id", () => {
+    assert.equal(getDemoScene("nope"), null);
+  });
+
+  test("returns the matching entry for a known id", () => {
+    const first = DEMO_SCENES[0];
+    assert.equal(getDemoScene(first.id), first);
+  });
+});
+
+describe("SCENE_COMPONENTS covers exactly the registry ids", () => {
+  test("no registry id is missing a component", () => {
+    for (const scene of DEMO_SCENES) {
+      assert.ok(
+        SCENE_COMPONENTS[scene.id],
+        `registry id "${scene.id}" has no entry in SCENE_COMPONENTS`,
+      );
+    }
+  });
+
+  test("no orphan components exist outside the registry", () => {
+    const registryIds = new Set(DEMO_SCENES.map((scene) => scene.id));
+    for (const id of Object.keys(SCENE_COMPONENTS)) {
+      assert.ok(registryIds.has(id), `SCENE_COMPONENTS has orphan id "${id}" not in registry`);
+    }
+  });
+
+  test("key sets are exactly equal", () => {
+    const registryIds = DEMO_SCENES.map((scene) => scene.id).sort();
+    const componentIds = Object.keys(SCENE_COMPONENTS).sort();
+    assert.deepEqual(componentIds, registryIds);
+  });
+});


### PR DESCRIPTION
## What
Seven full-viewport, loopable, brand-tokened animation scenes for demo-video B-roll, on a new dev-only route pair /demo-scenes + /demo-scenes/[scene] (same SF_MOTION_LAB gate + noindex as /motion-lab; nothing publicly reachable without the flag):

booking-cascade (AnimatedList money-loop stack w/ vendored icons) · calendar-connected (AnimatedBeam + Connected pill + synced booking card) · grounded-chat (phase-machine chat playback ending in a booking confirmation) · stat-payoff (NumberTickers + shiny anchor line) · sms-phone (pure-CSS phone frame + arriving confirmation text) · live-confetti (deterministic 48-particle burst, no canvas-confetti) · docker-terminal (compose-up sequence for the self-host video).

Stage host: restart (key bump), ?loop=1 deep-link, light/dark flip via data-mode="record", controls auto-hide after 3s so they never appear in recordings. Zero new dependencies; scenes compose the existing magic/motion primitives.

## Verification
- verify-runner PASS (9/9 registry tests incl. component-map-covers-registry; tsc delta 0; use-server clean; no migrations; scope confined; instrumentation-client revert verified).
- reviewer SHIP (gating/hydration/reduced-motion/timer-cleanup/Suspense all hold; 5 polish nits noted).
- VISUAL pass: all 7 scenes rendered in a real browser; caught + fixed 2 real bugs (sms bubble clipped by a height:100% overflow; cross-engine Math.cos hydration mismatch fixed by rounding).

Spec: docs/superpowers/specs/2026-07-14-demo-scenes-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)