### PR TITLE
fix(chatgpt-mcp): rate-limit build_workspace per openai/subject, not shared egress IP

### DIFF
--- a/docs/learnings/2026-07-15-shared-egress-ip-rate-limiting.md
+++ b/docs/learnings/2026-07-15-shared-egress-ip-rate-limiting.md
@@ -1,0 +1,22 @@
+# Rate-limiting a channel whose callers share egress IPs (ChatGPT MCP, PR #85)
+
+## The problem, in one line
+The ChatGPT app's `build_workspace` tool rate-limited by caller IP (3/hr) — but every ChatGPT user's tool calls arrive from OpenAI's handful of shared server egress IPs, so the whole channel collapsed to ~3 builds/hour total.
+
+## The approach
+1. Find the identity the platform already provides for this: OpenAI stamps `_meta["openai/subject"]` (anonymized, stable per-user id) on every MCP tools/call **exactly for rate limiting**, plus `_meta["openai/session"]` per conversation. Check the platform's docs for a per-user key before inventing one.
+2. Extract the id in the PURE wire layer (`extractOpenAiMeta` in `packages/crm/src/lib/chatgpt-app/chatgpt-mcp-rpc.ts`): trim, reject non-strings, length-cap to 128 (it becomes a Redis key).
+3. Express the limit policy as a PURE plan builder (`rate-limit-plan.ts`: `buildWorkspaceRateLimitChecks(ip, subject) → [{key, limit, windowMs}]`), and have the effectful deps layer just execute the plan against `checkRateLimit`. The policy — the part that can be subtly wrong — is now unit-testable with zero fakes.
+4. Thread the id through the DI'd handler as a new dep parameter (`buildWorkspace(args, meta)`), so the pass-through is covered by the existing fake-deps handler specs.
+5. Reuse the id for analytics: it became the PostHog distinct id, linking one user's build→browse→deploy funnel; `?ref=chatgpt` stamped on returned URLs (idempotent `URL.searchParams.set`) makes downstream claims attributable.
+
+## Judgment calls
+- **The caller-supplied id is forgeable wire data — never trust it alone.** Kept a coarse per-IP backstop (60/hr, 200/day) alongside the per-subject limit: a direct attacker rotating fake subjects burns their own IP's backstop, never a real user's allowance. Threat model: legit path (many users, one OpenAI IP) vs forge path (many subjects, one attacker IP) — the two keys cover each other's blind spot.
+- **Calls with NO subject got today's strict per-IP keys, not the loose backstop.** The naive reading of "IP as backstop at 60/hr" would have loosened the public endpoint 20× for plain curl callers. Missing-subject = non-ChatGPT traffic = keep the old rules, in the same shared bucket as the anonymous web route (no double-dip).
+- **Did NOT touch tool names/descriptions/schemas** — those trigger OpenAI app re-review. Server-side behavior and returned-URL content are free to change; the tool contract is not.
+- **Did NOT make the error message dynamic** per which limit tripped — one friendly message covers all four checks; per-key messaging is complexity with no user value.
+
+## The reusable rule, one line
+When callers are proxied through a platform's shared infrastructure, rate-limit on the platform-provided per-user id and demote the IP to an anti-forgery backstop — and express the limit policy as a pure plan (keys+limits out, effects elsewhere) so it's testable.
+
+Related: memory `marketplace-distribution-state` (the blocker this fixes), memory `seldonframe-security` (rate-limit invariants live next to the org-scope rules).

--- a/packages/crm/src/app/api/chatgpt/mcp/route.ts
+++ b/packages/crm/src/app/api/chatgpt/mcp/route.ts
@@ -22,8 +22,10 @@
 // with NO claim/purchase URL, NO price, and NO purchase CTA — deploy NEVER
 // charges a card and never directs the user out to buy anything.
 //
-// This route is a THIN wrapper: it reads the IP for the build rate-limit, binds
-// the real deps (lib/chatgpt-app/deps), and maps the DI'd handler's
+// This route is a THIN wrapper: it reads the IP for the build rate-limit
+// BACKSTOP (the strict limit keys on _meta["openai/subject"], extracted from
+// the JSON-RPC body by the handler — ChatGPT calls share OpenAI's egress IPs),
+// binds the real deps (lib/chatgpt-app/deps), and maps the DI'd handler's
 // { status, body } onto NextResponse. All dispatch logic lives in
 // lib/chatgpt-app/chatgpt-mcp-handler (unit-tested with fakes).
 
@@ -33,8 +35,8 @@ import { buildRealDeps } from "@/lib/chatgpt-app/deps";
 
 // CORS: an MCP client (ChatGPT) is server-hosted; mirror the rental endpoint's
 // permissive stance. The server exposes only the three high-level tools and
-// build_workspace is IP-rate-limited, so a permissive Origin doesn't loosen
-// anything (there's no per-user auth to leak).
+// build_workspace is rate-limited (per-subject + per-IP backstop), so a
+// permissive Origin doesn't loosen anything (there's no per-user auth to leak).
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
@@ -62,8 +64,8 @@ export async function GET() {
   );
 }
 
-/** The caller IP for the build_workspace rate-limit (matches the anonymous
- *  /api/v1/workspace/create route's resolution). */
+/** The caller IP for the build_workspace rate-limit backstop (matches the
+ *  anonymous /api/v1/workspace/create route's resolution). */
 function resolveRequestIp(request: NextRequest): string {
   const forwarded = request.headers.get("x-forwarded-for");
   if (forwarded) {

--- a/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-handler.ts
+++ b/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-handler.ts
@@ -35,6 +35,7 @@ import {
   parseBuildWorkspaceArgs,
   parseBrowseArgs,
   parseDeployArgs,
+  extractOpenAiMeta,
   formatMarketplaceList,
   formatBuildResult,
   formatDeployResult,
@@ -42,6 +43,7 @@ import {
   BROWSE_MARKETPLACE_TOOL,
   DEPLOY_AGENT_TOOL,
   type BuildWorkspaceArgs,
+  type OpenAiCallMeta,
 } from "./chatgpt-mcp-rpc";
 import type { MarketplaceAgentRow } from "@/lib/marketplace/agent-listings";
 import { captureMcpToolCall } from "@/lib/analytics/mcp-capture";
@@ -74,10 +76,11 @@ export type DeployAgentResult = {
 };
 
 export type ChatGptMcpDeps = {
-  /** Create a complete anonymous workspace from the parsed build args. Applies
-   *  the same IP rate-limit the anonymous route uses (throws a friendly Error on
-   *  limit → surfaces as a tool isError). */
-  buildWorkspace: (args: BuildWorkspaceArgs) => Promise<BuildWorkspaceResult>;
+  /** Create a complete anonymous workspace from the parsed build args. Rate-
+   *  limits per ChatGPT user via meta.subject (_meta["openai/subject"]) with a
+   *  coarse per-IP backstop — see rate-limit-plan.ts (throws a friendly Error
+   *  on limit → surfaces as a tool isError). */
+  buildWorkspace: (args: BuildWorkspaceArgs, meta: OpenAiCallMeta) => Promise<BuildWorkspaceResult>;
   /** List published marketplace agents, filtered. Public — no auth. */
   browse: (filters: { query?: string; niche?: string }) => Promise<MarketplaceAgentRow[]>;
   /** Deploy an agent into the workspace identified by the bearer token. */
@@ -150,6 +153,9 @@ async function handleToolsCall(
     typeof params.arguments === "object" && params.arguments !== null && !Array.isArray(params.arguments)
       ? (params.arguments as Record<string, unknown>)
       : {};
+  // OpenAI stamps _meta["openai/subject"] (anonymized per-user id — the
+  // rate-limit + analytics key) and _meta["openai/session"] on tool calls.
+  const meta = extractOpenAiMeta(params);
 
   switch (toolName) {
     case BUILD_WORKSPACE_TOOL: {
@@ -157,8 +163,8 @@ async function handleToolsCall(
       if (!parsed.ok) {
         return { status: 200, body: jsonRpcError(id, JSONRPC_INVALID_PARAMS, `Invalid params: ${parsed.error}`) };
       }
-      return runTool(id, toolName, args, deps, async () => {
-        const result = await deps.buildWorkspace(parsed.value);
+      return runTool(id, toolName, args, meta, deps, async () => {
+        const result = await deps.buildWorkspace(parsed.value, meta);
         return toolResult(formatBuildResult(result), { ...result });
       });
     }
@@ -168,7 +174,7 @@ async function handleToolsCall(
       if (!parsed.ok) {
         return { status: 200, body: jsonRpcError(id, JSONRPC_INVALID_PARAMS, `Invalid params: ${parsed.error}`) };
       }
-      return runTool(id, toolName, args, deps, async () => {
+      return runTool(id, toolName, args, meta, deps, async () => {
         const rows = await deps.browse(parsed.value);
         // structuredContent mirrors the DECLARED output schema exactly — the
         // raw MarketplaceAgentRow carries extra columns (price, rating, …)
@@ -188,7 +194,7 @@ async function handleToolsCall(
       if (!parsed.ok) {
         return { status: 200, body: jsonRpcError(id, JSONRPC_INVALID_PARAMS, `Invalid params: ${parsed.error}`) };
       }
-      return runTool(id, toolName, args, deps, async () => {
+      return runTool(id, toolName, args, meta, deps, async () => {
         const result = await deps.deploy({ workspaceToken: parsed.value.workspace_token, slug: parsed.value.agent_slug });
         if (!result.ok) {
           // A handled failure (e.g. expired token, unknown slug) → tool-level
@@ -224,6 +230,7 @@ async function runTool(
   id: JsonRpcId,
   toolName: string,
   args: Record<string, unknown>,
+  meta: OpenAiCallMeta,
   deps: ChatGptMcpDeps,
   body: () => Promise<Record<string, unknown>>,
 ): Promise<RpcOutcome> {
@@ -231,13 +238,14 @@ async function runTool(
   // PostHog MCP-analytics ($mcp_tool_call) — fire-and-silent, no-op without a
   // configured key, never blocks/throws into this response path. This server
   // is public/keyless (no bearer, no resolvable org at call time — see the
-  // file header), so distinctId/orgId fall back to "anonymous" per the
-  // helper's documented contract.
+  // file header). OpenAI's anonymized per-user subject (when present) becomes
+  // the distinct id so one ChatGPT user's build→browse→deploy funnel
+  // correlates; otherwise fall back to "anonymous" per the helper's contract.
   const capture = (success: boolean, errorCode?: string) =>
     captureMcpToolCall({
       surface: "chatgpt",
       tool: toolName,
-      distinctId: "anonymous",
+      distinctId: meta.subject ? `openai_${meta.subject}` : "anonymous",
       orgId: null,
       success,
       durationMs: Date.now() - startedAt,

--- a/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-rpc.ts
+++ b/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-rpc.ts
@@ -305,6 +305,57 @@ export function parseDeployArgs(args: Record<string, unknown>): ParseResult<Depl
   return { ok: true, value: { workspace_token: rawToken.trim(), agent_slug: rawSlug.trim() } };
 }
 
+// ─── OpenAI call metadata (_meta) ────────────────────────────────────────────
+
+/** The OpenAI-provided per-call metadata on a tools/call request. `subject` is
+ *  the anonymized, stable per-USER id OpenAI sends exactly for rate limiting —
+ *  ChatGPT tool calls all originate from OpenAI's SHARED server egress IPs, so
+ *  an IP key alone collapses the whole channel to one user's allowance.
+ *  `session` identifies the conversation (logged for funnel correlation). */
+export type OpenAiCallMeta = {
+  subject?: string;
+  session?: string;
+};
+
+// Subject/session become rate-limit keys + log fields — cap runaway values.
+const MAX_META_ID = 128;
+
+/** Trim to a non-empty, length-capped string, or undefined. */
+function metaString(v: unknown): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed.slice(0, MAX_META_ID) : undefined;
+}
+
+/** Extract `_meta["openai/subject"]` + `_meta["openai/session"]` from a
+ *  tools/call params object. Both are optional — a non-ChatGPT MCP caller
+ *  (or a probe) sends no `_meta` and gets an empty meta back. */
+export function extractOpenAiMeta(params: Record<string, unknown>): OpenAiCallMeta {
+  const meta =
+    typeof params._meta === "object" && params._meta !== null && !Array.isArray(params._meta)
+      ? (params._meta as Record<string, unknown>)
+      : {};
+  return {
+    subject: metaString(meta["openai/subject"]),
+    session: metaString(meta["openai/session"]),
+  };
+}
+
+// ─── attribution ─────────────────────────────────────────────────────────────
+
+/** Stamp `ref=chatgpt` onto a URL we hand back to ChatGPT (workspace, claim,
+ *  and deploy-admin URLs), so ChatGPT-attributed visits/claims are measurable
+ *  in analytics. Idempotent; an unparseable input is returned unchanged. */
+export function withChatGptRef(url: string): string {
+  try {
+    const u = new URL(url);
+    u.searchParams.set("ref", "chatgpt");
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 // ─── source assembly ─────────────────────────────────────────────────────────
 
 /**

--- a/packages/crm/src/lib/chatgpt-app/deps.ts
+++ b/packages/crm/src/lib/chatgpt-app/deps.ts
@@ -53,7 +53,13 @@ import type {
   BuildWorkspaceResult,
   DeployAgentResult,
 } from "./chatgpt-mcp-handler";
-import { assembleWorkspaceSource, type BuildWorkspaceArgs } from "./chatgpt-mcp-rpc";
+import {
+  assembleWorkspaceSource,
+  withChatGptRef,
+  type BuildWorkspaceArgs,
+  type OpenAiCallMeta,
+} from "./chatgpt-mcp-rpc";
+import { buildWorkspaceRateLimitChecks } from "./rate-limit-plan";
 
 const WORKSPACE_BASE_DOMAIN =
   process.env.WORKSPACE_BASE_DOMAIN?.trim() || "app.seldonframe.com";
@@ -85,15 +91,28 @@ const STARTER_IDS = new Set(STARTER_TEMPLATES.map((s) => s.id));
 class FriendlyToolError extends Error {}
 
 /**
- * Build a workspace from the parsed build args. Applies the SAME IP rate-limit
- * the anonymous /api/v1/workspace/create route uses (3/hr, 10/day per IP). On
- * limit, throws a friendly Error → the handler turns it into a tool isError so
+ * Build a workspace from the parsed build args. Rate-limits 3/hr + 10/day per
+ * ChatGPT USER (_meta["openai/subject"] — ChatGPT calls share OpenAI's egress
+ * IPs, so an IP key alone would collapse the channel) with a coarse per-IP
+ * backstop; calls without a subject keep the strict per-IP keys the anonymous
+ * /api/v1/workspace/create route uses. Plan in rate-limit-plan.ts. On limit,
+ * throws a friendly Error → the handler turns it into a tool isError so
  * ChatGPT shows the message instead of failing the connection.
  */
-async function buildWorkspace(ip: string, args: BuildWorkspaceArgs): Promise<BuildWorkspaceResult> {
-  const hourOk = await checkRateLimit(`anon-workspace-create:hour:${ip}`, 3, 60 * 60 * 1000);
-  const dayOk = await checkRateLimit(`anon-workspace-create:day:${ip}`, 10, 24 * 60 * 60 * 1000);
-  if (!hourOk || !dayOk) {
+async function buildWorkspace(
+  ip: string,
+  args: BuildWorkspaceArgs,
+  meta: OpenAiCallMeta,
+): Promise<BuildWorkspaceResult> {
+  // Funnel correlation: subject ties builds to one anonymized ChatGPT user,
+  // session to one conversation. Never PII — both are OpenAI-minted opaque ids.
+  console.log(
+    `[chatgpt-mcp] build_workspace subject=${meta.subject ?? "-"} session=${meta.session ?? "-"} ip=${ip}`,
+  );
+
+  const checks = buildWorkspaceRateLimitChecks(ip, meta.subject);
+  const results = await Promise.all(checks.map((c) => checkRateLimit(c.key, c.limit, c.windowMs)));
+  if (results.some((ok) => !ok)) {
     throw new FriendlyToolError(
       "Workspace creation is limited to 3 per hour and 10 per day. Please try again later, or sign up at app.seldonframe.com to create more.",
     );
@@ -161,9 +180,10 @@ async function buildWorkspace(ip: string, args: BuildWorkspaceArgs): Promise<Bui
   // (which still serves the seed landing, never a 404).
   const publicUrl = r1Ok ? `${APP_URL}/w/${result.slug}` : urls.home;
 
+  // ref=chatgpt on both URLs → ChatGPT-attributed visits/claims are measurable.
   return {
-    url: publicUrl,
-    claimUrl: structured.admin_url ?? undefined,
+    url: withChatGptRef(publicUrl),
+    claimUrl: structured.admin_url ? withChatGptRef(structured.admin_url) : undefined,
     workspaceToken: result.bearerToken,
   };
 }
@@ -223,7 +243,9 @@ async function deploy(input: { workspaceToken: string; slug: string }): Promise<
     return {
       ok: true,
       name: starter.name,
-      url: `${APP_URL}/admin/${encodeURIComponent(orgId)}?token=${encodeURIComponent(input.workspaceToken)}`,
+      url: withChatGptRef(
+        `${APP_URL}/admin/${encodeURIComponent(orgId)}?token=${encodeURIComponent(input.workspaceToken)}`,
+      ),
     };
   }
 
@@ -290,18 +312,20 @@ async function deploy(input: { workspaceToken: string; slug: string }): Promise<
   return {
     ok: true,
     name: listing.name,
-    url: `${APP_URL}/admin/${encodeURIComponent(orgId)}?token=${encodeURIComponent(input.workspaceToken)}`,
+    url: withChatGptRef(
+      `${APP_URL}/admin/${encodeURIComponent(orgId)}?token=${encodeURIComponent(input.workspaceToken)}`,
+    ),
   };
 }
 
 /**
- * Build the real deps for one request. `ip` is read from the request headers so
- * the build_workspace rate-limit keys on the caller's IP (matching the
- * anonymous route).
+ * Build the real deps for one request. `ip` is read from the request headers
+ * and serves as the build_workspace rate-limit BACKSTOP; the strict limit keys
+ * on the per-user _meta["openai/subject"] the handler extracts per call.
  */
 export function buildRealDeps(ip: string): ChatGptMcpDeps {
   return {
-    buildWorkspace: (args) => buildWorkspace(ip, args),
+    buildWorkspace: (args, meta) => buildWorkspace(ip, args, meta),
     browse: async (filters) => {
       const q = filters.query?.trim().toLowerCase();
       const niche = filters.niche?.trim().toLowerCase();

--- a/packages/crm/src/lib/chatgpt-app/rate-limit-plan.ts
+++ b/packages/crm/src/lib/chatgpt-app/rate-limit-plan.ts
@@ -1,0 +1,62 @@
+// ChatGPT App MCP — the PURE build_workspace rate-limit plan.
+//
+// WHY subject-first: ChatGPT tool calls originate from OpenAI's SHARED server
+// egress IPs, not the end user's IP. Under real traffic every ChatGPT user
+// shares a handful of IPs, so the old 3/hour-per-IP limit collapsed the whole
+// channel to ~3 builds/hour TOTAL. OpenAI sends _meta["openai/subject"] (an
+// anonymized, stable per-user id) on tool calls exactly for rate limiting —
+// so the strict allowance keys on the subject, and the IP stays only as a
+// coarse backstop against subject-rotation from a single non-OpenAI IP
+// (the subject is caller-supplied wire data, so it can be forged — but a
+// forger burns their own IP's backstop, never another user's allowance).
+//
+// Calls WITHOUT a subject (direct/non-ChatGPT MCP callers hitting this public
+// endpoint) keep TODAY'S strict per-IP keys — the same `anon-workspace-create`
+// bucket the anonymous /api/v1/workspace/create route uses — so this change
+// loosens nothing for anonymous direct traffic.
+//
+// Pure (no redis, no env, no I/O): returns the list of {key, limit, windowMs}
+// checks for deps.ts to execute against checkRateLimit.
+
+export type RateLimitCheck = {
+  key: string;
+  limit: number;
+  windowMs: number;
+};
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** The strict per-ChatGPT-user allowance (mirrors the anonymous web route). */
+export const SUBJECT_HOURLY_LIMIT = 3;
+export const SUBJECT_DAILY_LIMIT = 10;
+
+/** The coarse per-IP backstop when a subject is present. Must sit far above
+ *  the per-subject cap: one OpenAI egress IP legitimately carries MANY users. */
+export const IP_BACKSTOP_HOURLY_LIMIT = 60;
+export const IP_BACKSTOP_DAILY_LIMIT = 200;
+
+/**
+ * The rate-limit checks to run before creating a workspace from the ChatGPT
+ * MCP surface. ALL returned checks must pass (each check INCRs its window
+ * counter via checkRateLimit).
+ */
+export function buildWorkspaceRateLimitChecks(
+  ip: string,
+  subject: string | undefined,
+): RateLimitCheck[] {
+  if (subject) {
+    return [
+      { key: `chatgpt-workspace-create:subject:hour:${subject}`, limit: SUBJECT_HOURLY_LIMIT, windowMs: HOUR_MS },
+      { key: `chatgpt-workspace-create:subject:day:${subject}`, limit: SUBJECT_DAILY_LIMIT, windowMs: DAY_MS },
+      { key: `chatgpt-workspace-create:ip:hour:${ip}`, limit: IP_BACKSTOP_HOURLY_LIMIT, windowMs: HOUR_MS },
+      { key: `chatgpt-workspace-create:ip:day:${ip}`, limit: IP_BACKSTOP_DAILY_LIMIT, windowMs: DAY_MS },
+    ];
+  }
+  // No subject → the pre-existing strict per-IP keys, deliberately SHARED with
+  // the anonymous web route's bucket so a direct caller can't double-dip.
+  return [
+    { key: `anon-workspace-create:hour:${ip}`, limit: SUBJECT_HOURLY_LIMIT, windowMs: HOUR_MS },
+    { key: `anon-workspace-create:day:${ip}`, limit: SUBJECT_DAILY_LIMIT, windowMs: DAY_MS },
+  ];
+}

--- a/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-handler.spec.ts
+++ b/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-handler.spec.ts
@@ -40,6 +40,7 @@ const ROWS: MarketplaceAgentRow[] = [
 type Harness = {
   deps: ChatGptMcpDeps;
   built: Array<Record<string, unknown>>;
+  builtMeta: Array<{ subject?: string; session?: string }>;
   browsed: Array<{ query?: string; niche?: string }>;
   deployed: Array<{ workspaceToken: string; slug: string }>;
 };
@@ -50,14 +51,16 @@ function makeHarness(overrides?: {
   deploy?: ChatGptMcpDeps["deploy"];
 }): Harness {
   const built: Array<Record<string, unknown>> = [];
+  const builtMeta: Array<{ subject?: string; session?: string }> = [];
   const browsed: Array<{ query?: string; niche?: string }> = [];
   const deployed: Array<{ workspaceToken: string; slug: string }> = [];
 
   const deps: ChatGptMcpDeps = {
     buildWorkspace:
       overrides?.buildWorkspace ??
-      (async (args) => {
+      (async (args, meta) => {
         built.push(args as unknown as Record<string, unknown>);
+        builtMeta.push(meta);
         return {
           url: "https://acme.app.seldonframe.com",
           claimUrl: "https://app.seldonframe.com/admin/org-1?token=tok",
@@ -79,7 +82,7 @@ function makeHarness(overrides?: {
     now: () => NOW,
   };
 
-  return { deps, built, browsed, deployed };
+  return { deps, built, builtMeta, browsed, deployed };
 }
 
 function rpc(method: string, params?: unknown, id: number | string | null = 1) {
@@ -168,6 +171,34 @@ describe("handleChatGptRpc — build_workspace", () => {
     const structured = result.structuredContent as { url?: string; workspaceToken?: string };
     assert.equal(structured.url, "https://acme.app.seldonframe.com");
     assert.equal(structured.workspaceToken, "wst_fake_token");
+  });
+
+  test("_meta openai/subject + openai/session flow through to deps.buildWorkspace (per-user rate limiting)", async () => {
+    const h = makeHarness();
+    const out = await handleChatGptRpc(
+      rpc("tools/call", {
+        name: "build_workspace",
+        arguments: { business_name: "Acme HVAC" },
+        _meta: { "openai/subject": "sub_user_1", "openai/session": "sess_42" },
+      }),
+      h.deps,
+    );
+    assert.equal(out.status, 200);
+    assert.equal(h.builtMeta.length, 1);
+    assert.equal(h.builtMeta[0].subject, "sub_user_1");
+    assert.equal(h.builtMeta[0].session, "sess_42");
+  });
+
+  test("no _meta (a non-ChatGPT MCP caller) → empty meta, build still works", async () => {
+    const h = makeHarness();
+    const out = await handleChatGptRpc(
+      rpc("tools/call", { name: "build_workspace", arguments: { business_name: "Acme HVAC" } }),
+      h.deps,
+    );
+    assert.equal(out.status, 200);
+    assert.equal(h.builtMeta.length, 1);
+    assert.equal(h.builtMeta[0].subject, undefined);
+    assert.equal(h.builtMeta[0].session, undefined);
   });
 
   test("missing business_name → -32602 (validation), dep not called", async () => {

--- a/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-rpc.spec.ts
+++ b/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-rpc.spec.ts
@@ -14,6 +14,8 @@ import {
   parseBrowseArgs,
   parseDeployArgs,
   assembleWorkspaceSource,
+  extractOpenAiMeta,
+  withChatGptRef,
   formatMarketplaceList,
   formatBuildResult,
   formatDeployResult,
@@ -238,6 +240,68 @@ describe("assembleWorkspaceSource", () => {
 
   test("returns an empty string when nothing is provided", () => {
     assert.equal(assembleWorkspaceSource({}), "");
+  });
+});
+
+// ─── extractOpenAiMeta ───────────────────────────────────────────────────────
+
+describe("extractOpenAiMeta", () => {
+  test("reads openai/subject + openai/session from params._meta", () => {
+    const meta = extractOpenAiMeta({
+      name: "build_workspace",
+      arguments: { business_name: "Acme" },
+      _meta: { "openai/subject": "sub_abc123", "openai/session": "sess_xyz789" },
+    });
+    assert.equal(meta.subject, "sub_abc123");
+    assert.equal(meta.session, "sess_xyz789");
+  });
+
+  test("missing _meta → both undefined (a non-ChatGPT MCP caller)", () => {
+    const meta = extractOpenAiMeta({ name: "build_workspace", arguments: {} });
+    assert.equal(meta.subject, undefined);
+    assert.equal(meta.session, undefined);
+  });
+
+  test("blank / non-string / non-object shapes never yield a subject", () => {
+    assert.equal(extractOpenAiMeta({ _meta: { "openai/subject": "   " } }).subject, undefined);
+    assert.equal(extractOpenAiMeta({ _meta: { "openai/subject": 42 } }).subject, undefined);
+    assert.equal(extractOpenAiMeta({ _meta: "not-an-object" }).subject, undefined);
+    assert.equal(extractOpenAiMeta({ _meta: ["openai/subject"] }).subject, undefined);
+  });
+
+  test("trims and caps runaway ids (they become rate-limit keys)", () => {
+    const meta = extractOpenAiMeta({ _meta: { "openai/subject": `  ${"s".repeat(500)}  ` } });
+    assert.ok(meta.subject);
+    assert.ok(meta.subject!.length <= 128, "subject must be length-capped");
+    assert.equal(meta.subject, "s".repeat(128));
+  });
+});
+
+// ─── withChatGptRef ──────────────────────────────────────────────────────────
+
+describe("withChatGptRef", () => {
+  test("appends ref=chatgpt to a bare URL", () => {
+    assert.equal(
+      withChatGptRef("https://acme.app.seldonframe.com"),
+      "https://acme.app.seldonframe.com/?ref=chatgpt",
+    );
+  });
+
+  test("preserves existing query params (the token-bearing claim URL)", () => {
+    const out = withChatGptRef("https://app.seldonframe.com/admin/org-1?token=tok_abc");
+    const u = new URL(out);
+    assert.equal(u.searchParams.get("token"), "tok_abc");
+    assert.equal(u.searchParams.get("ref"), "chatgpt");
+  });
+
+  test("is idempotent (never stacks a second ref param)", () => {
+    const once = withChatGptRef("https://app.seldonframe.com/w/acme");
+    const twice = withChatGptRef(once);
+    assert.equal(twice, once);
+  });
+
+  test("an unparseable URL is returned unchanged (never throws)", () => {
+    assert.equal(withChatGptRef("not a url"), "not a url");
   });
 });
 

--- a/packages/crm/tests/unit/chatgpt-app/rate-limit-plan.spec.ts
+++ b/packages/crm/tests/unit/chatgpt-app/rate-limit-plan.spec.ts
@@ -1,0 +1,74 @@
+// ChatGPT App MCP — tests for the PURE build_workspace rate-limit plan.
+//
+// ChatGPT tool calls arrive from OpenAI's SHARED server egress IPs, so an
+// IP-keyed 3/hour limit collapses the whole channel to ~3 builds/hour across
+// ALL ChatGPT users. The plan keys the strict limit on _meta["openai/subject"]
+// (OpenAI's anonymized per-user id, sent exactly for rate limiting) and keeps
+// the IP only as a coarse backstop. The plan builder is pure (no redis, no
+// env) — deps.ts executes it against checkRateLimit.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildWorkspaceRateLimitChecks,
+  SUBJECT_HOURLY_LIMIT,
+  SUBJECT_DAILY_LIMIT,
+  IP_BACKSTOP_HOURLY_LIMIT,
+  IP_BACKSTOP_DAILY_LIMIT,
+} from "../../../src/lib/chatgpt-app/rate-limit-plan";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+describe("buildWorkspaceRateLimitChecks — subject present (a real ChatGPT call)", () => {
+  const checks = buildWorkspaceRateLimitChecks("20.1.2.3", "sub_abc");
+
+  test("strict 3/hr + 10/day limits key on the SUBJECT, not the IP", () => {
+    const hourly = checks.find((c) => c.limit === SUBJECT_HOURLY_LIMIT);
+    const daily = checks.find((c) => c.limit === SUBJECT_DAILY_LIMIT);
+    assert.ok(hourly && daily, "both strict windows present");
+    assert.equal(SUBJECT_HOURLY_LIMIT, 3);
+    assert.equal(SUBJECT_DAILY_LIMIT, 10);
+    assert.match(hourly!.key, /sub_abc/);
+    assert.match(daily!.key, /sub_abc/);
+    assert.doesNotMatch(hourly!.key, /20\.1\.2\.3/);
+    assert.equal(hourly!.windowMs, HOUR_MS);
+    assert.equal(daily!.windowMs, DAY_MS);
+  });
+
+  test("keeps a COARSE per-IP backstop (catches subject-rotation from one non-OpenAI IP)", () => {
+    const ipChecks = checks.filter((c) => c.key.includes("20.1.2.3"));
+    assert.ok(ipChecks.length >= 1, "an IP-keyed backstop must remain");
+    const hourly = ipChecks.find((c) => c.windowMs === HOUR_MS);
+    assert.ok(hourly);
+    assert.equal(hourly!.limit, IP_BACKSTOP_HOURLY_LIMIT);
+    assert.ok(
+      IP_BACKSTOP_HOURLY_LIMIT >= 60,
+      "backstop ceiling must be much higher than the per-subject cap",
+    );
+    const daily = ipChecks.find((c) => c.windowMs === DAY_MS);
+    assert.ok(daily);
+    assert.equal(daily!.limit, IP_BACKSTOP_DAILY_LIMIT);
+  });
+
+  test("two subjects on the same IP share the backstop keys but NOT the subject keys", () => {
+    const a = buildWorkspaceRateLimitChecks("20.1.2.3", "sub_a");
+    const b = buildWorkspaceRateLimitChecks("20.1.2.3", "sub_b");
+    const subjectKeys = (cs: typeof a) => cs.filter((c) => c.limit === SUBJECT_HOURLY_LIMIT).map((c) => c.key);
+    const ipKeys = (cs: typeof a) => cs.filter((c) => c.key.includes("20.1.2.3")).map((c) => c.key).sort();
+    assert.notDeepEqual(subjectKeys(a), subjectKeys(b));
+    assert.deepEqual(ipKeys(a), ipKeys(b));
+  });
+});
+
+describe("buildWorkspaceRateLimitChecks — subject missing (a direct/non-ChatGPT caller)", () => {
+  const checks = buildWorkspaceRateLimitChecks("9.9.9.9", undefined);
+
+  test("falls back to TODAY'S strict per-IP keys — no loosening for anonymous direct callers", () => {
+    assert.deepEqual(checks, [
+      { key: "anon-workspace-create:hour:9.9.9.9", limit: 3, windowMs: HOUR_MS },
+      { key: "anon-workspace-create:day:9.9.9.9", limit: 10, windowMs: DAY_MS },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

The ChatGPT plugin's `build_workspace` tool rate-limits by caller IP (3/hr, 10/day). ChatGPT tool calls originate from **OpenAI's shared server egress IPs**, not the end user's IP — so under real traffic all ChatGPT users share a handful of IPs and the entire channel collapses to ~3 builds/hour total. This was the flagged shared-egress-IP blocker for the (approved + live) ChatGPT app.

## Fix

- **Per-user rate limiting**: the strict 3/hr + 10/day allowance now keys on `_meta["openai/subject"]` — the anonymized per-user id OpenAI sends on tool calls exactly for this purpose. Extracted in the DI'd handler (pure wire helper `extractOpenAiMeta`), executed in `deps.ts` via a new pure plan builder (`rate-limit-plan.ts`).
- **IP kept as a coarse backstop** (60/hr, 200/day per IP) when a subject is present — catches subject-rotation abuse from a single non-OpenAI IP, since the subject is forgeable wire data. A forger burns their own IP's backstop, never another user's allowance.
- **No loosening for direct callers**: calls *without* a subject (non-ChatGPT MCP clients hitting this public endpoint) keep today's strict 3/hr + 10/day per-IP keys, still shared with the anonymous web route's bucket.
- **Funnel correlation**: `_meta["openai/session"]` is logged alongside the subject on every build, and the subject becomes the PostHog `$mcp_tool_call` distinct id (`openai_<subject>`) so one user's build→browse→deploy funnel links up.
- **Attribution**: `ref=chatgpt` is stamped on the workspace URL + claim URL returned by `build_workspace` and the admin URL returned by `deploy_agent` (idempotent, token param preserved) — ChatGPT-attributed visits/claims are now measurable.
- **No OpenAI re-review needed**: tool names/descriptions/schemas are untouched; all changes are server-side behavior.

## Tests

13 new unit tests (60 total in the chatgpt-app suite, all green): `_meta` extraction edge cases, ref-stamping idempotence/token preservation, subject-present vs subject-missing rate-limit plans, and handler pass-through of subject/session to the build dep.

## Verify gate

verify-runner: **PASS** — 60 tests green, tsc clean (only the pre-existing `copilot/turn` baseline error), use-server clean, no migrations, regression grep empty. Live smoke pending post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)