### PR TITLE
persona-loop: 'Describe the business' hero tab dead-ends on /try (URL-only) — route it to the signup description-build

### DIFF
--- a/packages/crm/src/components/landing/hero-submit-target.ts
+++ b/packages/crm/src/components/landing/hero-submit-target.ts
@@ -6,9 +6,12 @@
 //
 // Flag OFF (ungatedBuildEnabled=false): byte-identical to the pre-web-build
 // behavior — always routes to /signup?intent=build(&url=...).
-// Flag ON: routes to /try (Task 5's anonymous-build island), which reads
-// ?url= directly and falls back to the hero's localStorage seed for the
-// business-description tab.
+// Flag ON: the url tab routes to /try (the anonymous-build island, which is
+// URL-only — its GET .../build/stream takes no text/biz param). The biz tab
+// must NOT go to /try: it would dead-end on a read-only echo of the
+// description ("URL builds only for now"). It routes to /signup?intent=build,
+// where the hero's localStorage seed feeds the existing signup → /clients/new
+// description-build pipeline.
 
 export type HeroTabKind = "url" | "biz";
 
@@ -17,12 +20,9 @@ export function heroSubmitTarget(
   value: string,
   ungatedBuildEnabled: boolean,
 ): string {
-  if (ungatedBuildEnabled) {
-    if (tab === "url") {
-      const params = new URLSearchParams({ url: value });
-      return `/try?${params.toString()}`;
-    }
-    return "/try";
+  if (ungatedBuildEnabled && tab === "url") {
+    const params = new URLSearchParams({ url: value });
+    return `/try?${params.toString()}`;
   }
 
   const params = new URLSearchParams({ intent: "build" });

--- a/packages/crm/tests/unit/marketing-hero-target.spec.ts
+++ b/packages/crm/tests/unit/marketing-hero-target.spec.ts
@@ -18,10 +18,10 @@ test("flag off → byte-identical current behavior", () => {
   assert.equal(heroSubmitTarget("biz", "Family plumbing in Reno", false), "/signup?intent=build");
 });
 
-test("flag on → /try carries the url; biz tab still goes to /try", () => {
+test("flag on → /try carries the url; biz tab routes to signup (description build is signup-gated, /try is URL-only)", () => {
   assert.equal(
     heroSubmitTarget("url", "https://acme.com", true),
     "/try?url=https%3A%2F%2Facme.com",
   );
-  assert.equal(heroSubmitTarget("biz", "Family plumbing in Reno", true), "/try");
+  assert.equal(heroSubmitTarget("biz", "Family plumbing in Reno", true), "/signup?intent=build");
 });


### PR DESCRIPTION
**First finding of the nightly activation-persona-loop cloud routine** (smoke run, session `cse_01RRt88AhdkvV2jZ844wJoZs`). The cloud sandbox found and fixed this but had no GitHub write access (403 on push/PR/issue), so the fix was recreated and re-verified locally. One-time unblock for future nights: grant the Claude GitHub App write access to this repo.

## Persona
Wednesday → med-spa owner. Boutique med spas commonly have **no real website** — Instagram/Facebook only. This is exactly the visitor the "Describe the business" tab exists for.

## Funnel step + evidence
Homepage hero shows two equally-weighted tabs — "Paste a URL" and "Describe the business" — behind the same zero-friction "Build workspace" button. With `SF_WEB_UNGATED_BUILD` live (`/try` returns 200 in prod), the biz tab submits to `/try`, which is **URL-only**: its build stream (`GET .../build/stream?url=...`) takes no text param. The visitor's typed description renders read-only with:

> "URL builds only for now — paste your website above, or **sign up** to build from a description."

(`try-client.tsx:411-420`; the file's own header comment documents description-mode as a known unbuilt deviation.) The persona typed their business, hit the big build button, and got a wall. Bounce.

The unit test literally pinned the broken behavior: `heroSubmitTarget("biz", ..., true) === "/try"` — "biz tab still goes to /try".

## Root cause
`heroSubmitTarget` (`src/components/landing/hero-submit-target.ts`) routed **both** tabs to `/try` when the ungated flag is on, but `/try` only implements the URL path.

## Fix (smallest honest change — reuses the existing pipeline)
Flag on + biz tab now routes to `/signup?intent=build` — the hero's localStorage seed already feeds the proven signup → `/clients/new` description-build pipeline (identical to flag-off behavior for this tab). URL tab unchanged (`/try?url=...`). Other `heroSubmitTarget` callers (SEO website-grader, build-widget) pass `"url"` only — unaffected. Updated the one test that pinned the dead end.

## Gate results
- targeted unit: `marketing-hero-target.spec.ts` + `try-page-gate.spec.ts` → **3/3 pass**
- `tsc --noEmit`: 10 errors before AND after (stash-delta **0 new**)
- `check-use-server.sh` → clean · `check-migrations-journaled.mjs` → 0 orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)