### PR TITLE
fix(landing): subdomain /s honors theme.landingTemplate — /w parity

### DIFF
--- a/docs/learnings/2026-07-14-route-parity-shared-fn-and-midbuild-rebase.md
+++ b/docs/learnings/2026-07-14-route-parity-shared-fn-and-midbuild-rebase.md
@@ -1,0 +1,72 @@
+# Route-parity by shared-function extraction + reconciling a mid-build main advance
+
+## The problem, in one line
+
+Two routes rendering the same workspace (`/w/[slug]` and the subdomain's
+`/s/[orgSlug]/[...slug]`) diverged — one honored
+`organizations.theme.landingTemplate`, the other silently ignored it — and
+while the fix was being built, a sibling PR (#78, live-archetype-at-source)
+merged to main touching the exact code region being extracted.
+
+## The approach
+
+1. **Ground the seam before writing the spec.** Read both route files AND the
+   loader they share (`loadLandingPayload` in
+   `packages/crm/src/lib/landing/r1-save.ts`). The decisive fact was found
+   there, not in the routes: the loader's `landingTemplate` is read off the
+   org row itself, so /w's two-source precedence
+   (`r1?.landingTemplate ?? ctx.theme?.landingTemplate`) collapses to one
+   value whenever an r1 payload exists. That collapsed the fix from
+   "replicate a precedence chain" to "pass one field through".
+2. **Fix divergence by extraction, not duplication.** Lift the diverging
+   branch verbatim into one pure function
+   (`lib/landing/render-landing-template.tsx` — no db, no async, returns
+   `ReactElement | null`) and make BOTH routes call it. Purity is what makes
+   it unit-testable without mocks: tests assert on the returned element's
+   `type` and `props` (`element.type === LANDING_TEMPLATES[id]`) — no DOM, no
+   renderToString needed.
+3. **Cover the asymmetric case too.** /w rendered templates for soul-only
+   workspaces (no r1 row); /s didn't. The shared function takes
+   `r1 | null` + `soul`, so the second route gained the fallback nearly free.
+4. **On the mid-build main advance:** after the implementer finished,
+   `git diff --stat origin/main..HEAD` showed ~1,900 deletions that nobody
+   made — the tell that origin/main had advanced (a subagent's `git fetch`
+   had updated the ref). Diagnose with `git merge-base HEAD origin/main` and
+   diff against the merge-base to see the REAL change; then read the new main
+   commit's diff (`git show <sha>`) BEFORE rebasing, specifically asking "does
+   this change the semantics my extraction assumed?" (Here: #78 made the
+   loader return an already-live-normalized archetype — which composed
+   correctly with the extracted `r1?.archetype ?? themeArchetype` rule.)
+5. **After the rebase, sweep for cross-PR dead code.** Two PRs each removing
+   one of an import's two usages merge cleanly but leave a stale import that
+   neither PR had. Grep the merged file for every identifier the touched
+   hunks used (`ARCHETYPES` was imported but unused post-rebase). Re-run the
+   affected specs (both branches' — ours AND #78's) before re-verifying.
+
+## Judgment calls
+
+- **Did NOT change /w's archetype precedence** (baked-r1-first) even though it
+  looked inconsistent with the design-switch direction — that was the sibling
+  PR's territory. Centralizing into one shared function means whoever fixes
+  precedence next fixes both routes for free; fixing it here would have been
+  a scope collision.
+- **Did NOT add a route-level integration test.** Parity is guaranteed
+  structurally (one function, provably-equal inputs — the reviewer traced
+  both call sites' inputs to the same org-row fields); a db-mocked route test
+  would restate that at high cost. The end-to-end check is the post-deploy
+  smoke.
+- **Did NOT widen the diff for a real adjacent bug found in review** (/s
+  r1-home metadata hardcodes `index: true`, skipping the unclaimed-workspace
+  noindex rule) — filed as its own follow-up task instead. Minimal impact
+  beats opportunistic fixes.
+- **Did NOT merge or push to main** — branch + PR (#80) only; the merge call
+  is the human gate.
+
+## The reusable rule, one line
+
+When two render paths must never diverge, extract the branch into one pure
+shared function both call (drift becomes impossible, tests become mock-free);
+and when a subagent build spans time, always diff against
+`git merge-base HEAD origin/main` — a reverse-diff full of deletions you
+didn't make means main advanced, and the rebase needs a semantic read of the
+new commits plus a stale-import sweep, not just conflict resolution.

--- a/docs/superpowers/plans/2026-07-14-subdomain-landing-template-parity.md
+++ b/docs/superpowers/plans/2026-07-14-subdomain-landing-template-parity.md
@@ -1,0 +1,127 @@
+# Subdomain landing-template parity — plan
+
+Spec: `docs/superpowers/specs/2026-07-14-subdomain-landing-template-parity-design.md`
+Worktree: `.claude/worktrees/nostalgic-mcnulty-bcc4e0`, branch `claude/cranky-driscoll-e2efa0` off `origin/main` @ `ea4bffd9d`.
+
+TDD, commit-per-task. Run single specs with
+`cd packages/crm && node --import tsx --test tests/unit/landing/render-landing-template.spec.ts`
+(the repo runner `node scripts/run-unit-tests.js` globs everything and has a
+known DB-bound failure baseline — judge full-suite runs by delta only;
+baseline log: scratchpad `unit-baseline.log`).
+
+## Task 1 — shared `renderLandingTemplate` (test-first)
+
+1. Write `packages/crm/tests/unit/landing/render-landing-template.spec.ts`
+   covering spec test cases 1–6. Reuse the fixture style of
+   `tests/unit/r1-payload-to-template.spec.ts` (a representative
+   `R1LandingPayload` + a raw-soul object). Assert on the returned element's
+   `type` (`=== LANDING_TEMPLATES["clinical-luxe"]` etc.) and `props`
+   (`data.business_name`, `ctas.bookUrl/intakeUrl/callHref`, `theme`).
+   `process.env.WORKSPACE_BASE_DOMAIN` may be unset — assert hrefs contain the
+   slug + `/book` / intake path rather than a hardcoded host, or set the env
+   var in the spec's setup. Run → **must fail** (module doesn't exist).
+2. Create `packages/crm/src/lib/landing/render-landing-template.tsx` per the
+   spec signature. Body = /w's current template branch
+   (`/w/[slug]/page.tsx:179-206`) lifted verbatim:
+   - `if (!isLandingTemplateId(input.landingTemplate)) return null;`
+   - `const Tpl = LANDING_TEMPLATES[input.landingTemplate];`
+   - `withTemplateDefaults(input.r1 ? r1PayloadToTemplateData(input.r1.payload) : submittedSoulToTemplateData(input.soul), input.landingTemplate)`
+   - `const explicitArchetype = input.r1?.archetype ?? input.themeArchetype;`
+   - `explicitArchetype && explicitArchetype in ARCHETYPES ? archetypeToSfTheme(explicitArchetype as AestheticArchetypeId) : undefined`
+   - return `<Tpl data={templateData} ctas={buildTemplateCtas(input.slug, input.orgId, templateData.phone)} theme={sfTheme} />`
+   Carry over /w's explanatory comments (default-photos fill, explicit-archetype-only
+   re-skin) — they document non-obvious intent.
+3. Run the spec → green. Commit
+   `feat(landing): extract shared renderLandingTemplate from /w's template branch`.
+
+## Task 2 — /w refactor (behavior-preserving)
+
+1. In `packages/crm/src/app/(public)/w/[slug]/page.tsx`, replace the inline
+   template branch (lines ~179-206) with:
+   ```tsx
+   const templatePage = renderLandingTemplate({
+     slug,
+     orgId: ctx.orgId,
+     landingTemplate,
+     r1: r1 ? { payload: r1.payload, archetype: r1.archetype } : null,
+     soul: ctx.soul,
+     themeArchetype: ctx.theme?.aestheticArchetype,
+   });
+   if (templatePage) {
+     return (
+       <>
+         {templatePage}
+         {chatbotEmbed && <ChatbotEmbedScript embedUrl={chatbotEmbed.embedUrl} />}
+       </>
+     );
+   }
+   ```
+   Keep the big "Health-templates pilot" comment (move/trim as fits). Drop the
+   now-unused imports (`LANDING_TEMPLATES`, `withTemplateDefaults`,
+   `r1PayloadToTemplateData` — note `submittedSoulToTemplateData` is still used
+   by `generateMetadata`; `isLandingTemplateId`, `archetypeToSfTheme`,
+   `buildTemplateCtas` become unused; `ARCHETYPES`/`AestheticArchetypeId` are
+   still used by the R1 liveArchetype block). Verify each import's remaining
+   usage before removing — don't guess.
+2. Full unit run delta-clean + `npx tsc --noEmit` delta-clean (see repo
+   worktree-typecheck method; judge by delta vs main, not absolute zero).
+   Commit `refactor(landing): /w template branch → shared renderLandingTemplate`.
+
+## Task 3 — /s home branch honors landingTemplate (the fix)
+
+`packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx`:
+
+1. In the `isHomePage(pageSlug)` branch of the default export:
+   - **r1 case:** immediately after `if (r1Data) {`, before the href rewrite:
+     ```tsx
+     // Health-templates parity (mirrors /w/[slug]): a workspace that picked a
+     // premium template renders it on its subdomain too — /w and the subdomain
+     // must never diverge. The template builds its own workspace-scoped CTAs,
+     // so it skips the r1 href-rewrite below.
+     const templatePage = renderLandingTemplate({
+       slug: orgSlug,
+       orgId: r1Data.orgId,
+       landingTemplate: r1Data.landingTemplate,
+       r1: { payload: r1Data.payload, archetype: r1Data.archetype },
+       soul: null,
+       themeArchetype: r1Data.theme?.aestheticArchetype,
+     });
+     if (templatePage) {
+       const embed = await getPublicChatbotEmbed(r1Data.orgId);
+       return (
+         <>
+           {templatePage}
+           {embed && <ChatbotEmbedScript embedUrl={embed.embedUrl} />}
+         </>
+       );
+     }
+     ```
+   - **soul-only case:** in the `else` of `if (r1Data)` (new — today the null
+     case just falls through), resolve `getWorkspaceTemplateContext(orgSlug)`;
+     if ctx non-null, call `renderLandingTemplate` with
+     `landingTemplate: ctx.theme?.landingTemplate`, `r1: null`, `soul: ctx.soul`,
+     `themeArchetype: ctx.theme?.aestheticArchetype`; non-null → return it +
+     chatbot embed for `ctx.orgId`. Null / no ctx → fall through to the legacy
+     PageRenderer path unchanged.
+2. `generateMetadata` home branch: when `loadLandingPayload` returns null,
+   mirror /w's soul fallback (`getWorkspaceTemplateContext` →
+   `submittedSoulToTemplateData`; bail to `{}` when soul has no real
+   business_name — /w uses the `"Our Practice"` sentinel; robots per
+   `!(ownerId === null && settings["origin"] === WEB_UNGATED_ORIGIN)` — inline
+   the predicate, do NOT export the helper from /w's page.tsx (route-file
+   exports gotcha, L-31); canonical `/w/${orgSlug}`).
+3. Full unit run delta-clean + tsc delta-clean. Commit
+   `fix(landing): subdomain /s home honors theme.landingTemplate — /w parity`.
+
+## Task 4 — gate
+
+`/verify-build` via the verify-runner agent (independent checker), then
+reviewer on the whole diff. Fix-forward on FAIL; nothing merges without green.
+
+## Guardrails
+
+- Minimal impact: no changes to the legacy PageRenderer path, the /s services
+  branch, or /w's R1 (non-template) path beyond the extracted function call.
+- No new deps, no migrations, no env vars.
+- The shared module stays pure (no db imports) so it unit-tests without mocks
+  and either route can call it from any context.

--- a/docs/superpowers/specs/2026-07-14-subdomain-landing-template-parity-design.md
+++ b/docs/superpowers/specs/2026-07-14-subdomain-landing-template-parity-design.md
@@ -1,0 +1,135 @@
+# Subdomain landing-template parity — design
+
+**Date:** 2026-07-14
+**Status:** approved (gap + fix shape verified in the dispatching session, 2026-07-15 recon)
+**Branch:** `claude/cranky-driscoll-e2efa0` (worktree `nostalgic-mcnulty-bcc4e0`, off `origin/main` @ `ea4bffd9d`)
+
+## Problem
+
+`/s/[orgSlug]/[...slug]/page.tsx` — the renderer behind `<slug>.app.seldonframe.com`
+(the proxy rewrites the subdomain root to `/s/<slug>/home`) — never checks
+`theme.landingTemplate`. A workspace that picked a premium health template
+(persisted at `organizations.theme.landingTemplate`, rendered by
+`/w/[slug]/page.tsx` via `isLandingTemplateId` → `LANDING_TEMPLATES[...]`)
+still renders the R1 sections on its subdomain. **Every health-template
+workspace diverges between /w and its subdomain** — and the subdomain is the
+URL the operator actually hands out.
+
+## Ground truth (read, not guessed)
+
+- `/w/[slug]/page.tsx:166` — template precedence: `r1?.landingTemplate ?? ctx.theme?.landingTemplate`.
+  Both values are sourced from `organizations.theme.landingTemplate`
+  (`loadLandingPayload` reads it off the org row at `r1-save.ts:143-146`), so
+  inside a branch that already holds an r1 result, `r1.landingTemplate` alone
+  carries the exact same precedence.
+- `/w/[slug]/page.tsx:179-206` — the template branch:
+  `withTemplateDefaults(r1 ? r1PayloadToTemplateData(r1.payload) : submittedSoulToTemplateData(ctx.soul), landingTemplate)`,
+  `explicitArchetype = r1?.archetype ?? ctx.theme?.aestheticArchetype` →
+  `archetypeToSfTheme` (else `undefined` = template's signature palette),
+  CTAs via `buildTemplateCtas(slug, orgId, templateData.phone)`, plus the
+  chatbot embed script.
+- `/w` also renders a template for **soul-only** workspaces (no r1 row) via
+  `getWorkspaceTemplateContext` (`public-workspace.ts`). `/s` currently sends
+  those to the legacy `PageRenderer` fall-through.
+- `loadLandingPayload` already returns `landingTemplate`, `theme`
+  (normalized `OrgTheme`, includes `aestheticArchetype` post-#67), `archetype`,
+  `orgId` — no new queries needed for the r1 case.
+- Sibling branch `fix/live-archetype-at-source` is **not merged** to
+  origin/main as of this spec; we mirror /w's *current* precedence exactly and
+  centralize it so any later precedence fix lands in one place.
+
+## Fix shape
+
+**Extract /w's template branch into one shared function; both routes call it.**
+
+### New: `packages/crm/src/lib/landing/render-landing-template.tsx`
+
+```tsx
+export function renderLandingTemplate(input: {
+  slug: string;
+  orgId: string;
+  landingTemplate: string | undefined;
+  /** r1 content source (preferred). null → soul fallback. */
+  r1: { payload: R1LandingPayload; archetype: AestheticArchetypeId } | null;
+  /** raw organizations.soul — read only when r1 is null */
+  soul: unknown;
+  /** live org-theme archetype (theme.aestheticArchetype) */
+  themeArchetype: string | undefined;
+}): ReactElement | null
+```
+
+Returns `null` unless `isLandingTemplateId(input.landingTemplate)`; otherwise
+the `<Tpl data ctas theme>` element, byte-for-byte the logic /w has today
+(withTemplateDefaults fill, `r1?.archetype ?? themeArchetype` explicit-archetype
+rule, `in ARCHETYPES` guard, `buildTemplateCtas`). Pure given its inputs — no
+db, no async — so it unit-tests without mocks. The chatbot embed stays
+route-local (each route already loads it).
+
+### `/w/[slug]/page.tsx` — behavior-preserving refactor
+
+Replace lines ~179-206 with a call to `renderLandingTemplate` (pass
+`r1 ? { payload, archetype } : null`, `ctx.soul`, `ctx.theme?.aestheticArchetype`);
+keep the early return + chatbot embed wrapper. No rendering change.
+
+### `/s/[orgSlug]/[...slug]/page.tsx` — the actual fix
+
+In the home-page branch (`isHomePage(pageSlug)`):
+
+1. **r1 workspaces:** after `loadLandingPayload` succeeds, call
+   `renderLandingTemplate` with `r1Data`'s fields
+   (`landingTemplate: r1Data.landingTemplate`, `r1: { payload, archetype }`,
+   `soul: null`, `themeArchetype: r1Data.theme?.aestheticArchetype`). Non-null →
+   return it + chatbot embed. Null → existing R1 sections, unchanged.
+2. **Soul-only workspaces:** when `loadLandingPayload` returns null, call
+   `getWorkspaceTemplateContext(orgSlug)`; if it resolves and
+   `renderLandingTemplate` (with `ctx.theme?.landingTemplate`, `r1: null`,
+   `ctx.soul`) returns an element, return it + chatbot embed. Otherwise fall
+   through to the legacy PageRenderer path **unchanged** (old-landing
+   workspaces have no `landingTemplate`, so `isLandingTemplateId` fails and
+   nothing changes for them).
+3. **Metadata parity for soul-only template workspaces:** in
+   `generateMetadata`'s home branch, when there's no r1 payload, mirror /w's
+   soul fallback (title/description from `submittedSoulToTemplateData`,
+   `robots` per the unclaimed-anonymous-build rule, canonical `/w/${orgSlug}`
+   — /s canonicals already point at /w). Existing r1-home metadata is
+   untouched.
+
+## Out of scope
+
+- /w's archetype precedence itself (baked-r1-first) — `fix/live-archetype-at-source`
+  owns archetype normalization; centralizing into the shared function means its
+  fix (or any later one) lands on both routes automatically once both call it.
+- Service sub-pages (`/s/<slug>/services/<x>`) — same R1 rendering on both
+  routes today; templates are single-page.
+- No new deps, no migrations, no flag (this is a bug fix restoring an
+  intended invariant, not a new behavior).
+
+## Tests (node:test + tsx, `tests/unit/landing/render-landing-template.spec.ts`)
+
+Pure-function tests on the returned element (type + props — no DOM needed;
+`.spec.tsx`/renderToString available if needed):
+
+1. Unregistered / undefined `landingTemplate` → `null` (legacy workspaces safe).
+2. Registered id + r1 payload → `element.type === LANDING_TEMPLATES[id]`,
+   `props.data.business_name` from the payload, `props.ctas.bookUrl/intakeUrl`
+   workspace-scoped, `props.ctas.callHref` tel-normalized.
+3. `r1: null` + soul → data mapped via `submittedSoulToTemplateData`.
+4. Explicit archetype (r1.archetype or themeArchetype) in `ARCHETYPES` →
+   `props.theme` is the mapped SfTheme; r1.archetype wins over themeArchetype.
+5. No archetype anywhere / unknown archetype string → `props.theme === undefined`
+   (template renders its signature palette).
+6. `withTemplateDefaults` applied — empty photo slots filled from the
+   template's curated fixtures.
+
+Route-level equivalence is guaranteed structurally (both routes call the one
+function) — the post-deploy smoke (below) is the end-to-end check.
+
+## Verification
+
+- `/verify-build` gate (unit delta vs baseline at
+  `scratchpad/unit-baseline.log`, tsc stash-delta, check-use-server,
+  migration journal, regression grep).
+- **Post-deploy smoke:** pick a health-template workspace; its
+  `<slug>.app.seldonframe.com` root and `/w/<slug>` must render the same
+  template (same `<h1>`/hero sentinel, template-specific DOM marker present on
+  both, R1 `SiteShell` marker absent on both).

--- a/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
+++ b/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
@@ -22,6 +22,10 @@ import { loadLandingPayload } from "@/lib/landing/r1-save";
 import { rewriteR1Hrefs } from "@/lib/landing/r1-rewrite-hrefs";
 import { resolveMapQuery } from "@/lib/landing/map-embed";
 import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
+import { getWorkspaceTemplateContext } from "@/lib/landing/public-workspace";
+import { submittedSoulToTemplateData } from "@/lib/landing/r1-payload-to-template";
+import { renderLandingTemplate } from "@/lib/landing/render-landing-template";
+import { WEB_UNGATED_ORIGIN } from "@/lib/web-build/policy";
 import { Hero } from "@/components/landing-r1/sections/hero";
 import { ServicesGrid } from "@/components/landing-r1/sections/services-grid";
 import { Testimonials } from "@/components/landing-r1/sections/testimonials";
@@ -125,6 +129,29 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         },
       };
     }
+
+    // No r1 payload — mirror /w/[slug]'s soul fallback (Task 3 metadata
+    // parity) so a soul-only template workspace still gets a basic,
+    // indexable title/description on its subdomain instead of {}.
+    const ctx = await getWorkspaceTemplateContext(orgSlug);
+    const soul = ctx ? submittedSoulToTemplateData(ctx.soul) : null;
+    if (soul && soul.business_name !== "Our Practice") {
+      const description = soul.soul_description ?? soul.tagline;
+      // ctx is non-null here (soul came from it above).
+      const indexable = !(ctx!.ownerId === null && ctx!.settings["origin"] === WEB_UNGATED_ORIGIN);
+      return {
+        title: soul.business_name,
+        ...(description ? { description } : {}),
+        openGraph: {
+          title: soul.business_name,
+          ...(description ? { description } : {}),
+          type: "website",
+        },
+        robots: { index: indexable, follow: indexable },
+        // Canonical points at /w/[slug] — that is the authoritative URL.
+        alternates: { canonical: `/w/${orgSlug}` },
+      };
+    }
   }
 
   // Fallback: no extra metadata for old-landing sub-pages.
@@ -202,6 +229,28 @@ export default async function PublicSPage({ params }: PageProps) {
   if (isHomePage(pageSlug)) {
     const r1Data = await loadLandingPayload(orgSlug);
     if (r1Data) {
+      // Health-templates parity (mirrors /w/[slug]): a workspace that picked a
+      // premium template renders it on its subdomain too — /w and the subdomain
+      // must never diverge. The template builds its own workspace-scoped CTAs,
+      // so it skips the r1 href-rewrite below.
+      const templatePage = renderLandingTemplate({
+        slug: orgSlug,
+        orgId: r1Data.orgId,
+        landingTemplate: r1Data.landingTemplate,
+        r1: { payload: r1Data.payload, archetype: r1Data.archetype },
+        soul: null,
+        themeArchetype: r1Data.theme?.aestheticArchetype,
+      });
+      if (templatePage) {
+        const embed = await getPublicChatbotEmbed(r1Data.orgId);
+        return (
+          <>
+            {templatePage}
+            {embed && <ChatbotEmbedScript embedUrl={embed.embedUrl} />}
+          </>
+        );
+      }
+
       // bisect 3/4: rewrite generic CTA hrefs to workspace-scoped URLs.
       const workspaceUrls = buildWorkspaceUrls(
         orgSlug,
@@ -256,6 +305,32 @@ export default async function PublicSPage({ params }: PageProps) {
           {r1ChatbotEmbed && <ChatbotEmbedScript embedUrl={r1ChatbotEmbed.embedUrl} />}
         </SiteShell>
       );
+    } else {
+      // Soul-only template parity (mirrors /w/[slug]): no r1 payload, but the
+      // workspace may still have picked a premium template via
+      // theme.landingTemplate off the raw soul. Falls through to the legacy
+      // PageRenderer below when there's no workspace, no template, or the
+      // template dispatch returns null.
+      const ctx = await getWorkspaceTemplateContext(orgSlug);
+      if (ctx) {
+        const templatePage = renderLandingTemplate({
+          slug: orgSlug,
+          orgId: ctx.orgId,
+          landingTemplate: ctx.theme?.landingTemplate,
+          r1: null,
+          soul: ctx.soul,
+          themeArchetype: ctx.theme?.aestheticArchetype,
+        });
+        if (templatePage) {
+          const embed = await getPublicChatbotEmbed(ctx.orgId);
+          return (
+            <>
+              {templatePage}
+              {embed && <ChatbotEmbedScript embedUrl={embed.embedUrl} />}
+            </>
+          );
+        }
+      }
     }
   }
 

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -36,7 +36,6 @@ import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getPublicChatbotEmbed } from "@/lib/agents/public-embed";
 import { submittedSoulToTemplateData } from "@/lib/landing/r1-payload-to-template";
 import { renderLandingTemplate } from "@/lib/landing/render-landing-template";
-import { ARCHETYPES, type AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
 import { WEB_UNGATED_ORIGIN } from "@/lib/web-build/policy";
 
 type PageProps = {

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -34,19 +34,8 @@ import { rewriteR1Hrefs } from "@/lib/landing/r1-rewrite-hrefs";
 import { getServicePages } from "@/lib/landing/r1-site-tree";
 import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getPublicChatbotEmbed } from "@/lib/agents/public-embed";
-import {
-  LANDING_TEMPLATES,
-  isLandingTemplateId,
-} from "@/components/landing-templates/registry";
-import { withTemplateDefaults } from "@/components/landing-templates/default-photos";
-import {
-  r1PayloadToTemplateData,
-  submittedSoulToTemplateData,
-} from "@/lib/landing/r1-payload-to-template";
-import {
-  archetypeToSfTheme,
-  buildTemplateCtas,
-} from "@/lib/landing/template-adapters";
+import { submittedSoulToTemplateData } from "@/lib/landing/r1-payload-to-template";
+import { renderLandingTemplate } from "@/lib/landing/render-landing-template";
 import { ARCHETYPES, type AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
 import { WEB_UNGATED_ORIGIN } from "@/lib/web-build/policy";
 
@@ -170,36 +159,26 @@ export default async function WorkspaceLandingPage({ params }: PageProps) {
 
   // Health-templates pilot: when the workspace has opted into a premium
   // full-page template (persisted at organizations.theme.landingTemplate),
-  // render it as an alternative renderer. Content comes from the r1 payload
-  // when present, otherwise from the raw organizations.soul jsonb so soul-only
-  // workspaces still render. The template builds its own workspace-scoped CTAs
-  // (book/intake/tel:), so it does NOT need the r1 href-rewrite. Workspaces
-  // without a registered template fall through to the landing-r1 path, which
-  // requires an r1 payload.
-  if (isLandingTemplateId(landingTemplate)) {
-    const Tpl = LANDING_TEMPLATES[landingTemplate];
-    // Fill any empty photo slots with the template's curated fixture imagery
-    // (Claude Design's hand-picked photos) so the page looks like the designed
-    // template even when extraction captured few/no photos. Real photos win.
-    const templateData = withTemplateDefaults(
-      r1 ? r1PayloadToTemplateData(r1.payload) : submittedSoulToTemplateData(ctx.soul),
-      landingTemplate,
-    );
-    // Re-skin via the archetype palette ONLY when one is explicitly set (on
-    // the r1 payload or the org theme). Otherwise pass undefined so the
-    // template renders in its own signature default palette — the designed look.
-    const explicitArchetype = r1?.archetype ?? ctx.theme?.aestheticArchetype;
-    const sfTheme =
-      explicitArchetype && explicitArchetype in ARCHETYPES
-        ? archetypeToSfTheme(explicitArchetype as AestheticArchetypeId)
-        : undefined;
+  // render it as an alternative renderer via the shared renderLandingTemplate
+  // (also used by the /s/[orgSlug] subdomain route so the two never diverge).
+  // Content comes from the r1 payload when present, otherwise from the raw
+  // organizations.soul jsonb so soul-only workspaces still render. The
+  // template builds its own workspace-scoped CTAs (book/intake/tel:), so it
+  // does NOT need the r1 href-rewrite. Workspaces without a registered
+  // template fall through to the landing-r1 path, which requires an r1
+  // payload.
+  const templatePage = renderLandingTemplate({
+    slug,
+    orgId: ctx.orgId,
+    landingTemplate,
+    r1: r1 ? { payload: r1.payload, archetype: r1.archetype } : null,
+    soul: ctx.soul,
+    themeArchetype: ctx.theme?.aestheticArchetype,
+  });
+  if (templatePage) {
     return (
       <>
-        <Tpl
-          data={templateData}
-          ctas={buildTemplateCtas(slug, ctx.orgId, templateData.phone)}
-          theme={sfTheme}
-        />
+        {templatePage}
         {chatbotEmbed && <ChatbotEmbedScript embedUrl={chatbotEmbed.embedUrl} />}
       </>
     );

--- a/packages/crm/src/lib/landing/render-landing-template.tsx
+++ b/packages/crm/src/lib/landing/render-landing-template.tsx
@@ -1,0 +1,73 @@
+// packages/crm/src/lib/landing/render-landing-template.tsx
+//
+// Shared dispatcher for the premium full-page health/wellness landing
+// templates (registry.ts). Lifted verbatim out of /w/[slug]'s inline
+// template branch so /w/[slug] and the /s/[orgSlug]/[...slug] subdomain
+// route render byte-for-byte the same output for a workspace that opted
+// into a template — the two routes must never diverge (2026-07-14 parity
+// fix; see docs/superpowers/specs/2026-07-14-subdomain-landing-template-parity-design.md).
+//
+// Pure function: no db access, no async — takes already-resolved data and
+// returns a React element (or null). Unit-tests without mocks; either
+// route can call it from any context.
+
+import type { ReactElement } from "react";
+
+import {
+  LANDING_TEMPLATES,
+  isLandingTemplateId,
+} from "@/components/landing-templates/registry";
+import { withTemplateDefaults } from "@/components/landing-templates/default-photos";
+import {
+  r1PayloadToTemplateData,
+  submittedSoulToTemplateData,
+} from "@/lib/landing/r1-payload-to-template";
+import {
+  archetypeToSfTheme,
+  buildTemplateCtas,
+} from "@/lib/landing/template-adapters";
+import { ARCHETYPES, type AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
+import type { R1LandingPayload } from "@/lib/landing/r1-payload-prompt";
+
+export function renderLandingTemplate(input: {
+  slug: string;
+  orgId: string;
+  landingTemplate: string | undefined;
+  /** r1 content source (preferred). null → soul fallback. */
+  r1: { payload: R1LandingPayload; archetype: AestheticArchetypeId } | null;
+  /** raw organizations.soul — read only when r1 is null */
+  soul: unknown;
+  /** live org-theme archetype (theme.aestheticArchetype) */
+  themeArchetype: string | undefined;
+}): ReactElement | null {
+  // Non-template workspaces (or unregistered/undefined ids) render nothing
+  // here — callers fall through to the landing-r1 path.
+  if (!isLandingTemplateId(input.landingTemplate)) return null;
+
+  const Tpl = LANDING_TEMPLATES[input.landingTemplate];
+  // Fill any empty photo slots with the template's curated fixture imagery
+  // (Claude Design's hand-picked photos) so the page looks like the designed
+  // template even when extraction captured few/no photos. Real photos win.
+  const templateData = withTemplateDefaults(
+    input.r1
+      ? r1PayloadToTemplateData(input.r1.payload)
+      : submittedSoulToTemplateData(input.soul),
+    input.landingTemplate,
+  );
+  // Re-skin via the archetype palette ONLY when one is explicitly set (on
+  // the r1 payload or the org theme). Otherwise pass undefined so the
+  // template renders in its own signature default palette — the designed look.
+  const explicitArchetype = input.r1?.archetype ?? input.themeArchetype;
+  const sfTheme =
+    explicitArchetype && explicitArchetype in ARCHETYPES
+      ? archetypeToSfTheme(explicitArchetype as AestheticArchetypeId)
+      : undefined;
+
+  return (
+    <Tpl
+      data={templateData}
+      ctas={buildTemplateCtas(input.slug, input.orgId, templateData.phone)}
+      theme={sfTheme}
+    />
+  );
+}

--- a/packages/crm/tests/unit/landing/render-landing-template.spec.ts
+++ b/packages/crm/tests/unit/landing/render-landing-template.spec.ts
@@ -1,0 +1,284 @@
+// Tests for renderLandingTemplate — the shared pure-function template
+// dispatcher extracted from /w/[slug]'s inline template branch, so both
+// /w/[slug] and the /s/[orgSlug]/[...slug] subdomain route render the exact
+// same premium-template output (parity fix, 2026-07-14).
+//
+// Repo convention: node:test + tsx (see scripts/run-unit-tests.js). No
+// vitest in this monorepo; unit tests live at tests/unit/**/*.spec.ts.
+//
+// The function returns a plain React element (`React.createElement(Tpl, ...)`,
+// never JSX-rendered), so we assert directly on `.type` (referential
+// equality against LANDING_TEMPLATES[id]) and `.props` — no DOM/renderToString
+// needed.
+//
+// Coverage (spec test cases 1-6):
+//   1. Unregistered / undefined landingTemplate → null.
+//   2. Registered id + r1 payload → element.type is the registered
+//      component; props.data.business_name from the payload;
+//      props.ctas.bookUrl/intakeUrl are workspace-scoped;
+//      props.ctas.callHref is tel-normalized.
+//   3. r1: null + soul → data mapped via submittedSoulToTemplateData.
+//   4. Explicit archetype (r1.archetype or themeArchetype) in ARCHETYPES →
+//      props.theme is the mapped SfTheme; r1.archetype wins over
+//      themeArchetype.
+//   5. No archetype anywhere / unknown archetype string → props.theme is
+//      undefined (template renders its own signature palette).
+//   6. withTemplateDefaults applied — empty photo slots filled from the
+//      template's curated fixtures.
+
+import { describe, test, before } from "node:test";
+import assert from "node:assert/strict";
+
+before(() => {
+  // buildTemplateCtas / buildWorkspaceUrls read this; unset in CI by
+  // default. Fix it so href assertions are deterministic regardless of env.
+  process.env.WORKSPACE_BASE_DOMAIN = "app.seldonframe.com";
+});
+
+import { renderLandingTemplate } from "../../../src/lib/landing/render-landing-template";
+import { LANDING_TEMPLATES } from "../../../src/components/landing-templates/registry";
+import type { R1LandingPayload } from "../../../src/lib/landing/r1-payload-prompt";
+
+// ── Representative r1 fixture (mirrors r1-payload-to-template.spec.ts) ────────
+const fullPayload: R1LandingPayload = {
+  hero: {
+    archetype: "clinical-trust",
+    businessName: "Austin Family Chiropractic",
+    tagline: "Gentle, expert chiropractic care for the whole family",
+    subhead:
+      "A family-focused clinic serving every age — from infants to seniors.",
+    primaryCTA: { label: "Book a consultation", href: "/book" },
+    secondaryCTA: { label: "Book online", href: "/book" },
+    trustBadges: [{ label: "Licensed Doctors of Chiropractic" }],
+    reviewRating: 4.9,
+    reviewCount: 287,
+    emergencyService: false,
+    heroImage: {
+      src: "https://images.example.com/hero.jpg",
+      alt: "Gentle hands-on chiropractic care",
+    },
+  },
+  services: {
+    archetype: "clinical-trust",
+    eyebrow: "Our services",
+    heading: "Care for every body",
+    intro: "We treat the root cause, not just the symptoms.",
+    services: [
+      { id: "s1", name: "Spinal Adjustment", description: "Restore motion and relieve nerve pressure." },
+      { id: "s2", name: "Corrective Care Program", description: "A structured plan to fix the root cause." },
+      { id: "s3", name: "Prenatal Chiropractic", description: "Gentle, Webster-certified care through pregnancy." },
+    ],
+    cta: { label: "Call (512) 555-0182", href: "tel:+15125550182" },
+  },
+  testimonials: {
+    archetype: "clinical-trust",
+    eyebrow: "Patient reviews",
+    heading: "287 reviews. 4.9 stars.",
+    testimonials: [
+      { id: "t1", quote: "Dr. Mitchell's prenatal adjustments changed everything.", name: "Jennifer K.", city: "Austin", rating: 5 },
+    ],
+    reviewSummary: { rating: 4.9, count: 287, sources: "Google · Yelp" },
+  },
+  faq: {
+    archetype: "clinical-trust",
+    eyebrow: "Quick answers",
+    heading: "Frequently asked questions",
+    items: [
+      { id: "f1", question: "Do you accept insurance?", answer: "We accept most major plans." },
+    ],
+  },
+  footer: {
+    archetype: "clinical-trust",
+    businessName: "Austin Family Chiropractic",
+    tagline: "Whole-family chiropractic care since 2009.",
+    phone: "(512) 555-0182",
+    email: "hello@austinfamilychiro.com",
+    address: { line1: "3204 Bee Caves Rd, Suite 102", city: "Austin", state: "TX", zip: "78746" },
+    serviceAreas: ["Austin", "West Lake Hills", "Bee Cave"],
+    license: "Doctor of Chiropractic (DC)",
+    trustBadges: [{ label: "Licensed Doctors of Chiropractic" }],
+  },
+};
+
+const rawSoul = {
+  business_name: "Riverside Physiotherapy",
+  tagline: "Move better, live stronger",
+  phone: "(604) 555-0144",
+};
+
+const REGISTERED_ID = "earthy-modern-clinical"; // maps r1's clinical-trust vertical closely enough; id is what matters here
+
+describe("renderLandingTemplate — case 1: unregistered/undefined template", () => {
+  test("undefined landingTemplate → null", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: undefined,
+      r1: { payload: fullPayload, archetype: "clinical-trust" },
+      soul: null,
+      themeArchetype: undefined,
+    });
+    assert.equal(result, null);
+  });
+
+  test("unregistered string id → null", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: "not-a-real-template",
+      r1: { payload: fullPayload, archetype: "clinical-trust" },
+      soul: null,
+      themeArchetype: undefined,
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe("renderLandingTemplate — case 2: registered id + r1 payload", () => {
+  const result = renderLandingTemplate({
+    slug: "austin-family-chiro",
+    orgId: "org_abc",
+    landingTemplate: REGISTERED_ID,
+    r1: { payload: fullPayload, archetype: "clinical-trust" },
+    soul: null,
+    themeArchetype: undefined,
+  });
+
+  test("returns an element", () => {
+    assert.ok(result, "expected a non-null element");
+  });
+
+  test("element.type is the registered template component", () => {
+    assert.equal(result!.type, LANDING_TEMPLATES[REGISTERED_ID]);
+  });
+
+  test("props.data.business_name comes from the r1 payload", () => {
+    assert.equal(result!.props.data.business_name, "Austin Family Chiropractic");
+  });
+
+  test("props.ctas.bookUrl/intakeUrl are workspace-scoped", () => {
+    assert.match(result!.props.ctas.bookUrl, /austin-family-chiro/);
+    assert.ok(result!.props.ctas.intakeUrl, "expected an intakeUrl");
+    assert.match(result!.props.ctas.intakeUrl, /austin-family-chiro/);
+  });
+
+  test("props.ctas.callHref is tel-normalized from the payload phone", () => {
+    assert.equal(result!.props.ctas.callHref, "tel:5125550182");
+  });
+});
+
+describe("renderLandingTemplate — case 3: r1 null + soul fallback", () => {
+  const result = renderLandingTemplate({
+    slug: "riverside-physio",
+    orgId: "org_def",
+    landingTemplate: REGISTERED_ID,
+    r1: null,
+    soul: rawSoul,
+    themeArchetype: undefined,
+  });
+
+  test("returns an element mapped via submittedSoulToTemplateData", () => {
+    assert.ok(result);
+    assert.equal(result!.props.data.business_name, "Riverside Physiotherapy");
+    assert.equal(result!.props.data.tagline, "Move better, live stronger");
+  });
+
+  test("ctas.callHref derives from the soul's phone", () => {
+    assert.equal(result!.props.ctas.callHref, "tel:6045550144");
+  });
+});
+
+describe("renderLandingTemplate — case 4: explicit archetype re-skin", () => {
+  test("r1.archetype (in ARCHETYPES) → mapped SfTheme", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: { payload: fullPayload, archetype: "bold-urgency" },
+      soul: null,
+      themeArchetype: undefined,
+    });
+    assert.ok(result!.props.theme, "expected a theme object");
+    assert.ok(result!.props.theme.primary, "expected a primary color token");
+  });
+
+  test("themeArchetype used when r1.archetype absent (r1: null case)", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: null,
+      soul: rawSoul,
+      themeArchetype: "cinematic-aspirational",
+    });
+    assert.ok(result!.props.theme, "expected a theme object");
+  });
+
+  test("r1.archetype wins over themeArchetype when both present", () => {
+    const winsWithBoldUrgency = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: { payload: fullPayload, archetype: "bold-urgency" },
+      soul: null,
+      themeArchetype: "clinical-trust",
+    });
+    const clinicalTrustOnly = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: { payload: fullPayload, archetype: "clinical-trust" },
+      soul: null,
+      themeArchetype: "clinical-trust",
+    });
+    // Different archetype ids should map to different theme tokens (unless
+    // the palettes happen to collide, which bold-urgency/clinical-trust do
+    // not in this registry) — proves r1.archetype (not themeArchetype) drove
+    // the first result even though themeArchetype was also present.
+    assert.notDeepEqual(winsWithBoldUrgency!.props.theme, clinicalTrustOnly!.props.theme);
+  });
+});
+
+describe("renderLandingTemplate — case 5: no archetype / unknown archetype", () => {
+  test("no archetype anywhere → props.theme is undefined", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: null,
+      soul: rawSoul,
+      themeArchetype: undefined,
+    });
+    assert.equal(result!.props.theme, undefined);
+  });
+
+  test("unknown archetype string → props.theme is undefined", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: null,
+      soul: rawSoul,
+      themeArchetype: "not-a-real-archetype",
+    });
+    assert.equal(result!.props.theme, undefined);
+  });
+});
+
+describe("renderLandingTemplate — case 6: withTemplateDefaults fills empty photo slots", () => {
+  test("a payload with only a hero photo still yields service/about/gallery photos from the template fixture", () => {
+    const result = renderLandingTemplate({
+      slug: "acme",
+      orgId: "org_1",
+      landingTemplate: REGISTERED_ID,
+      r1: { payload: fullPayload, archetype: "clinical-trust" },
+      soul: null,
+      themeArchetype: undefined,
+    });
+    const photos = result!.props.data.photos as Array<{ role?: string; url: string }> | undefined;
+    assert.ok(Array.isArray(photos) && photos.length > 1, "expected multiple photos after default fill");
+    const roles = new Set(photos!.map((p) => p.role));
+    assert.ok(roles.has("hero"), "expected a hero photo");
+    assert.ok(roles.has("service"), "expected service photos filled from defaults");
+  });
+});

--- a/packages/crm/tests/unit/landing/render-landing-template.spec.ts
+++ b/packages/crm/tests/unit/landing/render-landing-template.spec.ts
@@ -35,9 +35,21 @@ before(() => {
   process.env.WORKSPACE_BASE_DOMAIN = "app.seldonframe.com";
 });
 
+import type { ReactElement } from "react";
+
 import { renderLandingTemplate } from "../../../src/lib/landing/render-landing-template";
 import { LANDING_TEMPLATES } from "../../../src/components/landing-templates/registry";
 import type { R1LandingPayload } from "../../../src/lib/landing/r1-payload-prompt";
+import type { TemplateProps } from "../../../src/components/landing-templates/_contract/types";
+
+// The function returns a plain (untyped-at-the-call-site) ReactElement | null
+// per its signature; this helper narrows it to the template's known props
+// shape so tests can read `.props.data` / `.props.ctas` / `.props.theme`
+// without `unknown` errors, and asserts non-null in one place.
+function props(el: ReactElement | null): TemplateProps {
+  assert.ok(el, "expected a non-null element");
+  return (el as ReactElement<TemplateProps>).props;
+}
 
 // ── Representative r1 fixture (mirrors r1-payload-to-template.spec.ts) ────────
 const fullPayload: R1LandingPayload = {
@@ -153,17 +165,17 @@ describe("renderLandingTemplate — case 2: registered id + r1 payload", () => {
   });
 
   test("props.data.business_name comes from the r1 payload", () => {
-    assert.equal(result!.props.data.business_name, "Austin Family Chiropractic");
+    assert.equal(props(result).data.business_name, "Austin Family Chiropractic");
   });
 
   test("props.ctas.bookUrl/intakeUrl are workspace-scoped", () => {
-    assert.match(result!.props.ctas.bookUrl, /austin-family-chiro/);
-    assert.ok(result!.props.ctas.intakeUrl, "expected an intakeUrl");
-    assert.match(result!.props.ctas.intakeUrl, /austin-family-chiro/);
+    assert.match(props(result).ctas.bookUrl, /austin-family-chiro/);
+    assert.ok(props(result).ctas.intakeUrl, "expected an intakeUrl");
+    assert.match(props(result).ctas.intakeUrl!, /austin-family-chiro/);
   });
 
   test("props.ctas.callHref is tel-normalized from the payload phone", () => {
-    assert.equal(result!.props.ctas.callHref, "tel:5125550182");
+    assert.equal(props(result).ctas.callHref, "tel:5125550182");
   });
 });
 
@@ -178,13 +190,12 @@ describe("renderLandingTemplate — case 3: r1 null + soul fallback", () => {
   });
 
   test("returns an element mapped via submittedSoulToTemplateData", () => {
-    assert.ok(result);
-    assert.equal(result!.props.data.business_name, "Riverside Physiotherapy");
-    assert.equal(result!.props.data.tagline, "Move better, live stronger");
+    assert.equal(props(result).data.business_name, "Riverside Physiotherapy");
+    assert.equal(props(result).data.tagline, "Move better, live stronger");
   });
 
   test("ctas.callHref derives from the soul's phone", () => {
-    assert.equal(result!.props.ctas.callHref, "tel:6045550144");
+    assert.equal(props(result).ctas.callHref, "tel:6045550144");
   });
 });
 
@@ -198,8 +209,8 @@ describe("renderLandingTemplate — case 4: explicit archetype re-skin", () => {
       soul: null,
       themeArchetype: undefined,
     });
-    assert.ok(result!.props.theme, "expected a theme object");
-    assert.ok(result!.props.theme.primary, "expected a primary color token");
+    assert.ok(props(result).theme, "expected a theme object");
+    assert.ok(props(result).theme!.primary, "expected a primary color token");
   });
 
   test("themeArchetype used when r1.archetype absent (r1: null case)", () => {
@@ -211,7 +222,7 @@ describe("renderLandingTemplate — case 4: explicit archetype re-skin", () => {
       soul: rawSoul,
       themeArchetype: "cinematic-aspirational",
     });
-    assert.ok(result!.props.theme, "expected a theme object");
+    assert.ok(props(result).theme, "expected a theme object");
   });
 
   test("r1.archetype wins over themeArchetype when both present", () => {
@@ -235,7 +246,7 @@ describe("renderLandingTemplate — case 4: explicit archetype re-skin", () => {
     // the palettes happen to collide, which bold-urgency/clinical-trust do
     // not in this registry) — proves r1.archetype (not themeArchetype) drove
     // the first result even though themeArchetype was also present.
-    assert.notDeepEqual(winsWithBoldUrgency!.props.theme, clinicalTrustOnly!.props.theme);
+    assert.notDeepEqual(props(winsWithBoldUrgency).theme, props(clinicalTrustOnly).theme);
   });
 });
 
@@ -249,7 +260,7 @@ describe("renderLandingTemplate — case 5: no archetype / unknown archetype", (
       soul: rawSoul,
       themeArchetype: undefined,
     });
-    assert.equal(result!.props.theme, undefined);
+    assert.equal(props(result).theme, undefined);
   });
 
   test("unknown archetype string → props.theme is undefined", () => {
@@ -261,7 +272,7 @@ describe("renderLandingTemplate — case 5: no archetype / unknown archetype", (
       soul: rawSoul,
       themeArchetype: "not-a-real-archetype",
     });
-    assert.equal(result!.props.theme, undefined);
+    assert.equal(props(result).theme, undefined);
   });
 });
 
@@ -275,7 +286,7 @@ describe("renderLandingTemplate — case 6: withTemplateDefaults fills empty pho
       soul: null,
       themeArchetype: undefined,
     });
-    const photos = result!.props.data.photos as Array<{ role?: string; url: string }> | undefined;
+    const photos = props(result).data.photos;
     assert.ok(Array.isArray(photos) && photos.length > 1, "expected multiple photos after default fill");
     const roles = new Set(photos!.map((p) => p.role));
     assert.ok(roles.has("hero"), "expected a hero photo");


### PR DESCRIPTION
## Problem

The subdomain renderer (`/s/[orgSlug]/[...slug]`, behind `<slug>.app.seldonframe.com`) never checked `organizations.theme.landingTemplate`. A workspace that picked a premium health template rendered it on `/w/[slug]` but got the plain R1 landing on its subdomain — **/w and the subdomain diverged for every health-template workspace**, and the subdomain is the URL operators actually hand out.

## Fix

Extract /w's template branch into one pure shared function both routes call, so the two renderers can never drift again:

- **`lib/landing/render-landing-template.tsx`** (new) — `renderLandingTemplate()`: `isLandingTemplateId` gate → `withTemplateDefaults` + `r1PayloadToTemplateData`/`submittedSoulToTemplateData` → explicit-archetype-only `archetypeToSfTheme` → `buildTemplateCtas`. Pure (no db/async) → unit-tests without mocks.
- **`/w/[slug]`** — behavior-preserving refactor onto the shared function.
- **`/s/[orgSlug]/[...slug]`** — the actual fix: the home branch now renders the template for **r1-payload** workspaces AND **soul-only** workspaces (via `getWorkspaceTemplateContext`), mirroring /w exactly; plus the matching `generateMetadata` soul-fallback. Legacy no-template workspaces hit `isLandingTemplateId → false` and fall through to the untouched R1 / PageRenderer paths.

Rebased onto #78 mid-flight (live-archetype-at-source merged while building): the loader now hands both routes an already-live-normalized `archetype`, which composes correctly with the shared function's `r1?.archetype ?? themeArchetype` rule; one stale `ARCHETYPES` import swept.

## Verification

- New spec `tests/unit/landing/render-landing-template.spec.ts` — 15/15 (null-gate for legacy ids, element/props for r1 + soul paths, archetype precedence + unknown-archetype → signature palette, default-photo fill, workspace-scoped CTAs).
- Independent verify-build gate: **PASS** (tsc 0 new errors, unit suite delta-clean vs the DB-bound baseline, check:use-server clean, zero migrations, regression grep empty).
- Independent reviewer: **SHIP**, no blocking findings (parity traced through `r1-save.ts`/`public-workspace.ts`; precedences provably equal).
- No new deps, no migrations, no flags.

## Post-deploy smoke (required)

Pick a health-template workspace: `<slug>.app.seldonframe.com` root and `/w/<slug>` must render the same template (template DOM marker on both, R1 `SiteShell` absent on both). Soul-only + template workspace subdomain should also now show the template instead of the legacy page.

Follow-up (pre-existing, out of scope, chip filed): /s r1-home metadata hardcodes `index: true`, skipping the Task-8 unclaimed-anonymous noindex rule that /w applies.

Spec: `docs/superpowers/specs/2026-07-14-subdomain-landing-template-parity-design.md` · Plan: `docs/superpowers/plans/2026-07-14-subdomain-landing-template-parity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)