### PR TITLE
feat(pricing): name the workspace-vs-sub-account distinction; drop $29 chip from proof strip

### DIFF
--- a/packages/crm/src/app/pricing/pricing-shell-marketing.tsx
+++ b/packages/crm/src/app/pricing/pricing-shell-marketing.tsx
@@ -240,6 +240,28 @@ export function PricingShellMarketing({ isAuthed, tiers }: PricingShellMarketing
             </div>
           </div>
 
+          {/* The workspace-vs-sub-account distinction, per audience — the one
+              sentence that answers "why pay $99+ when $29 already has
+              unlimited workspaces?": the hand-off. Both lines SSR'd with the
+              inactive one hidden, same pattern as the tier rows below. */}
+          <p
+            className={`mx-auto mt-4 max-w-[62ch] text-center text-[14px] leading-[1.55] text-[#6E665A] ${audience === "personal" ? "" : "hidden"}`}
+            aria-hidden={audience !== "personal"}
+          >
+            Businesses <strong className="font-[600] text-[#221D17]">you</strong> run —
+            unlimited workspaces, all under your own login. Your clients never need an
+            account here.
+          </p>
+          <p
+            className={`mx-auto mt-4 max-w-[62ch] text-center text-[14px] leading-[1.55] text-[#6E665A] ${audience === "agency" ? "" : "hidden"}`}
+            aria-hidden={audience !== "agency"}
+          >
+            What the agency tiers add is the <strong className="font-[600] text-[#221D17]">hand-off</strong>:
+            a <strong className="font-[600] text-[#221D17]">sub-account</strong> is your
+            client&apos;s own login — their workspace and portal, wearing your brand — while
+            you keep the master view of every client.
+          </p>
+
           {/* Both audience rows are server-rendered (inactive one CSS-hidden)
               so crawlers/LLMs see all five tiers — only visibility is client
               state (preserves the 2026-07-08 SSR hotfix). */}

--- a/packages/crm/src/components/landing/marketing-pricing-section.tsx
+++ b/packages/crm/src/components/landing/marketing-pricing-section.tsx
@@ -147,6 +147,12 @@ function AgencyTierGrid() {
             <strong className="font-[600] text-[var(--lp-ink)]">0% GMV</strong> — we don&apos;t
             tax your client work. Build it free, cancel anytime.
           </p>
+          <p className="mx-auto mt-3 max-w-[62ch] text-[14px] leading-[1.55] text-[var(--lp-muted)]">
+            What these tiers buy is the <strong className="font-[600] text-[var(--lp-ink)]">hand-off</strong>:
+            a <strong className="font-[600] text-[var(--lp-ink)]">sub-account</strong> is your
+            client&apos;s own login — their workspace, their portal, wearing your brand — while
+            you keep the master view.
+          </p>
         </div>
 
         {/* Three tier cards */}
@@ -229,8 +235,9 @@ function AgencyTierGrid() {
             Build your first client workspace free →
           </Link>
           <p className="text-[13px] leading-[1.55] text-[var(--lp-muted)]">
-            Running your own business instead of clients? Builder is $29/mo (unlimited
-            workspaces, your own AI key) and Managed is $49/mo on ours.{" "}
+            Running your own business instead of clients? Builder is $29/mo — the same
+            unlimited workspaces, but everything lives under your own login: no client
+            logins, no white-label. Managed is $49/mo on our keys.{" "}
             <Link
               href="/pricing"
               className="font-[600] text-[var(--lp-accent)] underline underline-offset-2"

--- a/packages/crm/src/components/landing/marketing-proof-strip.tsx
+++ b/packages/crm/src/components/landing/marketing-proof-strip.tsx
@@ -8,10 +8,12 @@
 import { AvatarCircles } from "@/components/ui/magic/avatar-circles";
 import { EditByChatDemo } from "@/components/landing/edit-by-chat-demo";
 
+// 2026-07-16 (Max): "$29/mo flat" chip removed — the homepage sells the
+// agency tiers now, so a $29 anchor here undercut the $99+ grid below.
+// Price talk lives in the pricing section + FAQ.
 const CHIPS = [
   "Build it free",
   "Live in 3 minutes",
-  "$29/mo flat",
   "No code",
   "Cancel anytime",
 ] as const;


### PR DESCRIPTION
## What (Max's catch, 2026-07-16)

"$29 unlimited workspaces" vs "$299 unlimited sub-accounts" read as the same thing at 10× the price. The actual distinction — the **hand-off** — was never stated. One canonical sentence, placed at the three confusion points (structure intact):

1. **/pricing** — per-audience clarifier between the toggle and the tier cards (both SSR'd, inactive CSS-hidden, same pattern as the tier rows):
   - *For your businesses*: "Businesses **you** run — unlimited workspaces, all under your own login. Your clients never need an account here."
   - *For your clients' businesses*: "What the agency tiers add is the **hand-off**: a **sub-account** is your client's own login — their workspace and portal, wearing your brand — while you keep the master view of every client."
2. **Homepage pricing grid** — sub-account definition line under the 0%-GMV subhead + sharpened solo escape hatch ("the same unlimited workspaces, but everything lives under your own login: no client logins, no white-label").
3. **Proof strip** — "$29/mo flat" chip removed (Max's call; it price-anchored against the $99+ grid on the same page). Four chips remain.

All claims catalog-true (`plans.ts`: Builder `maxSubAccounts: 0`, `fullWhiteLabel: false`, `clientPortal: false`).

## Verification
- verify-build gate: checks 1–5 **PASS** — 19/19 touched-suite tests; tsc 0 new (361 = baseline both branches); use-server clean; no migrations; regression grep empty (3 expected files only)
- Check 6 (live smoke) is structurally post-deploy for a pre-merge branch — post-merge smoke covers: `/` (definition line + no "$29/mo flat" chip + escape hatch), `/pricing` (both clarifier lines SSR'd, toggle swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)