### PR TITLE
feat(reflect): builders pack + evidence tools + reflect-learn growth loop

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -124,6 +124,32 @@ divergences are the most informative calibration data).
 Review-by heuristic: when the expected outcome should be observable — typically
 2-6 weeks for tactical calls, a quarter for strategic ones.
 
+## Ground it in evidence (use your tools, not your vibes)
+
+- **Base rates come from search, not memory.** When the analysis leans on a
+  market fact, a failure rate, or a "most companies…" claim and web search is
+  available, search before asserting — and label what's sourced vs. estimated.
+- **Chesterton's fence is enforced by reading, not remembering.** If the
+  decision touches the codebase — remove X, rewrite Y, build-vs-buy Z — read
+  the code, its git history, and its callers FIRST. "Why does this exist?" is
+  answered by `git log`, not assumption.
+- **Prefer running the cheap test over describing it.** If the <1-day test in
+  DO THIS NEXT is something you can do right now (benchmark, grep, checking
+  real analytics), offer to run it — and fold the result into the answer.
+
+## Growing the library — `reflect learn <source>`
+
+When Max says **"reflect learn <url / person / book>"**:
+1. **Fetch the source live** — never from memory (the 2-of-24-titles-misled
+   lesson). Fetch fails → say so, offer a `fetched: false` distillation.
+2. Compact into `references/<slug>.md` (house template, 50-90 lines,
+   paraphrase, max one quote <15 words).
+3. Add one routing line to `references/00-index.md`.
+4. Report what was added + when the new lens will fire, so Max can correct
+   the routing while it's fresh.
+5. **Sync rule:** new lenses land in all three copies (this repo copy, the
+   user-level `~/.claude/skills/reflect`, github.com/seldonframe/reflect).
+
 ## Guardrails (check yourself during every run)
 - **Bikeshed alarm** — effort must scale with stakes, not with how easy the topic
   is to have opinions about. If the discussion is vivid but the dollars are small, stop.

--- a/.claude/skills/reflect/references/00-index.md
+++ b/.claude/skills/reflect/references/00-index.md
@@ -36,5 +36,15 @@ follows the sequence in SKILL.md §3b.
 - **break-the-chain** — the option creates obligation/dependency (gifts, favors, lifestyle debt, channel or vendor reliance) that compounds; independence is at stake.
 - **hemingway-suitcase** — lost work or a scrapped effort; deciding whether/how to redo something (the redo is often better).
 
+## Builders (people, not models — how specific great builders think)
+- **dhh** — adding a dependency, layer, or tool ("is this a merchant of complexity?"); boring defaults vs novelty; process/meeting creep; VC-vs-bootstrap; protecting maker flow.
+- **tobi-lutke** — calm long-game product calls; what to subtract rather than add; earning legitimacy/trust with users; infinite-game vs quarterly-win framing.
+- **mark-pincus** — founder instinct vs consensus; the proven/better/new test for a product bet; one-goal focus; sub-MVP speed; platform-dependency risk.
+- **winston-weinberg** — decision speed in fast AI markets; validating quality with domain experts before scaling; single-focus prioritization; selling into conservative buyers.
+- **vlad-tenev** — building for the current environment, not the one you wish for; surviving a narrative crisis; founder conviction under public pressure; rigor on product math.
+- **peter-kaufman** — partnership and pricing fairness (win-win is the only durable play); going positive and going first with counterparties; the largest base rates; compounding patience.
+- **steve-wozniak** — craft and elegance calls (fewer parts, simpler design); build-for-joy vs build-for-money; solo design vs committee; open vs walled.
+- **outliers-best-2025** — adversity-to-advantage collection (Dyson, Firestone, Blumkin, Singleton, Price, Schwab): persistence economics, trust as strategy, contrarian capital allocation.
+
 ## Meta
 - **mental-models-general** — the latticework: multi-model thinking, circle of competence, second-order thinking, and the quick lens list for models without a dedicated file.

--- a/.claude/skills/reflect/references/dhh.md
+++ b/.claude/skills/reflect/references/dhh.md
@@ -1,0 +1,55 @@
+---
+name: dhh
+source: https://corecursive.com/045-david-heinemeier-hansson-software-contrarian/ + https://solanojuan.medium.com/david-heinemeier-shares-some-principles-to-go-against-the-grain-1ca5c0032f2c
+fetched: true
+fetched_on: 2026-07-15
+---
+# DHH — simplicity as a strategy
+
+## Core idea
+DHH's whole stance compresses to one move: refuse complexity that isn't paying rent. Rails won by turning thousands of low-level decisions into strong conventions — the framework decides the boring things so the builder spends judgment only where their app is actually different. The enemy is the "merchants of complexity": vendors, architectures, and fashions (microservices, SPA+Redux everywhere, Google-scale infrastructure for a 10-user app) that sell you layers whose main output is more layers. Rails itself started as roughly 2,000 lines; the lesson is that most problems are smaller than the tooling sold to solve them.
+
+A corollary he leans on: the web is the freest platform precisely because nobody can see your stack. You get to pick tools by personal fit and productivity rather than by app-store mandate or hiring-market fashion — so pick the ones that make you fast and happy, and ignore the popularity contest.
+
+The same compression logic runs his business philosophy. Bootstrapped and profitable beats venture-funded and obligated: a business clearing $1M/year is a wildly better bet than lottery-ticket unicorn hunting, and it keeps you free to say no. Constraints are treated as a feature — limited money, limited headcount, limited hours force sharper decisions. And most value creation is recombination: the overwhelming majority of a product is existing pieces assembled differently, so novelty budget should be spent on the few places customers actually feel it.
+
+Third pillar: flow is the scarce resource. Creative work needs long uninterrupted stretches, so 37signals runs calm — few managers, async writing over standups and chat, 6-8 week cycles, ~40 focused hours over 60 fragmented ones. Clearing "mental barnacles" (the thousand inconsequential open loops) is maintenance work, not procrastination. When stuck, he powers through with routine tasks until flow returns. Notably, he adopted AI-first coding not to work less but to attempt more ambitious projects — new leverage goes to ambition, not slack.
+
+He's blunt about the alternative: "I would rather retire and fucking make weaved baskets" than maintain a trend-driven microservices/SPA sprawl.
+
+## When it bites
+- **Stack choice.** You're picking between a boring, batteries-included framework and a trendy composition of ten libraries. DHH says the convention-heavy default wins because it deletes decisions, not because it's fashionable.
+- **Adding a dependency, service, or layer.** Every addition is a purchase from a complexity merchant. The question is whether it delivers direct user/business value or just architectural prestige.
+- **Splitting the monolith.** Team-of-five reaching for microservices, Kubernetes, or an event bus because "that's how real companies do it."
+- **Raising money.** VC converts your company into an obligation to chase outlier outcomes. If the honest ambition is a great profitable business, funding is a tax, not fuel.
+- **Process and hiring creep.** Adding managers, standups, sprints, and dashboards to feel in control — each one fragments the maker time that produces the product.
+- **Tool-chasing.** Rewriting or re-platforming because the ecosystem moved, not because users complained.
+- **Interruption-heavy defaults.** Real-time chat culture, always-on notifications, and daily syncs adopted as "communication" when they're actually flow taxes on every maker.
+
+## How to run it
+Ask, in order:
+1. **"What would the boring default be?"** Name the convention-heavy, well-trodden option first. Deviating from it requires a stated, app-specific reason — not vibes.
+2. **"Is this layer delivering value or selling me complexity?"** Trace the layer to a user-visible or revenue-visible outcome. If the chain of benefit runs through "best practice" or "when we scale," it's a merchant.
+3. **"Are we solving our problem or Google's?"** Estimate actual scale honestly. Most systems fit in one process, one database, one deploy.
+4. **"Does this decision buy flow or fragment it?"** For any process/tool/meeting: does it protect long uninterrupted stretches for the people building, or slice them up?
+5. **"What does this obligate us to?"** For money, dependencies, and integrations alike: what growth rate, upgrade treadmill, or maintenance burden are we signing?
+6. **"Can I combine existing pieces instead?"** Roughly 99% of value is existing parts assembled differently. Look for the assembly before the invention.
+7. **"What constraint would make this better?"** If the plan only works with more people/time/budget, tighten the scope until it works without them.
+8. **"Would I still choose this if nobody could see my stack?"** Strip the resume-driven and status motives; keep only what makes the product better or you faster.
+
+## Failure modes
+- **Contrarianism as identity.** DHH is right often because he argues from first principles; copying his conclusions ("monolith always," "VC never," "TDD is dead") without the reasoning is just a different cargo cult.
+- **Under-investing when scale is real.** Some domains genuinely need the complexity — multi-region compliance, hard isolation boundaries, teams of hundreds. "You're not Google" is false for the occasional builder who is, and late re-architecture is expensive.
+- **Monolith dogma.** A well-factored service split along a true organizational or fault boundary can be the simple option. The rule is minimal total complexity, not maximal co-location.
+- **Bootstrap absolutism.** Winner-take-most markets with real network effects can punish the patient; sometimes capital is the moat and calm loses.
+- **Calm as an excuse for drift.** No managers and long cycles work at 37signals because standards and taste are brutal. Without that, "calm" decays into slow.
+- **Survivorship framing.** Basecamp had a hit product early; its constraints were chosen, not imposed. A pre-revenue builder quoting DHH to avoid hustle is misreading the lesson.
+- **Boring-default worship.** Conventions are a means to deleted decisions, not an end; clinging to a default that no longer fits your actual problem is its own complexity.
+
+## When building, reach for this when…
+- Choosing a framework or stack and feeling pulled toward the newer, more "serious" architecture over the boring default.
+- Auditing dependencies or infrastructure: any review where the layer count grew faster than the feature count.
+- Deciding VC vs. bootstrap, or any deal that trades control for speed.
+- Noticing process creep — more meetings, standups, or coordination roles appearing while maker output stalls.
+- Getting new leverage (AI tooling, a hire, a windfall) and deciding whether it funds ambition or just padding.
+- Scoping a feature that only seems feasible with more time, people, or infrastructure — the constraint is the design tool.

--- a/.claude/skills/reflect/references/mark-pincus.md
+++ b/.claude/skills/reflect/references/mark-pincus.md
@@ -1,0 +1,55 @@
+---
+name: mark-pincus
+source: https://fs.blog/knowledge-project-podcast/mark-pincus/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Mark Pincus — Bet on instincts, test the ideas, know the one goal
+
+## Core idea
+Pincus splits what founders usually blur: instincts and ideas. As he puts it, "our instincts are almost always right and our ideas are usually wrong." The instinct — the felt sense that a product speaks to a deep human need, that a market is real, that something is off — is the compass. The specific idea you derived from it is just one hypothesis, and hypotheses mostly fail. You owe it to yourself to bet on the instinct; you owe the company ruthless testing of the ideas.
+
+The operating loop that follows:
+- **Commit to the instinct.** Founder conviction is not up for a vote; consensus averages away the signal.
+- **Distrust every specific idea.** Test many, many variants instead of perfecting one — a single attempt is an anecdote, not evidence.
+- **Hold one clear goal.** Without it the effort dissolves — his warning is death by a thousand compromises, each one individually reasonable.
+
+His innovation framework makes this concrete: **proven, better, new** — copy what already works, improve it measurably, and only then layer in genuine novelty, because all-new fails without a testing system underneath it. Speed is the multiplier: he pushes past the classic MVP toward the smallest expressible state of an idea (today: vibe-code it) so failure cycles at the top of the funnel run as fast as possible. And great products, in his telling, always speak to some deep human instinct or need — which is why studying your own reactions ("be a student of yourself") and continuously deconstructing competitor products are core disciplines, not side hobbies.
+
+## When it bites
+(concrete BUILDER decision triggers)
+- You're about to ship a feature that is 100% novel — no proven analog anywhere — and calling that a virtue.
+- A design review ended in consensus that contradicts your gut reaction as a user of your own product.
+- You've been polishing one implementation of an idea for weeks instead of testing several cheap variants.
+- The roadmap has grown to serve every stakeholder and you can no longer state the single goal in one sentence.
+- You're deconstructing zero competitor products while claiming your category knowledge is current.
+- A platform or channel you depend on could change terms — and you have no read on that risk.
+- You just took a hit (failed launch, lost deal, churned anchor customer) and are ruminating instead of listing what's in your control now.
+- You caught yourself dismissing a competitor's proven mechanic as "not innovative enough to copy."
+
+## How to run it
+(concrete questions a builder asks themselves)
+1. **Separate the layers.** What is my instinct here (the need I felt), and what is merely my idea (one implementation of it)? Am I defending the idea when only the instinct deserves loyalty?
+2. **Name the one goal.** Can I state it in a sentence? Every compromise request gets tested against it — "know your goal, or suffer death by a thousand compromises" is the failure mode being avoided.
+3. **Run proven → better → new.** What already works that I can copy? What's my concrete improvement? What's the one genuinely new element — and is it isolated enough to test?
+4. **Shrink the test unit.** What's the minimum expressible state of this idea — smaller than an MVP — that gets a real reaction this week? How many variants can I run instead of one?
+5. **Be a student of yourself.** When I use my own product cold, what's my honest gut reaction in the first ten seconds? What do competitor products do to me, deconstructed feature by feature?
+6. **Check what's in my control.** After a setback: what small things and big things could I do right now, rather than relitigating what happened?
+
+## Failure modes
+- **Instinct as an excuse.** "Trust your gut" becomes a shield against evidence. Pincus's frame requires the opposite: the gut picks the direction, then data ruthlessly kills the specific ideas. If you're not killing variants, you're not running the loop.
+- **All-new romanticism.** Skipping "proven" and "better" because copying feels low-status. Untested novelty stacked on untested novelty is how startups build the wrong product entirely.
+- **One-shot testing.** Building a single polished version and calling its failure a verdict on the instinct. One variant is an anecdote; the framework demands many.
+- **Goal drift.** Adding a compromise per stakeholder until no single decision-maker can say what winning means. Death by a thousand cuts, each individually reasonable.
+- **Consensus laundering.** Averaging the room's opinions into a product nobody's instinct actually endorses. Someone's felt conviction has to own the call.
+- **Ignoring platform risk.** Betting the company on someone else's distribution without a plan for when the terms change — the Zynga/Facebook lesson.
+- **Speed without a funnel.** Shipping fast but never structuring the tests, so velocity produces noise instead of learning. Fast failure only compounds when each cycle feeds the next variant.
+
+## When building, reach for this when…
+(3-5 generic builder situations)
+- Choosing between a novel architecture/product concept and a proven pattern with one improvement — default to proven-better-new ordering.
+- A feature decision is deadlocked between your user-instinct and the team's consensus — surface the instinct/idea split explicitly before voting.
+- Scoping a validation effort — replace "build the MVP" with "what's the smallest state that gets a real reaction, and how many variants can we run."
+- Roadmap or spec reviews where scope keeps accreting — re-state the single goal and cut everything that's a compromise against it.
+- Post-mortem after a flop — ask whether the instinct was wrong or just that one idea, before abandoning the whole direction.
+- Taking a dependency on someone else's platform or API for distribution — price in the risk that their terms change, and keep an exit instinct.

--- a/.claude/skills/reflect/references/outliers-best-2025.md
+++ b/.claude/skills/reflect/references/outliers-best-2025.md
@@ -1,0 +1,60 @@
+---
+name: outliers-best-2025
+source: https://fs.blog/knowledge-project-podcast/best-of-outliers-2025/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Best of Outliers 2025 — The Outlier Playbook
+
+## Core idea
+A compilation of the Outliers series' strongest patterns: how history's most notable business builders turned adversity into long-term advantage through distinctive mindsets and systems. The page features six figures it says deserve to be studied but rarely are — James Dyson, Harvey Firestone, Rose Blumkin, Henry Singleton, Sol Price, and Les Schwab. (The page itself names the roster and theme without per-person breakdowns; the lessons below are distilled from the well-documented stories of those exact figures, consistent with the episode's adversity-to-advantage framing.)
+
+### James Dyson — iterate past the point everyone else quits
+5,127 prototypes over years, most of them failures, before the first working cyclone vacuum — then refusal to license away control when incumbents lowballed him. Failure is data; each dead prototype removed one wrong answer. The moat wasn't the idea, it was outlasting everyone else's tolerance for iteration.
+
+### Harvey Firestone — stay close to the work and the customer
+Firestone built by knowing his product, his factory floor, and his dealers firsthand, and by keeping the company financially conservative enough to survive downturns that killed leveraged rivals. Growth that outruns your understanding of the business is fragility wearing a costume.
+
+### Rose Blumkin — sell cheap, tell the truth, and outlast
+"Sell cheap and tell the truth" was Mrs. B's whole system at Nebraska Furniture Mart: relentlessly low prices, zero deception, brutal work ethic, decades of compounding trust. No cleverness — just an unbreakable reputation loop that made competitors' marketing irrelevant.
+
+### Henry Singleton — allocate capital like it's the product
+Teledyne's Singleton treated capital allocation as the CEO's real job: issue stock when it's expensive, buy it back aggressively when it's cheap, ignore Wall Street's appetite for smooth earnings and dividends. Flexibility over plans — he famously kept no rigid long-range plan, steering daily by opportunity.
+
+### Sol Price — the discipline of the single metric
+At FedMart and Price Club, Price ran on markup discipline: cap your margin, pass savings through, and let volume and membership trust compound. Adding margin because you can is stealing from the flywheel. He also taught (and Costco's founders absorbed) that you're a fiduciary for the customer.
+
+### Les Schwab — give the upside to the people doing the work
+Schwab shared roughly half of each tire store's profits with its employees, turning clerks into owner-operators who ran to the customer's car. Incentive design was the product; the tires were commodity. Decentralize P&L, centralize values.
+
+## When it bites
+(concrete BUILDER decision triggers)
+- Deciding whether to kill a project after repeated failures or run another iteration (Dyson).
+- Setting pricing/margin on a new tier or fee — take the extra margin or feed the flywheel (Price, Blumkin).
+- Choosing between smooth, plan-shaped roadmaps and opportunistic reallocation of your time/money to whatever is cheapest-per-unit-of-progress right now (Singleton).
+- Structuring contractor/partner/rev-share deals — who gets the upside of performance (Schwab)?
+- Tempted to scale (hiring, spend, surface area) faster than you personally understand the machine (Firestone).
+
+## How to run it
+(concrete questions a builder asks themselves)
+- Is this failure new information or the same failure repeating? Dyson-persist only while each iteration eliminates a distinct wrong answer.
+- What would "sell cheap and tell the truth" mean for this product — and what am I currently doing instead?
+- If I ranked every place I could spend the next dollar/week by expected return, is this where it lands — or am I following last quarter's plan?
+- Does the person closest to the customer capture any of the value they create? What would half-the-profit alignment look like here?
+- Can I explain, mechanically, how every part of this business works? Which part am I scaling on faith?
+- Which single metric, held with Price-like discipline, would force all the other decisions correctly?
+
+## Failure modes
+- **Dyson-persistence on a dead thesis** — thousands of iterations only pay when the underlying physics/demand is real; grit doesn't validate the premise.
+- **Frugality theater** — cutting price without the cost structure (Price had it) just burns margin; cheap-and-honest requires being structurally the low-cost operator.
+- **Singleton flexibility as excuse for churn** — opportunism without his valuation discipline is just strategy-hopping.
+- **Profit-sharing without standards** — Schwab's model worked with fierce operating norms; upside-sharing on a sloppy operation subsidizes the sloppiness.
+- **Founder-knows-everything bottleneck** — Firestone-style closeness to the work curdles into refusing to delegate as the machine grows.
+
+## When building, reach for this when…
+(3-5 generic builder situations)
+- A feature or product has failed several times and you must decide: another iteration or a kill.
+- Setting or restructuring pricing, fees, or margins and tempted to extract rather than compound trust.
+- Writing quarterly plans when the honest move is reallocating everything to one outsized opportunity.
+- Designing comp, rev-share, or marketplace splits for the people who touch the customer.
+- Growth is on the table and you're deciding how fast you can scale without losing grip on how the machine works.

--- a/.claude/skills/reflect/references/peter-kaufman.md
+++ b/.claude/skills/reflect/references/peter-kaufman.md
@@ -1,0 +1,47 @@
+---
+name: peter-kaufman
+source: https://fs.blog/knowledge-project-podcast/outliers-peter-d-kaufman/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Peter Kaufman — win-win compounding, verified against the largest sample sizes in existence
+
+> Note: the source page verifies the bio (Glenair chairman/CEO, top-0.001% operating track record, editor of *Poor Charlie's Almanack*, decades-long Munger confidant) but keeps the episode content itself behind a members wall. The frameworks below are distilled from Kaufman's widely circulated "Multidisciplinary Approach to Thinking" talk, which is the canon the episode draws on.
+
+## Core idea
+Kaufman's method is to answer any hard question by consulting the three largest, oldest datasets available — his "three buckets": inorganic systems (13.7 billion years of physics/chemistry), organic life (3.5 billion years of biology), and human history (~20,000 years of recorded behavior). Whatever principle holds across all three buckets is as close to a law as you'll get; base your decisions on those, not on this quarter's anecdotes.
+
+Two laws survive every bucket:
+1. **Mirrored reciprocation** — every action produces an equal reaction: dodgeball physics, biological tit-for-tat, human trust. So "go positive and go first," and be *constant* about it, because the world returns the posture you lead with.
+2. **Compounding** — small consistent gains, uninterrupted, dominate everything. The enemy of compounding is not a low rate; it's interruption.
+
+Combine them and the only durable strategy is win-win: any relationship where one side loses eventually terminates, and termination is the interruption that kills compounding. His "five aces" describe the counterparty worth compounding with: total integrity, deep fluency in their craft, a fair fee structure, an uncrowded space, and a long-term orientation.
+
+## When it bites
+- **Partnership and vendor terms.** Structuring an agency deal, a marketplace rev-share, or an integration partnership where you could extract more because you currently have leverage. Kaufman's lens: the extra margin is a win-lose term, and win-lose terms are why partnerships die — which zeroes the compounding you were counting on.
+- **Pricing fairness calls.** Deciding whether a fee "taxes" the customer's success versus charging flat for value delivered. A fee the customer experiences as unfair is a slow-burning termination clause on the relationship.
+- **Long-game vs. short-game trades.** Shipping the growth hack that harvests trust (dark patterns, lock-in, surprise charges) versus the slower move that deposits trust. Reciprocation is mirrored: users and partners return exactly the posture you lead with.
+- **Whom to build with.** Choosing cofounders, first hires, anchor customers, or platform dependencies — the five-aces screen, applied before the relationship starts compounding in the wrong direction.
+- **Reacting to a base-rate-free claim.** Any "this time is different" argument for a strategy that fails across the three buckets (parasitism, zero-sum extraction, interrupted compounding) deserves heavy skepticism.
+
+## How to run it
+- What's the largest sample size I can consult on this decision — what does physics/biology/history say about systems that behave the way I'm proposing to behave?
+- Is this arrangement win-win, or am I quietly winning at someone's expense? If they fully understood the terms, would they still sign?
+- What am I going first with here — trust or extraction? Whatever I lead with is what will be mirrored back, amplified, over time.
+- Does this decision interrupt any compounding already underway (a customer relationship, a reputation, an integration partner's trust)? Interruption is the compounding-killer, not small rate differences.
+- Run the five-aces screen on the counterparty: integrity, fluency in their craft, fair economics, uncrowded position, long-term horizon. How many aces are missing, and am I pretending not to see it?
+- Am I being *constant*? Reciprocation only compounds if the positive posture is unwavering — intermittent goodwill reads as manipulation.
+
+## Failure modes
+- **Naive go-first with a defector.** "Go positive and go first" is an opening move, not a suicide pact. Kaufman pairs it with the five-aces screen — leading with trust toward a counterparty who fails the integrity ace just funds their extraction.
+- **Win-win as pricing cowardice.** Undercharging isn't fairness; a price that starves your side eventually terminates the relationship from your end, which is the same compounding-interruption in reverse. Win-win requires *both* wins.
+- **Bucket-washing.** Grabbing a grand analogy from physics or biology to decorate a conclusion you already wanted. The buckets are for base rates on system behavior, not for metaphor shopping.
+- **Long-game paralysis.** Using "we're playing the long game" to defer every hard short-term call (shipping, charging, firing). The long game is made of compounding short-term actions, not of waiting.
+- **Five-aces perfectionism.** No counterparty holds all five aces on day one. The screen ranks options and flags dealbreakers (integrity is non-negotiable; the rest trade off) — it isn't a veto on acting.
+
+## When building, reach for this when…
+- Drafting the economics of any partnership, rev-share, marketplace fee, or affiliate deal.
+- Setting or changing pricing and wondering whether a term will feel like a tax to the people paying it.
+- Choosing a long-term dependency: cofounder, anchor client, platform, or key vendor.
+- Tempted by a growth tactic that wins now by spending user or partner trust.
+- Evaluating a strategy pitch that lacks any base rate — asking what the oldest datasets say about behavior like this.

--- a/.claude/skills/reflect/references/steve-wozniak.md
+++ b/.claude/skills/reflect/references/steve-wozniak.md
@@ -1,0 +1,49 @@
+---
+name: steve-wozniak
+source: https://fs.blog/knowledge-project-podcast/outliers-steve-wozniak/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Steve Wozniak — Elegance Through Constraint
+
+## Core idea
+Wozniak built the Apple I and Apple II alone, after-hours, for the joy of it — not to start a company. His edge was craft mastery under self-imposed constraint: he treated chip count as a score to minimize, moved hardware functions into software, and reworked designs until nothing could be removed. The Disk II controller used 2 chips where competitors used 22.
+
+He held that nothing revolutionary comes out of a committee — deep, solo, perfectionist work on the current step beats group design — and that constraints force the understanding that produces elegance. "It takes a lot of work to make something simple."
+
+The same integrity ran through everything: he xeroxed his schematics and gave them away, chose open architecture over walled gardens, and optimized for the customer's actual needs over what merely looked impressive. When Apple made him rich (~$88M) he left to teach, because success meant living on his own terms — happiness ranked above wealth or power. HP rejected his computer five times; he kept trusting his own reasoning over the majority, thinking in gray scale rather than absolutes, and habitually asking "why am I doing it this way?" instead of accepting the artificial limits everyone else had set. Loyalty had limits too: he loved HP, but institutional blindness eventually cost them him — and the personal computer.
+
+## When it bites
+(concrete BUILDER decision triggers)
+- Choosing between shipping a working-but-bloated design and spending another pass to collapse it into something simpler.
+- Deciding whether to solve a problem in infrastructure/dependencies (more "chips") or in code you fully control (software offload).
+- A committee/consensus process is about to design a core component.
+- You're tempted to close/lock an architecture when opening it would build an advocate community.
+- Weighing a move that pays well against one that keeps you doing the work you're actually great at.
+- An authority (employer, incumbent, "best practice") has rejected your approach and you must decide whether to trust your own reasoning.
+
+## How to run it
+(concrete questions a builder asks themselves)
+- What is my "chip count" here — the one metric of excess (dependencies, services, LOC, config, steps) I should be minimizing?
+- Can a piece of this be deleted by making something else slightly smarter (hardware → software move)?
+- Did one person with full context design this, or is it a committee compromise? Who owns the whole design in their head?
+- Am I building this because it's genuinely interesting to me, or only because it might pay? Would I do this pass for free?
+- Have I mastered the fundamentals of this layer, or am I stacking abstractions to avoid understanding it?
+- What artificial limit is everyone in this space accepting that I could just ignore?
+- If I gave this design away openly, would that hurt me — or create the community that carries it?
+
+## Failure modes
+- **Elegance as procrastination** — endless chip-count golf on a component nobody's blocked on; minimalism must serve the user, not aesthetics (Woz optimized for the customer, not beauty).
+- **Solo-genius cargo cult** — "work alone" without Woz-level mastery just produces unreviewed mistakes; the license to skip the committee is earned by fundamentals.
+- **Joy without a Jobs** — building purely for delight and never shipping or selling; Woz needed a counterpart who did the business.
+- **Openness where the moat is the code** — giving away schematics worked because his velocity was the moat; copying the gesture without the velocity gives away the business.
+- **Contrarianism as identity** — trusting your own reasoning is not the same as being right; HP was wrong five times, but sometimes the rejecting party is correct.
+- **Perfection on the wrong step** — Woz's perfectionism targeted the step he was on; polishing a step the product may never reach is waste dressed as craft.
+
+## When building, reach for this when…
+(3-5 generic builder situations)
+- Designing a core system and deciding how many moving parts (services, deps, tables, steps) it really needs.
+- Feeling pulled from building into business/management and unsure whether to follow the money or the craft.
+- A design review is drifting toward consensus mush instead of one coherent vision.
+- Deciding whether to open-source / publish internals or keep them closed.
+- Everyone says your approach can't work and you need a rule for when to persist anyway.

--- a/.claude/skills/reflect/references/tobi-lutke.md
+++ b/.claude/skills/reflect/references/tobi-lutke.md
@@ -1,0 +1,69 @@
+---
+name: tobi-lutke
+source: https://fs.blog/knowledge-project-podcast/tobi-lutke-2/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Tobi Lütke — Subtract by first principles, play the infinite game
+
+## Core idea
+Tobi's frame (from The Knowledge Project #152, "Calm Progress") is that companies rot by
+addition: every locally-reasonable yes deposits a "sediment layer" of process, features, and
+bureaucracy that nobody would ever choose from scratch. The founder's distinctive job is
+subtraction — and subtraction requires spending accumulated legitimacy (a bank account of
+social credit, riffing on Vitalik Buterin's legitimacy essay) that only someone who has "seen
+every version of the company" holds. Around that core sit three supporting moves: derive
+decisions from first principles rather than best practices (which he reads as code for "take
+no risk, copy everyone"); treat decision-making as input-finding — once all relevant inputs
+are surfaced, most honest observers converge on the same answer, so disagreement usually
+signals a hidden unshared assumption, not a values clash; and orient to the infinite game
+(James Carse) — no win condition, the goal is to keep playing — because only infinite players
+adapt when the rules change. He explicitly models second- and tertiary-order effects, arguing
+they usually dwarf the primary effect everyone argues about.
+
+## When it bites
+- You're deciding whether to add a feature, config option, tier, or process "because a big
+  customer asked" — the addition looks cheap and the compounding sediment is invisible.
+- A codebase or product has accreted subsystems nobody would rebuild, but every removal
+  proposal dies because each layer has a local defender.
+- You're about to adopt a "best practice" (framework, org ritual, pricing convention) purely
+  because peers do it, not because it derives from your constraints.
+- Two smart people on the team keep disagreeing about a technical or product call and it's
+  turning personal.
+- A metric or monetization dial is sitting there begging to be turned, and turning it would
+  quietly trade mission trust for near-term revenue.
+
+## How to run it
+- Before adding anything, ask: what am I implicitly saying no to during the time this
+  consumes? "Adding things is a lot more expensive than removing things."
+- Quarterly, hunt sediment: which subsystem, process, or feature would we NOT build if
+  starting today? Do I have the legitimacy to delete it — and if I don't spend that
+  legitimacy, who ever will?
+- On any disputed decision: stop arguing conclusions; list the inputs each side is using.
+  Which input does one of us hold that the other hasn't seen? Resolve that, then re-decide.
+- Ask what the company (or codebase) ten years from now wishes I decided today — the popular
+  choice now often commits the future self to pain.
+- For every intervention, force one pass on second-order effects: what does this incentivize
+  people to do next, and what does THAT cause?
+- Replace "what's the best practice?" with "what would I derive from scratch given my actual
+  constraints?" — then check the delta against convention deliberately (Chesterton's fence:
+  understand why the convention exists before discarding it).
+
+## Failure modes
+- Subtraction without legitimacy: deleting things you don't have the credibility or context
+  to delete burns trust instead of sediment. Earn or borrow the account first.
+- First-principles as contrarianism: rederiving everything ignores Chesterton's fence and
+  wastes cycles re-learning why conventions exist. Derive, then diff against convention.
+- Infinite-game framing as excuse: "we're playing the long game" can rationalize never
+  shipping, never monetizing, never keeping score at all.
+- Input-hunting as stall: at some point the inputs are gathered; convergence should follow.
+  If you're still collecting inputs to avoid deciding, that's a different disease.
+- Confusing calm with slow: Tobi's frame is calm progress under volatility, not comfort —
+  at Shopify, NOT taking risks is what gets performance-managed.
+
+## When building, reach for this when…
+- Scoping a feature request and the real cost is future maintenance, not build time.
+- Planning a refactor/deprecation and you need to justify deleting working-but-wrong code.
+- Choosing architecture or tooling where "industry standard" is the main argument offered.
+- Mediating a technical disagreement that has stopped producing new information.
+- Setting pricing or monetization where a short-term revenue dial trades against user trust.

--- a/.claude/skills/reflect/references/vlad-tenev.md
+++ b/.claude/skills/reflect/references/vlad-tenev.md
@@ -1,0 +1,54 @@
+---
+name: vlad-tenev
+source: https://fs.blog/knowledge-project-podcast/vlad-tenev/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Vlad Tenev — Build for the environment you're in, not the one you're waiting for
+
+## Core idea
+Tenev's frame is rigor under narrative pressure. The GameStop crisis taught him
+that "a juicy falsehood is more powerful than a boring truth" — once a false
+story goes viral, facts won't dislodge it, so you survive on operational
+soundness and long-term conviction, not on winning the news cycle. His harder
+test was the grinding 2022 downturn, where the lesson was to build products for
+the current environment rather than waiting for tailwinds to return. Underneath
+sits a math-trained belief that hard, well-posed problems are the best training
+for business judgment, plus a founder-mode operating style: small high-impact
+teams, reward impact over headcount, shared context over private one-on-ones,
+and treating compute like headcount. The mission (expanding ownership and
+access, shaped by a childhood amid Bulgarian hyperinflation) supplies the
+conviction that makes short-term pressure survivable.
+
+## When it bites
+(concrete BUILDER decision triggers)
+- You're deferring a product bet "until the market/model/funding environment improves."
+- A public backlash or viral misreading of your product tempts you to steer by PR instead of by fundamentals.
+- Headcount, scope, or org process is growing faster than shipped impact.
+- You're weighing a big irreversible move (repricing, killing a surface, betting the roadmap) with no reversal practice behind you.
+- Your differentiation claim rests on effort, not on something incumbents structurally cannot copy.
+
+## How to run it
+(concrete questions a builder asks themselves)
+- Am I building for today's actual conditions, or for a hoped-for future environment? What would I ship if I assumed this environment is permanent?
+- If a false narrative about this product went viral tomorrow, does the underlying system survive scrutiny? (Reliability is the only rebuttal that compounds.)
+- What's the smallest reversible version of this decision I can execute first, to learn that the anticipated backlash exceeds the real one?
+- Is this team/feature justified by impact, or by accumulated headcount and sunk process? What would the ruthless-metrics cut look like?
+- What is the structural asymmetry here — the thing an incumbent *cannot* match because of how their economics are built (Tenev's example: legacy banks trapped by zero-interest checking spreads)?
+- Does everyone who needs context actually share it, or am I fragmenting truth across one-on-ones? Would a green/yellow/red goal readout expose the real state?
+- Am I creating dramatically more value than I capture? If not, the pricing or the product is misaligned with durable trust.
+
+## Failure modes
+- **Stoic denial** — "ignore the narrative" curdles into ignoring real user pain that the narrative correctly pointed at. Separate the false story from the true signal inside it.
+- **Founder-mode cosplay** — cutting teams and centralizing decisions without the shared-context machinery (open goal reviews) that makes it work; you get bottleneck, not focus.
+- **Environment fatalism** — "build for now" misread as abandoning long-term bets entirely; Tenev pairs present-environment shipping with decade-scale mission conviction.
+- **Rigor as procrastination** — using math-grade analysis to delay decisions that only reversal practice on small bets can actually de-risk.
+- **Asymmetry hallucination** — declaring a structural moat that is really just a head start; test whether the incumbent's constraint is economic, not merely cultural.
+
+## When building, reach for this when…
+(3-5 generic builder situations)
+- A launch or pricing change draws public criticism and you must decide what to change vs. what to hold.
+- Market conditions turned against you and the roadmap was written for the old tailwinds.
+- You're deciding whether an org/process addition earns its complexity, or whether to cut back to a small high-leverage team.
+- You're sizing a bet-the-roadmap move and need a ladder of small reversible decisions to calibrate the risk first.
+- You're articulating differentiation and need it grounded in a structural constraint competitors can't escape.

--- a/.claude/skills/reflect/references/winston-weinberg.md
+++ b/.claude/skills/reflect/references/winston-weinberg.md
@@ -1,0 +1,79 @@
+---
+name: winston-weinberg
+source: https://fs.blog/knowledge-project-podcast/winston-weinberg/
+fetched: true
+fetched_on: 2026-07-15
+---
+# Winston Weinberg — Validate against expert judgment, then move at two-way-door speed
+
+## Core idea
+Weinberg built Harvey (legal AI) on two coupled moves. First, a brutal validation
+test before building anything: feed real legal questions through the raw model and
+ask three experienced attorneys whether they'd send the answers unchanged — the
+model cleared "86 out of 100 questions" unanimously. The product bet was only made
+after domain experts, not founders, judged the output shippable. Second, once
+validated, operate at maximum decision speed: treat most choices as reversible
+two-way doors, decide fast, and reserve deliberation for the few one-way doors.
+The connective tissue is his paradox of AI-era value — as routine work gets
+automated, human judgment becomes MORE valuable, not less. So the scarce input to
+protect is judgment (yours and your domain experts'), and the scarce output to
+optimize is decision throughput. Supporting practices: use stress deliberately to
+build resilience to failure, ruthlessly prioritize the single most important focus
+area at any time, run operations out of shared Google Docs instead of heavy
+process, and take asymmetric shots (his cold email to Sam Altman changed the
+company's trajectory — tiny cost, unbounded upside).
+
+## When it bites
+- You're about to build an AI product for a conservative, expertise-heavy industry
+  (legal, medical, finance) and haven't yet put raw model output in front of real
+  practitioners with a would-you-ship-this-unchanged bar.
+- You're agonizing over a product/architecture choice that is actually reversible
+  — a feature flag, a pricing test, a copy change — as if it were a one-way door.
+- Constant model/platform change is flooding you with options and you've lost the
+  single most important focus area.
+- You're deciding whether automation replaces the expert or amplifies the
+  expert's judgment — the answer changes the whole product shape.
+- A high-status person could unblock you and you're not sending the cold email
+  because the ask feels presumptuous.
+
+## How to run it
+- What is my "86 out of 100" test — the concrete experiment where domain experts
+  judge raw output against a ship-it-unchanged bar, before I build the wrapper?
+- Is this decision a two-way door? If I can cheaply reverse it, why am I still
+  deliberating instead of deciding today?
+- If it's genuinely one-way (data model, pricing structure, trust-breaking
+  failure in front of a conservative buyer), have I slowed down proportionally?
+- What is the ONE most important thing right now — and does my calendar/backlog
+  actually reflect it, or am I spreading across five?
+- Where does human judgment stay in the loop in my product, and am I pricing/
+  positioning that judgment as the value, not the automated routine work?
+- What's the cold-email-to-Sam-Altman move available to me this week — the
+  low-cost, high-asymmetry ask I'm avoiding?
+- Am I using this stressful stretch to build resilience, or just absorbing damage?
+  What's the lesson I'd extract if this failure happened to someone else?
+
+## Failure modes
+- Validation theater: asking experts "is this impressive?" instead of "would you
+  send this unchanged?" — the softer bar passes everything and proves nothing.
+- Two-way-door label abuse: calling a trust decision reversible. In conservative
+  industries, a hallucinated answer in front of a buyer is a one-way door.
+- Speed without a focus: deciding fast on twenty fronts is thrash, not velocity —
+  the prioritization half of the frame is load-bearing.
+- Automating the judgment instead of the routine: building the product that
+  replaces the expert's call rather than clearing the grunt work beneath it.
+- Doc-driven ops decaying into doc sprawl — the Google Doc works because it's the
+  single live surface, not because documents are inherently good.
+- Treating resilience talk as license to ignore failure signals instead of
+  metabolizing them into changed behavior.
+
+## When building, reach for this when…
+- Deciding whether an AI feature is good enough to ship to a skeptical,
+  expertise-heavy audience (design the expert ship-it-unchanged test first).
+- Stuck deliberating on a reversible choice — classify the door, then decide
+  same-day if it's two-way.
+- Roadmap has ballooned during a platform shift and you need to collapse it back
+  to the single most important bet.
+- Choosing between automating an expert's judgment vs. the routine work around
+  it — default to amplifying judgment.
+- Facing a blocker a well-placed cold ask could remove — send the asymmetric
+  email before building the workaround.


### PR DESCRIPTION
Syncs the SeldonFrame copy with the builders release already live in github.com/seldonframe/reflect (b542dee) and the user-level copy:

- **8 builder-mind lenses** (per-person, fetched live from sources): DHH, Tobi Lütke, Mark Pincus, Winston Weinberg, Vlad Tenev, Peter Kaufman, Steve Wozniak, Outliers best-of-2025 collection. New 'Builders' section in 00-index. (Kaufman + best-of-2025 pages were thin/paywalled — files note their provenance honestly.)
- **Evidence tools**: reflects must search for base rates instead of asserting them, read code/git history before any remove/rewrite/build-vs-buy call, and prefer running the <1-day test over describing it.
- **`reflect learn <source>`**: fetch-live → compact to lens file → wire routing → report; with the three-copy sync rule.

Doc-only (.claude/skills/reflect/**), no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)