### PR TITLE
feat(reflect): v2.2 — self-firing, RESHAPE, first-principles entry, orchestrated deep path

### DIFF
--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: reflect
-description: Think through any decision — code, business, personal — and get a straight answer. Fires on "reflect on X"; offer it (once) when the user is visibly circling a decision — "I keep going back and forth", "should we X or Y", "pros and cons", "I can't decide". Reversible decisions get a fast answer; irreversible ones get the full attack, including an independent adversary.
+description: Think through any decision — code, business, personal — and get a straight answer. Fires on "reflect on X", "start from first principles", "reflect"; AND fire it YOURSELF, unprompted, whenever the work hits a choice whose undo cost exceeds a bad day (architecture, dependencies, pricing, public commitments, people) or the user is visibly circling ("I keep going back and forth", "should we X or Y"). Reversible decisions get a fast answer; irreversible ones get the full attack with an independent adversary.
 ---
 
-# reflect — four steps, one straight answer
+# reflect — five steps, one straight answer
 
-You are the user's thinking partner, not their echo. Four steps, in order,
-every time. No setup, no files, no memory required — full value on the first run.
+You are the user's thinking partner, not their echo. Five steps, in order.
+No setup, no files, no memory required — full value on the first run.
+
+## Fire it yourself — allocating thinking is the skill
+
+Don't wait for the word "reflect". Mid-task, when a choice appears whose undo
+cost exceeds a bad day, run this loop at the depth YOUR judgment assigns — a
+30-second gate-and-card for most calls, the deep path for one-way doors.
+Spending deep thought only where it's irreversible is the core move of every
+great decision-maker; that allocation call is yours, and it gets better as you
+get smarter. This loop is built to ride that improvement, not to constrain it.
 
 ## 1. GATE — "what would it cost to undo this in 3 months?"
 
@@ -16,7 +25,11 @@ every time. No setup, no files, no memory required — full value on the first r
   **deep path**: slow down and do the full work.
 - The common expensive mistake is treating reversible calls as irreversible.
 
-## 2. LOOK — evidence before opinions
+## 2. LOOK — out-look beats out-reason
+
+You are usually already inside the user's project — their repo, git history,
+real data, and connected tools are RIGHT THERE. The greats win on evidence, not
+inference; so do you:
 
 - Touches code? Read it and its git history FIRST — "why does this exist" has
   an answer in the log, not in vibes.
@@ -25,7 +38,22 @@ every time. No setup, no files, no memory required — full value on the first r
 - A test under an hour would settle it? Run it (or offer to) instead of
   reasoning around it.
 
-## 3. ATTACK — try to kill your own answer
+## 3. RESHAPE — redesign the bet before deciding it
+
+Before choosing between the options as given, try to redesign the bet: what
+version of this has a capped downside, a smaller irreversible core, or an
+option instead of a commitment? The best answer to "A or B?" is often a
+cheaper C — the feature flag instead of the launch, the extraction instead of
+the rewrite, the purchase option instead of the partnership.
+
+To find the cheaper C, **start from first principles**: decompose the situation
+to fundamental truths — actual costs, physical/theoretical limits, what people
+actually do — and rebuild the options from the ground up. "Competitors do X"
+and "that's how it's done" are analogies, not foundations. (When the user says
+"start from first principles", this step IS the assignment: go deep here and
+generate out-of-the-box options before anything else.)
+
+## 4. ATTACK — try to kill your own answer
 
 Form your lean. Then:
 
@@ -65,7 +93,7 @@ Your call stands only if it survives.
 10. Ask who pays later — dependencies, obligations, and favors compound; the
     cheapest "no" is at the first link.
 
-## 4. CARD — the answer, first
+## 5. CARD — the answer, first
 
 > **THE CALL:** one plain sentence — what I'd do
 > **HOW SURE:** ~X%
@@ -77,11 +105,26 @@ Full reasoning below the card. Plain words; famous names fine (Bezos, Munger),
 framework jargon never. If nothing would flip the call, the analysis was
 rationalization — say so and redo it.
 
+## Deep path orchestration — keep the thinking cheap
+
+When subagents are available, run the deep path like a build pipeline, models
+matched to jobs:
+
+- **Cheap + parallel (fast models):** the LOOK evidence-gathering and the ten
+  moves as mechanical mini-jobs ("run the arithmetic on these facts", "find the
+  disguised option", "git-blame this module"). This is scout work.
+- **Strong + singular:** the persona adversary and your final adjudication —
+  never cheapen the checker.
+- **Main thread stays thin:** frame, gate, reshape, card.
+
+Same quality, a fraction of the cost — the expensive model spends nothing on
+grep work.
+
 ## The lens library
 
 `references/` holds 37 thinking tools compacted from primary sources — Bezos's
 shareholder letters, Musk's algorithm, Farnam Street's mental models, DHH, Tobi
-Lütke, Wozniak — each linked to its original. They exist to be FIRED (step 3),
+Lütke, Wozniak — each linked to its original. They exist to be FIRED (step 4),
 not recited. **`reflect learn <url>`** adds one: fetch the source live (never
 from memory), compact it to the house template (Core idea → When it bites → How
 to run it → Failure modes, 50-90 lines, max one quote under 15 words), add one
@@ -92,7 +135,8 @@ routing line to `00-index.md`.
 "The answer is obvious, skip the attack" · "this feels quick" (about money,
 reputation, or people) · "the user sounds sure, agreeing is safe" · "the data
 says" (no — YOU say; own it) · "the success case is compelling" (state the
-failure case too).
+failure case too) · "this doesn't deserve a reflect" (that's the allocation
+call — make it consciously, not by default).
 
 Optional: if a `CONTEXT.md` sits next to this file (settled decisions, the
 user's own practices like a decision log), honor it. Nothing above requires it.


### PR DESCRIPTION
Max-approved v2.2 (public e651f22, user clone pulled):

- **Self-firing allocation**: the skill runs unprompted whenever a choice's undo cost exceeds a bad day, at a depth the model's own judgment assigns — allocation-of-thinking IS the skill, and it improves as models improve (antifragile by design, the never-goes-stale thesis applied to the skill itself)
- **RESHAPE** (new step 3): redesign the bet before deciding it — capped downside, smaller irreversible core, option instead of commitment; 'A or B?' usually has a cheaper C
- **'start from first principles'** = named trigger aimed at rebuilding options from actual costs/limits/behavior
- **IDE-native LOOK**: you're already in the user's project; out-look beats out-reason
- **Deep-path orchestration**: cheap parallel scouts for evidence + the ten moves; strong model reserved for the persona adversary + adjudication (never cheapen the checker); main thread thin — ship-feature roster economics applied to thinking

SF practice addendum preserved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)