### PR TITLE
fix(seo): /s subdomain honors the Task 8 unclaimed-anonymous-build noindex rule

### DIFF
--- a/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
+++ b/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
@@ -19,13 +19,13 @@ import type { LandingSection } from "@/lib/landing/types";
 // sticky CTA). The fall-through keeps the OLD system intact for
 // workspaces that have no _r1 row (all existing production workspaces).
 import { loadLandingPayload } from "@/lib/landing/r1-save";
+import { shouldIndexWorkspace } from "@/lib/web-build/policy";
 import { rewriteR1Hrefs } from "@/lib/landing/r1-rewrite-hrefs";
 import { resolveMapQuery } from "@/lib/landing/map-embed";
 import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getWorkspaceTemplateContext } from "@/lib/landing/public-workspace";
 import { submittedSoulToTemplateData } from "@/lib/landing/r1-payload-to-template";
 import { renderLandingTemplate } from "@/lib/landing/render-landing-template";
-import { WEB_UNGATED_ORIGIN } from "@/lib/web-build/policy";
 import { Hero } from "@/components/landing-r1/sections/hero";
 import { ServicesGrid } from "@/components/landing-r1/sections/services-grid";
 import { Testimonials } from "@/components/landing-r1/sections/testimonials";
@@ -63,6 +63,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     if (r1Data && page) {
       const businessName = r1Data.payload.footer.businessName;
       const title = `${page.name} — ${businessName}`;
+      // Task 8: unclaimed anonymous web-build workspaces stay noindexed on
+      // the subdomain too — same predicate as /w/[slug].
+      const indexable = shouldIndexWorkspace(r1Data.ownerId, r1Data.settings);
       return {
         title,
         description: page.summary,
@@ -72,7 +75,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
           ...(page.heroPhoto ? { images: [{ url: page.heroPhoto.src }] } : {}),
           type: "website",
         },
-        robots: { index: true, follow: true },
+        robots: { index: indexable, follow: indexable },
         // Canonical uses relative path style, matching the home-page metadata
         // above which uses `/w/${orgSlug}` (not an absolute subdomain URL).
         alternates: { canonical: `/w/${orgSlug}/services/${slug[1]}` },
@@ -86,6 +89,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     const r1Data = await loadLandingPayload(orgSlug);
     if (r1Data) {
       const { seo, payload } = r1Data;
+      // Task 8: unclaimed anonymous web-build workspaces stay noindexed on
+      // the subdomain too — same predicate as /w/[slug]. Without this, a
+      // workspace noindexed on /w was still indexable on its subdomain.
+      const indexable = shouldIndexWorkspace(r1Data.ownerId, r1Data.settings);
       return {
         title: seo.title,
         description: seo.description,
@@ -95,7 +102,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
           ...(seo.ogImage ? { images: [{ url: seo.ogImage }] } : {}),
           type: "website",
         },
-        robots: { index: true, follow: true },
+        robots: { index: indexable, follow: indexable },
         // Canonical points to /w/[slug] — that is the authoritative URL
         // for the R-framework page; /s/[slug]/home is the proxy rewrite.
         alternates: { canonical: `/w/${orgSlug}` },
@@ -138,7 +145,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     if (soul && soul.business_name !== "Our Practice") {
       const description = soul.soul_description ?? soul.tagline;
       // ctx is non-null here (soul came from it above).
-      const indexable = !(ctx!.ownerId === null && ctx!.settings["origin"] === WEB_UNGATED_ORIGIN);
+      const indexable = shouldIndexWorkspace(ctx!.ownerId, ctx!.settings);
       return {
         title: soul.business_name,
         ...(description ? { description } : {}),

--- a/packages/crm/src/app/(public)/w/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/w/[slug]/page.tsx
@@ -36,19 +36,11 @@ import { buildWorkspaceUrls } from "@/lib/billing/anonymous-workspace";
 import { getPublicChatbotEmbed } from "@/lib/agents/public-embed";
 import { submittedSoulToTemplateData } from "@/lib/landing/r1-payload-to-template";
 import { renderLandingTemplate } from "@/lib/landing/render-landing-template";
-import { WEB_UNGATED_ORIGIN } from "@/lib/web-build/policy";
+import { shouldIndexWorkspace } from "@/lib/web-build/policy";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
 };
-
-// Task 8: unclaimed anonymous web-build workspaces (created via the /try
-// paste-box flow, no owner attached yet) stay out of the search index until
-// claimed via signup. Claimed workspaces and every non-web-build workspace
-// keep the existing indexable behavior.
-function shouldIndexWorkspace(ownerId: string | null, settings: Record<string, unknown>): boolean {
-  return !(ownerId === null && settings["origin"] === WEB_UNGATED_ORIGIN);
-}
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;

--- a/packages/crm/src/lib/web-build/policy.ts
+++ b/packages/crm/src/lib/web-build/policy.ts
@@ -7,6 +7,20 @@ export const WEB_BUILD_RATE_WINDOW_MS = 24 * 60 * 60 * 1000;
 /** organizations.settings.origin marker for anonymous web builds (no schema column). */
 export const WEB_UNGATED_ORIGIN = "web_ungated";
 
+/**
+ * Task 8: unclaimed anonymous web-build workspaces (created via the /try
+ * paste-box flow, no owner attached yet) stay out of the search index until
+ * claimed via signup. Claimed workspaces and every non-web-build workspace
+ * keep the existing indexable behavior. Shared by the /w and /s public
+ * routes so subdomain metadata can never drift from the /w rule again.
+ */
+export function shouldIndexWorkspace(
+  ownerId: string | null,
+  settings: Record<string, unknown>,
+): boolean {
+  return !(ownerId === null && settings["origin"] === WEB_UNGATED_ORIGIN);
+}
+
 export function isWebUngatedBuildOn(env: {
   SF_WEB_UNGATED_BUILD?: string | undefined;
 }): boolean {

--- a/packages/crm/tests/unit/web-build-policy.spec.ts
+++ b/packages/crm/tests/unit/web-build-policy.spec.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   isWebUngatedBuildOn,
   isAutopayConsoleOn,
+  shouldIndexWorkspace,
   WEB_BUILD_RATE_LIMIT,
   WEB_BUILD_RATE_WINDOW_MS,
   WEB_UNGATED_ORIGIN,
@@ -26,6 +27,18 @@ test("flag: SF_AUTOPAY_CONSOLE — on only for exact '1' (trimmed); everything e
   assert.equal(isAutopayConsoleOn({ SF_AUTOPAY_CONSOLE: "true" }), false);
   assert.equal(isAutopayConsoleOn({ SF_AUTOPAY_CONSOLE: "0" }), false);
   assert.equal(isAutopayConsoleOn({}), false);
+});
+
+test("shouldIndexWorkspace: noindex ONLY for unclaimed anonymous web builds (Task 8)", () => {
+  // The one noindex case: no owner AND web_ungated origin.
+  assert.equal(shouldIndexWorkspace(null, { origin: WEB_UNGATED_ORIGIN }), false);
+  // Claimed web-build workspace → indexable again.
+  assert.equal(shouldIndexWorkspace("user_123", { origin: WEB_UNGATED_ORIGIN }), true);
+  // Unowned but not a web build (e.g. MCP-created) → indexable.
+  assert.equal(shouldIndexWorkspace(null, {}), true);
+  assert.equal(shouldIndexWorkspace(null, { origin: "mcp" }), true);
+  // Fully ordinary workspace → indexable.
+  assert.equal(shouldIndexWorkspace("user_123", {}), true);
 });
 
 test("constants", () => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2244,3 +2244,22 @@ C4 close-out with empirical SLICE 11 data.
   once — audit `overflowX` across `components/seo/*` and kill the ones on
   diagram/sequence wrappers. Keep the fix responsive (compare grids → 1 column
   below ~520px) and reduced-motion aware.
+
+## L-43 — Never delta-check a baseline with `git checkout <ref> -- .` in the working repo; it STAGES the ref's content
+
+- **Trigger:** To prove 10 landing-spec failures were pre-existing, I ran
+  `git checkout origin/main -- .` → ran the specs → `git checkout -- .` →
+  `git stash pop`. Two traps fired at once: (1) `checkout <ref> -- <path>`
+  updates the INDEX as well as the worktree, so the follow-up `checkout -- .`
+  restored from the index (still main's content) and silently left the branch's
+  own commit reverted-but-staged; (2) the earlier `git stash` had nothing to
+  save (post-rebase tree was clean), so `stash pop` grabbed an UNRELATED
+  months-old stash entry. Recovery needed `git restore --source=HEAD --staged
+  --worktree .` plus verifying the old stash list was untouched.
+- **Rule:** For "does this test fail on main too?" use a THROWAWAY checkout —
+  `git worktree add <tmp> origin/main`, run the spec there, `git worktree
+  remove <tmp>` — never mutate the working repo's index. If you must stash,
+  first confirm `git stash` actually created an entry (clean trees make the
+  later `pop` land on someone else's stash). Cheapest of all when the specs
+  don't import your changed files: prove isolation by grepping the failing
+  specs' imports against your diff, and skip the baseline run entirely.


### PR DESCRIPTION
## The leak

The r1-home and per-service `generateMetadata` branches of `/s/[orgSlug]/[...slug]` hardcoded `robots: { index: true, follow: true }`. Meanwhile `/w/[slug]` applies `shouldIndexWorkspace(ownerId, settings)` (noindex when `ownerId === null && settings.origin === "web_ungated"`). Result: an unclaimed anonymous web-build workspace was noindexed on `/w` but **fully indexable on its own subdomain** — the exact leak Task 8 was meant to close. Surfaced during the 2026-07-14 subdomain template-parity review (PR #80).

## The fix (rebased onto main post-#80)

- `shouldIndexWorkspace` extracted into `lib/web-build/policy.ts` (shared module next to `WEB_UNGATED_ORIGIN` — deliberately NOT exported from a page.tsx, per the route-file-exports gotcha L-31)
- `/w/[slug]/page.tsx` imports it instead of its inline copy — behavior unchanged
- `/s` computes robots via the predicate in **all three** metadata branches: r1-home, `/services/<service>` (identical hardcode), and #80's soul-only fallback (which had its own inline copy of the expression — now the shared call)
- Uses `r1Data.ownerId` / `r1Data.settings`, which `loadLandingPayload` already returns

## Verification (post-rebase)

- `node --test --import tsx tests/unit/web-build-policy.spec.ts` → 7/7 pass (new `shouldIndexWorkspace` cases: unclaimed+web_ungated → noindex; claimed, non-web-build, ordinary → indexable)
- `tests/unit/landing/render-landing-template.spec.ts` (PR #80's parity spec) → 15/15 pass
- `tsc --noEmit` on packages/crm → exit 0
- Landing suite: 11 failures are pre-existing main baseline (marketing FAQ/hero/brand-mark copy tests — verified identical failures on origin/main's code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)