### PR TITLE
fix(seo): tool-card OG hook invisible — green === dark since forest rebrand

### DIFF
--- a/docs/learnings/2026-07-15-invisible-not-missing-rendered-output.md
+++ b/docs/learnings/2026-07-15-invisible-not-missing-rendered-output.md
@@ -1,0 +1,56 @@
+# Invisible ≠ missing: diagnose "text doesn't show" by color equality, not data flow
+
+## The problem, in one line
+The live `/api/og?kind=tool` Open Graph image showed no hook text regardless of
+the `?hook=` query param — it looked like the param was being dropped.
+
+## The approach
+1. Trace the data flow BEFORE touching anything: route
+   (`packages/crm/src/app/api/og/route.tsx`) parses + clamps `hook`, passes it
+   to `ToolCard` (`packages/crm/src/lib/seo/og-card.tsx`), which clamps again
+   and renders it. Data flow was fully intact — so stop hunting for a dropped
+   param.
+2. When the data provably reaches the render, the next suspect is
+   PRESENTATION: check the style values on the rendered node against its
+   container. Here `color: OG_COLORS.green` (#1F2B24) sat on
+   `backgroundColor: OG_COLORS.dark` (#1F2B24) — byte-identical. The text was
+   drawn, in background-colored ink.
+3. Confirm WHERE the equality came from with `git log -S'"#1F2B24"'` on the
+   file: a brand rebrand commit changed `green` from emerald #059669 to the
+   logo's deep forest #1F2B24 — which happened to equal the existing `dark` —
+   without applying the rebrand's own on-dark rule ("forest on light surfaces,
+   cream on dark").
+4. Pin the regression with a test that asserts VISIBILITY, not presence: walk
+   the pure element tree (the card layouts are hook-free function components,
+   so `type(props)` expands them without a DOM), collect each text node's
+   inherited `style.color`, and assert hook color ≠ card `backgroundColor`.
+   A presence assertion would have passed throughout the bug's whole life.
+5. Fix minimally at the reported site (hook → `OG_COLORS.paper`), leave a
+   CAUTION comment at the palette (the trap's source), and file the sibling
+   occurrences (other cards use green-on-dark too) as a separate task instead
+   of sweeping them into this change.
+
+## Judgment calls
+- Did NOT change `OG_COLORS.green` globally: green is correct as a fill and on
+  light surfaces (BestCard text, pills, brand tile on paper) — only
+  green-as-text-on-dark is broken. A global change would have "fixed" the bug
+  by breaking the light cards.
+- Did NOT fix the other five affected card elements in the same commit even
+  though it's the same root cause: accent choice on dark cards is
+  brand-sensitive (two previous greens were rejected by the founder), so that
+  pass needs a visual check, and the task explicitly asked for minimal blast
+  radius on a live endpoint. Spawned a follow-up task naming every affected
+  element instead.
+- Did NOT add the blanket "no text node may match its background" invariant to
+  the test yet — it would fail on the not-yet-fixed sibling cards and block
+  this fix; it belongs in the follow-up.
+- Trusted code reading + git evidence over reproducing the live PNG render:
+  color equality is deterministic; a satori render would have added cost
+  without adding proof.
+
+## The reusable rule, one line
+When rendered output "doesn't show" but the data flow checks out, diff the
+foreground style against its container before suspecting the data — and after
+any palette/rebrand sweep, grep for the new hex used as BOTH a text color and
+a background, because equality there is silent invisibility that presence
+tests never catch.

--- a/packages/crm/src/lib/seo/og-card.tsx
+++ b/packages/crm/src/lib/seo/og-card.tsx
@@ -26,6 +26,9 @@ export const OG_HEIGHT = 630;
 export const OG_COLORS = {
   ink: "#221D17",
   paper: "#F6F2EA",
+  // CAUTION: green === dark since the forest rebrand (#68). Green is safe as
+  // a background/fill or on light surfaces only — text colored `green` on a
+  // `dark`/`ink` card is invisible. Use `paper` for text accents on dark.
   green: "#1F2B24",
   dark: "#1F2B24",
 } as const;
@@ -362,7 +365,10 @@ export function ToolCard({ name, hook }: { name: string; hook: string }): ReactE
           {safeName}
         </div>
         {safeHook ? (
-          <div style={{ display: "flex", fontSize: 40, fontWeight: 700, fontFamily: "Inter-Bold", color: OG_COLORS.green, lineHeight: 1.2 }}>
+          // paper, not green: since the forest rebrand green === dark, so
+          // green text on a dark card is invisible (the rebrand rule is
+          // forest on light surfaces, cream on dark ones).
+          <div style={{ display: "flex", fontSize: 40, fontWeight: 700, fontFamily: "Inter-Bold", color: OG_COLORS.paper, lineHeight: 1.2 }}>
             {safeHook}
           </div>
         ) : null}

--- a/packages/crm/tests/unit/seo/og-card.spec.ts
+++ b/packages/crm/tests/unit/seo/og-card.spec.ts
@@ -24,6 +24,48 @@ import {
   VsCard,
 } from "../../../src/lib/seo/og-card";
 
+// Minimal element-tree walker for the layout components: expands function
+// components (they're pure — no hooks/state) and collects every text node
+// with its nearest inherited `style.color`, plus the root backgroundColor.
+// This lets us assert VISIBILITY (text color ≠ card background), which is
+// how the tool-card hook regressed in the forest rebrand: the hook was
+// still rendered, but in green #1F2B24 on a #1F2B24 background.
+type TextNode = { text: string; color: string | undefined };
+
+type ElementLike = {
+  type?: unknown;
+  props?: { style?: { color?: string; backgroundColor?: string }; children?: unknown };
+};
+
+function collectTextNodes(node: unknown, inheritedColor: string | undefined, out: TextNode[]): void {
+  if (node == null || typeof node === "boolean") return;
+  if (typeof node === "string" || typeof node === "number") {
+    out.push({ text: String(node), color: inheritedColor });
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) collectTextNodes(child, inheritedColor, out);
+    return;
+  }
+  const el = node as ElementLike;
+  if (typeof el.type === "function") {
+    collectTextNodes((el.type as (props: unknown) => unknown)(el.props), inheritedColor, out);
+    return;
+  }
+  const color = el.props?.style?.color ?? inheritedColor;
+  collectTextNodes(el.props?.children, color, out);
+}
+
+/** Expand function components until the first host element and return its
+ *  backgroundColor — the card's background. */
+function rootBackground(node: unknown): string | undefined {
+  let el = node as ElementLike;
+  while (el && typeof el.type === "function") {
+    el = (el.type as (props: unknown) => unknown)(el.props) as ElementLike;
+  }
+  return el?.props?.style?.backgroundColor;
+}
+
 describe("clamp", () => {
   test("returns the string unchanged when under the limit", () => {
     assert.equal(clamp("hello", 10), "hello");
@@ -192,6 +234,49 @@ describe("layout components render without throwing", () => {
 
   test("DefaultCard renders with no input", () => {
     assert.doesNotThrow(() => DefaultCard());
+  });
+});
+
+describe("tool-card hook renders VISIBLY", () => {
+  // Regression: the forest rebrand set OG_COLORS.green = #1F2B24 — identical
+  // to OG_COLORS.dark, the ToolCard background — so the hook line was drawn
+  // in background-colored text and every live tool card showed no hook.
+  // Presence in the tree is not enough; the color must differ from the
+  // card's background.
+  test("a provided hook appears in the tree with a color that differs from the background", () => {
+    const hook = "What do missed calls cost you?";
+    const card = ToolCard({ name: "Missed Call Calculator", hook });
+    const background = rootBackground(card);
+    assert.ok(background, "expected the card root to declare a backgroundColor");
+
+    const texts: TextNode[] = [];
+    collectTextNodes(card, undefined, texts);
+    const hookNode = texts.find((t) => t.text === hook);
+    assert.ok(hookNode, "hook text is missing from the rendered element tree");
+    assert.ok(hookNode.color, "hook text has no explicit color");
+    assert.notEqual(
+      hookNode.color.toLowerCase(),
+      background.toLowerCase(),
+      `hook is rendered in the card's own background color (${background}) — invisible`,
+    );
+  });
+
+  test("an overlong hook is ellipsized within the component cap", () => {
+    const card = ToolCard({ name: "Free Tool", hook: "y".repeat(200) });
+    const texts: TextNode[] = [];
+    collectTextNodes(card, undefined, texts);
+    const hookNode = texts.find((t) => t.text.startsWith("yyy"));
+    assert.ok(hookNode, "clamped hook text missing from the tree");
+    assert.ok(hookNode.text.length <= 70, `hook not clamped: ${hookNode.text.length} chars`);
+    assert.ok(hookNode.text.endsWith("…"), "overlong hook should end with an ellipsis");
+  });
+
+  test("an empty hook renders no dangling hook element", () => {
+    const card = ToolCard({ name: "Free Tool", hook: "" });
+    const texts: TextNode[] = [];
+    collectTextNodes(card, undefined, texts);
+    // Only the name, the pill copy, and the brand mark should remain.
+    assert.ok(texts.every((t) => t.text.trim().length > 0));
   });
 });
 


### PR DESCRIPTION
## What
The live `/api/og?kind=tool` card showed no hook text regardless of the `?hook=` param (verified live 2026-07-15, 2 pulls). The param was never dropped — route parses + clamps it (90), `ToolCard` clamps again (70) and renders it — but in `OG_COLORS.green`, which the forest rebrand (#68) changed from emerald `#059669` to `#1F2B24`, byte-identical to `OG_COLORS.dark`, the card background. Drawn in background-colored ink.

## Fix
- ToolCard hook renders in `OG_COLORS.paper` (cream) — the rebrand's own rule: forest on light surfaces, cream on dark.
- CAUTION comment on `OG_COLORS` marking the `green === dark` trap.

## Test
New "tool-card hook renders VISIBLY" suite: walks the pure element tree (layouts are hook-free function components — no satori needed) and asserts the hook's inherited color ≠ the card's `backgroundColor`. Pins visibility, not presence (presence never regressed). Plus ellipsis-clamp and empty-hook cases. Verified red-before / green-after.

## Verify-build
PASS (verify-runner): 33/33 og-card + 7/7 page-metadata; tsc delta 0 vs main; use-server clean; no migrations; regression grep empty; live smoke `/api/og` 200 PNG.

## Known remaining (separate task, already spawned)
Same root cause on the other dark cards: SfVsCard competitor name, AltCard "alternative", VsCard kicker, DefaultCard tagline, AccentBar, BrandMark tile — all green-on-dark. Being handled in an independent session.

Note: route serves `s-maxage=2592000`, so previously-crawled OG URLs may stay stale up to 30 days; fresh param combos render correctly immediately post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)