### PR TITLE
feat(reflect): musk pack (5 lenses) — physics thinking, the Algorithm, speed, truth loop, founder hardness

### DIFF
--- a/.claude/skills/reflect/references/00-index.md
+++ b/.claude/skills/reflect/references/00-index.md
@@ -46,5 +46,12 @@ follows the sequence in SKILL.md §3b.
 - **steve-wozniak** — craft and elegance calls (fewer parts, simpler design); build-for-joy vs build-for-money; solo design vs committee; open vs walled.
 - **outliers-best-2025** — adversity-to-advantage collection (Dyson, Firestone, Blumkin, Singleton, Price, Schwab): persistence economics, trust as strategy, contrarian capital allocation.
 
+### The Musk pack (from The Book of Elon Musk — deepens the first-principles lens)
+- **musk-physics-thinking** — cost or feasibility assumptions taken on faith ("industry standard", "that's impossible"); compute the physics floor and the theoretical limit; run the Idiot Index on anything expensive.
+- **musk-algorithm** — feature, process, or requirement creep; before optimizing or automating ANYTHING: question the requirement (with a named owner), then delete — in that order.
+- **musk-speed** — setting deadlines; choosing what to optimize next (attack THE constraint, not everything); speed as offense and defense; runway math.
+- **musk-truth-loop** — you're avoiding a metric, a post-mortem, or bad news; everyone around you agrees with you.
+- **musk-founder-hardness** — quit-the-job, found-vs-join, and persist-vs-fold calls when the stakes are existential.
+
 ## Meta
 - **mental-models-general** — the latticework: multi-model thinking, circle of competence, second-order thinking, and the quick lens list for models without a dedicated file.

--- a/.claude/skills/reflect/references/musk-algorithm.md
+++ b/.claude/skills/reflect/references/musk-algorithm.md
@@ -1,0 +1,68 @@
+---
+name: musk-algorithm
+source: https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/the-algorithm, https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/simplicity-wins
+fetched: true
+fetched_on: 2026-07-15
+---
+# Musk — the Algorithm: question, delete, simplify, accelerate, automate
+
+## Core idea
+A five-step process for improving anything — a product, a factory line, a workflow — where the ORDER is the whole point.
+First shrink the problem (question requirements, delete parts), then and only then improve what remains (simplify, accelerate, automate).
+Run the steps out of order and you polish, speed up, or robotize things that should not exist.
+
+The book's five steps, in its order and wording:
+1. **Make your requirements less dumb.** Every requirement must trace to a named person who takes responsibility — not a department, not "the spec." Requirements from smart people are the most dangerous, because you're less likely to question them.
+2. **Try very hard to delete the part or process.** The bias runs toward keeping things "just in case," so counter-bias hard: if you aren't forced to add back roughly 10% of what you deleted, you didn't delete enough.
+3. **Simplify or optimize** — only what survived deletion. The most common mistake of smart engineers is optimizing a thing that should not exist; they're trained to answer the question, not to question the question.
+4. **Accelerate cycle time.** Speed up only after the process is the right process — digging your own grave faster is not progress.
+5. **Automate — last.** The costliest error is automating a flawed process early. Tesla ripped hundreds of robots out of its lines after premature automation.
+
+The canonical cautionary tale: fiberglass mats on Tesla battery packs were automated, accelerated, and optimized — before anyone discovered they served no purpose at all. Deleting them erased ~$2M of robotics along with the part.
+
+The companion simplicity doctrine holds that simplicity IS the win condition — fewer components, fewer failure points, lower cost. "The best part is no part. The best process is no process."
+- Simplicity emerges from accumulated small removals, not one dramatic redesign (Fremont output rose ~40% by removing steps).
+- Local optimization of many parts in isolation creates global complexity: fifty independently-optimized components needing rivets AND welds AND resin were replaced by a single casting that dissolved the interfaces (Model Y's rear casting cut the body shop ~30%, ~300 robots).
+- Honest caveat from the book: simplifying is conceptually easy but brutally hard to actually do.
+
+## When it bites
+- **Feature creep** — the roadmap grows because nothing is ever deleted; every feature has a "requirement" behind it that no one owns.
+- **Process creep** — standups, approval steps, dashboards, CI stages accumulate; each was once reasonable, none has a named owner who'd defend it today.
+- **"Requirements" nobody owns** — a constraint inherited from an old decision, a departed founder, or vague "compliance," treated as physics when it's actually a person's stale opinion.
+- **Automating a broken flow** — writing cron jobs, agents, or integrations around a workflow you've never questioned; you've made the dumb thing permanent and load-bearing.
+- **Optimizing what should be deleted** — performance-tuning, refactoring, or A/B-testing a page, service, or step whose real best state is "gone."
+
+## How to run it
+Run the steps as questions, strictly in this order — never skip forward.
+Anything you're about to optimize or automate must first survive steps 1 and 2.
+
+1. **Question every requirement.**
+   Ask: "Which named human made this requirement, and would they defend it today?"
+   If the answer is a department, a doc, or "that's how it's done," the requirement is unverified.
+   Be MOST suspicious of requirements from smart, credible people — those are the ones nobody challenges.
+2. **Delete the part or process.**
+   Ask: "What happens if this part / step / feature simply doesn't exist?"
+   Delete aggressively and expect to restore some of it — if you never add anything back (~10% rule), you were too timid.
+3. **Simplify or optimize what survived.**
+   Ask: "How do we make this smaller, cheaper, cleaner?"
+   Watch for fifty local optimizations creating one global mess; prefer the single-casting move that deletes the interfaces between parts.
+4. **Accelerate cycle time.**
+   Ask: "How do we shorten the loop?" Faster builds, deploys, feedback — on a flow already verified as the right flow.
+   Speeding up the wrong process just gets you to the wrong place sooner.
+5. **Automate — last.**
+   Ask: "Now that it's questioned, pruned, simple, and fast — should a machine or agent run it?"
+   Automation is the reward for finishing steps 1–4, never a substitute for them.
+
+## Failure modes
+- **Deleting the load-bearing thing.** The 10% add-back rule assumes cheap reversibility. For one-way doors (data deletion, public API removal, burned trust), pair with Chesterton's fence: understand why the part exists, THEN delete it if the reason is dead.
+- **Using "question requirements" to dodge accountability.** Step 1 demands a named owner for every requirement; it is not a license to ignore constraints you dislike. If you delete a constraint, YOUR name goes on that decision.
+- **Deletion theater.** Cutting visible, cheap things (a meeting, a button) while the real complexity — the org structure, the architecture — goes unquestioned.
+- **Stopping at step 3.** Treating "we simplified it" as done and forfeiting the compounding wins of faster cycles; or the inverse, worshiping speed on a process nobody has questioned.
+- **Confusing simple with easy.** The book itself concedes simplifying is hard to execute. Budget real effort; it doesn't fall out of a slogan.
+
+## When building, reach for this when…
+- A feature, service, or process step is about to get an optimization/refactor sprint — first ask whether it should exist at all.
+- You're about to automate anything (agent, cron, pipeline stage): verify the underlying flow survived questioning and deletion first.
+- A spec or backlog keeps growing and nobody can name who owns each requirement — run step 1 as an audit.
+- The system has many locally-reasonable parts but the whole feels baroque — look for the single-casting move that deletes the interfaces between them.
+- You catch yourself keeping something "just in case" — that phrase is the delete-step trigger; you're supposed to occasionally be wrong about deletions.

--- a/.claude/skills/reflect/references/musk-founder-hardness.md
+++ b/.claude/skills/reflect/references/musk-founder-hardness.md
@@ -1,0 +1,61 @@
+---
+name: musk-founder-hardness
+source: https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/eat-glass-and-stare-into-the-abyss, https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/becoming-a-founder
+fetched: true
+fetched_on: 2026-07-15
+---
+# Musk — eating glass: deciding when it's existential
+
+## Core idea
+Bill Lee's line, which Musk adopted: "Starting a company is like eating glass and staring into the abyss."
+The metaphor has two distinct halves, and both are load-bearing:
+
+- **The abyss** is permanent existential threat. With 90-99% of startups failing, the founder lives with
+  *get this right or the company dies* as a background hum, not an occasional crisis.
+  Musk lived it literally — SpaceX, Tesla, and SolarCity all faced imminent death for extended stretches.
+- **The glass** is the work itself: you spend most of your time on problems the *company* needs solved,
+  not problems you *want* to solve. Founding means chewing through unglamorous, necessary work you wish
+  weren't yours — and some glass has to be chewed indefinitely, even after the abyss recedes.
+
+His decision posture under existential stakes: when bankruptcy is weeks away, spend minimal energy on the big picture.
+Hold a directional heading and accept constant zigzagging around it — you try not to deviate too far from the path,
+but you will, and that's the mechanic, not a failure of it.
+
+On who should found, he's selective rather than evangelical:
+
+- Embark only where success is *genuinely one of the possible outcomes* — a concrete, articulable path to it existing.
+- He left his Stanford PhD because the internet met that bar while academic papers mostly didn't (percentagewise, few ever get used).
+- He favors software for a first venture because it's capital-efficient — he carried $110K in college debt, and software you can write yourself, without tooling or equipment.
+- He names the fuel plainly: pressure and necessity drive creativity. His own pre-founder path ran through farm work, a lumber mill, and self-funded school — scarcity wasn't theoretical.
+
+The counterweight to all the darkness: reconcile yourself to probable failure *before* starting, and only proceed
+if you're still compelled. But don't over-fear it either — the realistic worst case isn't death or destitution.
+It's just failure.
+
+## When it bites
+- **Quit-the-job / leave-the-program decisions** — Musk's PhD exit is the template: the question isn't "is this safe?" but "is success genuinely a possible outcome here, and is it a bigger outcome than the path I'm on?"
+- **Near-death company moments** — runway measured in weeks, a make-or-break deal, a launch that must work. The lens says: shrink strategy time, hold heading, zigzag tactically.
+- **Found vs. join** — if you can't pre-accept probable failure and still feel compelled, join. Compulsion after honest odds-reckoning is the qualifying test, not confidence.
+- **Persist-vs-fold calls** — when you're deciding whether the abyss is survivable or you're just habituated to staring at it.
+- **Choosing a first venture** — the capital-efficiency filter: prefer what you can build yourself before what needs tooling, equipment, or permission.
+
+## How to run it
+1. **Pre-mortem the odds honestly.** Write down that failure is the base-rate outcome. If the pull survives that admission, proceed; if the decision only works with rosy odds, it doesn't work.
+2. **Bound the worst case.** Name what failure actually costs you (money, time, ego). Musk's point: it's rarely ruin. If the true worst case is "failure, then a job," stop pricing it as death.
+3. **Separate abyss from glass.** Existential threats get triage priority; unpleasant-but-necessary work just gets *done*. Don't let glass-eating fatigue masquerade as an existential signal.
+4. **In crisis, cut strategy to a sliver.** Fix the heading, then permit yourself large tactical deviations without re-litigating the destination each time.
+5. **Apply the possibility test to the venture itself.** Success must be certain to be among the possible outcomes — if you can't articulate a concrete path where it works, that's a no, however exciting the space.
+
+## Failure modes
+- **Glorifying suffering.** The metaphor describes the cost; it doesn't make misery a KPI. Chewing glass on problems *nobody* needs solved is just self-harm with a pitch deck.
+- **Persistence bias.** Musk's companies survived their 2008-era abysses, so the lore says "hold on." But sometimes folding IS the right call — the lens's own worst-case step exists precisely so you can fold rationally instead of clinging.
+- **Survivorship in founder lore.** We quote the founders whose abyss-staring paid off. The 90-99% who stared just as hard are silent. Treat the metaphor as a cost forecast, not a success recipe.
+- **Confusing compulsion with sunk cost.** "Still compelled after accepting failure odds" is the test at the *start*; three years in, feeling unable to stop is often just escalation of commitment wearing compulsion's clothes.
+- **Over-fearing the abyss.** The inverse failure: pricing failure as annihilation and therefore never starting (or never making the aggressive move the moment demands).
+
+## When building, reach for this when…
+- You're deciding whether to quit stable work to go full-time on the venture — run the honest-odds + bounded-worst-case sequence before the emotional argument.
+- The company hits a genuine near-death moment and you're tempted to redesign strategy instead of zigzagging tactically toward the same heading.
+- You're choosing between founding and joining, and need a test sharper than "do I believe in myself."
+- A persist-vs-fold call is live and you can't tell resilience from sunk-cost clinging — re-run the compulsion test as if starting today.
+- You're picking a first (or next) product and need the capital-efficiency filter: can I build this myself, now, without permission or heavy tooling?

--- a/.claude/skills/reflect/references/musk-physics-thinking.md
+++ b/.claude/skills/reflect/references/musk-physics-thinking.md
@@ -1,0 +1,58 @@
+---
+name: musk-physics-thinking
+source: https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/first-principles-thinking, https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/thinking-in-limits, https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/seek-the-nature-of-the-universe
+fetched: true
+fetched_on: 2026-07-15
+---
+# Musk — physics thinking: first principles, limits, ground truth
+
+## Core idea
+Most reasoning is analogy: we copy what exists because it's conventional. That's efficient for daily life but yields only slight iterations. Physics thinking replaces the copy with a derivation, in three moves:
+
+1. **First principles.** Identify what you're most confident is true at a foundational level, check it against physics (conservation laws), decompose the thing to its raw constituents, then reason upward from material facts.
+   - Tesla's canonical case: the industry priced battery packs at ~$600/kWh "forever," but pricing the raw materials (cobalt, nickel, aluminum, carbon, polymers, steel) at London Metal Exchange rates gave a cost floor of ~$80/kWh. The gap was the opportunity.
+   - At SpaceX, raw materials were only 1–2% of a finished rocket's cost — the "magic wand number" (what it would cost if assembly were free).
+   - The **Idiot Index** — finished-part cost ÷ raw-material cost — flags the inefficiency: a rocket nozzle half-jacket cost $13,000 with only $200 of steel in it.
+2. **Thinking in limits.** Scale the idea to extremes — vastly larger and vastly smaller — to see whether a constraint is inevitable physics or accumulated foolishness. Envision the theoretically perfect product (the ideal arrangement of atoms) and work backward from that limit, rather than forward from the status quo.
+   - Boring Company case: LA subway ran ~$1B/mile. Shrink tunnel diameter from 26–28 ft to 12 ft → cross-section drops ~4x → ~4–5x cheaper. Run the boring machine continuously instead of 50% of the time → 2x. Combined: ~8x cost reduction — and the machines still run far below their power/thermal limits (another 2–4x available). Cities are 3D but roads are 2D; tunnels have effectively unlimited vertical room.
+   - Manufacturing corollary: if a part is still expensive at 1M units/yr, volume isn't the problem — the design is. Optimal manufacturing asymptotes to raw materials plus licensing.
+   - Per Musk, "the word impossible is more or less banned in physics" — when a team says impossible, his counter-move is to ask what it would take.
+3. **Seek the nature of the universe (ground truth).** The chapters frame this as a philosophy of curiosity.
+   - Start from acknowledged ignorance (Musk on the meaning of life: he doesn't know — *yet*) rather than false certainty.
+   - Trust the empirically validated chain — quarks → hydrogen → 13.8 billion years → sentient beings — as proof that reasoning from physics upward actually works at the largest scale.
+   - Finding the right question is the hard part (the Douglas Adams point: the universe is the answer; the question is what's missing). Reality, not consensus or convention, is the referee.
+
+The chapters note first principles determines whether success is *possible*, never that it's guaranteed — the analysis gives you a floor and a ceiling, not a promise.
+
+## When it bites
+Reach for this lens when you hear (or catch yourself saying):
+- **Cost assumptions stated as constants** — "batteries cost $X/kWh," "AI inference costs $Y/seat," "support costs $Z/ticket." Ask what the input costs actually sum to.
+- **"That's impossible" / "that's just how the industry does it"** — the claim is either physics or habit; force the distinction.
+- **Pricing floors inherited from incumbents** — a competitor's price is their cost structure plus margin plus history, not your floor. (SF's own BYOK/COGS≈0 flat pricing is exactly this move against per-seat/per-usage taxers.)
+- **Capacity/throughput planning** — "we can handle N builds/calls/tenants per day." What does the hardware/API limit actually allow, and what fraction are you at?
+- **Make-vs-buy and vendor quotes** — any quote with a high Idiot Index (price >> underlying inputs) is a build-or-negotiate signal.
+
+## How to run it
+Concrete questions, in order:
+1. What am I most confident is true here at the foundational level? Would it survive a physics check?
+2. Decompose: what are the raw inputs (materials, API tokens, compute-hours, human-minutes) and what do they cost at spot rates? That sum is the floor.
+3. Compute the Idiot Index: current cost ÷ raw-input cost. Anything ≫10x is process, not physics.
+4. What's the theoretical limit — the perfect product/process if assembly were free and machines ran at their physical maximum? What % of that limit are we at today?
+5. Work backward from the limit: what specific constraints (diameter, duty cycle, batch size) create the gap, and which are rules/habits vs. laws?
+6. Push to extremes: what happens at 1M units? At 1 unit? If cost doesn't collapse with volume, the design is wrong.
+7. When someone says impossible: ask what it would take — enumerate the conditions instead of accepting the verdict.
+8. Am I optimizing an answer or still hunting the right question? Spend real time on question-framing before deriving.
+
+## Failure modes
+- **Physics isn't the only constraint.** Regulation, trust, distribution, org politics, and human adoption are real even though they're not in the materials bill. The $80/kWh floor took a decade of engineering to approach; the lens finds the destination, not the travel time.
+- **First-principles theater.** Re-deriving everything from atoms as a status move, or using "first principles" to dress up a conclusion you already wanted. If the decomposition doesn't change any number, it was decoration.
+- **Analogy is fine — often correct — for cheap, reversible decisions.** Copying the standard SaaS onboarding flow costs you nothing; derive from scratch only where the payoff justifies the derivation cost. Musk's own framing: analogy for daily life, first principles for the few things that must be new.
+- **Possible ≠ probable.** The chapters are explicit that the method only establishes possibility; a floor-price analysis is not a business case, and "the limit allows it" is not evidence you can execute it.
+- **Ignoring the denominator of time.** Limits reasoning tells you where the asymptote is; markets punish you for arriving at the asymptote late or early.
+
+## When building, reach for this when…
+- A vendor, incumbent, or your own spreadsheet treats a cost as fixed — decompose to raw inputs and compute the Idiot Index before accepting it.
+- You're setting pricing and tempted to anchor on competitors — derive your true COGS floor first, then price on value, not their history.
+- Someone (including you) says "impossible," "not how it's done," or "the platform won't allow it" — sort the claim into physics vs. habit, then ask what it would take.
+- You're capacity-planning or optimizing a pipeline — establish the theoretical max (tokens/sec, builds/day, calls/agent) and measure what % of it you currently hit.
+- A part/feature stays expensive despite scale — stop pushing volume and redesign; the gap to raw-input cost is a design flaw, not a volume problem.

--- a/.claude/skills/reflect/references/musk-speed.md
+++ b/.claude/skills/reflect/references/musk-speed.md
@@ -1,0 +1,72 @@
+---
+name: musk-speed
+source:
+  - https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/dont-waste-time
+  - https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/speed-is-both-offense-and-defense
+  - https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/set-aggressive-timelines
+  - https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/attack-the-constraint
+fetched: true
+fetched_on: 2026-07-15
+---
+# Musk — speed and the constraint
+
+## Core idea
+Time is the one resource you cannot buy back — Musk treats scrapping equipment or money as acceptable, scrapping time as not. From that premise, four moves compound into one operating system:
+
+1. **Don't waste time.** Run on a "maniacal sense of urgency" — the antidote to the organizational
+   decay that creeps in as companies grow. Kill meetings that don't earn their attendee-hours;
+   walking out when you add no value is respect, not rudeness. Urgency-frequency should fall
+   once the urgent thing resolves — permanent all-hands cadence is decay wearing a badge.
+2. **Speed is offense AND defense.** Offense: faster iteration means more learning cycles per
+   year, and a factory at 2x speed *is* two factories — output economics competitors need
+   5-10 plants to match. High-quality thinking compounds the same way: at scale, one good
+   half-hour of decision-making swung outcomes by roughly $100M. Defense: like the SR-71,
+   which survived 3,000+ missiles with no armor because nothing could catch it, moving fast
+   makes you hard to hit — by incumbents, and by your own burn rate (early SpaceX weighed
+   every day of delay against ~$100k/day of burn plus forgone revenue).
+3. **Aggressive timelines as forcing function.** Work expands to fill the time given; almost
+   nothing finishes ahead of schedule. So set the "impossible" date on purpose (Model 3
+   assumed all 7,000 parts arriving perfectly) — it disciplines the team, the suppliers, and
+   the sequencing, and it exposes the constraint early. Musk openly admits his schedules are
+   optimistic, sometimes delusional — the bet is that on exponential trajectories, eventual
+   delivery matters more than calendar precision. That is an honest cost, not a footnote:
+   Musk timelines famously slip, and the credibility bill comes due somewhere.
+4. **Attack THE constraint.** Throughput equals the speed of the slowest, least lucky part.
+   If 9,999 of 10,000 line elements work, the one failure sets your rate. So don't optimize
+   everywhere — find the single bottleneck and pour disproportionate effort into it. SpaceX
+   put 10-100x more engineering into the Raptor's *manufacturing system* than into the engine
+   itself; the chapter's whole claim is that design difficulty is overrated and
+   manufacturing (the constraint) is underrated by orders of magnitude.
+
+The synthesis: urgency sets the culture, speed is the strategy, aggressive dates are the mechanism, and constraint-attack is where the effort actually goes. Speed everywhere except the bottleneck is theater.
+
+## When it bites
+Builder-entrepreneur triggers:
+- **Sprint planning** — you're padding estimates "to be safe" and work is quietly expanding to fill them.
+- **Deadline setting** — choosing between a comfortable date and a forcing-function date for a launch, demo, or client deliverable.
+- **Choosing what to optimize** — the roadmap spreads effort evenly across features/polish while one step (activation, onboarding, deploy pipeline, sales follow-up) caps all throughput.
+- **Competitive pressure** — a funded incumbent or fast copycat is in your space; your only structural moat is cycle time.
+- **Cash runway math** — every week of delay has a dollar cost (burn + forgone revenue); slow shipping is silently spending the runway.
+
+## How to run it
+Concrete questions to ask against the live decision:
+- **What is THE constraint right now?** Name the single slowest/least-lucky part of the pipeline (idea→ship→user→revenue). Is this week's effort aimed at it, or at something comfortable?
+- **What would this look like in half the time — what would we cut?** Not "work twice as hard": which scope, meetings, approvals, and nice-to-haves disappear? What's left is usually the actual product.
+- **Is speed here offense or defense?** Am I buying learning cycles (offense) or outrunning burn/incumbents (defense)? If neither, the speed pressure may be fake urgency.
+- **Price the delay.** Burn per day + forgone revenue per day = the real cost of "next sprint." Does the delay still look free?
+- **Meeting audit:** which recurring meetings would I not reschedule if they vanished? Cancel those; urgency-frequency should decline once the urgent thing resolves.
+- **If the deadline is aggressive on purpose, say so** — internally it's a forcing function; externally, promise the date you'd bet on.
+
+## Failure modes
+- **Timelines that burn trust and people.** "Optimistic, sometimes delusional" dates work once as a forcing function; repeated externally-missed dates train customers, investors, and the team to discount everything you say — and grind people down. The Model 3 ramp nearly broke Tesla's workforce before it broke records.
+- **Speed on the wrong problem.** Shipping fast off-bottleneck is motion, not progress — you accumulate polished features while the one constraining step (e.g. distribution, manufacturing, activation) stays broken. Musk's own point: heroic design speed is worthless if the line moves at the slowest part.
+- **Slipping deadlines as culture.** When "the date always moves" becomes ambient, the forcing function inverts: nobody plans against dates at all, and the padding returns wearing a mask.
+- **Urgency theater.** Maniacal urgency about everything equals urgency about nothing; the point of constraint-thinking is that most things explicitly do NOT deserve the sprint.
+- **Single-point fragility.** Optimizing purely for speed concentrates risk in the least lucky part — Tesla's suppliers' fires, earthquakes, and tsunamis set the schedule. Attacking the constraint includes de-risking it.
+
+## When building, reach for this when…
+- Scoping a feature or launch and the "safe" timeline feels comfortable — halve it and cut scope instead.
+- Weekly planning: before assigning work, force one sentence naming the current bottleneck and check the plan attacks it.
+- A competitor announcement or copycat appears — respond with cycle time, not feature-count matching.
+- Runway math is tightening — convert every open project's delay into dollars/day before choosing what to pause.
+- You notice recurring meetings, approvals, or polish passes that no longer map to anything urgent — that's the decay urgency exists to prevent.

--- a/.claude/skills/reflect/references/musk-truth-loop.md
+++ b/.claude/skills/reflect/references/musk-truth-loop.md
@@ -1,0 +1,45 @@
+---
+name: musk-truth-loop
+source: https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/obsess-over-truth, https://www.elonmuskbook.org/the-book-of-elon-musk-free-online-version/feedback-over-feelings
+fetched: true
+fetched_on: 2026-07-15
+---
+# Musk — obsess over truth, feedback over feelings
+
+## Core idea
+Musk treats truth-seeking as pathological, not optional. His physics training frames it: physical law is the only non-negotiable; everything else — plans, opinions, org charts — is a recommendation. The main enemy is wishful thinking, which he names as the most natural and most costly human error in business: filtering out contradictory information, holding unvalidated axioms, and mistaking a dream for a genuinely new idea. The remedy is a running feedback loop — rigorous self-analysis plus actively solicited criticism — because when a venture starts without clear direction, survival comes from rapid adaptation to adversity, not initial perfection.
+
+The second half is the social cost of that loop. Reality doesn't care whether the rocket team feels good; it cares whether the rocket was right. So he inverts normal information flow: "All bad news should be given loudly and often" — good news quietly and once. He evaluates people on whether they can seek criticism and improve, criticizes the action rather than the person, and warns that excessive camaraderie makes teams reluctant to challenge each other's work. Sparing one person's feelings at the expense of the mission ends up hurting far more people — his example is a manager who refused to fire underperformers and thereby blocked the course correction everyone needed. He counts wanting to be liked as a real weakness.
+
+## When it bites
+- **Interpreting user feedback**: you remember the two enthusiastic users and quietly discount the five who churned silently. Churn is the physics; compliments are the recommendation.
+- **Deciding whether a launch "went well"**: "good engagement" is wishful thinking until you've validated the axiom — did anyone pay, book, or return? Define the observable end-state before you look.
+- **Metrics you avoid looking at**: the dashboard you haven't opened in two weeks is the one carrying the bad news. Bad news should be loud and frequent; if it's quiet, you've muted it, not fixed it.
+- **Advisors who only agree**: a circle that never challenges your work is the false-camaraderie trap. If nobody has recently told you something you didn't want to hear, your feedback loop is broken, not your product perfect.
+- **Pivot-or-persist calls**: the venture that started without clear direction survives by adapting to adversity fast — persisting on the original plan out of identity is wishful thinking with a roadmap.
+- **Your own demo**: you unconsciously drive around the broken path when showing the product. The path you avoid is the truth you're managing.
+
+## How to run it
+1. **Separate physics from recommendation.** For the decision at hand, list what is externally verifiable (payments, retention, latency, laws of the domain) vs. what is opinion, plan, or hope. Argue only from the first column.
+2. **Audit your axioms.** Write the 2-3 assumptions the plan rests on. For each: is it validated, is it actually relevant here, and does the conclusion really follow? Most reasoning failures are at this step, not in the logic downstream.
+3. **Run the wishful-thinking check.** Ask: "If I wanted this to be false, what evidence would I look for?" Then go look for exactly that. Filtering out contradictory data is the default; you must schedule the counter-search.
+4. **Invert the news channel.** Make bad news loud and frequent (alerts, standing review of the worst metric); let good news be quiet and once. If your reporting does the opposite, redesign it.
+5. **Solicit criticism deliberately.** Ask users, advisors, and teammates specifically what's wrong or weak — and grade yourself on whether you can receive it and improve, the same bar Musk sets for hiring.
+6. **Criticize the work, not the person** — including when the person is you. "The onboarding flow failed" keeps the loop open; "I'm bad at this" closes it.
+7. **Adapt fast on contact with adversity.** When reality contradicts the plan, the plan loses — immediately, not after one more sprint of hoping.
+
+## Failure modes
+- **Truth-obsession as license for cruelty.** The chapter itself separates the action from the person; quoting "physics doesn't care about feelings" to justify brutal, personal communication is misreading the lens. The goal is an unblocked information channel, not dominance.
+- **Mistaking one loud critic for ground truth.** A single angry user is a data point, not physics. Validate the axiom: is this critic representative, is the complaint relevant, does the conclusion follow? Loud ≠ true.
+- **Wanting-to-be-disliked as a badge.** Musk calls wanting to be liked a weakness; performing harshness to signal rigor is the same ego game wearing a different mask.
+- **Feedback loop without adaptation.** Collecting bad news loudly and then not changing course is worse than not collecting it — it trains everyone that the channel is decorative.
+- **Firing-fast theater.** The refused-to-terminate example is about unblocking course correction, not about churn for its own sake; the test is whether the change fixes the loop.
+- **Physics-cosplay for taste questions.** Not every decision has a physical ground truth; declaring your design preference "just physics" is wishful thinking promoted to law.
+- **Analysis as avoidance.** Endless axiom-auditing can itself become a way to never ship and never face the only feedback that counts: contact with users.
+
+## When building, reach for this when…
+- You're about to declare a launch, feature, or campaign a success and haven't yet defined what observable outcome would count as failure.
+- You notice a metric, cohort, or support inbox you've been avoiding for more than a few days.
+- Every recent conversation about your product has been agreeable — no advisor, user, or teammate has pushed back in weeks.
+- You're rationalizing weak numbers with a story ("early days", "wrong audience") instead of a validated axiom.
+- A teammate, contractor, or vendor is underperforming and you're protecting the relationship instead of naming the problem — check whether one person's comfort is costing the whole project.


### PR DESCRIPTION
Syncs the SF copy with the public repo (47af070): 5 Musk lenses compacted from 13 live-fetched Book-of-Elon-Musk chapters (physics-thinking incl. Idiot Index + thinking-in-limits, the 5-step Algorithm in the book's exact order, speed/attack-the-constraint, obsess-over-truth/feedback-over-feelings, eating-glass founder calls) + Musk subsection in 00-index. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)