### PR TITLE
feat(marketing): "Try it inside ChatGPT" CTA across guides, /sell, /tools, /ai-agents

### DIFF
--- a/packages/crm/src/app/(public)/sell/page.tsx
+++ b/packages/crm/src/app/(public)/sell/page.tsx
@@ -12,6 +12,7 @@ import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/mark
 import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { guidesInCluster } from "@/lib/seo/guides";
+import { ChatGptCtaButton } from "@/components/seo/chatgpt-cta";
 
 export const metadata: Metadata = {
   title: "Sell AI Agents: Direct, White-Label, Marketplace, or MCP | SeldonFrame",
@@ -105,6 +106,7 @@ export default function SellHubPage(): ReactElement {
           <Link href="/guides" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "11px 22px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
             Browse all guides
           </Link>
+          <ChatGptCtaButton />
         </div>
 
         <section style={{ marginTop: 44 }}>

--- a/packages/crm/src/app/(public)/tools/agency-margin-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/agency-margin-calculator/page.tsx
@@ -9,6 +9,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { AgencyMarginCalculator } from "@/components/seo/agency-margin-calculator";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { buildOgUrl } from "@/lib/seo/og-card";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 
@@ -134,6 +135,7 @@ export default function AgencyMarginCalculatorPage(): ReactElement {
         </section>
 
         <BuildWidget ungatedBuildEnabled={isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })} />
+        <ChatGptCtaCard />
       </main>
       <MarketplaceFooter />
     </div>

--- a/packages/crm/src/app/(public)/tools/ai-website-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/ai-website-generator/page.tsx
@@ -16,6 +16,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { AuthorByline, articleLd } from "@/components/seo/author-byline";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { buildOgUrl } from "@/lib/seo/og-card";
 
@@ -109,6 +110,7 @@ export default function AiWebsiteGeneratorPage(): ReactElement {
         </p>
 
         <BuildWidget ungatedBuildEnabled={ungatedBuildEnabled} heading="Build your website free" />
+        <ChatGptCtaCard />
 
         <section style={{ padding: "40px 0 0" }}>
           <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>How it works</h2>

--- a/packages/crm/src/app/(public)/tools/free-booking-page/page.tsx
+++ b/packages/crm/src/app/(public)/tools/free-booking-page/page.tsx
@@ -15,6 +15,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { AuthorByline, articleLd } from "@/components/seo/author-byline";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { buildOgUrl } from "@/lib/seo/og-card";
 
@@ -108,6 +109,7 @@ export default function FreeBookingPagePage(): ReactElement {
         </p>
 
         <BuildWidget ungatedBuildEnabled={ungatedBuildEnabled} heading="Get your booking page free" />
+        <ChatGptCtaCard />
 
         <section style={{ padding: "40px 0 0" }}>
           <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What's included</h2>

--- a/packages/crm/src/app/(public)/tools/gohighlevel-cost-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/gohighlevel-cost-calculator/page.tsx
@@ -9,6 +9,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { GohighlevelCostCalculator } from "@/components/seo/gohighlevel-cost-calculator";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { buildOgUrl } from "@/lib/seo/og-card";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 
@@ -135,6 +136,7 @@ export default function GohighlevelCostCalculatorPage(): ReactElement {
         </section>
 
         <BuildWidget ungatedBuildEnabled={isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })} />
+        <ChatGptCtaCard />
       </main>
       <MarketplaceFooter />
     </div>

--- a/packages/crm/src/app/(public)/tools/hubspot-pricing-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/hubspot-pricing-calculator/page.tsx
@@ -9,6 +9,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { HubspotPricingCalculator } from "@/components/seo/hubspot-pricing-calculator";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { buildOgUrl } from "@/lib/seo/og-card";
 import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
@@ -147,6 +148,7 @@ export default function HubspotPricingCalculatorPage(): ReactElement {
         </section>
 
         <BuildWidget ungatedBuildEnabled={isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })} />
+        <ChatGptCtaCard />
       </main>
       <MarketplaceFooter />
     </div>

--- a/packages/crm/src/app/(public)/tools/klaviyo-cost-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/klaviyo-cost-calculator/page.tsx
@@ -9,6 +9,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { KlaviyoCostCalculator } from "@/components/seo/klaviyo-cost-calculator";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { buildOgUrl } from "@/lib/seo/og-card";
 import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
@@ -147,6 +148,7 @@ export default function KlaviyoCostCalculatorPage(): ReactElement {
         </section>
 
         <BuildWidget ungatedBuildEnabled={isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })} />
+        <ChatGptCtaCard />
       </main>
       <MarketplaceFooter />
     </div>

--- a/packages/crm/src/app/(public)/tools/voice-ai-cost-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/voice-ai-cost-calculator/page.tsx
@@ -9,6 +9,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { VoiceAiCostCalculator } from "@/components/seo/voice-ai-cost-calculator";
 import { BuildWidget } from "@/components/seo/build-widget";
+import { ChatGptCtaCard } from "@/components/seo/chatgpt-cta";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { buildOgUrl } from "@/lib/seo/og-card";
 import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
@@ -148,6 +149,7 @@ export default function VoiceAiCostCalculatorPage(): ReactElement {
         </section>
 
         <BuildWidget ungatedBuildEnabled={isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })} />
+        <ChatGptCtaCard />
       </main>
       <MarketplaceFooter />
     </div>

--- a/packages/crm/src/components/seo/agent-page-cta.tsx
+++ b/packages/crm/src/components/seo/agent-page-cta.tsx
@@ -18,6 +18,7 @@ import type { ReactElement } from "react";
 import Link from "next/link";
 import { MarketplaceIcon } from "@/components/marketplace/marketplace-icons";
 import { MKT } from "@/components/marketplace/marketplace-data";
+import { ChatGptCtaButton } from "@/components/seo/chatgpt-cta";
 
 export type AgentPageCtaProps = {
   /** Display name of the agent (for the deploy headline). */
@@ -158,6 +159,8 @@ export function AgentPageCta({
             <MarketplaceIcon name="terminal" size={17} />
             Rent via MCP
           </button>
+
+          <ChatGptCtaButton dark />
         </div>
 
         {mcpOpen ? (

--- a/packages/crm/src/components/seo/chatgpt-cta.tsx
+++ b/packages/crm/src/components/seo/chatgpt-cta.tsx
@@ -1,0 +1,89 @@
+// Secondary "Try it inside ChatGPT" CTA — surfaced across guides, /sell, the
+// AI agent pages, and the free tools. SeldonFrame is listed in the ChatGPT
+// plugin directory; this nudges builders who are already living inside
+// ChatGPT toward the same free, no-signup build flow via that surface.
+//
+// Deliberately secondary in every idiom below — it must never compete with
+// the page's primary build CTA. Server component (no "use client"): it's a
+// static link, nothing interactive.
+
+import type { ReactElement } from "react";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { CHATGPT_PLUGIN_URL } from "@/lib/seo/chatgpt-app";
+
+export type ChatGptCtaProps = {
+  /** Render the dark idiom for placement on MKT.dark backgrounds. */
+  dark?: boolean;
+};
+
+/** Secondary button — drops into an existing CTA flex row as a third link. */
+export function ChatGptCtaButton({ dark }: ChatGptCtaProps): ReactElement {
+  return (
+    <a
+      href={CHATGPT_PLUGIN_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="sf-link"
+      style={{
+        border: dark ? "1.5px solid rgba(246,242,234,0.35)" : `1.5px solid ${MKT.ink10}`,
+        color: dark ? MKT.paper : MKT.ink,
+        padding: "11px 22px",
+        borderRadius: 12,
+        fontWeight: 700,
+        fontSize: 15,
+        textDecoration: "none",
+        background: dark ? "transparent" : "rgba(255,255,255,0.5)",
+      }}
+    >
+      Try it inside ChatGPT ↗
+    </a>
+  );
+}
+
+/** Full-width secondary card for the free-tool pages. */
+export function ChatGptCtaCard({ dark }: ChatGptCtaProps): ReactElement {
+  return (
+    <div
+      style={{
+        marginTop: 24,
+        border: dark ? "none" : `1px solid ${MKT.ink10}`,
+        borderRadius: 16,
+        padding: "24px 26px",
+        background: dark ? MKT.dark : "rgba(255,255,255,0.55)",
+        color: dark ? MKT.paper : MKT.ink,
+      }}
+    >
+      <div style={{ fontSize: 18, fontWeight: 800, letterSpacing: "-0.01em" }}>Try it inside ChatGPT</div>
+      <p
+        style={{
+          margin: "8px 0 16px",
+          fontSize: 15,
+          lineHeight: 1.6,
+          color: dark ? "rgba(246,242,234,0.7)" : "rgba(34,29,23,0.7)",
+        }}
+      >
+        SeldonFrame is in the ChatGPT plugin directory. Describe your business in a chat and get a live website,
+        booking page, CRM, and AI chatbot — free, no signup.
+      </p>
+      <a
+        href={CHATGPT_PLUGIN_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="sf-link"
+        style={{
+          border: dark ? "1.5px solid rgba(246,242,234,0.35)" : `1.5px solid ${MKT.ink10}`,
+          color: dark ? MKT.paper : MKT.ink,
+          padding: "11px 22px",
+          borderRadius: 12,
+          fontWeight: 700,
+          fontSize: 15,
+          textDecoration: "none",
+          background: dark ? "transparent" : "rgba(255,255,255,0.5)",
+          display: "inline-block",
+        }}
+      >
+        Open in ChatGPT ↗
+      </a>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/guide-page.tsx
+++ b/packages/crm/src/components/seo/guide-page.tsx
@@ -14,6 +14,7 @@ import { monthYearToIso } from "@/lib/seo/month-iso";
 import { GuideDiagramView, GuideDiagramStyles, faviconUrl } from "@/components/seo/guide-diagrams";
 import type { GuideCallout } from "@/lib/seo/guides/types";
 import { tokenizeInlineMarkup, stripInlineMarkup, startsWithKindOfLike } from "@/lib/seo/guide-inline";
+import { ChatGptCtaButton } from "@/components/seo/chatgpt-cta";
 
 /** Split a section body into paragraphs on blank lines. */
 function paragraphs(body: string): string[] {
@@ -182,6 +183,7 @@ export function GuidePage({ slug }: { slug: string }): ReactElement {
               <Link href="/signup" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "11px 22px", borderRadius: 12, fontWeight: 700, fontSize: 15, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
                 Build free
               </Link>
+              <ChatGptCtaButton />
             </div>
           </div>
 

--- a/packages/crm/src/lib/seo/chatgpt-app.ts
+++ b/packages/crm/src/lib/seo/chatgpt-app.ts
@@ -1,3 +1,3 @@
-// The public ChatGPT plugin listing. Placeholder = directory search deep link;
-// TODO(Max): swap for the canonical listing URL from the plugin submission portal.
-export const CHATGPT_PLUGIN_URL = "https://chatgpt.com/plugins?q=seldonframe";
+// The canonical SeldonFrame listing in the ChatGPT plugin directory.
+export const CHATGPT_PLUGIN_URL =
+  "https://chatgpt.com/plugins/plugin_asdk_app_6a3bc9df52f88191ab3a89189e00be7d";

--- a/packages/crm/src/lib/seo/chatgpt-app.ts
+++ b/packages/crm/src/lib/seo/chatgpt-app.ts
@@ -1,0 +1,3 @@
+// The public ChatGPT plugin listing. Placeholder = directory search deep link;
+// TODO(Max): swap for the canonical listing URL from the plugin submission portal.
+export const CHATGPT_PLUGIN_URL = "https://chatgpt.com/plugins?q=seldonframe";


### PR DESCRIPTION
## What

SeldonFrame is now approved + live in the ChatGPT plugin directory. This wave points our existing organic traffic at that deep link with a secondary "Try it inside ChatGPT" CTA on every major marketing surface:

- **All 92 guides** — third button in the existing "Put a number on it" CTA box (`components/seo/guide-page.tsx`)
- **/sell hub** — added to the top button row
- **All ~171 /ai-agents pages** — dark-variant button in the shared `AgentPageCta`
- **7 tool pages** — `ChatGptCtaCard` below `BuildWidget` (agency-margin, ai-website-generator, free-booking-page, gohighlevel-cost, hubspot-pricing, klaviyo-cost, voice-ai-cost calculators)

New shared pieces: `components/seo/chatgpt-cta.tsx` (button + card, server-only, MKT-token inline styles) and one constant `lib/seo/chatgpt-app.ts` → `CHATGPT_PLUGIN_URL`.

## Verify

verify-runner: **PASS** — 1457 unit tests green · 0 new tsc errors · use-server clean · no migrations · regression grep empty · 9 routes live-smoked HTTP 200 (/sell, /guides, all 7 tool pages).

## Follow-ups (not blocking)

- `CHATGPT_PLUGIN_URL` currently points at the directory search (`chatgpt.com/plugins?q=seldonframe`); swap in the canonical listing URL from the plugin portal (single constant).
- 12 bespoke tool pages (a2p-10dlc-checker, missed-call-calculator, website-grader, …) have no `BuildWidget` anchor and were left unwired — separate mechanical pass if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)