### PR TITLE
feat(reflect): /reflect decision-making loop — 23 compacted mental-model lenses + calibration log

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: reflect
+description: Run Max's decision-making loop on any decision — strategy, product, pricing, build, or personal. Invoke whenever Max says "reflect" / "reflect on X", or when facing a consequential decision that deserves structured treatment. Stakes-scaled - reversible decisions get a fast pass, irreversible ones get the full battery. Every run ends with an opinionated recommendation and a decision-log entry.
+---
+
+# /reflect — the decision-making loop
+
+Compacted from ~24 Farnam Street mental-model articles + the Bezos framework.
+The library lives in `references/` — **load only the lenses the decision needs**
+(routing table: `references/00-index.md`). Never load all of them; that is its
+own failure mode (man-with-a-hammer, analysis theater).
+
+Decision log: `docs/decisions/LOG.md` (+ one file per Type-1 decision).
+
+## Upstream rule — settled decisions stay settled
+
+CLAUDE.md §1b decisions (positioning, pricing ladder, BYOK-as-plumbing, no-Zapier,
+reuse-don't-rebuild) are **not re-litigated** by a reflect. If a reflect surfaces
+genuinely new evidence against a settled decision, say so explicitly and flag it
+for Max — do not quietly reopen it.
+
+## The loop
+
+### 0. Review-debt check (always, first)
+Scan `docs/decisions/LOG.md` for entries whose **review-by date has passed** and
+status is still `open`. Surface them before anything else:
+> "Before this reflect: on <date> we predicted <expected outcome> by <review-by>.
+> What happened?" — update the entry's status/outcome from Max's answer (or from
+> evidence you can check yourself). This is the calibration flywheel; skipping it
+> makes the whole system decorative.
+
+### 1. Frame the decision (decision-anatomy)
+State, in 2-4 sentences:
+- **The actual decision** — often not the question as asked. Ask "what problem is
+  this decision solving?" before accepting the framing.
+- **Owner** — whose call is this? (Max / Claude / a customer / nobody-yet)
+- **Trigger** — why now? What breaks if we decide nothing? (No-decision is a decision.)
+- **What's conspicuous** — list the crucial information in plain sight before
+  analyzing (Robinson: stupidity = overlooking the conspicuous, not lacking IQ).
+
+If a decision-critical fact exists only in Max's head, ask it now — one focused
+question, not an interview. Otherwise state assumptions explicitly and continue.
+
+### 2. Classify — the Bezos gate (references/bezos-type1-type2.md, decision-matrix.md)
+- **Type 2 (two-way door):** reversible at tolerable cost, blast radius contained.
+  → **Quick pass** (§3a). Deciding fast IS the optimization; ~70% of the
+  information is the target, not 90%.
+- **Type 1 (one-way door):** irreversible or expensive to reverse — public
+  commitments, pricing/positioning changes, partnerships, anything touching trust
+  ("never-lies"), large irreversible spends, hiring/firing.
+  → **Full run** (§3b).
+- When unsure, ask: "what would it cost to undo this in 3 months?" If the answer
+  is "a bad week," it's Type 2. Most decisions are Type 2 — treating them as
+  Type 1 is the more common and more expensive error (velocity loss).
+
+### 3a. Quick pass (Type 2)
+1. Pick the **3 most-biting lenses** from `references/00-index.md`. Before
+   committing to them, one availability check: *am I picking these because they
+   fit, or because they're vivid/recent?*
+2. Run them briefly (a few sentences each).
+3. Output (§4) in one or two paragraphs. Log = one line in LOG.md.
+Total effort target: minutes, not hours. If a quick pass keeps growing, either
+the decision was misclassified (go to §3b) or you're bikeshedding (stop).
+
+### 3b. Full run (Type 1)
+Work through, loading each reference as you use it:
+1. **First principles** — decompose to fundamental truths (costs, physics of the
+   business, what customers actually do). Where is the reasoning analogy-based
+   ("competitors do X", "that's how SaaS works")? Rebuild those parts from ground truth.
+2. **Chesterton's fence** — if the decision removes/replaces something existing,
+   establish why it exists before touching it.
+3. **Inversion + pre-mortem** (mandatory) — "it's 6 months later and this decision
+   failed badly. What killed it?" List the top 3 causes and whether each is
+   detectable early or preventable cheaply.
+4. **Second-order effects / externalities** — "and then what?" for each option:
+   who reacts, what breaks downstream, what incentive does this create?
+5. **Optionality & slack** — which option preserves the most future options per
+   unit of commitment? Does any option consume all slack (schedule, cash,
+   attention) and leave nothing for surprises?
+6. **Explore/exploit** — early in a domain → weight exploration; proven channel/
+   feature → exploit. Check the interval: how long can we still benefit from
+   what we'd learn?
+7. **Probability sanity-check** — every estimate used gets a base-rate check
+   (what's the outside view / reference class?) and a best-case audit: the plan
+   must survive the *likely* case, and the worst day, not just the demo day.
+8. **Decision matrix** — only if genuinely 3+ options × 3+ criteria; weight
+   criteria before scoring options (else the matrix launders a pre-made choice).
+
+### 4. Recommend (always, both paths)
+End with, in this order:
+1. **The call** — one sentence, opinionated. No option menus without a pick.
+2. **Confidence** — a number (e.g., "~75%"), not an adverb.
+3. **What would change my mind** (mandatory) — 1-3 specific observations that
+   would flip the recommendation. This is the anti-rationalization tripwire.
+4. **Cheap tests** — anything under a day's effort that would raise confidence
+   before committing (only if such tests exist).
+
+### 5. Log (always)
+Append to `docs/decisions/LOG.md`:
+```
+| YYYY-MM-DD | <decision, one line> | <call> | T1/T2 | <expected outcome> | <review-by> | open |
+```
+Type 1 additionally gets `docs/decisions/YYYY-MM-DD-<slug>.md` with: framing,
+options considered, lenses run and what each surfaced, the recommendation block
+(§4), and Max's final call if it differed from the recommendation (record both —
+divergences are the most informative calibration data).
+Review-by heuristic: when the expected outcome should be observable — typically
+2-6 weeks for tactical calls, a quarter for strategic ones.
+
+## Guardrails (check yourself during every run)
+- **Bikeshed alarm** — effort must scale with stakes, not with how easy the topic
+  is to have opinions about. If the discussion is vivid but the dollars are small, stop.
+- **Availability check** — the lenses and examples that come to mind first are the
+  recent/vivid ones, not necessarily the right ones. Scan 00-index.md deliberately.
+- **Defensive-decision check** — is this recommendation optimizing the outcome, or
+  protecting the recommender? "The safe-looking option" needs the same scrutiny as
+  the bold one.
+- **Captaincy** — Claude recommends; Max decides. Never launder a recommendation
+  as "the data says." Own it: "I'd do X because Y."
+- **Break the chain** — if an option creates compounding obligation or dependency
+  (favors, vendor/channel reliance, lifestyle-debt-style commitments), price that
+  loss of independence in; the cheapest time to say no is at the first link.
+- **Optimistic Path** (house rule) — the recommendation must state what happens in
+  the failure case, not only the success case.
+
+## Failure modes of this skill itself
+- Running all 24 lenses = analysis theater. Three good lenses beat twenty.
+- Using the loop to justify a pre-made decision — the "what would change my mind"
+  line exists to catch this; if nothing would, the reflect was rationalization.
+- Skipping the log because the decision felt small. Small logged decisions are
+  cheap calibration data; unlogged ones are nothing.

--- a/.claude/skills/reflect/references/00-index.md
+++ b/.claude/skills/reflect/references/00-index.md
@@ -1,0 +1,40 @@
+# Lens routing table
+
+One line per lens: **when it bites**. Load a reference file only when its trigger
+matches the decision at hand. Quick pass = pick the 3 best matches; full run
+follows the sequence in SKILL.md §3b.
+
+## The loop's backbone (structural — used by SKILL.md itself)
+- **decision-anatomy** — framing any decision: what's actually being decided, by whom, why now.
+- **bezos-type1-type2** — the classify gate: reversible→fast, irreversible→slow; 70% info rule; disagree-and-commit.
+- **decision-matrix** — 3+ options × 3+ criteria and stakes justify the ceremony; weight criteria first.
+- **ooda-loop** — competitive/adversarial situations; when tempo of iteration matters more than any single decision.
+
+## Reasoning quality
+- **first-principles** — the reasoning smells like analogy ("competitors do X", "that's standard"); costs or constraints taken on faith.
+- **inversion-avoid-stupidity** — before any big commit: what would make this fail / what's the conspicuous thing being overlooked; deciding while rushed, tired, stressed, or in a group.
+- **chestertons-fence** — removing/replacing anything that already exists (code, process, pricing term, positioning line) without knowing why it's there.
+- **gian-carlo-rota** — choosing what to work on and how to present it; leverage from a few reusable tricks; working on what others care about.
+
+## Bias & probability
+- **availability-bias** — the decision leans on vivid/recent examples (one loud customer, last week's incident, a viral post).
+- **probability-errors** — any estimate, forecast, or "X% chance" in the analysis; base rates being ignored.
+- **algorithms-bias** — automating a decision or trusting a model/heuristic; bias entering via training data and proxy features; overrides should carry a stated reason.
+- **best-case** — the plan only works if everything goes right; timelines/projections anchored on the demo-day scenario.
+- **worst-day** — designing anything that must survive its worst day (infra, support load, cash buffer, reputation risk).
+
+## Time, options & second-order
+- **explore-exploit** — new channel/feature/market vs doubling down on what works; how much runway remains to benefit from learning.
+- **optionality** — choosing between committing now vs keeping doors open; lock-in decisions (vendors, architectures, public promises).
+- **slack** — schedules/budgets/attention at 100% utilization; "we can squeeze it in" reasoning.
+- **externalities** — the option affects parties not at the table (clients' clients, marketplace builders, future self); "and then what?"
+
+## Human & organizational
+- **bikeshed** — a trivial topic is consuming outsized discussion; strong opinions arriving on the easiest-to-opine part.
+- **defensive-decisions** — the appeal of an option is that nobody could blame us; CYA reasoning; "safe" big-brand choice.
+- **captaincy** — deferring to authority/convention instead of owning the call; recommendation hiding behind "the data".
+- **break-the-chain** — the option creates obligation/dependency (gifts, favors, lifestyle debt, channel or vendor reliance) that compounds; independence is at stake.
+- **hemingway-suitcase** — lost work or a scrapped effort; deciding whether/how to redo something (the redo is often better).
+
+## Meta
+- **mental-models-general** — the latticework: multi-model thinking, circle of competence, second-order thinking, and the quick lens list for models without a dedicated file.

--- a/.claude/skills/reflect/references/algorithms-bias.md
+++ b/.claude/skills/reflect/references/algorithms-bias.md
@@ -1,0 +1,42 @@
+---
+name: algorithms-bias
+source: https://fs.blog/algorithms-and-bias/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Algorithms and Bias
+
+## Core idea
+Humans and algorithms fail differently, and the article argues neither should decide alone. Human judgment degrades in predictable ways — we drop information when tired, and we bend evidence toward the outcome we already want. Algorithms are immune to fatigue and motivated reasoning, so they can override those irrationalities and apply a rule consistently. But algorithms are built by humans on human-generated data, so they quietly inherit our prejudices: the article's example is a programmer-recruiting platform that learned to weight visits to Japanese manga sites — a proxy that systematically disadvantaged women with caregiving responsibilities, with no one having intended it.
+
+Two structural sources of algorithmic bias get named. First, data quality — garbage in, garbage out: historical datasets have gaps (women are chronically underrepresented; the default Reference Man — a ~70kg young Caucasian male — stands in for all of humanity in safety gear and medical dosing, with dangerous results). Second, mathematical limits: some fairness problems are provably unsolvable — a recidivism predictor cannot hold both accuracy and error rates equal across demographic groups simultaneously, so a value judgment is baked in no matter what.
+
+The article's stance is ultimately optimistic: nothing inherent in these systems forces them "to repeat the biases of the past." The path: transparency (auditable, regulated models), representative data, and positioning algorithms as decision-support in partnership with a human — not a replacement for judgment.
+
+## When it bites
+- You're choosing between "let the model/rule decide" and "let the expert decide" — the real answer is usually a designed division of labor.
+- A model performs well on aggregate metrics while quietly failing a subgroup the training data underrepresents.
+- A learned proxy feature correlates with a protected or irrelevant trait (the manga-site problem): the algorithm found a shortcut, not the skill.
+- The training data describes a Reference User who isn't your actual population.
+- Someone claims a scoring system is "objective because it's math" — the values are hidden in the data and the impossibility trade-offs, not absent.
+
+## How to run it
+1. Split the decision: let the algorithm do what it's good at (consistency, no fatigue, no motivated reasoning) and reserve the human for what it can't see (context, subgroup harm, changed conditions).
+2. Audit the inputs: whose behavior generated this data? Who is missing from it? A gap in the data becomes a systematic failure in the output.
+3. Interrogate proxies: for each heavy feature, ask what it actually measures and who it accidentally excludes.
+4. Name the fairness trade-off explicitly: when equal accuracy and equal error rates can't coexist, choose deliberately and write the choice down — silence just means the data chose.
+5. Demand transparency: if you can't inspect why the model decided, you can't catch inherited bias — prefer auditable rules over opaque scores for consequential calls.
+6. Override the algorithm only with a stated reason (new information, known data gap, subgroup harm) — not because the output merely feels wrong; "feels wrong" is often the exact irrationality the algorithm exists to override.
+
+## Failure modes
+- **Automation worship**: treating the algorithm's output as objective truth and blindly perpetuating the old injustices encoded in its training data.
+- **Reflexive override**: humans discarding algorithmic output whenever it contradicts intuition, which reintroduces fatigue and motivated reasoning — the failure the rule was built to fix.
+- **Aggregate blindness**: validating on overall accuracy while a subgroup gets systematically worse outcomes.
+- **Fairness hand-waving**: assuming a clever metric can satisfy every fairness definition at once when it's mathematically impossible — someone must own the trade-off.
+
+## Applies here when…
+- Never-lies enforcement: guardrails + auto-evals + read-back are the "algorithm" that overrides the LLM's (and the builder's) motivated optimism — keep them deterministic and auditable, and require a stated reason to override a red eval.
+- Lead scoring / routing / autopay rules built for agency clients: audit which proxy features drive them, and check performance per client vertical, not just aggregate — an SMB trades dataset has its own "Reference Man."
+- The dream/persona reflection loops: cluster-and-propose (algorithm) + Max approves (human) is exactly the partnership pattern — resist auto-applying lessons.
+- Build-vs-reuse and pricing calls: run the mechanical checklist/math first (crossover at ~$3.5k GMV, verify-build gates), and treat gut overrides as needing an explicit, written reason.
+- Choosing model-graded vs deterministic gates in CI: prefer transparent, inspectable checks for merge-blocking decisions; opaque scorers only as advisory signal.

--- a/.claude/skills/reflect/references/availability-bias.md
+++ b/.claude/skills/reflect/references/availability-bias.md
@@ -1,0 +1,41 @@
+---
+name: availability-bias
+source: https://fs.blog/availability-bias-cognitive-distortion/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Availability Bias
+
+## Core idea
+The availability heuristic is a mental shortcut: we judge how likely or important something is by how easily examples come to mind. Ease of recall is a decent proxy for frequency only when memory is a fair sample of reality — and it almost never is. Memory over-indexes on what is recent, vivid, shocking, distinctive, emotionally charged, repeated, story-shaped, or personally experienced. So the map of "what feels common" drifts away from what is actually common.
+
+The article's compact statement of the resulting distortion: "We overestimate the likelihood of unlikely events" — and, symmetrically, we underestimate the likelihood of likely ones. Dramatic rarities (plane crashes, shark attacks) loom large; mundane killers (car accidents, drowning) fade. The bias is symmetric and doubly costly — wasted worry and resources on the improbable, plus poor preparation for the probable.
+
+## When it bites
+- Anything decided right after a salient event: one scary incident, one glowing anecdote, one viral post reshapes your sense of "what usually happens."
+- Evaluations that lean on memory instead of records: the article's manager who rates an employee on the last few weeks rather than the whole year.
+- Visibility compounding into false signal: past award winners win again partly because they're easier to recall, not because they're better.
+- Social-media-fed expectations: highlight reels make rare lifestyles feel like the norm.
+- Risk panics driven by vivid coverage (the article cites Agent Orange, asbestos, breast-implant scares) where felt danger outran measured danger.
+- Any moment you catch yourself reasoning from "the examples I can think of" rather than from counted cases.
+
+## How to run it
+1. Notice the trigger: if a judgment formed fast and an anecdote is doing the work, flag it.
+2. Ask: is this easy to recall because it's frequent, or because it's recent / vivid / emotional / mine?
+3. Go to base rates: what does the full population of cases look like, counted rather than remembered?
+4. Zoom out to the long-term trend line instead of the latest outlier.
+5. Consult the written record: the article's key habit is documenting information systematically and reviewing old notes before deciding, precisely because memory is a biased retrieval system.
+6. Slow down on decisions that matter — invest deliberate thinking time; availability wins when you decide at recall-speed.
+
+## Failure modes
+- **Overcorrection**: dismissing every vivid signal as bias. Sometimes the dramatic recent event IS the base-rate shift (a real regime change). Availability is a reason to check the data, not to ignore the event.
+- **Availability of counter-examples**: "I thought of an exception, so the pattern is false" is the same bias pointed backwards.
+- **Group amplification**: teams share the same recent vivid events, so consensus can just be shared availability, not independent confirmation.
+- **Sterile base rates**: hiding behind aggregate statistics when your situation genuinely differs from the reference class.
+
+## Applies here when…
+- Reading user feedback: one angry churned builder or one delighted testimonial is vivid; the funnel metrics (e.g. the ~22 signups → 0 paying activation-wall finding) are the base rate. Decide from the counted funnel, not the loudest anecdote.
+- Picking distribution channels: the channel where a competitor's post went viral last week feels high-yield; check the documented channel-rank data (YT → X → HN/PH → Reddit) before reallocating effort.
+- Post-incident engineering: right after a production bug, that failure class feels like THE risk — weigh it against the full vision_check / eval failure distribution before rebuilding guardrails around one memorable outage.
+- Competitor panic: a GHL/rival launch that's all over X feels existential; measure actual keyword/traffic movement before repositioning.
+- Roadmap calls from recent conversations: the last three sales calls are the most available data points, not the representative ones — check the CRM record across all deals.

--- a/.claude/skills/reflect/references/best-case.md
+++ b/.claude/skills/reflect/references/best-case.md
@@ -1,0 +1,41 @@
+---
+name: best-case
+source: https://fs.blog/best-case/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Best-Case Outcomes Are Statistical Outliers
+
+## Core idea
+The best-case outcome is just one point on a wide distribution of possible results — and a rare one. Optimism is genuinely useful: without it, nobody would start a company, enter a relationship, or attempt anything hard. The failure is not in hoping for the best; it is in *planning* as if the best case were the likely case.
+
+Even ventures that succeed almost never unfold on the imagined path — unanticipated consequences, missing information, and timeline slips are the norm, not the exception. The article's historical examples (the polio vaccine, clean drinking water) were enormous wins that still arrived slower and less completely than hoped. And the more variables involved (more people, more dependencies, more moving parts), the less probable the ideal outcome becomes — a quiet family Friday night has few variables and a decent shot at its best case; a multi-party venture does not.
+
+FS's prescription: expect a realistic *range* of outcomes rather than fixating on one ideal result. Preparing across the spectrum of possibilities (including the wide spectrum of human behavior) buys resilience and peace of mind. The article closes on Maya Angelou's stance: "Hoping for the best, prepared for the worst, and unsurprised by anything in between."
+
+## When it bites
+- Any forecast, roadmap, or launch plan whose success case requires several independent things to go right at once.
+- Projects with many stakeholders or dependencies — complexity compounds against the ideal path.
+- Decisions where the imagined upside is vivid and the downside is abstract (new market, new channel, new hire).
+- Timelines: the best-case schedule quietly becomes the committed schedule.
+- Post-hoc judgment: even historical triumphs (the article cites vaccines, clean water) were partial and slower than hoped.
+
+## How to run it
+1. Write down the best case explicitly — then label it an outlier, not the plan.
+2. Sketch the distribution: worst case, median case, best case. Plan resourcing and commitments against the *median*, survival against the worst.
+3. Count the variables. Each additional person, dependency, or unknown lowers the odds of the ideal path; simplify where possible.
+4. Ask: "What would I do if this takes 2x as long and delivers half the imagined result?" If the answer is "still worth it," proceed.
+5. Pre-commit to being unsurprised: list three plausible mid-range outcomes so none of them feels like failure when it arrives.
+
+## Failure modes
+- **Weaponized pessimism** — using "best case is an outlier" to kill every ambitious bet. The article defends optimism as the fuel for attempting hard things; the correction is in planning, not in aspiration.
+- **Analysis paralysis** — modeling infinite scenarios instead of a simple worst/median/best trio.
+- **Sandbagging** — padding every estimate so much that the plan carries no information.
+- **Ignoring asymmetry** — some bets are worth making *because* the best case is huge and the worst case is cheap; the model warns against expecting the outlier, not against buying cheap exposure to it.
+
+## Applies here when…
+- Revenue/adoption projections for a pricing or packaging change assume the best-case conversion path (e.g., "flip the flag and signups convert") — plan against the median funnel, not the demo-day one.
+- Positioning bets ("never-lies will land immediately with agencies") — vivid upside story, many independent variables (channel, message, ICP readiness) that each must go right.
+- Feature build-vs-reuse calls where the build estimate is the best-case estimate; reuse decisions should be judged against the median build timeline, which is where reality lands.
+- Distribution channel picks (YT, X, Reddit, Show HN) — one viral outcome is the statistical outlier; commit to channels that work at median performance.
+- Partnership/marketplace forecasts that require multiple parties to behave ideally — every added counterparty moves the best case further into the tail.

--- a/.claude/skills/reflect/references/bezos-type1-type2.md
+++ b/.claude/skills/reflect/references/bezos-type1-type2.md
@@ -1,0 +1,42 @@
+---
+name: bezos-type1-type2
+source: https://productmindset.substack.com/p/bezos-decision-making-framework
+fetched: true
+fetched_on: 2026-07-15
+---
+# Bezos Type 1 / Type 2 Decisions
+
+## Core idea
+Bezos splits decisions by one axis: reversibility.
+
+- **Type 1 — one-way doors.** Consequential and nearly irreversible (selling the company, quitting a job). Walk through and you can't walk back. These deserve slow, methodical, deliberate process.
+- **Type 2 — two-way doors.** Changeable and reversible (launching a service, adjusting pricing, starting a side project). They can feel weighty, but undoing them costs relatively little. These should be made fast, by individuals or small groups close to the work — not by the top of the org.
+
+The article's five rules for high-velocity decision-making: (1) match the process to the decision type instead of one uniform methodology; (2) push decision authority down so leadership isn't the bottleneck; (3) decide "with somewhere around 70 percent of the information you wish you had" — waiting for 90% usually means you're too slow; (4) replace sequential hierarchical approval chains with simultaneous dialogue; (5) use disagree-and-commit to keep moving once perspectives are aired. Bezos modeled the last one himself, greenlighting an Amazon Studios show he was skeptical of because the team had conviction — he asked them to gamble with him rather than demanding consensus.
+
+## When it bites
+- You're agonizing over something you could ship behind a flag, watch, and revert in a day.
+- A cheap, reversible experiment has been sitting in "needs more analysis" for weeks.
+- You're about to make a genuinely irreversible call (public pricing commitment, brand pivot, contract) with the same casualness as a UI tweak.
+- A team is escalating routine calls upward, and the calendar of the most senior person is the real constraint on velocity.
+- Two smart people disagree and the decision is stalled waiting for consensus that will never come.
+
+## How to run it
+1. Ask first: **can this be undone, and at what cost?** Be honest — most decisions that feel like Type 1 are Type 2 (feature flags, small launches, price tests). Very few are true one-way doors.
+2. If Type 2: decide now, at ~70% of the information you'd like, with the smallest group that has context. Set a tripwire for what "revert" looks like and move.
+3. If Type 1: slow down deliberately. Gather more information, widen the input, sleep on it, model the failure case.
+4. When people disagree on a Type 2 call: air the arguments once, then someone says "I disagree and commit" and everyone executes as if they agreed.
+5. Audit your process regularly: are you running heavyweight review on two-way doors?
+
+## Failure modes
+- **Type-1 process on Type-2 decisions** → slowness, reflexive risk aversion, too few experiments, and ultimately diminished invention. This is the common failure in organizations of any size.
+- **Type-2 process on Type-1 decisions** → fast, casual, irreversible disasters. Speed is only a virtue where the door swings both ways.
+- **Misclassification** — calling something reversible when unwinding it is actually expensive (reputation, data migration, public commitments). Reversibility is about the real cost to undo, not whether an undo button technically exists.
+- **Disagree-and-commit as a gag order** — using it to skip the disagreement stage instead of to end it after genuine airing.
+
+## Applies here when…
+- Feature flags make almost every SeldonFrame ship a two-way door — flip on, smoke, flip off. Treat "should we build/merge X" as Type 2 and default to velocity.
+- Pricing is the standing Type 1: the ladder ($29/$49/$99+) and the "never-taxes" 2% GMV structure are public commitments (see §1b "do not re-litigate") — changing them again burns trust, so they got deliberate, slow treatment once and are now settled.
+- Positioning bets (never-lies / never-taxes / never-goes-stale) are near-Type-1 once broadcast across 90+ SEO guides and the landing — re-messaging costs a full content rewrite.
+- Distribution experiments (a Reddit post, an X thread format, one YouTube video) are pure Type 2 — decide at 70%, ship, read the numbers, iterate.
+- The build loop already encodes disagree-and-commit: human gates at spec + merge, subagents commit to the approved plan without re-litigating it mid-build.

--- a/.claude/skills/reflect/references/bikeshed.md
+++ b/.claude/skills/reflect/references/bikeshed.md
@@ -1,0 +1,68 @@
+---
+name: bikeshed
+source: https://fs.blog/bikeshed-effect/
+fetched: true
+fetched_on: 2026-07-15
+---
+# The Bikeshed Effect (Parkinson's Law of Triviality)
+
+## Core idea
+Parkinson observed that the time a group spends on an agenda item is inversely
+proportional to its importance and complexity. His illustration: a finance
+committee faces three items — a £10M nuclear power plant, a £350 bike shed, and
+a £21 coffee budget. The reactor sails through in minutes because almost nobody
+in the room can evaluate reactor engineering, and no one wants to expose that.
+The bike shed gets a long debate about roofing materials, because everyone can
+picture a shed. The coffee budget consumes the most time of all — every person
+has an opinion on coffee. As the article puts it, "the simpler a topic is, the
+more people will have an opinion." Attention flows to what is comprehensible,
+not to what is consequential; big decisions get rubber-stamped while trivia
+gets scrutinized.
+
+## When it bites
+- A meeting spends 40 minutes on naming, button copy, or a logo shade after
+  nodding through an architecture or pricing decision in five.
+- Review threads swell on formatting and wording while the risky core change
+  gets a single "LGTM."
+- Everyone in the room is contributing — a warning sign, since on genuinely
+  hard topics most people should be outside their circle of competence.
+- People weigh in to avoid looking uninformed or to demonstrate presence, not
+  because their input changes the outcome.
+- Mixed agendas: a trivial item sitting next to a major one siphons the
+  group's energy toward the trivial.
+
+## How to run it
+- Before debating, ask: is discussion time here proportional to the stakes?
+  If the cheap item is eating the clock, name the effect and move on.
+- Give every meeting a stated purpose specific enough that off-purpose
+  opinions are visibly off-purpose.
+- Invite only people with relevant expertise; the audience size for a decision
+  should shrink as its technicality rises.
+- Never mix unrelated agenda items — separate the reactor from the coffee.
+- Appoint one owner who ranks items by importance, sets time boxes, and
+  checks the meeting achieved its objective.
+- Weight input by demonstrated competence on the specific question, not by
+  seniority or enthusiasm.
+
+## Failure modes
+- Using "that's bikeshedding" to dismiss legitimate small-but-real concerns —
+  sometimes the shed detail (a security default, a price point) actually
+  matters to users.
+- Inverting the error: rushing big decisions to *avoid* looking like
+  bikeshedders, so the reactor gets even less scrutiny than before.
+- Treating silence on complex items as consensus when it is actually
+  incomprehension — the fix is better preparation, not faster approval.
+- Gatekeeping so hard that non-experts who hold key context get excluded.
+
+## Applies here when…
+- A pricing/packaging review spends its hour on tier names and page copy while
+  the 2% GMV mechanics or the crossover math get waved through.
+- Landing-page threads debate hero wording and button green while the
+  positioning bet underneath (never-lies vs speed vs price) goes unexamined.
+- Build reviews pile comments on file layout and naming while the actual seam
+  (auth scoping, org resolution, booking backend) gets one glance.
+- Roadmap discussions gravitate to easy-to-picture features (themes, widgets)
+  over hard ones (reliability evals, cross-tenant learning) because everyone
+  can opine on a theme.
+- Time spent choosing between distribution channels is driven by which channel
+  is easiest to discuss (X posts) rather than which moves revenue.

--- a/.claude/skills/reflect/references/break-the-chain.md
+++ b/.claude/skills/reflect/references/break-the-chain.md
@@ -1,0 +1,71 @@
+---
+name: break-the-chain
+source: https://fs.blog/break-the-chain/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Break the Chain
+
+## Core idea
+The article ("Break the Chain: Stop Being a Slave") is about chains of **obligation and
+dependency**, and how accepting small comforts compounds into losing your freedom to
+choose. Accepting a gift, favor, or lifestyle upgrade rarely stays a one-off: it creates
+an invisible debt, and each link makes the next one easier to accept and harder to refuse.
+The author declines an expensive laptop from a vendor — not because the laptop is bad,
+but because accepting it would create a felt obligation the vendor could later cash in
+for access worth far more than the laptop. The same cascade runs in personal finance:
+spending rises with every raise, debt accumulates, wants outpace resources, and people
+end up trapped in jobs they hate because their lifestyle owns them. Each link was locally
+reasonable; the chain as a whole is servitude. The article's Nietzsche framing: "No price
+is too high to pay for the privilege of owning yourself."
+
+The discipline is the ability to say no — accepting a first-order negative (paying your
+own way, forgoing the upgrade, an awkward refusal at dinner) to buy a second-order
+positive (independence, optionality, the freedom to walk away). Self-sufficiency starts
+with dropping the mindset that anyone owes you something. The moment to break the chain
+is at the first link, when the cost of refusal is smallest; every accepted link raises
+the price of the eventual no.
+
+## When it bites
+- A counterparty offers something valuable "for free" — discounted tools, comped access,
+  a favor — where the real price is future influence over your decisions.
+- Recurring costs are ratcheting up with revenue, quietly converting optionality into
+  obligation (the lifestyle-debt cycle, in company form).
+- You notice you can no longer say no to a partner, platform, or big customer because
+  too much now depends on them.
+- The justification for accepting the next link is "everyone does it" or "it would be
+  rude/awkward to refuse."
+- You're optimizing the first-order outcome (free thing now) and not pricing the
+  second-order one (who owns your future choices).
+
+## How to run it
+1. At any offered gift, favor, or sweetheart deal, ask: what does the giver plausibly
+   expect back, and when? If the honest answer is "influence," decline.
+2. Price the chain, not the link: what does accepting make harder to refuse next time?
+3. Prefer first-order-negative / second-order-positive trades: pay your own way where
+   the alternative creates dependence.
+4. Audit standing dependencies periodically: which vendors, platforms, or customers
+   could you not walk away from today? Reduce the worst one.
+5. Break chains at the first link — say the awkward no early, when it's cheapest.
+
+## Failure modes
+- Refusing all help and all leverage on principle — the model targets dependence-creating
+  obligations, not collaboration, partnership, or fair trades.
+- Confusing frugality with independence: hoarding cash while becoming operationally
+  captive to one platform misses the point.
+- Using "no strings attached" self-talk to accept the string anyway — if it would feel
+  costly to refuse the giver's next ask, the string exists.
+- Breaking chains late and dramatically instead of early and cheaply, turning a small
+  awkward no into a burned relationship.
+
+## Applies here when…
+- Partnership and marketplace offers (revenue shares, "free" placement, comped tiers
+  from a platform) — ask what future ask the freebie is buying before accepting.
+- Vendor/stack picks: the no-Zapier, BYOK, push-outward rules exist precisely to avoid
+  dependency chains; any exception should be argued as a chain, not a link.
+- Pricing integrity: discount-for-favor deals with early agencies create obligations
+  that later collide with flat never-taxes pricing — pay the first-order cost of "no."
+- Distribution: becoming dependent on one channel's algorithm (or one big agency's
+  revenue) is the lifestyle-debt cycle in company form; keep the option to walk.
+- Fixed-cost creep with MRR growth — every recurring commitment added "because we can
+  afford it now" is a link that makes future pivots more expensive.

--- a/.claude/skills/reflect/references/captaincy.md
+++ b/.claude/skills/reflect/references/captaincy.md
@@ -1,0 +1,73 @@
+---
+name: captaincy
+source: https://fs.blog/inner-sense-of-captaincy/
+fetched: true
+fetched_on: 2026-07-15
+---
+# The Inner Sense of Captaincy
+
+## Core idea
+The article draws on David Whyte's *Crossing the Unknown Sea*, which treats
+work as a sea voyage and asks each person to develop an "inner sense of
+captaincy" — acting as if you are responsible for the vessel, regardless of
+your rank. Whyte's formative story: aboard a ship in the Galápagos, the
+captain fell asleep on watch and the boat nearly ran onto rocks. Whyte's first
+instinct was to blame the captain — the man formally in charge. His later
+realization was harder: the whole crew, himself included, saw the drift and
+could have dropped a second anchor without waiting for permission. They had
+outsourced their agency to a title. The article extends this to
+organizations: they tend to reward visible problem-solvers and ignore quiet
+preventers, which perversely incentivizes letting problems ripen. And strong
+leaders can create the same abdication — a previous captain, Raphael, was so
+capable that he effectively incapacitated his crew; because he handled
+everything, they never learned to act on their own judgment. Captaincy means
+owning outcomes proactively — maintaining the boat, reading the weather,
+acting on early warning signs — instead of deferring to authority or waiting
+for circumstance to force a response.
+
+## When it bites
+- You notice a drifting risk and your first move is to flag it upward and
+  wait, though you could act (drop the second anchor) yourself.
+- Post-mortems resolve to "the owner/lead/vendor dropped the ball" and stop
+  there — blame as a substitute for agency.
+- A highly capable leader or tool handles everything, and the people around
+  it quietly stop exercising judgment.
+- Prevention work is invisible in your reward structure, so everyone waits to
+  be the hero who fixes the fire instead of the one who prevents it.
+- You describe your situation mainly in terms of what circumstances or other
+  people are doing to you.
+
+## How to run it
+- When something is going wrong, ask: what could *I* do right now without
+  permission that reduces the danger? Then do it, and inform — don't ask.
+- In any failure review, list what every person present could have done
+  earlier, not just what the formally responsible party missed.
+- Audit your "vessel": what maintenance, monitoring, or preparation is your
+  own responsibility that you've been treating as someone else's?
+- If you lead: deliberately leave room for the crew to act — competence that
+  does everything trains everyone else to do nothing. Build initiative, not
+  dependence.
+- Reward prevention explicitly, or accept that you are training people to
+  wait for fires.
+
+## Failure modes
+- Captaincy as cover for going rogue: acting unilaterally on decisions that
+  genuinely need coordination or consent isn't agency, it's a collision risk.
+- Ownership theater — feeling responsible for everything, acting on nothing.
+- Diffusing accountability: "everyone owns it" sliding into no one owning
+  it. The point is *additional* personal agency, not deleted roles.
+- Blaming individuals for abdication when the structure (rewards, an
+  all-doing leader) is what trained the passivity.
+
+## Applies here when…
+- Waiting on a platform, partner, or model vendor to fix something SF could
+  route around today — the settled push-outward stance is captaincy applied
+  to architecture: be the source of truth, never the dependent.
+- A shipped-but-dark flag, pending smoke test, or unmerged green PR sits for
+  days because it is "someone's" (or some loop's) job — drop the anchor.
+- The build loop's automation gets so good that judgment atrophies: agents
+  handle everything, and no human reads the seams (the Raphael trap).
+- A client-facing failure gets filed as "the agency misconfigured it" instead
+  of asking what guardrail SF itself could have added upstream.
+- Distribution stalls while waiting for a channel, algorithm, or gatekeeper
+  to notice SF, rather than acting on owned channels now.

--- a/.claude/skills/reflect/references/chestertons-fence.md
+++ b/.claude/skills/reflect/references/chestertons-fence.md
@@ -1,0 +1,40 @@
+---
+name: chestertons-fence
+source: https://fs.blog/chestertons-fence/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Chesterton's Fence
+
+## Core idea
+G.K. Chesterton's parable: a reformer finds a fence across a road and wants it gone. The wiser reply: go away and think — you may clear it only once you "know why it was put up in the first place." The principle is not a defense of the status quo; it is a rule about *sequence*. You earn the right to change or remove something established only after you can explain the purpose it was serving. Fences rarely build themselves — someone paid a cost to erect this one, which is evidence (not proof) that it did something. Acting on a system you don't understand means acting on consequences you can't see.
+
+This is second-order thinking applied to existing systems: the first-order view says "this thing is in my way, delete it"; the second-order view asks what the thing is quietly holding back, and what ripples removal sends through everything connected to it — effects that can surface years later.
+
+## When it bites
+- You inherit code, a process, a rule, or a config line that looks pointless and are tempted to delete it on sight.
+- A structure seems inefficient (hierarchy, approval step, redundant check) and "flat/simple" feels obviously better. The article's example: hierarchy-free companies don't remove power, they make it informal — charisma replaces qualification.
+- Removing a "bad" habit or norm without asking what need it was meeting — the need finds a replacement, often worse.
+- Something looks wasteful by design (the peacock's tail): the inefficiency IS the function (a costly signal). Optimizing it away destroys what it did.
+- Sweeping reform energy: the urge to tear down many old things at once, before understanding any of them individually.
+
+## How to run it
+1. Name the fence precisely: what exactly would you remove or change?
+2. Ask: who put it up, when, and what problem were they solving? If you can't answer, that's your task before any removal — dig (git blame, ask the author, read the original decision doc).
+3. Ask whether that original problem still exists. This is the crucial branch.
+4. If the reason is dead (the condition it guarded against is gone), remove the fence confidently — the principle explicitly permits this. It does NOT say every fence must stand forever; it says removal requires understanding first.
+5. If the reason is alive, either keep the fence or design a replacement that covers the same failure mode before demolition.
+6. Before executing, run the ripple check: what second-order effects does removal trigger in adjacent systems?
+
+## Failure modes
+- **Fence-worship**: misusing the principle as blanket conservatism — "we can't change anything." The article is explicit that the point is understanding before change, not preventing change. Once you know the reason and it no longer holds, removal is the correct move.
+- **Fake reasons**: accepting "we've always done it this way" as the explanation. That's not the reason the fence was built; that's the absence of one. Keep digging.
+- **Infinite research**: some fences genuinely have no discoverable reason (lost history, accident, cargo cult). At some point you probe carefully — remove behind a flag, in a reversible way — rather than stall forever.
+- **Assuming intelligence where there was none**: some fences were erected by mistake or for reasons that were bad even at the time. The principle asks you to *find* the reason, not to presume it was good.
+
+## Applies here when…
+- Retiring anything marked SHIPPED-but-dark (a feature flag, an old pricing line, a legacy route like `(marketing)/`): find out why it was gated or kept before deleting — CLAUDE.md's superseded-pricing history exists precisely because old fences had reasons.
+- "Reuse, don't rebuild" decisions: before replacing an existing pipeline (e.g. `createFullWorkspace`, `bookingMode`), understand why it was shaped that way — its odd corners usually encode a client-facing failure that already happened once.
+- Simplifying the funnel or onboarding ("why do we ask for X here?"): a seemingly redundant step may be the guardrail that keeps never-lies true; know its purpose before cutting friction.
+- Re-litigating settled direction (§1b constraints, no-Zapier, BYO-OAuth): these fences have documented reasons — check whether the reason changed before proposing removal.
+- Third-party conventions that look dumb (Stripe metadata patterns, Vercel config, migration hand-numbering): assume a reason exists, find it, then decide.

--- a/.claude/skills/reflect/references/decision-anatomy.md
+++ b/.claude/skills/reflect/references/decision-anatomy.md
@@ -1,0 +1,46 @@
+---
+name: decision-anatomy
+source: https://fs.blog/decision-anatomy/
+fetched: true
+fetched_on: 2026-07-15
+---
+# The Anatomy of a Great Decision
+
+## Core idea
+The Farnam Street article dissects what a decision is actually made of, using the Marshall Plan as its worked example. Its first move is separating **decision quality from outcome quality**: a sound process can still produce a bad result (information is always incomplete), and a sloppy process can get lucky. Judge the decision by its anatomy — the questions asked, the principles applied, the perspectives considered — not by how the dice landed.
+
+Great decisions, per the article, share two qualities: they are grounded in **principles rather than tactics** (durable truths about how the world works, not clever moves), and they run the situation through a **multidisciplinary lens** rather than a single frame.
+
+The structure it lays out:
+1. **Frame the real problem first.** Before generating options, ask: what are we actually trying to achieve? What underlying problems are we solving? What does success look like? The Marshall planners defined the problem as preventing the conditions for another war, not merely "rebuild Europe."
+2. **Establish principles.** They anchored on durable truths like strong economies minimize social unrest, and nations that trade and cooperate don't fight each other.
+3. **Apply multiple perspectives.** Economic, political, humanitarian, historical, and psychological lenses were run simultaneously — the psychology of post-WWI resentment shaped the design as much as the economics did.
+
+From that anatomy came three structural choices: give money rather than lend it; let the recipient nations allocate the funds among themselves; and invite Russia, forcing clarity about who stood where. Throughout, the planners chose "outcomes over optics" — substance over what would look good politically.
+
+## When it bites
+- You're comparing options before anyone has stated what problem they solve or what success looks like.
+- A past decision is being judged (or a decider punished/rewarded) purely on how it turned out.
+- The whole discussion is running through a single lens — pure economics, pure engineering, pure growth — with no one asking how it lands psychologically or politically.
+- The proposal is a clever tactic with no durable principle underneath it; it would stop making sense the moment conditions shift.
+- You're optimizing how a choice will *look* (to investors, Twitter, the team) over what it will *do*.
+
+## How to run it
+1. Write the frame before the options: what are we trying to achieve, what's the underlying problem, what does success look like? If the frame is wrong, every option is wrong.
+2. Name the principles the decision rests on — statements that would still be true in five years. If you can't name one, you're picking tactics.
+3. Deliberately rotate lenses: economics, psychology, incentives, history, second-order politics. Ask what each discipline would flag.
+4. Design the decision's structure (the concrete choices, like grant-vs-loan) so each element traces back to a principle plus a lens.
+5. Afterward, grade the process, not the result: given what was knowable then, were the right questions asked? Log that grade, not just the outcome.
+
+## Failure modes
+- **Resulting** — inferring process quality from outcome; it teaches you to repeat lucky recklessness and abandon sound bets that missed.
+- **Solving the stated problem instead of the real one** — polished analysis on a mis-framed question produces confident wrong answers.
+- **Single-lens tunnel** — the decision is "correct" in one discipline and disastrous in another (economically optimal, psychologically humiliating — the exact WWI-reparations mistake the Marshall planners studied).
+- **Optics capture** — choosing what narrates well over what works; the article's counter-example is deliberately paying political costs for substance.
+
+## Applies here when…
+- Framing before options is the spec gate: "brainstorm → spec" exists so the loop argues about the real problem (e.g., activation-wall = ~22 signups → 0 paying) before generating features to build.
+- Judge shipped bets by process, not outcome: a Reddit launch that flops or an X post that hits says little by itself — grade whether the channel pick followed the playbook and what the delta taught.
+- Pricing/GMV restructuring was principle-driven ("we don't tax your work" = durable principle) rather than tactical rate-tuning — future packaging calls should trace to a principle the same way.
+- Run the multi-lens pass on partnership/marketplace calls: economics (5% fee), incentives (rerouting arbitrage), psychology (does the builder feel taxed?), optics-vs-outcomes (state the crossover math openly).
+- "Never-lies" over demo-flash is outcomes-over-optics: read-back enforcement and honest 422s look worse in a demo but are the substance the positioning rests on.

--- a/.claude/skills/reflect/references/decision-matrix.md
+++ b/.claude/skills/reflect/references/decision-matrix.md
@@ -1,0 +1,75 @@
+---
+name: decision-matrix
+source: https://fs.blog/decision-matrix/
+fetched: true
+fetched_on: 2026-07-15
+---
+# The Decision Matrix
+
+## Core idea
+Not all decisions deserve the same decider or the same amount of process. Leaders drown
+because urgent-but-trivial decisions crowd out the few that actually matter. The matrix
+sorts every decision along two axes — is it **reversible**, and is it **consequential** —
+yielding four types with different handling:
+
+- **Irreversible + inconsequential → delegate.** Even though it can't be undone, the
+  stakes are low; these are the training ground where a team develops judgment cheaply.
+- **Reversible + inconsequential → delegate.** Lowest stakes of all; same reasoning.
+- **Reversible + consequential → run experiments.** These decisions masquerade as one
+  big high-stakes call, but because they can be undone, the right move is to lead through
+  experimentation: frame the decision as a test with success metrics defined up front,
+  gather real data, then commit or roll back.
+- **Irreversible + consequential → your full attention.** These are the only decisions
+  that genuinely deserve slow, personal deliberation. The author's practice: take a
+  30-minute walk before deciding, unless the situation truly demands immediacy.
+
+Making it work requires defining, explicitly and publicly, what "consequential" and
+"reversible" mean in your context, so the team can classify without you. At first people
+check their classification with you; over time they internalize it and decide alone. The
+author reported roughly a 75% drop in decisions reaching them, with better overall
+decision quality and a more engaged team.
+
+## When it bites
+- Every decision in the company routes through the founder, regardless of stakes.
+- A cheap, undoable choice has been debated for days as if it were existential.
+- A genuinely one-way door (a public commitment, a brand change, a contract) got
+  rushed with the same casualness as a config tweak.
+- A big reversible bet is being treated as all-or-nothing instead of as a testable
+  experiment with metrics and a rollback path.
+- Delegation stalls because "consequential" was never defined, so everything escalates.
+
+## How to run it
+1. Classify first, deliberate second: is it reversible? is it consequential? Write the
+   one-line justification.
+2. Inconsequential (either kind) → hand it off; resist re-deciding it. Let the small
+   irreversible ones build the delegate's judgment.
+3. Reversible + consequential → convert to an experiment: define the success metric and
+   the reversal trigger before starting, then let data decide.
+4. Irreversible + consequential → slow down deliberately (the walk), gather dissent,
+   and only then commit.
+5. Publish your definitions of "consequential" and "reversible" so classification stops
+   requiring you.
+
+## Failure modes
+- Misclassifying one-way doors as two-way because reversal is *technically* possible but
+  practically ruinous (reputation, migration cost, public pricing).
+- Inflating everything to "consequential" — the matrix only saves time if most decisions
+  honestly land in the delegate/experiment boxes.
+- Using "it's reversible" to skip defining success metrics — an experiment without a
+  predefined bar is just a slow way to avoid deciding.
+- Delegating the decision but not the authority, so everything boomerangs back anyway.
+
+## Applies here when…
+- Pricing/packaging changes: published prices and the "we don't tax your work" promise
+  are near-irreversible + consequential — walk-before-deciding territory, never a
+  same-day tweak.
+- Feature build-vs-reuse calls are usually reversible + consequential — frame as an
+  experiment behind a feature flag with a predefined success metric, not a debate.
+- Copy, guide, and landing-page variants are reversible and mostly inconsequential —
+  let the loop/subagents decide them; Max's review is wasted there.
+- Positioning bets (never-lies/never-taxes/never-goes-stale) compound publicly with
+  every artifact shipped — treat the frame itself as irreversible even when any single
+  page is not.
+- Distribution channel picks (YT vs X vs Reddit cadence) are reversible experiments;
+  a marketplace fee structure or partnership term is a one-way door — don't process
+  them identically.

--- a/.claude/skills/reflect/references/defensive-decisions.md
+++ b/.claude/skills/reflect/references/defensive-decisions.md
@@ -1,0 +1,73 @@
+---
+name: defensive-decisions
+source: https://fs.blog/defensive-decision-making/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Defensive Decision-Making
+
+## Core idea
+A defensive decision is one made to protect the decider rather than to produce
+the best outcome — the second-best option chosen because it is the most
+justifiable if things go wrong. The article's emblematic example (via Rory
+Sutherland): executives' assistants kept booking flights through Heathrow even
+when London City Airport was plainly better for the trip, because Heathrow was
+the default nobody could be blamed for. Pick the non-standard option and fail,
+and the failure is yours; pick the default and fail, and the blame diffuses.
+It is the "nobody ever got fired for buying IBM" logic generalized. The
+mechanism is asymmetry: in most organizations a good outcome is merely
+expected (little upside for the decider), while a bad outcome from a
+non-standard choice can cost a career (severe downside). Under that payoff,
+defensive defaults are individually rational — and collectively corrosive,
+because an organization staffed with default-choosers stops finding better
+options at all. In the article's words: "It wasn't the best decision we could
+make, but it was the most defensible."
+
+## When it bites
+- The option on the table is popular, standard, or vendor-brand-safe, and its
+  main argument is "no one will question it."
+- You catch yourself pre-drafting the explanation for a failure before making
+  the choice — optimizing the story, not the outcome.
+- Committees, sign-offs, and paper trails are being used to spread
+  accountability rather than to improve the decision.
+- The decider bears the downside personally but captures none of the upside
+  (agency work for clients, employees choosing tools, doctors ordering
+  cover-your-back tests).
+- "Best practice" is invoked without anyone checking it is best for *this*
+  case.
+
+## How to run it
+- Ask directly: if I were personally guaranteed no blame, would I still choose
+  this option? If the answer changes, the current choice is defensive.
+- Separate the two questions: (1) which option has the best expected outcome?
+  (2) which is easiest to defend? Only merge them consciously, never silently.
+- Make the asymmetry explicit: what is my real downside if the bold option
+  fails, and is it actually career-sized or just uncomfortable?
+- As a leader, fix the incentive, not the person: reward well-reasoned bets
+  that fail, and treat defensible-but-worse choices as the real error.
+- Write the decision rationale before the outcome is known, so quality of
+  reasoning — not hindsight — is what gets judged.
+
+## Failure modes
+- Contrarianism cosplay: rejecting the default *because* it is the default.
+  Sometimes IBM/Heathrow genuinely is the best option; the sin is choosing it
+  for protection, not choosing it at all.
+- Ignoring legitimate robustness: for irreversible, catastrophic-tail
+  decisions, the conservative option can be the genuinely optimal one.
+- Preaching boldness to people whose downside you don't share — psychological
+  safety has to be real before you ask others to drop their armor.
+- Using "we accept failed bets" as cover for skipping the reasoning step.
+
+## Applies here when…
+- Pricing calls drift toward what competitors charge because it's defensible
+  ("everyone does per-seat/usage") instead of the never-taxes flat model the
+  positioning actually demands.
+- Build-vs-reuse picks the big-name SaaS dependency "to be safe" when the
+  settled direction is push-outward, no-middleware, owned rails.
+- A positioning bet gets watered down to hedge language ("AI tools for
+  everyone") because a sharp claim (never-lies) feels blameable if it fails.
+- Distribution picks default to saturated channels (generic paid ads, one
+  more directory) because failure there looks normal, while an unproven
+  channel with better fit dies in review.
+- Agency-facing features get scoped to whatever clients can't complain about,
+  rather than what makes their front-office measurably book more jobs.

--- a/.claude/skills/reflect/references/explore-exploit.md
+++ b/.claude/skills/reflect/references/explore-exploit.md
@@ -1,0 +1,58 @@
+---
+name: explore-exploit
+source: https://fs.blog/explore-or-exploit-how-to-choose-new-opportunities/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Explore / Exploit
+
+## Core idea
+Every repeated choice — restaurants, cities, careers, relationships — is a tension
+between exploring (trying something new to gain information) and exploiting (cashing
+in on the best thing you already know). Drawing on Brian Christian and Tom Griffiths'
+*Algorithms to Live By*, the article's central claim is that the deciding variable is
+the **interval**: how much time remains to use what you learn. Their rule, paraphrased:
+explore while there's still time to benefit from the knowledge; exploit when it's time
+to cash in. As they put it, "Seizing a day and seizing a lifetime are two entirely
+different endeavors."
+
+So the same choice flips with the horizon. On a vacation's last night, go to the
+proven favorite restaurant (exploit). At the start of a 40-year career or a new city,
+sample widely (explore) — the information compounds over every remaining decision.
+Exploration has value beyond the immediate outcome: it raises the odds of finding
+something better than your current best, and nearly every attempt yields data even
+when it fails. Early failures are tuition, not verdicts, and shouldn't suppress later
+boundary-pushing.
+
+Two more findings from the underlying math: settling too early is the characteristic
+error, because both you and the world change — nostalgia-driven repeat picks decay.
+And upper-confidence-bound-style algorithms justify optimism: absent evidence, assume
+the best about new options, because the regret of never trying dominates the cost of a
+few disappointing samples.
+
+## When it bites
+- You keep defaulting to the known-good option (vendor, channel, format, stack) purely because it's known.
+- You're near the start of a long interval (new market, new product line, new year) and behaving as if it's the end.
+- You're near the end of an interval (launch week, closing quarter, deadline) and still sampling novelties.
+- A new option is being dismissed on zero evidence rather than tried once.
+- A failed experiment is about to be generalized into "we don't do that kind of thing."
+
+## How to run it
+1. Name the interval: how long will this decision's knowledge stay usable? Long horizon → weight explore; short → weight exploit.
+2. Ask what a new option would teach even if it fails — information value counts alongside outcome value.
+3. Apply optimism-under-uncertainty: score unknowns by their plausible upside, not their unproven mean; try before condemning.
+4. Schedule the shift: deliberately front-load exploration and taper into exploitation as the horizon closes — don't let it happen by mood.
+5. Re-open exploration when the world changes (new model, new competitor, new channel): a shifted landscape resets the interval.
+
+## Failure modes
+- Exploring forever: novelty-seeking dressed up as strategy — no compounding, no cash-in.
+- Exploiting too early: locking onto the first working thing and missing categorically better options.
+- Ignoring the interval entirely and running one fixed explore/exploit mix regardless of remaining time.
+- Treating one bad sample as proof — undersampling noisy options kills the optimism the math actually recommends.
+
+## Applies here when…
+- Distribution channel picks: the ranked ladder (YT → X → Show-HN/PH → Reddit) is an exploit list — budget explicit explore slots for unranked channels while SF's horizon is long and early.
+- Model/provider choices ride the interval: never-goes-stale means every frontier release resets exploration; re-test rather than exploit last quarter's model pick.
+- Positioning and content formats: with years of runway, sample new wedges/angles cheaply now; near a launch window, freeze and exploit the proven message.
+- Feature build-vs-reuse: exploit the existing pipeline by default (reuse-don't-rebuild), but grant genuinely new capability bets an optimistic first trial before writing them off.
+- One failed experiment (a flat post, a dead channel, a rejected pitch) is data, not a rule — don't let it close a category.

--- a/.claude/skills/reflect/references/externalities.md
+++ b/.claude/skills/reflect/references/externalities.md
@@ -1,0 +1,58 @@
+---
+name: externalities
+source: https://fs.blog/externalities-why-we-can-never-do-one-thing/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Externalities (You Can Never Do Merely One Thing)
+
+## Core idea
+An externality is an effect of a decision that lands on parties who didn't agree to it
+and aren't compensated for it. The article's frame comes from ecologist Garrett
+Hardin's First Law of Ecology — "We can never do one thing" — because every action
+touches a system, and systems answer back. The discipline this implies is
+second-order thinking: before intervening, ask *and then what?* — what are the wider
+repercussions once the system reacts?
+
+The article sorts externalities three ways. **Negative**: uncompensated costs pushed
+onto bystanders — the factory whose pollution harms neighbors while the harm never
+shows up in the product's price; the label can even become a way of abdicating
+responsibility. **Positive**: uncontracted benefits — Pascal and Fermat worked on a
+gambling dispute and produced probability theory for every field; network effects,
+where each new marketplace user makes the product more valuable for all (with the
+attendant free-rider problem). **Positional**: effects that operate through
+comparison — one coworker staying late resets the norm and makes everyone worse off;
+a luxury good loses its value if everyone owns one.
+
+The Prohibition case study shows intervention-scale ripples: banning alcohol in 1920
+was meant to do one thing, and instead spawned black markets, organized crime, deaths
+from unsafe homemade liquor, and collapsed tax revenue — while cutting drinking only
+about half. Small externalities also compound quietly over time, reshaping
+relationships and societies before anyone prices them.
+
+## When it bites
+- Any intervention pitched as doing exactly one thing — a pricing change, a ban, an incentive, a default.
+- Costs are landing on someone outside the decision (users, partners, future-you) and thus stay invisible to the decider.
+- A metric improved and nobody asked what absorbed the displaced pressure.
+- Incentives or norms are shifting because of comparison effects (everyone matching a new baseline).
+- A benefit you're generating is being captured by free riders — or you're the free rider on someone else's.
+
+## How to run it
+1. Before acting, ask "and then what?" at least twice — first-order effect, system's response, response to the response.
+2. List who is affected but not at the table; those unpriced parties are where the externalities pool.
+3. Look for all three types: costs pushed out, benefits leaking out, and positional/norm shifts.
+4. Check whether the intervention's target can route around it (Prohibition test): what does the black-market version of compliance look like?
+5. Re-inspect after shipping: compounding second-order effects show up on a lag — schedule the "what actually rippled?" review.
+
+## Failure modes
+- Analysis paralysis: infinite "and then what?" chains can veto every action — bound the analysis to plausible, material ripples.
+- Labeling harms "externalities" as a shrug — the frame is for anticipating and owning effects, not excusing them.
+- Only hunting negatives: missing positive externalities means underinvesting in things (docs, open tools, standards) whose spillover is the point.
+- Overclaiming second-order predictions: ripples are directionally foreseeable, rarely precisely — hedge the intervention, not just the forecast.
+
+## Applies here when…
+- Pricing/packaging moves ripple: the 2% GMV fee shapes agency-tier upgrades and rerouting incentives — always ask what arbitrage or resentment the fee structure trains customers into.
+- Positional effects in the marketplace: featured templates and leaderboards reset builder norms; one agency undercutting on price can drag the whole marketplace's floor down.
+- Positive externalities are a strategy: free guides, open-source images, and the free-forever workspace spill value that recruits builders — budget for the free riders on purpose.
+- Platform interventions (caps, gates, feature flags): before flipping, run the Prohibition test — how will builders route around the constraint, and is that path worse than the behavior?
+- Never-lies guardrails: an agent's wrong answer is an externality on the SMB's customer, who never chose SF — the unpriced third party is exactly who the reliability positioning protects.

--- a/.claude/skills/reflect/references/first-principles.md
+++ b/.claude/skills/reflect/references/first-principles.md
@@ -1,0 +1,42 @@
+---
+name: first-principles
+source: https://fs.blog/elon-musk-framework-thinking/
+fetched: true
+fetched_on: 2026-07-15
+---
+# First-Principles Thinking
+
+## Core idea
+The Farnam Street article contrasts two modes of reasoning. Most people reason **by analogy**: they look at what others are already doing and copy it with small variations. Musk argues the better frame for hard problems is the physicist's: "boil things down to their fundamental truths and reason up from there." Instead of accepting the current form of a thing — its price, its design, its assumed constraints — you decompose it into what is physically or logically true, then rebuild the solution from those parts.
+
+The article is candid that analogy isn't a sin: pure first-principles reasoning is mentally exhausting, and most of daily life runs fine on analogy. The dividing line is novelty — when you're trying to do something genuinely new, analogy only ever gets you a slightly modified copy of the existing thing, while the physics approach can reach counterintuitive answers (the way physics reached quantum mechanics by trusting fundamentals over intuition). The article also carries a second piece of Musk advice: actively solicit negative feedback, especially from friends — obvious-sounding, rarely done, disproportionately valuable.
+
+(Note: this FS article does not include the battery-cost numbers; that example appears in other Musk interviews.)
+
+## When it bites
+- You're pricing, packaging, or designing something by copying the incumbent ("everyone in this market charges per-seat, so we will").
+- A cost or constraint is being treated as a law of nature when it's actually just the current market's habit.
+- Someone justifies a plan mainly by "that's how X company does it" rather than by why it works.
+- You're stuck: every option on the table is a variant of the same inherited template.
+- An expert's "impossible" is really "nobody has done it," not "physics forbids it."
+
+## How to run it
+1. State the received wisdom explicitly ("agents platforms must charge per usage because costs scale").
+2. Decompose to fundamentals: what is *actually* true here — real costs, real physics, real user needs, real constraints? Strip out convention, habit, and pricing of the current incumbents.
+3. Ask what each fundamental truly costs or requires at floor, not at today's market price.
+4. Reason **up** from those fundamentals to a solution, ignoring how the existing product got built.
+5. Sanity-check with analogy afterwards — if your first-principles answer differs wildly from everyone else's, know exactly which assumption you rejected and why.
+6. Invite negative feedback on the conclusion before committing; you want the flaw found by a friend, not the market.
+
+## Failure modes
+- **First-principles theater** — decomposing into "fundamentals" that are actually just your own assumptions restated; the method is only as good as the truths at the bottom.
+- **Applying it everywhere** — re-deriving routine decisions from scratch is exhausting and slow; analogy is the correct tool for cheap, low-stakes, well-trodden choices.
+- **Ignoring accumulated wisdom** — sometimes the convention encodes a real constraint (regulation, human behavior) you haven't seen yet; deviation should be explainable, not just contrarian.
+- **Analysis as procrastination** — using "let me get to fundamentals" to avoid shipping a reversible test that would answer the question empirically.
+
+## Applies here when…
+- The flat-pricing bet is first-principles already: fundamental truth = BYOK makes COGS≈0, so per-usage taxing is convention, not necessity — "we don't tax your work" falls out of the physics, not out of copying GHL.
+- Build-vs-reuse calls: decompose to what the feature *fundamentally* needs before assuming a new subsystem — the front-office bridge reusing `createFullWorkspace` is reasoning from what exists, not from how competitors structure theirs.
+- Positioning: don't copy incumbent messaging by analogy ("all-in-one CRM"); reason from the fundamental buyer pain (agents that lie, platforms that tax, stacks that go stale).
+- Distribution: when a channel playbook is inherited ("SaaS must do paid ads"), check the fundamentals — SF's real edge is generatable supply-side content, which favors SEO/YouTube over paid.
+- Skip it for low-stakes calls (component naming, minor copy, tooling defaults) — analogy to the codebase's existing patterns is the right answer there.

--- a/.claude/skills/reflect/references/gian-carlo-rota.md
+++ b/.claude/skills/reflect/references/gian-carlo-rota.md
@@ -1,0 +1,42 @@
+---
+name: gian-carlo-rota
+source: https://fs.blog/gian-carlo-rota/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Gian-Carlo Rota's Lessons
+
+## Core idea
+FS distills twelve practical lessons from mathematician Gian-Carlo Rota's 1996 talk "Ten Lessons I Wish I Had Been Taught" — mostly about communicating ideas and doing durable work.
+
+The communication cluster: every lecture should make exactly one point (more and the audience drifts back to their own thoughts); never run over time (absorption dies after ~50 minutes regardless of importance); relate to your audience by acknowledging their work first (recognition is a powerful motivator); give people one memorable thing to take home (they forget content, remember anecdotes, jokes, and images); keep the blackboard spotless (presentation polish signals the work itself is careful); make note-taking easy (note-takers spread your ideas for you); and write informative introductions with motivation, history, and credit up front.
+
+The work cluster: publish the same work several times — each iteration improves through feedback and reaches new audiences; expect to be remembered more for expository/synthesis work than for original results; every mathematician has only a few tricks — top performers reuse a small toolkit relentlessly rather than attempting everything; don't sweat contingent (fixable) mistakes, only fatal ones — and build safety margins that convert fatal errors into contingent ones; and use Feynman's method: keep a dozen favorite problems constantly in mind and test every new trick or result against all of them for occasional breakthroughs.
+
+## When it bites
+- Any pitch, landing page, talk, or doc that tries to make three points and lands zero.
+- Shipping an idea once and moving on, when the compounding returns come from re-publishing and iterating it across venues.
+- Chasing novelty when your leverage is in a few proven tricks applied again and again.
+- Treating all mistakes as equal — either over-panicking at fixable ones or under-margining against fatal ones.
+- Sloppy presentation (typos, broken demo, messy "blackboard") silently discounting solid work.
+
+## How to run it
+1. Before communicating anything, name the ONE point. Cut everything that doesn't serve it; save the rest for another artifact.
+2. Give the audience a take-home: one image, one anecdote, one number they will repeat to someone else.
+3. Inventory your few tricks — the 3-5 moves that produced your past wins — and check whether the current problem can be solved with one of them before inventing a new one.
+4. Re-publish deliberately: same core idea, new venue, new framing, improved by last round's feedback.
+5. Classify each risk as fatal vs. contingent. Spend margin (buffers, flags, reversibility) converting fatal into contingent; then stop worrying about the contingent ones.
+6. Feynman's method: keep a standing list of ~12 open problems; run every new tool, model capability, or idea against the list.
+
+## Failure modes
+- **One-point dogma as thinness** — one point doesn't mean shallow; Rota's formula is one theme *with variations*.
+- **Self-plagiarism drift** — re-publishing the same work without improvement or a new audience is spam, not iteration.
+- **Trick lock-in** — "a few tricks" hardens into refusing new tools; the toolkit is small but not frozen (Feynman's method is the intake valve).
+- **Misclassifying fatal as contingent** — waving off a mistake that actually destroys the foundation (e.g., a trust-breaking bug in a never-lies product is fatal, not cosmetic).
+
+## Applies here when…
+- Positioning: never-lies / never-taxes / never-goes-stale is three points — every individual surface (a landing page, an X post, a sales call) should lead with ONE and let the others be variations.
+- Content engine: the guides/X/YouTube loops are Rota's "publish the same work several times" — one build session should be re-published as guide, post, and video, each pass improved by response data.
+- SF's few tricks are named in CLAUDE.md ("reuse, don't rebuild", the build loop, push-outward): before any new subsystem, check whether an existing trick (createFullWorkspace, bookingMode) already solves it.
+- Fatal-vs-contingent maps to the flag discipline: shipping dark behind SF_* flags is margin that converts would-be-fatal launches into contingent, reversible ones.
+- Expository work compounds: the docs, guides, and comparison pages will build more durable reputation than any single clever feature — budget for synthesis, not just origination.

--- a/.claude/skills/reflect/references/hemingway-suitcase.md
+++ b/.claude/skills/reflect/references/hemingway-suitcase.md
@@ -1,0 +1,78 @@
+---
+name: hemingway-suitcase
+source: https://fs.blog/hemingway-suitcase/
+fetched: true
+fetched_on: 2026-07-15
+---
+# The Hemingway Suitcase
+
+## Core idea
+December 1922, Gare de Lyon, Paris: Hemingway's wife Hadley, traveling to
+bring him his work, briefly left their bags with a porter while she bought
+water — she was ill and rushing. The suitcase holding nearly everything he
+had written vanished: originals, handwritten notes for a novel, and (as he
+learned to his horror) the carbon copies too, packed in the same case. Only
+two stories survived. Hemingway was devastated enough to travel back to Paris
+just to confirm it was real, and wrote about the anguish decades later. The
+article draws two lessons. First, on how the loss happened: it wasn't one big
+mistake but converging vulnerabilities — illness, time pressure, an
+unfamiliar, chaotic environment — the exact conditions under which capable
+people commit what Adam Robinson defines as stupidity, "overlooking or
+dismissing crucial information." Second, on what the loss produced: Hemingway
+didn't quit; forced to rewrite from nothing, he developed the stripped,
+short-sentence style he became famous for, and four years later published
+*The Sun Also Rises*. The work was gone; the capacity that produced it was
+not — and the redo, done by a writer who had already made every mistake once,
+came out better.
+
+## When it bites
+- Work is destroyed or invalidated — lost files, a dead branch, a rewrite
+  forced by a platform change — and the instinct is to mourn the artifact
+  instead of asking what the redo could improve.
+- You (or your process) are operating under the stupidity-inducing trio:
+  rushed, tired/sick, outside routine — precisely when backups get skipped
+  and the carbons ride in the same suitcase.
+- Sunk-cost grief keeps a team patching a first draft that would honestly be
+  faster and better rebuilt from what they now know.
+- All copies of something irreplaceable travel together — a single point of
+  failure disguised as diligence.
+
+## How to run it
+- Separate what's truly lost (the artifact, the hours) from what's retained
+  (the judgment, the map of dead ends, the sharpened taste). Usually the
+  second list is the valuable one.
+- Treat a forced redo as a design opportunity: version two is written by
+  someone who has already solved the problem once. Ask what the first version
+  taught before retyping it.
+- Audit for suitcase risk: never let originals and "backups" share one
+  container, one branch, one account, one vendor.
+- Notice the conditions, not just the person: when a task must happen under
+  time pressure, fatigue, or novelty, add friction — checklists, a second
+  pair of eyes — because that's when crucial details get dismissed.
+- After any loss, resist the urge to reconstruct verbatim; rewrite toward
+  what you were actually trying to say.
+
+## Failure modes
+- Romanticizing loss: "it'll come back better" is not a backup strategy, and
+  most lost work is just lost. The lesson is resilience *given* a loss, not
+  indifference to prevention.
+- Using the redo excuse to churn: rewriting things that weren't lost and
+  didn't need rewriting (the Runaway Refactor in disguise).
+- Blaming the Hadley: pinning a systems failure (no separation of copies) on
+  the individual who happened to be holding the bag.
+- Assuming capacity always survives — some losses (data, trust, a client's
+  records) are genuinely unrecoverable and deserve prevention-grade paranoia.
+
+## Applies here when…
+- A branch, worktree, or generated build is lost or superseded — the specs,
+  lessons files, and memory notes are the capacity; the code is the suitcase.
+- A model deprecation or platform shift invalidates a subsystem: rebuild on
+  the thin-harness thesis rather than reconstructing the old shape (that is
+  never-goes-stale, practiced).
+- Late-night, pre-launch, rushed-merge conditions are exactly when the
+  Robinson trio strikes — that's when the verify-build gate must not be
+  skipped.
+- Client workspace data, souls, and brains must never share one failure
+  domain with their backups — no carbons in the suitcase.
+- A rejected positioning draft or landing page isn't wasted: the rewrite,
+  informed by what got cut, is usually the sharper artifact.

--- a/.claude/skills/reflect/references/inversion-avoid-stupidity.md
+++ b/.claude/skills/reflect/references/inversion-avoid-stupidity.md
@@ -1,0 +1,86 @@
+---
+name: inversion-avoid-stupidity
+source: https://fs.blog/how-not-to-be-stupid/ and https://fs.blog/avoid-bad-decisions/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Inversion: Avoid Stupidity Before Seeking Brilliance
+
+## Core idea
+Most decision improvement doesn't come from getting smarter — it comes from removing the
+conditions under which smart people do dumb things. Adam Robinson defines stupidity as
+"overlooking or dismissing conspicuously crucial information." It is not the opposite of
+intelligence; it is the cost of intelligence operating in a complex environment. The
+inversion move: instead of asking "how do I make a brilliant call?", ask "what would make
+me blow this one?" and neutralize those conditions first. The stakes are real — hospital
+errors are a leading cause of death, and the Tenerife air disaster happened despite
+checklists, because the conditions for stupidity were all present.
+
+Robinson identifies seven factors that create stupidity-prone conditions:
+1. Being outside your normal environment (or a change in routine)
+2. Presence of a group — social dynamics degrade individual judgment
+3. Presence of an expert (or being the expert) — deference or overconfidence
+4. Intense focus on a task or outcome — tunnel vision crowds out the periphery
+5. Information overload — including multitasking; divided attention multiplies error odds
+6. Physical or emotional stress, or fatigue — a sleepless night degrades you like alcohol
+7. Rushing or a sense of urgency — often the first factor to trigger the rest
+
+The factors are additive: two or three together are enough. Even Yo-Yo Ma left a
+million-dollar cello in a taxi under just three of them (unfamiliar setting, rushing,
+preoccupation).
+
+The companion piece adds principles for avoiding bad decisions outright:
+- **Manage your mental state.** Never make important decisions tired, emotional,
+  distracted, or rushed — the same conditions as Robinson's factors.
+- **Define the problem yourself.** Never accept someone else's framing wholesale; the
+  person who first surfaces a problem rarely has the best vantage on it.
+- **Check information quality.** Get as close to the source as possible; weigh the
+  incentives and proximity of whoever is telling you. Filtered, second-hand information
+  degrades fast.
+- **Reflect deliberately.** Experience without reflection is one year repeated twenty
+  times. Be less busy; keep a journal; review decisions against what actually happened.
+- **Substance over optics.** Decide as an owner would, not for defensibility. The
+  instinct to pick the position that looks safest is how avoidably bad calls get made.
+
+## When it bites
+- You're about to decide something consequential late at night, mid-crisis, or right
+  after a frustrating exchange.
+- A deadline, launch window, or "we need an answer now" pressure is compressing the call.
+- You're deciding in a group thread or live call, with a confident expert in the room.
+- You're juggling several workstreams and the decision arrives as an interrupt.
+- The problem framing arrived pre-packaged from someone else (a user, a competitor move,
+  a hot take) and you never restated it in your own terms.
+
+## How to run it
+1. Before deciding, count the seven factors present right now. Two or more → defer the
+   decision or deliberately slow it down.
+2. Ask the inversion question: "What conspicuously crucial information could I be
+   overlooking or dismissing?" Name the thing you'd feel dumbest about missing.
+3. Restate the problem from scratch in your own words before evaluating any proposal.
+4. Trace each key input to its source: who earned this knowledge, and what's their
+   incentive?
+5. Decide as the owner: "Would I make the same call if optics were irrelevant?"
+6. Log the decision and revisit it later — reflection is what converts the outcome into
+   a lesson.
+
+## Failure modes
+- Treating the checklist as a formality while rushing anyway — presence of a checklist
+  didn't prevent Tenerife; changed behavior does.
+- Using "avoid stupidity" as license for permanent inaction — inversion prunes bad moves,
+  it doesn't excuse never making one.
+- Only checking the factors on big decisions; the cascade usually starts on a small one
+  made in a hurry.
+- Confusing low confidence with prudence — the point is removing bad conditions, not
+  hedging every call.
+
+## Applies here when…
+- A pricing or packaging change is drafted in the same session as a frustrating churn
+  event or competitor announcement — emotional state + urgency is two factors already.
+- A positioning pivot idea arrives from one loud prospect or a viral post: someone else
+  defined the problem; restate it against the never-lies/never-taxes/never-goes-stale frame.
+- Late-night ship pressure before a launch (Reddit/HN/X) pushes a merge without the
+  verify gate — rushing + fatigue + outcome fixation is the classic triple.
+- Partnership or marketplace terms are negotiated live with a confident counterparty —
+  expert-in-the-room dynamics; take it async before agreeing.
+- A build-vs-reuse call is made while context-switching across worktrees — information
+  overload is exactly when the existing pipeline gets overlooked and rebuilt.

--- a/.claude/skills/reflect/references/mental-models-general.md
+++ b/.claude/skills/reflect/references/mental-models-general.md
@@ -1,0 +1,74 @@
+---
+name: mental-models-general
+source: https://fs.blog/mental-models/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Mental Models — the latticework
+
+## Core idea
+A mental model is a simplified explanation of how something works — a compression of
+reality that keeps the key information and drops the rest, the way a map does. Because
+each model is a map, none is the territory: every model highlights some aspects of a
+situation and hides others, and mistaking your model for reality is where the danger
+lives (things that look good on paper but fail in practice).
+
+The article's central claim: a *latticework* of models drawn from many disciplines
+(physics, biology, systems, math, economics, human nature) beats deep single-discipline
+thinking, because real problems don't respect academic boundaries. Munger's framing —
+you need "a mind that can jump the jurisdictional boundaries" — is the whole thesis:
+take the durable big ideas from every field, hang new experiences on that lattice, and
+you avoid problems and spot opportunities that single-lens thinkers miss.
+
+Two boundary models frame all the rest: the map is not the territory (your model is an
+abstraction — update it against what IS true, not what you want to be true) and the
+circle of competence (what matters is not how big your circle is but knowing exactly
+where its edge sits; judgments inside it are reliable, ventures outside it are trouble).
+
+## Quick lens list
+- **The map is not the territory**: any time you're reasoning from a spec, metric, dashboard, or model instead of the live thing — ask what the map is hiding.
+- **Circle of competence**: before a bet, ask whether this decision sits inside what you genuinely know; at the edge, borrow someone else's circle or shrink the bet.
+- **Second-order thinking**: ask "and then what?" — optimize for the whole journey, not the next move; first-order wins often carry second-order bills.
+- **Thought experiments**: run the decision in a mental sandbox first — cheap way to expose hidden assumptions and unintended consequences before paying real costs.
+- **Probabilistic thinking (as mindset)**: hold "I don't know for sure, but based on evidence…" — assign rough likelihoods, update as data arrives, and let go of false certainty.
+- **Occam's razor**: prefer the explanation with the fewest assumptions until it's disproven — but remember sometimes the truth genuinely is complex.
+- **Hanlon's razor**: before assuming malice (a competitor's move, a churned customer, a rude reply), assume incompetence or accident — it's the far more common cause.
+- **Incentives**: to predict behavior, find the incentive; if a system produces weird outcomes, someone is being paid (in money, status, or comfort) to produce them.
+- **Margin of safety**: build buffers that look like overcaution — in runway, capacity, promises made — because surviving the unexpected is what lets you compound.
+- **Trade-offs / opportunity cost**: every yes is a no to something else; price decisions by the best alternative forgone, not just their direct cost.
+- **Leverage**: hunt for the small force applied at the right point that yields outsized output — but wielded at maximum all the time, it wipes you out.
+- **Inertia & activation energy**: starting is the expensive part; once in motion, momentum is cheap — budget disproportionate effort for launches and changes of direction.
+- **Friction/viscosity**: reducing resistance is often easier than adding force — remove steps before adding pushes.
+- **Velocity (not speed)**: speed in circles is zero progress; direction matters as much as pace.
+- **Feedback loops**: find what output feeds back into input — reinforcing loops explain runaway growth and death spirals alike.
+- **Bottlenecks**: throughput is set by the constraint; the real leverage is finding and fixing the bottleneck, not improving everything else.
+- **Scale**: what works small breaks large — re-ask every design question when volume 10x's.
+- **Diminishing returns**: easy wins come first; when each unit of effort buys less, move to a new curve instead of grinding the old one.
+- **Regression to the mean**: extreme results (a viral post, a terrible week) revert toward average — don't rebuild strategy around an outlier.
+- **Multiply by zero**: in a multiplicative system, one zero (trust, reliability, a broken step) zeroes the whole product — fix zeros before optimizing anything else.
+- **Sampling & randomness**: small samples lie and humans are terrible at recognizing randomness — insist on enough data before calling a trend.
+- **Local vs global maxima**: don't settle for the first peak; sometimes you must descend (get worse) to reach a higher hill.
+- **Surface area**: more exposure means more inbound ideas AND more vulnerability — choose deliberately where to be exposed.
+- **Red Queen effect**: competitors adapt too; there is no permanent lead, only a rate of adaptation.
+- **Niches**: specialists out-compete larger generalist rivals inside a well-chosen niche.
+- **Reciprocity**: give the behavior you want returned — goodwill and opportunity tend to come back in kind.
+- **Relativity / vantage points**: two observers of the same event walk away with different interpretations — locate your own vantage point before judging theirs.
+- **Critical mass**: change is invisible until enough accumulates, then self-sustaining — persist to the tipping point or don't start.
+- **Emergence**: combined parts create properties none of them have alone; judge systems, not components.
+- **Gresham's law**: bad drives out good — in markets, content feeds, and marketplaces, unpoliced low quality crowds out high quality.
+- **Creative destruction**: the new displacing the old is the health of the system — expect your own stack to be displaced and plan to ride it.
+- **Efficiency caution**: maximal short-term efficiency rarely yields long-term efficiency — over-optimization eats your margin of safety.
+
+## Failure modes
+- **Man with a hammer**: forcing your favorite model onto every problem. The cure is the latticework itself — more models, and checking a situation against several before acting.
+- **Mistaking the model for reality**: models are maps; treating one as the territory (managing to the metric, hiring off the resume) fails exactly when reality diverges from the abstraction.
+- **Tunnel vision**: fixating on solving a problem one way and missing simpler routes — the model chose the solution before you looked at the problem.
+- **Refusing to update the map**: reconciling what you want to be true with what is true is painful, so stale models persist long after the territory changed.
+- **Simplicity worship**: Occam's razor misapplied — sometimes the truth is complex and the simplest story omits real facts.
+
+## Applies here when…
+- **Pricing/packaging calls**: incentives + second-order thinking — the flat no-GMV-tax pricing IS an incentive design; before changing tiers, ask what behavior each fee incentivizes and "and then what?" for the agency channel.
+- **Build-vs-reuse decisions**: multiply-by-zero + bottleneck — one unreliable subsystem zeroes never-lies; find the current constraint (usually distribution, not features) before building anything new, and reuse the existing pipeline first.
+- **Distribution channel picks (SEO/YouTube/X/Reddit)**: sampling + regression to the mean + surface area — don't reallocate off one viral post or one dead week; demand enough samples per channel, and treat each channel as added surface area (inbound leads AND inbound noise).
+- **Positioning bets**: circle of competence + map-is-not-the-territory — competitor teardowns and market maps are maps; validate against live customer conversations, and stay inside the agency/SMB-front-office circle where SF actually has an edge.
+- **Riding model improvements (never-goes-stale)**: Red Queen + creative destruction — the thin harness is a bet that adaptation rate beats feature depth; expect today's blocks to be displaced and keep the harness thin enough to ride the next wave.

--- a/.claude/skills/reflect/references/ooda-loop.md
+++ b/.claude/skills/reflect/references/ooda-loop.md
@@ -1,0 +1,44 @@
+---
+name: ooda-loop
+source: https://fs.blog/ooda-loop/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Boyd's OODA Loop
+
+## Core idea
+John Boyd — "Forty-Second Boyd," the fighter pilot who won dogfights in under 40 seconds — distilled decision-making under uncertainty into a repeating four-stage cycle:
+
+- **Observe:** gather information about the situation, separating signal from noise (the ER-doctor skill: collect what matters, filter what doesn't).
+- **Orient:** interpret it — the stage Boyd called the schwerpunkt, the main emphasis of the whole loop. Orientation means noticing and correcting the cognitive biases, cultural assumptions, and stale mental models that distort what you observed. Boyd's image is building a "mental snowmobile": disassembling ideas from many disciplines and recombining the parts to fit the situation in front of you.
+- **Decide:** pick among options — but treat the choice as a testable hypothesis, not a final answer (guarding against first-conclusion bias).
+- **Act:** execute, which is really running the experiment; the result feeds the next Observe.
+
+The strategic punchline is **tempo**. Boyd argued you should "operate at a faster tempo than our adversaries" — cycling the loop faster than a competitor makes your moves unpredictable and disorienting; they end up reacting to your last position while you've already moved. Systematic speed of iteration beats any single superior decision. Boyd named four barriers to accurate orientation — cultural tradition, genetic heritage, gaps in analytical skill, and information overload — and prescribed deliberately destroying flawed assumptions and rebuilding with better mental models. The loop generalizes far beyond air combat: medicine, law, business, sports, intelligence.
+
+## When it bites
+- You're polishing one "perfect" decision while a competitor ships three imperfect iterations and learns from each.
+- Your read of the market/user is filtered through a stale mental model — you're observing fresh data but orienting with last year's assumptions.
+- A rival is forcing you to react to their moves; you're inside *their* loop instead of them inside yours.
+- Feedback from the last action never made it back into the next observation — you're looping open-circuit.
+- You're drowning in dashboards (information overload) and mistaking more observation for better orientation.
+
+## How to run it
+1. Shrink the cycle time: what's the smallest ship that produces a real observation? Prefer three fast loops to one slow deliberation.
+2. Before deciding, spend the effort on **orientation**: which of my assumptions would Boyd tell me to destroy? What would someone from a different discipline see in this same data?
+3. Frame each decision as a hypothesis with an expected observable result; write down what you expect to see.
+4. Act, then actually close the loop — compare the result to the prediction before starting the next cycle.
+5. Track your tempo against the competition's: if their release/content/pricing cadence is faster, they are getting inside your loop; fix cycle time before fixing decision quality.
+
+## Failure modes
+- **Speed without orientation** — cycling fast on a distorted map just gets you lost quicker; tempo amplifies whatever your orientation is, good or bad.
+- **First-conclusion lock-in** — treating Decide as commitment instead of hypothesis, so contradicting observations get rationalized away.
+- **Observation addiction** — endless data-gathering as a substitute for acting; the loop only teaches you when Act happens.
+- **Fighting a tempo war where none exists** — some decisions (Type 1, one-way doors) are not dogfights; raw speed there is recklessness, not advantage.
+
+## Applies here when…
+- The build loop (brainstorm → spec → build → verify → merge → memory) *is* an OODA loop — its edge over slower agencies/incumbents is cycle time, and "never-goes-stale" is a tempo claim: the thin harness re-orients on every model release faster than fat platforms can.
+- Distribution channel picks: run the loop weekly — observe GSC/DataForSEO/YT analytics, re-orient on what's actually ranking, decide next content wave as a hypothesis, ship, re-read.
+- Memory files, lessons.md, and the dream/extract-approach skills are the Orient stage made explicit — they exist to destroy stale assumptions before the next cycle, not just to log history.
+- Against GHL-class incumbents: SF can't out-feature them, but it can out-tempo them — ship, observe churn/activation, re-orient positioning while their roadmap is still in committee.
+- Watch for observation addiction: another analytics dashboard is not a decision; if a question can be answered by a cheap reversible ship, act instead of instrumenting.

--- a/.claude/skills/reflect/references/optionality.md
+++ b/.claude/skills/reflect/references/optionality.md
@@ -1,0 +1,58 @@
+---
+name: optionality
+source: https://fs.blog/preserving-optionality/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Preserving Optionality
+
+## Core idea
+Against the standard advice to specialize hard and early, the article argues for
+preserving optionality: keeping multiple viable paths open — skills, relationships,
+resources, positions — especially choices with capped downside and open-ended upside.
+The future is unpredictable; over-specialization creates dependency on one scenario
+and fragility when the landscape shifts. As Chris Rock put it, "Wealth is not about
+having a lot of money; it's about having options."
+
+Optionality compounds. Each preserved option increases future adaptability, and
+options beget options: the athlete who avoids injury stays in the game and accumulates
+more chances to win (the Shannon Turley coaching example — flexibility and injury
+prevention over max lifts); the lean startup with low fixed costs can keep pivoting
+toward product-market fit; Baron Rothschild could buy into post-Waterloo panic because
+he had kept dry powder. The article's rough decision rule: exercise an option when
+doing so creates more future options; decline opportunities that are restrictive; take
+small risks with asymmetric upside.
+
+The inverse danger is the "tyranny of small decisions": options rarely vanish in one
+dramatic choice. They erode through accumulated incremental commitments nobody
+recognized as commitments — the way decades of individually-sensible choices produced
+car dependency and foreclosed alternatives. Note: the article itself does not dwell on
+the cost of never committing (lost mastery, lost compounding); that failure mode is
+real and belongs in the checklist below.
+
+## When it bites
+- A decision quietly forecloses future paths (exclusive deal, lock-in architecture, niche-only positioning) and nobody priced that in.
+- You're about to specialize or commit based on a forecast of a fast-changing landscape.
+- A string of small, individually reasonable commitments is accumulating into an irreversible position.
+- An opportunity has small bounded downside and large open upside — and you're hesitating as if it were symmetric.
+- Chaos or panic in the environment: dislocations are when held options pay off.
+
+## How to run it
+1. For each choice, ask: which future options does this open, and which does it kill?
+2. Prefer reversible moves; demand much higher expected value before making irreversible ones.
+3. Hunt asymmetry: take cheap options (experiments, relationships, capabilities) whose worst case is small and known.
+4. Audit the small-decision drift quarterly: what have we become committed to without ever deciding to?
+5. Exercise, don't hoard: when an option's payoff window is open and exercising it creates further options, commit fully — preserved-forever options decay to zero.
+
+## Failure modes
+- Perpetual hedging: never committing kills mastery, compounding, and momentum — optionality is for choosing well, not for avoiding choice.
+- Paying too much for options (in money, focus, or complexity) that will never realistically be exercised.
+- Treating every commitment as bad; irreversible commitments are fine when the payoff clearly justifies the foreclosure.
+- Using "keeping options open" as respectable-sounding procrastination on a decision that is actually ripe.
+
+## Applies here when…
+- Surface-agnostic architecture is bought optionality: the 6-primitives model keeps voice/chat/SMS/email/MCP all live — resist features that hard-couple to one surface.
+- Positioning bets: going all-in on one vertical (e.g., trades) vs. keeping the horizontal never-lies/never-taxes frame — price what each forecloses before committing.
+- BYOK + no-Zapier + push-outward are anti-lock-in choices that preserve SF's options (and customers'); dependencies on a middleware or single provider spend that optionality.
+- Watch tyranny-of-small-decisions drift: each quick integration, pricing exception, or bespoke agency favor accretes into de-facto commitments — audit them.
+- But don't hoard: when a wedge shows real traction (e.g., a proof sprint converting), exercise the option and commit — a launch delayed to "stay flexible" is the hedging failure mode.

--- a/.claude/skills/reflect/references/probability-errors.md
+++ b/.claude/skills/reflect/references/probability-errors.md
@@ -1,0 +1,43 @@
+---
+name: probability-errors
+source: https://fs.blog/common-probability-errors/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Common Probability Errors
+
+## Core idea
+Most probability mistakes aren't math errors — they're structural errors about how events relate. The article catalogs five recurring ones:
+
+1. **Assuming independence when events are dependent.** Connected events have correlated probabilities. A driver with one accident is statistically likelier to have another (insurers price this); steps in a plan share causes, so delays compound rather than average out.
+2. **Treating independent events as dependent — the gambler's fallacy.** Past outcomes don't bend future odds of a truly independent event. After a million heads in a row, a fair coin is still 50/50 next flip: "The outcome of one has no effect on the outcome of another."
+3. **Clusters happen.** Scan a large enough population and improbable-looking clusters are inevitable by pure chance. A geographic cancer cluster may have no environmental cause at all — our pattern-matching machinery (apophenia) insists on a story anyway.
+4. **The prosecutor's fallacy.** Quoting a probability stripped of its statistical context. A "one in a million" DNA match sounds damning — until you learn it was found by searching a database of a million samples, where one match is roughly expected.
+5. **Ignoring regression to the mean.** Extreme results carry a large luck component, so the follow-up tends back toward average. A spectacular season, quarter, or launch is partly fortune; expecting a repeat mistakes variance for skill.
+
+## When it bites
+- Project planning: scheduling tasks as if their delays are independent (they share staffing, dependencies, and shocks — error #1).
+- "We're due": expecting a win because of a losing streak, or a quiet period because incidents have been frequent (error #2).
+- Spotting a pattern in a dashboard slice — a spike of churn in one cohort, failures clustering on one route — and hunting a cause before asking if chance over many slices explains it (error #3).
+- Evaluating a striking match or anomaly without asking how many chances there were to find one (error #4 — the multiple-comparisons trap).
+- Judging people, channels, or strategies off their single best or worst result (error #5).
+
+## How to run it
+1. Before multiplying or extrapolating probabilities, ask: are these events actually independent? What common causes link them?
+2. For streaks, ask the opposite: is there ANY mechanism connecting past to future here? If not, the streak carries zero information.
+3. When a cluster or pattern appears, first compute (or estimate) how surprising it would be given how many places you looked. Clusters often fool us — take random chance seriously as the null explanation.
+4. For any impressive statistic, demand its context: out of how many trials/searches/candidates was this found? A snapshot number without its denominator is not evidence.
+5. Judge skill by the track record, not the peak — expect extreme results to regress and plan for the mean, not the outlier.
+
+## Failure modes
+- **Independence nihilism**: deciding everything is correlated, so no estimate is possible. Many things are independent enough; the discipline is checking, not despairing.
+- **Chance as a thought-terminator**: "it's probably just a cluster" can dismiss a real signal. Chance is the null hypothesis, not the conclusion — test it.
+- **Regression misread as decline**: an outlier performer returning to their (high) mean is not "getting worse," and intervening right after a bad outlier will look effective even if it did nothing.
+- **Gambler's-fallacy inversion (hot hand)**: assuming streaks must continue is the same structural error as assuming they must end.
+
+## Applies here when…
+- Revenue/GMV projections: builder signups, activation, and churn are NOT independent — they share the macro AI-agent hype cycle, so best-case-everywhere compounding overstates the tail.
+- Launch planning: the ship-feature loop's steps (build → verify → smoke → deploy) share causes of delay; budget for compounding, not averaged, slippage.
+- Reading eval/vision_check dashboards: a cluster of failures in one workspace or route may be chance across many workspaces — check the denominator before rearchitecting.
+- Interpreting a viral post or a spike week: expect regression to the mean; set the content-engine cadence on the track record, not the best week.
+- A/B-ish pricing or landing reads: a striking conversion difference found after slicing many segments is the prosecutor's fallacy in analytics clothing.

--- a/.claude/skills/reflect/references/slack.md
+++ b/.claude/skills/reflect/references/slack.md
@@ -1,0 +1,57 @@
+---
+name: slack
+source: https://fs.blog/slack/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Slack (Efficiency Is the Enemy)
+
+## Core idea
+Total efficiency is a myth — and chasing it makes organizations and people worse, not
+better. Slack is deliberately uncommitted capacity: time, money, people, or attention
+held in reserve rather than maximally utilized. The article leans heavily on Tom
+DeMarco (*Slack: Getting Past Burnout, Busywork, and the Myth of Total Efficiency*),
+who defines slack as "the degree of freedom required to effect change." His deeper
+point: slack is when reinvention happens — the time when you are zero percent busy.
+
+The load-bearing distinction is efficiency vs. effectiveness. Efficiency is doing a
+thing with minimum waste; effectiveness is doing the right thing. You can make a
+system more efficient while making it strictly worse, because the "waste" you cut was
+the adaptive capacity. DeMarco's sliding-puzzle analogy makes it concrete: fill the
+empty square with a ninth tile and the puzzle is 100% space-efficient — and permanently
+frozen. The empty square is what lets anything move.
+
+At 100% utilization: backlogs form because nothing can be absorbed immediately;
+scarcity of time depletes cognition and magnifies every failure; people optimize for
+looking busy over doing the right work; work expands to fill whatever time exists,
+manufacturing false urgency. The Gloria/Tony example (an assistant who often looks
+idle but can respond instantly to anything urgent) shows slack as responsiveness the
+executive is effectively buying. Amos Tversky's research secret — being slightly
+underemployed — is the same idea for thinking work.
+
+## When it bites
+- Every calendar slot, sprint, dollar, or headcount is committed before the period starts.
+- A small surprise (bug, outage, hot lead, competitor move) causes cascading delays because nothing can absorb it.
+- "We're all slammed" is the standing answer to any new opportunity.
+- Strategic/reflective work keeps losing to urgent-but-committed work.
+- A plan's viability depends on nothing going wrong.
+
+## How to run it
+1. Ask: where is this system at ~100% utilization? That's where change is impossible.
+2. Distinguish efficient from effective — what "right thing" is the busyness crowding out?
+3. Deliberately budget reserve: unallocated time in the week, buffer in the plan, cash not earmarked, one person not fully loaded.
+4. Treat idle-looking capacity as purchased responsiveness, not waste to be trimmed.
+5. Before committing the last unit of capacity, ask what it costs in adaptability — slack is the currency of change; spending all of it means buying zero optionality.
+
+## Failure modes
+- Using "slack" to excuse chronic under-delivery or avoidance — slack is reserve capacity, not permission to coast.
+- Padding everything uniformly; slack has value where volatility and change pressure are highest, not everywhere equally.
+- Preserving slack that never gets spent — hoarded reserve is just waste with a strategy label.
+- Confusing personal laziness with organizational slack; DeMarco's argument is structural, not motivational.
+
+## Applies here when…
+- The build loop is queued solid: every Claude session, worktree, and week pre-committed means no capacity to jump on a model release, a viral post, or a hot inbound lead — and "never-goes-stale" depends on riding gains fast.
+- Roadmap slicing: leaving explicit unplanned slices per week beats a fully-loaded todo.md; something always breaks (smoke failures, Vercel env drift) and needs absorbing.
+- Pricing/COGS decisions: BYOK keeps margin slack — resist commitments (managed telephony, SLAs) that push effective utilization of Max's attention or margin to 100%.
+- Solo-founder attention is the scarcest resource: guard zero-percent-busy time for positioning and wedge thinking, or the loop only ever exploits.
+- Partnership/agency commitments: don't fill every distribution channel slot; keep one open for the channel that doesn't exist yet.

--- a/.claude/skills/reflect/references/worst-day.md
+++ b/.claude/skills/reflect/references/worst-day.md
@@ -1,0 +1,40 @@
+---
+name: worst-day
+source: https://fs.blog/worst-day/
+fetched: true
+fetched_on: 2026-07-15
+---
+# You're Only As Good As Your Worst Day
+
+## Core idea
+True quality — of a product, a company, a leader, a person — is revealed on the worst day, not the average one. Crisis behavior is honest signaling: it cannot be faked, because it reflects actual preparation and actual values rather than marketing promises or calm-weather polish.
+
+The pattern holds at every level. A product's quality is what the customer experiences when something breaks, not when everything works. A company's worth shows in how it responds to disruption — whether crisis decisions (e.g., reflexive layoffs vs. long-term thinking) match its stated priorities. Leaders are remembered for how they steered through wars, disasters, and uncertainty, not for presiding over calm; family and employers likewise remember the crisis moments over the ordinary ones. As the article quotes Publilius Syrus: "Anyone can steer the ship when the sea is calm."
+
+The strategic implication: design, prepare, and evaluate for the worst day deliberately rather than coasting on the average one — those who plan for disaster can turn their worst day into their best.
+
+## When it bites
+- Evaluating anything by its demo/average-day performance: uptime on a quiet Tuesday, support quality when nothing is broken, a hire's polish in interviews.
+- Building systems whose failure behavior was never designed — errors, outages, angry customers, refund requests.
+- Judging vendors, partners, or your own company by promises rather than by an observed bad-day response.
+- Personal/reputational moments: one badly handled crisis outweighs months of routine competence in others' memory.
+
+## How to run it
+1. For any system or commitment, ask: "What does the worst day look like, concretely?" Name the failure scenario (outage, hallucination, missed booking, churned anchor client).
+2. Design the worst-day experience on purpose: what does the customer see, who is notified, what is the recovery path, what do we say?
+3. Evaluate by worst-day evidence: when comparing options (tools, partners, hires), weight how each behaved when something went wrong over how it performs when everything is fine.
+4. Rehearse: run the failure drill before the failure (flip drills, incident runbooks, restore-from-backup tests).
+5. Check value alignment in advance: decide *now* what you will not do under pressure, because crisis decisions expose real priorities.
+
+## Failure modes
+- **Paranoia as strategy** — optimizing everything for catastrophe makes the average day slow and expensive; the point is to *survive and shine* on the worst day, not to live in it.
+- **Worst-day theater** — writing runbooks nobody rehearses; unfaked signaling requires actual drills, not documents.
+- **Misidentifying the worst day** — hardening against the dramatic failure (server down) while the real worst day is quiet (agent confidently lies to a customer).
+- **Judging others by one bad day without base rates** — a single crisis is evidence, but pattern beats incident.
+
+## Applies here when…
+- The never-lies positioning IS a worst-day promise: an SF agent's worth is what it does when it doesn't know the answer — read-back, guardrails, and vision_check gates are worst-day design, and they're the honest signal agencies can sell.
+- A client's front office on its worst day (missed after-hours call, double-booked slot, wrong quote) is what the SMB remembers — build and demo the recovery path, not just the happy booking flow.
+- Feature-flag flips and deploys: the flip drill and smoke-on-live discipline exist because merge-day green is the calm sea; judge readiness by the rollback story.
+- Pricing/packaging decisions under pressure (a big agency demands a discount, GMV fee pushback): decide the "we don't tax your work" line now so the worst-day negotiation doesn't expose different values.
+- Vendor and dependency picks (LLM providers, Twilio, Composio): weight their outage behavior and degradation modes over their benchmark-day performance.

--- a/docs/decisions/LOG.md
+++ b/docs/decisions/LOG.md
@@ -1,0 +1,14 @@
+# Decision log
+
+Written by the `/reflect` skill (`.claude/skills/reflect/`). One line per decision.
+Type-1 decisions also get a full entry file: `docs/decisions/YYYY-MM-DD-<slug>.md`.
+
+**Status values:** `open` (outcome pending) · `hit` (outcome ≈ expected) ·
+`miss` (outcome diverged — note why) · `moot` (overtaken by events).
+
+Every reflect run starts by scanning this table for past-due `review-by` dates
+with status `open`, and surfaces them for calibration review.
+
+| Date | Decision | Call | Type | Expected outcome | Review-by | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-07-15 | Wire /reflect into ship-feature's brainstorm phase vs keep standalone | Keep standalone; automate only on evidence | T2 | Manual usage over ~5 features shows where reflect earns its keep; no missed-lens regrets | 2026-08-15 | open |

--- a/docs/superpowers/specs/2026-07-15-reflect-decision-loop-design.md
+++ b/docs/superpowers/specs/2026-07-15-reflect-decision-loop-design.md
@@ -1,0 +1,101 @@
+# /reflect — Decision-Making Loop (Design)
+
+**Date:** 2026-07-15 · **Status:** Approved by Max (chat, 2026-07-15)
+
+## Purpose
+
+Compact ~24 decision-making articles (fs.blog mental models + Bezos framework) into a
+skill-driven decision loop. When Max says **"reflect on X"**, Claude runs a structured,
+stakes-scaled decision process and logs the outcome for later calibration review.
+
+## Decisions locked (via clarifying Q&A)
+
+| Question | Answer |
+| --- | --- |
+| Scope | Everything — strategy, product/pricing, build/architecture, personal calls |
+| Structure | Core loop (SKILL.md) + per-model reference files loaded on demand |
+| Depth | Scaled by stakes — Bezos Type-1/Type-2 gate routes quick vs. full run |
+| Decision log | Log everything (`docs/decisions/`) with expected outcome + review-by date |
+| Fidelity | Faithful compaction of each article + short "applies here when…" section |
+| Sourcing | Fetch all articles live; compact from actual text (no full-text copies — copyright) |
+| Interaction | Opinionated recommendation first; ask only decision-critical gaps |
+| Calibration | Self-checking — every reflect starts by surfacing past-due review-by entries |
+
+## File layout
+
+```
+.claude/skills/reflect/
+  SKILL.md                      # the loop: review-debt → frame → classify → run → recommend → log
+  references/
+    00-index.md                 # routing table: one line per lens, when it bites
+    bezos-type1-type2.md        # reversibility gate, 70% rule, disagree-and-commit
+    first-principles.md         # Musk physics-not-analogy
+    chestertons-fence.md  ooda-loop.md  decision-anatomy.md  decision-matrix.md
+    inversion-avoid-stupidity.md   # how-not-to-be-stupid + avoid-bad-decisions (merged)
+    availability-bias.md  probability-errors.md  algorithms-bias.md
+    slack.md  optionality.md  explore-exploit.md  externalities.md
+    bikeshed.md  defensive-decisions.md  captaincy.md
+    best-case.md  worst-day.md  break-the-chain.md
+    hemingway-suitcase.md  gian-carlo-rota.md
+    mental-models-general.md    # the FS hub: latticework + top models not covered above
+docs/decisions/
+  LOG.md                        # index: date · decision · call · stakes · review-by · status
+  YYYY-MM-DD-<slug>.md          # full entries for Type-1 reflects
+```
+
+## Reference file format (each ~40–80 lines)
+
+```markdown
+---
+name: <slug>
+source: <url(s)>
+fetched: true|false            # false = distilled from knowledge (fetch failed)
+fetched_on: 2026-07-15
+---
+# <Model name>
+## Core idea          — faithful compaction of the article
+## When it bites      — concrete triggers
+## How to run it      — steps / questions to actually apply it
+## Failure modes      — how the model misleads when misapplied
+## Applies here when… — SeldonFrame-flavored triggers (pricing, positioning, feature bets)
+```
+
+Copyright constraint: paraphrase; at most one short quote (<15 words) per file.
+
+## The loop (SKILL.md contract)
+
+1. **Review-debt check** — scan `docs/decisions/LOG.md` for past-due review-by dates; surface first.
+2. **Frame** (decision-anatomy) — the actual decision, owner, trigger, cost of no-decision.
+3. **Classify** (Bezos gate) — Type 1 (irreversible/high-stakes) vs Type 2 (reversible):
+   - Type 2 → quick pass: 3 most-biting lenses from `00-index.md`, one-paragraph
+     opinionated recommendation at ~70% information. Log = one line in LOG.md.
+   - Type 1 → full run: first-principles decomposition, inversion + pre-mortem
+     (mandatory), second-order effects/externalities, optionality check, decision
+     matrix when genuinely multi-option, probability sanity-check on estimates.
+     Full log entry file.
+4. **Recommend** — always ends with: the call, confidence, **"what would change my
+   mind"** (mandatory), and cheap tests that would raise confidence.
+5. **Log** — append LOG.md line (+ entry file for Type 1) with expected outcome and
+   review-by date.
+
+Baked-in guardrails: bikeshed alarm (effort ∝ stakes), availability check on lens
+choice, defensive-decision check (protecting outcome vs. protecting self), and
+CLAUDE.md §1b settled-decisions rule is upstream of any reflect (never re-litigate).
+
+## Build plan
+
+1. Fan out ~7 subagents; each fetches its assigned URLs live and writes the reference
+   files directly (template above). FS hub article gets a dedicated agent.
+   Bezos substack fallback: Bezos shareholder letters (primary source), noted in file.
+2. Main session writes SKILL.md, 00-index.md, seeds docs/decisions/LOG.md.
+3. Review pass over all files (maker ≠ checker spirit: spot-check fidelity + format).
+4. Verify end-to-end: run a real reflect on a live pending decision; confirm routing,
+   output shape, and log write.
+5. Commit → push → PR to main.
+
+## Success criteria
+
+- "reflect on <topic>" reliably triggers the skill and produces a stakes-scaled,
+  opinionated output with the mandatory tripwires.
+- All ~23 reference files present, faithful, and individually loadable.
+- Decision log grows with each reflect; past-due reviews surface automatically.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,6 +7,25 @@ with a checkable plan, gets ticked off as it ships, and ends with a review block
 
 ## In flight
 
+### Task — /reflect decision loop (2026-07-15, branch feat/reflect-decision-loop)
+
+Compact ~24 FS.blog/Bezos decision articles into `.claude/skills/reflect/` (core loop +
+per-lens reference files) + `docs/decisions/LOG.md` calibration log.
+Spec (approved in chat): docs/superpowers/specs/2026-07-15-reflect-decision-loop-design.md
+
+- [x] Design approved by Max (8 decisions locked via Q&A)
+- [x] Spec written + self-reviewed
+- [x] Worktree off origin/main
+- [x] 7 fetch agents dispatched (24 URLs → 23 reference files)
+- [x] SKILL.md (the loop) + references/00-index.md + docs/decisions/LOG.md written
+- [x] All reference files landed (agents 7/7, all 24 URLs fetched live, 0 fallbacks)
+- [x] Review pass: structural check 23/23 green + spot-read (bezos, break-the-chain) — 2 fidelity
+      corrections applied (break-the-chain = obligation chains, not mistake cascades;
+      algorithms-bias = bias-in-algorithms framing, not Meehl)
+- [x] End-to-end verify: reflect ran on "wire reflect into ship-feature?" — quick-pass routing,
+      output shape, and LOG.md write all confirmed (first real entry logged)
+- [ ] Commit → push → PR to main
+
 ### Task — Green-main slices 2+3: stale UI expectations + archetype invariant (2026-07-10, branch fix/ci-stale-test-expectations)
 
 Baseline: main run 29097414557 — 107 unique failing spec names (0 new failures allowed; judge by delta).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -24,7 +24,14 @@ Spec (approved in chat): docs/superpowers/specs/2026-07-15-reflect-decision-loop
       algorithms-bias = bias-in-algorithms framing, not Meehl)
 - [x] End-to-end verify: reflect ran on "wire reflect into ship-feature?" — quick-pass routing,
       output shape, and LOG.md write all confirmed (first real entry logged)
-- [ ] Commit → push → PR to main
+- [x] Commit → push → PR #84 to main
+
+**Review:** Shipped in one pass. 7 parallel fetch agents, 24/24 URLs fetched live (no
+paywalls, no fallbacks). Two fidelity catches from fetching the real articles instead of
+trusting title-based assumptions: break-the-chain is about obligation/dependency chains
+(not mistake cascades) and algorithms-bias is Fry-style bias-in-algorithms (not Meehl) —
+SKILL.md + index corrected to match. Loop verified end-to-end with a real logged decision.
+Lesson: when compacting external sources, fetch before framing — 2 of 24 titles lied.
 
 ### Task — Green-main slices 2+3: stale UI expectations + archetype invariant (2026-07-10, branch fix/ci-stale-test-expectations)
 


### PR DESCRIPTION
## What

A new `/reflect` skill: Max says **"reflect on X"** and Claude runs a stakes-scaled decision loop built from ~24 Farnam Street mental-model articles + the Bezos framework, ending in an opinionated recommendation and a logged, reviewable prediction.

## Structure (thin loop, fat lenses)

- **`.claude/skills/reflect/SKILL.md`** — the loop: review-debt check → frame (decision-anatomy) → Bezos Type-1/Type-2 gate → quick pass (3 lenses, ~70% info) or full run (first-principles, mandatory inversion + pre-mortem, second-order effects, optionality, probability sanity-check) → recommendation with confidence + mandatory *"what would change my mind"* → log.
- **`references/`** — 23 lens files, each faithfully compacted from a **live fetch** of the source article (all 24 URLs fetched, zero knowledge-fallbacks), with a SeldonFrame-flavored *"applies here when…"* section. `00-index.md` is the routing table.
- **`docs/decisions/LOG.md`** — calibration log; every reflect first surfaces past-due review-by entries ("you predicted X — what happened?").

## Guardrails baked in

Bikeshed alarm (effort ∝ stakes), availability check on lens choice, defensive-decision check, captaincy (Claude recommends, Max decides), and CLAUDE.md §1b settled decisions stay upstream — a reflect never re-litigates them.

## Verification

- Structural check: 23/23 reference files with full frontmatter + all 5 sections.
- Fidelity spot-reads; 2 corrections applied where my assumptions diverged from the real articles (break-the-chain = obligation chains, not mistake cascades; algorithms-bias = bias-in-algorithms, not Meehl-style rules-beat-experts).
- End-to-end reflect ran on a live decision ("wire /reflect into ship-feature?") — quick-pass routing, output shape, and LOG.md write all confirmed; the entry is the log's first row.

Spec (approved in chat): `docs/superpowers/specs/2026-07-15-reflect-decision-loop-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)