### PR TITLE
feat(chatgpt-app): v2 widgets — build-result card + agent carousel + invocation strings

### DIFF
--- a/docs/superpowers/plans/2026-07-15-chatgpt-widgets-v2.md
+++ b/docs/superpowers/plans/2026-07-15-chatgpt-widgets-v2.md
@@ -1,0 +1,66 @@
+# ChatGPT app v2 — widgets (inline card + browse carousel) + invocation strings
+
+Status: PLANNED — **blocked until the rate-limit re-key session lands** (it edits the
+same lib/chatgpt-app files). Build in a fresh worktree off main AFTER that merge.
+
+## Why
+Satisfaction/completion are the inputs OpenAI ranks for enhanced distribution;
+text-only tool output is the weakest part of the current UX. Widgets are the
+biggest available upgrade. Build on the **MCP Apps standard** (`_meta.ui.resourceUri`,
+`ui/*` bridge) with the ChatGPT alias (`_meta["openai/outputTemplate"]`) — the same
+widget then works in any MCP Apps host (never-goes-stale).
+
+## Scope (deliberately small — 3 pieces)
+
+1. **Invocation strings** (zero-risk, pure metadata):
+   - build_workspace: invoking "Building your workspace…" / invoked "Workspace live."
+   - browse_marketplace: "Browsing free agents…" / "Agents found."
+   - deploy_agent: "Installing agent…" / "Agent installed."
+   Via `_meta["openai/toolInvocation/invoking"|"invoked"]` (≤64 chars).
+
+2. **build_workspace inline card** — dark card: business name, live URL as the
+   hero link, three chips (Website · Booking · CRM · AI chat), one primary CTA
+   "Open your site ↗" (link-out to the workspace URL) + secondary "Claim it"
+   (claim URL — FREE, so policy-clean; still NO prices/paid anything anywhere).
+   No remote images in v2 (empty CSP = easiest review); the card is typographic.
+
+3. **browse_marketplace carousel** — 3–8 free agents, each: name, one-line
+   description, category badge, single CTA "Add to my workspace" which calls
+   `deploy_agent` from the widget (`tools/call` via the bridge; requires the
+   workspace_token to be present in widget state — pass it through
+   `structuredContent` only when build_workspace ran earlier in the convo,
+   else the CTA falls back to `ui/message` "Install <slug>").
+
+## Implementation notes
+- Handler must add `resources/list` + `resources/read` to the RPC dispatch
+  (current: initialize / tools/list / tools/call / notifications). Resources:
+  `ui://widget/build-result.html`, `ui://widget/agent-carousel.html`, served as
+  `text/html;profile=mcp-app`, self-contained (inline CSS/JS, no external hosts).
+- Widget JS: listen for `ui/notifications/tool-result`, render from
+  `structuredContent`; treat it as untrusted; support the approval-gated case
+  (missing initial input is normal). Use `window.openai` ONLY behind feature
+  detection.
+- `structuredContent` must keep matching declared `outputSchema` exactly
+  (review checks this) — extend schemas + content together.
+- Tool descriptors get `_meta.ui.resourceUri` + `_meta["openai/outputTemplate"]`
+  on build_workspace and browse_marketplace only (deploy_agent stays text +
+  invocation strings).
+- Keep the wire layer unit-tested with fakes (extend chatgpt-mcp-rpc/handler specs):
+  resources round-trip, descriptor meta present, structuredContent↔schema parity.
+
+## Submission checklist (Max)
+1. Deploy to prod, verify `resources/read` over the live endpoint.
+2. Plugin portal → new draft version → **Scan Tools** AFTER deploy → verify the
+   scanned meta shows the resource URIs + CSP → submit with release notes
+   ("adds inline result card + agent carousel; no new data collected").
+3. Screenshots now allowed/expected (app has a UI) — capture card + carousel.
+4. `_meta.ui.domain`: needed for submission review of UI apps (unique origin);
+   decide the origin (e.g. https://chatgpt-widgets.seldonframe.com) or keep the
+   default sandbox origin if scan accepts it — verify in the portal during scan.
+5. Publish after approval; old version keeps serving until then (backward-compatible
+   contract: only ADD meta/fields, never rename/remove).
+
+## Policy tripwires (do not cross)
+- No prices, no paid agents, no upsell language in any widget. Claim = free.
+- Minimal data: widgets render only what the tools already return.
+- No iframes (`frameDomains` stays unset), no external fetches (empty `connectDomains`).

--- a/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-handler.ts
+++ b/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-handler.ts
@@ -45,6 +45,7 @@ import {
   type BuildWorkspaceArgs,
   type OpenAiCallMeta,
 } from "./chatgpt-mcp-rpc";
+import { CHATGPT_WIDGET_RESOURCES, getChatGptWidgetResourceContent } from "./widgets";
 import type { MarketplaceAgentRow } from "@/lib/marketplace/agent-listings";
 import { captureMcpToolCall } from "@/lib/analytics/mcp-capture";
 
@@ -61,6 +62,9 @@ export type BuildWorkspaceResult = {
   url: string;
   claimUrl?: string;
   workspaceToken: string;
+  /** The business name, as given. Additive field (2026-07-15 widgets v2) —
+   *  rendered on the build-result widget alongside the live URL. */
+  name?: string;
 };
 
 /** The result of deploying an agent. Free agents instantiate inline (url).
@@ -96,9 +100,20 @@ export type RpcOutcome = {
 };
 
 /** Shape an MCP tools/call success: a human text block PLUS structuredContent
- *  (the raw machine-readable object) for Apps-SDK clients that render rich UI. */
-function toolResult(text: string, structured: Record<string, unknown>): Record<string, unknown> {
-  return { ...toolTextResult(text), structuredContent: structured };
+ *  (the raw machine-readable object) for Apps-SDK clients that render rich UI,
+ *  PLUS an optional top-level `_meta` — the WIDGET-ONLY channel (delivered to
+ *  the rendered component, never to the model — unlike structuredContent,
+ *  which is model-visible and must mirror the declared outputSchema exactly). */
+function toolResult(
+  text: string,
+  structured: Record<string, unknown>,
+  meta?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    ...toolTextResult(text),
+    structuredContent: structured,
+    ...(meta ? { _meta: meta } : {}),
+  };
 }
 
 /**
@@ -124,6 +139,12 @@ export async function handleChatGptRpc(rawBody: string, deps: ChatGptMcpDeps): P
         status: 200,
         body: jsonRpcResult(id, {
           ...buildInitializeResult({ agentName: "SeldonFrame" }),
+          // This server ALSO speaks resources/list + resources/read (the two
+          // widget resources) — advertise the capability. buildInitializeResult
+          // is shared with the agent-marketplace rental endpoint (which does
+          // NOT support resources), so we add it here rather than in the
+          // shared helper.
+          capabilities: { tools: {}, prompts: {}, resources: {} },
           instructions: CHATGPT_SERVER_INSTRUCTIONS,
         }),
       };
@@ -137,6 +158,33 @@ export async function handleChatGptRpc(rawBody: string, deps: ChatGptMcpDeps): P
 
     case "tools/call":
       return handleToolsCall(id, params, deps);
+
+    case "resources/list":
+      // Public — no auth gate, same as tools/list. The two widget resources
+      // (build-result card + agent carousel).
+      return {
+        status: 200,
+        body: jsonRpcResult(id, {
+          resources: CHATGPT_WIDGET_RESOURCES.map(({ uri, name, description, mimeType }) => ({
+            uri,
+            name,
+            description,
+            mimeType,
+          })),
+        }),
+      };
+
+    case "resources/read": {
+      const uri = typeof params.uri === "string" ? params.uri : "";
+      const content = getChatGptWidgetResourceContent(uri);
+      if (!content) {
+        return {
+          status: 200,
+          body: jsonRpcError(id, JSONRPC_INVALID_PARAMS, `Unknown resource: ${uri || "(none)"}`),
+        };
+      }
+      return { status: 200, body: jsonRpcResult(id, { contents: [content] }) };
+    }
 
     default:
       return { status: 200, body: jsonRpcError(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${method}`) };
@@ -165,7 +213,14 @@ async function handleToolsCall(
       }
       return runTool(id, toolName, args, meta, deps, async () => {
         const result = await deps.buildWorkspace(parsed.value, meta);
-        return toolResult(formatBuildResult(result), { ...result });
+        // The widget reads the token from result._meta (widget-only channel,
+        // hidden from the model). structuredContent ALSO carries workspaceToken
+        // (an existing, required outputSchema field) — kept for backward
+        // compatibility per the additive-only contract; see the task report
+        // for the tradeoff.
+        return toolResult(formatBuildResult(result), { ...result }, {
+          "seldonframe/workspaceToken": result.workspaceToken,
+        });
       });
     }
 

--- a/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-rpc.ts
+++ b/packages/crm/src/lib/chatgpt-app/chatgpt-mcp-rpc.ts
@@ -18,6 +18,7 @@
 
 import type { McpToolDescriptor } from "@/lib/agents/mcp/client";
 import type { MarketplaceAgentRow } from "@/lib/marketplace/agent-listings";
+import { BUILD_RESULT_WIDGET_URI, AGENT_CAROUSEL_WIDGET_URI } from "./widgets";
 
 // Re-export the transport envelope builders we share with the rental MCP, so
 // the handler can import the whole wire vocabulary from one ChatGPT module.
@@ -71,7 +72,33 @@ export type ChatGptToolDescriptor = McpToolDescriptor & {
     idempotentHint?: boolean;
   };
   outputSchema?: Record<string, unknown>;
+  /** Free-form tool metadata: invocation strings (openai/toolInvocation/*),
+   *  widget wiring (ui.resourceUri + the openai/outputTemplate alias), and
+   *  openai/widgetAccessible. See buildInvocationMeta / buildWidgetMeta. */
+  _meta?: Record<string, unknown>;
 };
+
+/** `_meta["openai/toolInvocation/invoking"|"invoked"]` — the two short status
+ *  strings ChatGPT shows while/after a tool call runs. Kept ≤64 chars per the
+ *  Apps SDK guidance. */
+function buildInvocationMeta(invoking: string, invoked: string): Record<string, unknown> {
+  return {
+    "openai/toolInvocation/invoking": invoking,
+    "openai/toolInvocation/invoked": invoked,
+  };
+}
+
+/** Wire a tool descriptor to its widget resource: the MCP Apps
+ *  `ui.resourceUri` field plus the ChatGPT-specific `openai/outputTemplate`
+ *  alias (same URI — one widget works under either spelling) and a one-
+ *  sentence `openai/widgetDescription` for the host's own UI. */
+function buildWidgetMeta(resourceUri: string, widgetDescription: string): Record<string, unknown> {
+  return {
+    ui: { resourceUri },
+    "openai/outputTemplate": resourceUri,
+    "openai/widgetDescription": widgetDescription,
+  };
+}
 
 /**
  * The `tools/list` result: the three ChatGPT tools with real MCP inputSchemas,
@@ -134,8 +161,19 @@ export function buildChatGptToolsList(): { tools: ChatGptToolDescriptor[] } {
               type: "string",
               description: "Link to manage the workspace (no signup, expires in about 7 days).",
             },
+            name: {
+              type: "string",
+              description: "The business name, as given — rendered on the build-result widget.",
+            },
           },
           required: ["url", "workspaceToken"],
+        },
+        _meta: {
+          ...buildInvocationMeta("Building your workspace…", "Workspace live."),
+          ...buildWidgetMeta(
+            BUILD_RESULT_WIDGET_URI,
+            "Shows the newly built workspace with links to the live site and free claim.",
+          ),
         },
       },
       {
@@ -181,6 +219,13 @@ export function buildChatGptToolsList(): { tools: ChatGptToolDescriptor[] } {
           },
           required: ["agents"],
         },
+        _meta: {
+          ...buildInvocationMeta("Browsing free agents…", "Agents found."),
+          ...buildWidgetMeta(
+            AGENT_CAROUSEL_WIDGET_URI,
+            "Shows the free agents found, each with a button to add it to the workspace.",
+          ),
+        },
       },
       {
         name: DEPLOY_AGENT_TOOL,
@@ -215,6 +260,12 @@ export function buildChatGptToolsList(): { tools: ChatGptToolDescriptor[] } {
             error: { type: "string" },
           },
           required: ["ok"],
+        },
+        // Stays text-only (no widget resourceUri) — but IS callable FROM the
+        // agent-carousel widget's CTA, so it needs widgetAccessible:true.
+        _meta: {
+          ...buildInvocationMeta("Installing agent…", "Agent installed."),
+          "openai/widgetAccessible": true,
         },
       },
     ],

--- a/packages/crm/src/lib/chatgpt-app/deps.ts
+++ b/packages/crm/src/lib/chatgpt-app/deps.ts
@@ -185,6 +185,9 @@ async function buildWorkspace(
     url: withChatGptRef(publicUrl),
     claimUrl: structured.admin_url ? withChatGptRef(structured.admin_url) : undefined,
     workspaceToken: result.bearerToken,
+    // Additive (2026-07-15 widgets v2) — the business name, rendered on the
+    // build-result widget alongside the live URL.
+    name: args.business_name,
   };
 }
 

--- a/packages/crm/src/lib/chatgpt-app/widgets.ts
+++ b/packages/crm/src/lib/chatgpt-app/widgets.ts
@@ -1,0 +1,372 @@
+// ChatGPT App v2 — MCP Apps widget resources.
+//
+// Two self-contained HTML documents served over `resources/read`, rendered
+// inline by an MCP Apps host (ChatGPT, or any other MCP Apps client) alongside
+// the matching tool's result. Both documents are:
+//   - typographic only — NO remote images, NO external requests (empty CSP)
+//   - inline CSS/JS, system font stack, dark theme (#1F2B24 / #F6F2EA / green)
+//   - defensive about untrusted data: every value from structuredContent is
+//     written via textContent, never innerHTML
+//   - tolerant of the "no input yet" state (approval-gated tools may mount the
+//     widget before any tool-result arrives)
+//
+// Kept in their own file (rather than inline in chatgpt-mcp-rpc.ts) so the wire
+// layer stays lean and readable — these are large template-literal blobs.
+
+/** Stable MCP resource URIs. Referenced from tool descriptor `_meta.ui` and
+ *  from `resources/list` + `resources/read`. */
+export const BUILD_RESULT_WIDGET_URI = "ui://widget/build-result.html";
+export const AGENT_CAROUSEL_WIDGET_URI = "ui://widget/agent-carousel.html";
+
+/** The `_meta` object every widget resource's CONTENTS carry: the modern MCP
+ *  Apps `ui` shape plus the legacy ChatGPT alias, both declaring an EMPTY CSP
+ *  (no external connect/resource domains — the widgets are self-contained). */
+function widgetResourceMeta(): Record<string, unknown> {
+  return {
+    ui: {
+      prefersBorder: true,
+      csp: { connectDomains: [], resourceDomains: [] },
+    },
+    "openai/widgetCSP": { connect_domains: [], resource_domains: [] },
+  };
+}
+
+// ─── build-result card ────────────────────────────────────────────────────
+//
+// Renders a build_workspace result: business name, the live URL as the hero
+// link, a row of four static chips (Website · Booking · CRM · AI chat), a
+// primary "Open your site ↗" CTA (workspace url), and a secondary "Claim it
+// (free)" CTA (claim url, omitted when absent). No prices, no upsell — the
+// claim flow is free, full stop.
+
+const BUILD_RESULT_WIDGET_HTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: transparent;
+  }
+  .card { background: #1F2B24; color: #F6F2EA; border-radius: 16px; padding: 20px 22px; max-width: 480px; }
+  .biz { font-size: 12px; opacity: .7; margin: 0 0 6px; letter-spacing: .04em; text-transform: uppercase; }
+  .hero { display: block; font-size: 19px; font-weight: 600; color: #4ade80; text-decoration: none; word-break: break-all; margin-bottom: 14px; }
+  .hero:hover { text-decoration: underline; }
+  .chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 18px; }
+  .chip { background: rgba(74,222,128,.12); color: #4ade80; border: 1px solid rgba(74,222,128,.35); border-radius: 999px; padding: 4px 12px; font-size: 12px; font-weight: 500; }
+  .ctas { display: flex; gap: 10px; flex-wrap: wrap; }
+  .btn { display: inline-block; text-decoration: none; font-size: 14px; font-weight: 600; border-radius: 10px; padding: 10px 16px; }
+  .btn-primary { background: #4ade80; color: #0f1a12; }
+  .btn-secondary { background: transparent; color: #F6F2EA; border: 1px solid rgba(246,242,234,.25); }
+  .empty { opacity: .65; font-size: 14px; margin: 0; }
+</style>
+</head>
+<body>
+<div class="card" id="card"><p class="empty" id="empty">Building your workspace&hellip;</p></div>
+<script>
+(function () {
+  var CHIPS = ["Website", "Booking", "CRM", "AI chat"];
+  var card = document.getElementById("card");
+
+  function clear(el) {
+    while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  function render(data) {
+    if (!data || typeof data.url !== "string" || data.url.length === 0) return;
+    clear(card);
+
+    var biz = document.createElement("p");
+    biz.className = "biz";
+    biz.textContent = typeof data.name === "string" && data.name ? data.name : "Your workspace";
+    card.appendChild(biz);
+
+    var hero = document.createElement("a");
+    hero.className = "hero";
+    hero.href = data.url;
+    hero.target = "_blank";
+    hero.rel = "noopener noreferrer";
+    hero.textContent = data.url;
+    card.appendChild(hero);
+
+    var chips = document.createElement("div");
+    chips.className = "chips";
+    for (var i = 0; i < CHIPS.length; i++) {
+      var chip = document.createElement("span");
+      chip.className = "chip";
+      chip.textContent = CHIPS[i];
+      chips.appendChild(chip);
+    }
+    card.appendChild(chips);
+
+    var ctas = document.createElement("div");
+    ctas.className = "ctas";
+
+    var open = document.createElement("a");
+    open.className = "btn btn-primary";
+    open.href = data.url;
+    open.target = "_blank";
+    open.rel = "noopener noreferrer";
+    open.textContent = "Open your site \\u2197";
+    ctas.appendChild(open);
+
+    if (typeof data.claimUrl === "string" && data.claimUrl.length > 0) {
+      var claim = document.createElement("a");
+      claim.className = "btn btn-secondary";
+      claim.href = data.claimUrl;
+      claim.target = "_blank";
+      claim.rel = "noopener noreferrer";
+      claim.textContent = "Claim it (free)";
+      ctas.appendChild(claim);
+    }
+    card.appendChild(ctas);
+  }
+
+  function structuredContentOf(payload) {
+    if (!payload) return null;
+    if (payload.structuredContent) return payload.structuredContent;
+    if (payload.result && payload.result.structuredContent) return payload.result.structuredContent;
+    return null;
+  }
+
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.type === "ui/notifications/tool-result") {
+      render(structuredContentOf(msg.params || msg));
+    }
+  });
+
+  try {
+    if (window.openai && window.openai.toolOutput) {
+      render(window.openai.toolOutput);
+    }
+  } catch (e) {}
+})();
+</script>
+</body>
+</html>
+`;
+
+// ─── agent carousel ────────────────────────────────────────────────────────
+//
+// Renders a browse_marketplace result: a horizontal scroll row of up to 8
+// free-agent cards (name, one-line description, category badge), each with a
+// single "Add to my workspace" CTA. The CTA calls deploy_agent directly via a
+// `tools/call` postMessage WHEN a workspace_token is available on the widget's
+// own channel (result._meta / widgetState — never structuredContent, never
+// hard-coded); otherwise it falls back to a `ui/message` follow-up so the
+// model can drive deploy_agent itself.
+
+const AGENT_CAROUSEL_WIDGET_HTML = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: transparent;
+  }
+  .row { display: flex; gap: 12px; overflow-x: auto; padding: 4px 2px 10px; -webkit-overflow-scrolling: touch; }
+  .row::-webkit-scrollbar { height: 6px; }
+  .row::-webkit-scrollbar-thumb { background: rgba(246,242,234,.2); border-radius: 3px; }
+  .card { flex: 0 0 220px; background: #1F2B24; color: #F6F2EA; border-radius: 14px; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+  .badge { align-self: flex-start; background: rgba(74,222,128,.12); color: #4ade80; border: 1px solid rgba(74,222,128,.35); border-radius: 999px; padding: 2px 10px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .03em; }
+  .name { font-size: 15px; font-weight: 600; margin: 0; }
+  .desc { font-size: 13px; opacity: .75; margin: 0; line-height: 1.4; flex: 1; }
+  .cta { margin-top: auto; background: #4ade80; color: #0f1a12; border: none; border-radius: 10px; padding: 9px 12px; font-size: 13px; font-weight: 600; cursor: pointer; }
+  .cta:active { opacity: .85; }
+  .empty { opacity: .65; font-size: 14px; padding: 8px 2px; margin: 0; }
+</style>
+</head>
+<body>
+<div class="row" id="row"><p class="empty" id="empty">Browsing agents&hellip;</p></div>
+<script>
+(function () {
+  var row = document.getElementById("row");
+  var MAX_CARDS = 8;
+  var token = null;
+
+  function clear(el) {
+    while (el.firstChild) el.removeChild(el.firstChild);
+  }
+
+  // Feature-detect a workspace_token the HOST may be carrying forward from an
+  // earlier build_workspace tool result in this same conversation. There is no
+  // channel that guarantees this reaches a DIFFERENT tool result's widget —
+  // absence here is the normal case, and the CTA falls back to ui/message.
+  function findToken(meta) {
+    try {
+      if (meta && typeof meta["seldonframe/workspaceToken"] === "string" && meta["seldonframe/workspaceToken"]) {
+        return meta["seldonframe/workspaceToken"];
+      }
+    } catch (e) {}
+    try {
+      if (window.openai && window.openai.widgetState && typeof window.openai.widgetState.workspaceToken === "string") {
+        return window.openai.widgetState.workspaceToken;
+      }
+    } catch (e) {}
+    try {
+      if (
+        window.openai &&
+        window.openai.toolOutput &&
+        window.openai.toolOutput._meta &&
+        typeof window.openai.toolOutput._meta["seldonframe/workspaceToken"] === "string"
+      ) {
+        return window.openai.toolOutput._meta["seldonframe/workspaceToken"];
+      }
+    } catch (e) {}
+    return null;
+  }
+
+  function addToWorkspace(slug) {
+    if (token) {
+      window.parent.postMessage(
+        {
+          jsonrpc: "2.0",
+          id: "deploy_" + slug + "_" + Date.now(),
+          method: "tools/call",
+          params: { name: "deploy_agent", arguments: { workspace_token: token, agent_slug: slug } },
+        },
+        "*",
+      );
+    } else {
+      window.parent.postMessage(
+        { type: "ui/message", payload: { content: "Install " + slug + " into my workspace" } },
+        "*",
+      );
+    }
+  }
+
+  function render(data) {
+    if (!data || !Array.isArray(data.agents)) return;
+    clear(row);
+    var agents = data.agents.slice(0, MAX_CARDS);
+    if (agents.length === 0) {
+      var empty = document.createElement("p");
+      empty.className = "empty";
+      empty.textContent = "No agents found.";
+      row.appendChild(empty);
+      return;
+    }
+    for (var i = 0; i < agents.length; i++) {
+      var agent = agents[i];
+      if (!agent || typeof agent.slug !== "string" || typeof agent.name !== "string") continue;
+
+      var card = document.createElement("div");
+      card.className = "card";
+
+      if (typeof agent.niche === "string" && agent.niche.length > 0) {
+        var badge = document.createElement("span");
+        badge.className = "badge";
+        badge.textContent = agent.niche;
+        card.appendChild(badge);
+      }
+
+      var name = document.createElement("p");
+      name.className = "name";
+      name.textContent = agent.name;
+      card.appendChild(name);
+
+      var desc = document.createElement("p");
+      desc.className = "desc";
+      desc.textContent = typeof agent.description === "string" ? agent.description : "";
+      card.appendChild(desc);
+
+      var cta = document.createElement("button");
+      cta.className = "cta";
+      cta.type = "button";
+      cta.textContent = "Add to my workspace";
+      (function (theSlug) {
+        cta.addEventListener("click", function () {
+          addToWorkspace(theSlug);
+        });
+      })(agent.slug);
+      card.appendChild(cta);
+
+      row.appendChild(card);
+    }
+  }
+
+  function structuredContentOf(payload) {
+    if (!payload) return null;
+    if (payload.structuredContent) return payload.structuredContent;
+    if (payload.result && payload.result.structuredContent) return payload.result.structuredContent;
+    return null;
+  }
+
+  function metaOf(payload) {
+    if (!payload) return null;
+    if (payload._meta) return payload._meta;
+    if (payload.result && payload.result._meta) return payload.result._meta;
+    return null;
+  }
+
+  window.addEventListener("message", function (event) {
+    var msg = event.data;
+    if (!msg || typeof msg !== "object") return;
+    if (msg.type === "ui/notifications/tool-result") {
+      var payload = msg.params || msg;
+      var t = findToken(metaOf(payload));
+      if (t) token = t;
+      render(structuredContentOf(payload));
+    }
+  });
+
+  try {
+    var t2 = findToken(null);
+    if (t2) token = t2;
+    if (window.openai && window.openai.toolOutput) {
+      render(window.openai.toolOutput);
+    }
+  } catch (e) {}
+})();
+</script>
+</body>
+</html>
+`;
+
+/** One MCP resource descriptor + its self-contained HTML text. */
+export type ChatGptWidgetResource = {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+};
+
+/** The `resources/list` entries for the two widgets — no `text` here (that's
+ *  `resources/read`'s job); listing stays a lightweight index. */
+export const CHATGPT_WIDGET_RESOURCES: ChatGptWidgetResource[] = [
+  {
+    uri: BUILD_RESULT_WIDGET_URI,
+    name: "Workspace build result",
+    description: "Inline card showing the newly built workspace's live URL, chips, and free claim link.",
+    mimeType: "text/html;profile=mcp-app",
+  },
+  {
+    uri: AGENT_CAROUSEL_WIDGET_URI,
+    name: "Agent carousel",
+    description: "Horizontal row of free agents from browse_marketplace, each with an install CTA.",
+    mimeType: "text/html;profile=mcp-app",
+  },
+];
+
+/** The full `resources/read` contents entry for one widget URI, or undefined
+ *  for an unknown URI (the handler turns that into a JSON-RPC error). */
+export function getChatGptWidgetResourceContent(uri: string): Record<string, unknown> | undefined {
+  const resource = CHATGPT_WIDGET_RESOURCES.find((r) => r.uri === uri);
+  if (!resource) return undefined;
+  const html = uri === BUILD_RESULT_WIDGET_URI ? BUILD_RESULT_WIDGET_HTML : AGENT_CAROUSEL_WIDGET_HTML;
+  return {
+    uri,
+    mimeType: resource.mimeType,
+    text: html,
+    _meta: widgetResourceMeta(),
+  };
+}

--- a/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-handler.spec.ts
+++ b/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-handler.spec.ts
@@ -15,6 +15,7 @@ import {
   type ChatGptMcpDeps,
 } from "../../../src/lib/chatgpt-app/chatgpt-mcp-handler";
 import { MCP_PROTOCOL_VERSION, JSONRPC_INVALID_PARAMS, JSONRPC_METHOD_NOT_FOUND } from "../../../src/lib/marketplace/agent-mcp-rpc";
+import { BUILD_RESULT_WIDGET_URI, AGENT_CAROUSEL_WIDGET_URI } from "../../../src/lib/chatgpt-app/widgets";
 import type { MarketplaceAgentRow } from "../../../src/lib/marketplace/agent-listings";
 
 const NOW = new Date("2026-06-23T12:00:00Z");
@@ -151,6 +152,70 @@ describe("handleChatGptRpc — lifecycle", () => {
   });
 });
 
+// ─── resources/list + resources/read (v2 widgets) ────────────────────────────
+
+describe("handleChatGptRpc — resources", () => {
+  test("resources/list → both widget URIs, no auth required", async () => {
+    const { deps } = makeHarness();
+    const out = await handleChatGptRpc(rpc("resources/list"), deps);
+    assert.equal(out.status, 200);
+    const resources =
+      (out.body as { result?: { resources?: Array<{ uri: string; mimeType: string }> } }).result?.resources ?? [];
+    assert.deepEqual(
+      resources.map((r) => r.uri).sort(),
+      [AGENT_CAROUSEL_WIDGET_URI, BUILD_RESULT_WIDGET_URI].sort(),
+    );
+    for (const r of resources) {
+      assert.equal(r.mimeType, "text/html;profile=mcp-app");
+    }
+  });
+
+  test("resources/read round-trips the build-result widget HTML with mimeType + _meta", async () => {
+    const { deps } = makeHarness();
+    const out = await handleChatGptRpc(rpc("resources/read", { uri: BUILD_RESULT_WIDGET_URI }), deps);
+    assert.equal(out.status, 200);
+    const contents =
+      (out.body as { result?: { contents?: Array<Record<string, unknown>> } }).result?.contents ?? [];
+    assert.equal(contents.length, 1);
+    const content = contents[0];
+    assert.equal(content.uri, BUILD_RESULT_WIDGET_URI);
+    assert.equal(content.mimeType, "text/html;profile=mcp-app");
+    assert.match(content.text as string, /<!doctype html>/i);
+    // no iframes and no <img src> (typographic-only, no remote images/requests)
+    assert.doesNotMatch(content.text as string, /<iframe/i);
+    assert.doesNotMatch(content.text as string, /<img/i);
+    const meta = content._meta as Record<string, unknown>;
+    assert.deepEqual((meta.ui as { csp?: unknown }).csp, { connectDomains: [], resourceDomains: [] });
+    assert.deepEqual(meta["openai/widgetCSP"], { connect_domains: [], resource_domains: [] });
+  });
+
+  test("resources/read round-trips the agent-carousel widget HTML", async () => {
+    const { deps } = makeHarness();
+    const out = await handleChatGptRpc(rpc("resources/read", { uri: AGENT_CAROUSEL_WIDGET_URI }), deps);
+    const contents =
+      (out.body as { result?: { contents?: Array<Record<string, unknown>> } }).result?.contents ?? [];
+    assert.equal(contents[0].uri, AGENT_CAROUSEL_WIDGET_URI);
+    assert.equal(contents[0].mimeType, "text/html;profile=mcp-app");
+    assert.match(contents[0].text as string, /Add to my workspace/);
+  });
+
+  test("resources/read with an unknown URI → a JSON-RPC error, not a crash", async () => {
+    const { deps } = makeHarness();
+    const out = await handleChatGptRpc(rpc("resources/read", { uri: "ui://widget/does-not-exist.html" }), deps);
+    assert.equal(out.status, 200);
+    const error = (out.body as { error?: { code?: number; message?: string } }).error;
+    assert.equal(error?.code, JSONRPC_INVALID_PARAMS);
+    assert.match(error?.message ?? "", /Unknown resource/);
+  });
+
+  test("resources/read with a missing uri param → a JSON-RPC error", async () => {
+    const { deps } = makeHarness();
+    const out = await handleChatGptRpc(rpc("resources/read", {}), deps);
+    const error = (out.body as { error?: { code?: number } }).error;
+    assert.equal(error?.code, JSONRPC_INVALID_PARAMS);
+  });
+});
+
 // ─── tools/call: build_workspace ─────────────────────────────────────────────
 
 describe("handleChatGptRpc — build_workspace", () => {
@@ -223,6 +288,26 @@ describe("handleChatGptRpc — build_workspace", () => {
     assert.equal(result.isError, true);
     const content = result.content as Array<{ text: string }>;
     assert.match(content[0].text, /limited to 3 per hour/);
+  });
+
+  test("carries the workspace token in the widget-only result._meta, while structuredContent stays a valid outputSchema instance", async () => {
+    const h = makeHarness();
+    const out = await handleChatGptRpc(
+      rpc("tools/call", { name: "build_workspace", arguments: { business_name: "Acme HVAC" } }),
+      h.deps,
+    );
+    const result = (out.body as { result?: Record<string, unknown> }).result!;
+
+    // Widget-only channel: the token lives at the top-level result._meta,
+    // namespaced so it can never collide with a future openai/* key.
+    const meta = result._meta as Record<string, unknown>;
+    assert.equal(meta["seldonframe/workspaceToken"], "wst_fake_token");
+
+    // structuredContent still satisfies the declared outputSchema (url +
+    // workspaceToken required) — model-visible fields are untouched.
+    const structured = result.structuredContent as { url?: string; workspaceToken?: string };
+    assert.equal(structured.url, "https://acme.app.seldonframe.com");
+    assert.equal(structured.workspaceToken, "wst_fake_token");
   });
 });
 

--- a/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-rpc.spec.ts
+++ b/packages/crm/tests/unit/chatgpt-app/chatgpt-mcp-rpc.spec.ts
@@ -20,6 +20,7 @@ import {
   formatBuildResult,
   formatDeployResult,
 } from "../../../src/lib/chatgpt-app/chatgpt-mcp-rpc";
+import { BUILD_RESULT_WIDGET_URI, AGENT_CAROUSEL_WIDGET_URI } from "../../../src/lib/chatgpt-app/widgets";
 import type { MarketplaceAgentRow } from "../../../src/lib/marketplace/agent-listings";
 
 // ─── tools/list ──────────────────────────────────────────────────────────────
@@ -92,6 +93,57 @@ describe("buildChatGptToolsList", () => {
       assert.ok(tool.outputSchema, `${tool.name} is missing outputSchema`);
       assert.equal((tool.outputSchema as { type?: string }).type, "object");
     }
+  });
+
+  // ─── v2 widgets: invocation strings + widget wiring ─────────────────────
+
+  test("every tool declares ≤64-char openai/toolInvocation invoking + invoked strings", () => {
+    const expected: Record<string, [string, string]> = {
+      build_workspace: ["Building your workspace…", "Workspace live."],
+      browse_marketplace: ["Browsing free agents…", "Agents found."],
+      deploy_agent: ["Installing agent…", "Agent installed."],
+    };
+    for (const tool of buildChatGptToolsList().tools) {
+      const meta = tool._meta as Record<string, unknown>;
+      assert.ok(meta, `${tool.name} is missing _meta`);
+      const invoking = meta["openai/toolInvocation/invoking"];
+      const invoked = meta["openai/toolInvocation/invoked"];
+      assert.equal(invoking, expected[tool.name][0]);
+      assert.equal(invoked, expected[tool.name][1]);
+      assert.ok((invoking as string).length <= 64, `${tool.name} invoking string too long`);
+      assert.ok((invoked as string).length <= 64, `${tool.name} invoked string too long`);
+    }
+  });
+
+  test("build_workspace + browse_marketplace wire ui.resourceUri + the openai/outputTemplate alias + a widgetDescription", () => {
+    const tools = buildChatGptToolsList().tools;
+    const build = tools.find((t) => t.name === "build_workspace")!;
+    const browse = tools.find((t) => t.name === "browse_marketplace")!;
+
+    const buildMeta = build._meta as Record<string, unknown>;
+    assert.equal((buildMeta.ui as { resourceUri?: string }).resourceUri, BUILD_RESULT_WIDGET_URI);
+    assert.equal(buildMeta["openai/outputTemplate"], BUILD_RESULT_WIDGET_URI);
+    assert.ok((buildMeta["openai/widgetDescription"] as string).length > 0);
+
+    const browseMeta = browse._meta as Record<string, unknown>;
+    assert.equal((browseMeta.ui as { resourceUri?: string }).resourceUri, AGENT_CAROUSEL_WIDGET_URI);
+    assert.equal(browseMeta["openai/outputTemplate"], AGENT_CAROUSEL_WIDGET_URI);
+    assert.ok((browseMeta["openai/widgetDescription"] as string).length > 0);
+  });
+
+  test("build_workspace outputSchema additively gains `name` without dropping the existing required fields", () => {
+    const tool = buildChatGptToolsList().tools.find((t) => t.name === "build_workspace")!;
+    const schema = tool.outputSchema as { properties: Record<string, unknown>; required?: string[] };
+    assert.ok("name" in schema.properties, "outputSchema should declare `name`");
+    assert.deepEqual(schema.required, ["url", "workspaceToken"]);
+  });
+
+  test("deploy_agent stays text-only (no widget resourceUri) but is openai/widgetAccessible", () => {
+    const tool = buildChatGptToolsList().tools.find((t) => t.name === "deploy_agent")!;
+    const meta = tool._meta as Record<string, unknown>;
+    assert.equal(meta["openai/widgetAccessible"], true);
+    assert.equal(meta.ui, undefined);
+    assert.equal(meta["openai/outputTemplate"], undefined);
   });
 });
 


### PR DESCRIPTION
## What

v2 of the ChatGPT app surface (SeldonFrame is live in the plugin directory): the UI upgrade that turns text-only tool output into widgets, built on the **MCP Apps standard** (`_meta.ui.resourceUri`, `ui/*` postMessage bridge) with ChatGPT compatibility aliases (`openai/outputTemplate`), so the same widgets run in any MCP Apps host.

- **`ui://widget/build-result.html`** — dark inline card for `build_workspace`: business name, live URL hero link, Website/Booking/CRM/AI-chat chips, "Open your site ↗" + "Claim it (free)". Typographic only, zero external requests, empty CSP.
- **`ui://widget/agent-carousel.html`** — free-agent carousel for `browse_marketplace` (3–8 cards, "Add to my workspace" CTA → `tools/call deploy_agent` when a token source exists, `ui/message` fallback otherwise).
- **Invocation strings** on all 3 tools ("Building your workspace…" / "Workspace live." etc.).
- Handler grows `resources/list` + `resources/read` (`text/html;profile=mcp-app`), `resources` capability, and a widget-only `_meta` channel (`seldonframe/workspaceToken`) on the build result. `structuredContent` ↔ `outputSchema` parity preserved (additive `name` field only).

Policy tripwires held: no prices, no paid agents, no upsell language, no iframes, no external fetches (free-utility contract from the approved submission).

## Verify

verify-runner: **PASS** — 516 tests green (70 chatgpt-app + adjacent suites) · 0 new tsc errors · use-server clean · no migrations · regression grep empty. Implementer-side: 66/66 chatgpt-app specs incl. 6 new groups (resources round-trip, descriptor meta, schema parity, token/_meta split).

## After merge (Max)

Deploy is backward-compatible (published v1 snapshot keeps working). To ship the widgets to users: plugin portal → new draft version → **Scan Tools after deploy** → verify resource URIs + CSP in the scan → submit with release notes → publish on approval. Screenshots of card + carousel are now expected in the submission. Full checklist in `docs/superpowers/plans/2026-07-15-chatgpt-widgets-v2.md` (ships with this PR).

Note: the rate-limit re-key session (openai/subject) is still in flight and touches `deps.ts`/handler — whichever lands second takes a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)