### PR TITLE
feat(landing): every free-start CTA enters through the hero chatbox

### DIFF
--- a/packages/crm/src/app/(public)/charts/ai-front-office-trends/page.tsx
+++ b/packages/crm/src/app/(public)/charts/ai-front-office-trends/page.tsx
@@ -169,7 +169,7 @@ export default function AiFrontOfficeChartPage(): ReactElement {
             builds the site, CRM, booking calendar and AI receptionist in about 3 minutes — free, before you sign up.
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 22 }}>
-            <a href="/signup" style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            <a href="/#hero-form" style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
               Start for free
             </a>
             <a

--- a/packages/crm/src/app/(public)/charts/ai-recommendation-index/page.tsx
+++ b/packages/crm/src/app/(public)/charts/ai-recommendation-index/page.tsx
@@ -221,7 +221,7 @@ export default function AiRecommendationIndexPage(): ReactElement {
             before you sign up.
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 22 }}>
-            <a href="/signup" style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            <a href="/#hero-form" style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
               Start for free
             </a>
             <a

--- a/packages/crm/src/app/docs/page.tsx
+++ b/packages/crm/src/app/docs/page.tsx
@@ -253,7 +253,7 @@ export default function DocsHome() {
           </p>
           <div className="flex flex-wrap justify-center gap-3 pt-2">
             <Link
-              href="/signup"
+              href="/#hero-form"
               className="inline-flex h-10 items-center px-5 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
             >
               Start building

--- a/packages/crm/src/components/landing/marketing-faq-section.tsx
+++ b/packages/crm/src/components/landing/marketing-faq-section.tsx
@@ -162,7 +162,7 @@ export function LandingMarketingFaqSection() {
               Compare all plans →
             </Link>
             <Link
-              href="/signup"
+              href="/#hero-form"
               className="inline-flex items-center gap-2 rounded-[11px] border border-[rgba(34,29,23,.18)] px-5 py-3 text-[14px] font-[500] text-[#221D17] transition-colors hover:border-[#1F2B24]/50"
             >
               Start free

--- a/packages/crm/src/components/landing/marketing-nav.tsx
+++ b/packages/crm/src/components/landing/marketing-nav.tsx
@@ -10,7 +10,10 @@
 // Shopify-homepage redesign (2026-07-06) — single CTA, minimal nav. The
 // center nav links, the "For agencies →" button, and the mobile drawer
 // (now unnecessary with no nav links) are removed. Right cluster is just
-// a subtle "Log in" link + one primary CTA ("Start for free" → /signup).
+// a subtle "Log in" link + one primary CTA ("Start for free" → /#hero-form,
+// the hero chatbox — Max 2026-07-16: every free-start CTA enters through the
+// chatbox so all visitors get the build-first onboarding; /signup stays for
+// Log in-adjacent and auth flows only).
 
 "use client";
 
@@ -124,7 +127,7 @@ export function MarketingNav() {
             Log in
           </Link>
           <Link
-            href="/signup"
+            href="/#hero-form"
             className="inline-flex h-9 items-center justify-center gap-2 whitespace-nowrap rounded-[11px] bg-[var(--lp-cta-bg)] px-4 text-[13.5px] font-semibold text-[var(--lp-cta-ink)] shadow-[0_1px_2px_color-mix(in_oklab,var(--lp-ink)_10%,transparent),0_6px_16px_color-mix(in_oklab,var(--lp-ink)_10%,transparent),0_18px_40px_color-mix(in_oklab,var(--lp-ink)_6%,transparent),inset_0_1.5px_0_rgba(255,255,255,.12)] transition-all hover:-translate-y-px hover:shadow-[0_2px_4px_color-mix(in_oklab,var(--lp-ink)_12%,transparent),0_12px_26px_color-mix(in_oklab,var(--lp-ink)_14%,transparent),inset_0_1.5px_0_rgba(255,255,255,.14)] active:translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--lp-accent)]"
           >
             Start for free

--- a/packages/crm/src/components/seo/claude-project-brief-generator.tsx
+++ b/packages/crm/src/components/seo/claude-project-brief-generator.tsx
@@ -136,7 +136,7 @@ export function ClaudeProjectBriefGenerator(): ReactElement {
           plus the website, CRM, booking calendar and AI receptionist the brief can only describe.
         </p>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
-          <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 14.5, textDecoration: "none" }}>
+          <a href="/#hero-form" style={{ background: INK, color: "#F6F2EA", padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 14.5, textDecoration: "none" }}>
             Build it free in 3 minutes
           </a>
           <a

--- a/packages/crm/src/lib/marketplace/render-home-markdown.ts
+++ b/packages/crm/src/lib/marketplace/render-home-markdown.ts
@@ -140,7 +140,7 @@ export function renderHomeMarkdown(baseUrl: string = HOME_BASE_URL): string {
   lines.push(`- Pricing: ${base}/pricing`);
   lines.push(`- Agent marketplace: ${base}/marketplace`);
   lines.push(`- AI agent library: ${base}/ai-agents`);
-  lines.push(`- Start free: ${base}/signup`);
+  lines.push(`- Start free (builds from the homepage chatbox): ${base}/#hero-form`);
   lines.push("");
   lines.push(`See the full homepage: ${base}/`);
   lines.push("");

--- a/packages/crm/src/lib/seo/alternative-pages-extras.ts
+++ b/packages/crm/src/lib/seo/alternative-pages-extras.ts
@@ -8,7 +8,7 @@
 
 import { getCompetitor, type Competitor } from "@/lib/seo/alternative-pages";
 
-export const START_HREF = "/signup";
+export const START_HREF = "/#hero-form";
 /** SeldonFrame-branded 15-min demo booking (bookings template row on the
  *  seldonframe workspace — see the booking_slug='default' template). */
 export const DEMO_HREF = "https://app.seldonframe.com/book/seldonframes-workspace-7798/default";

--- a/packages/crm/tests/unit/marketplace/render-home-markdown.spec.ts
+++ b/packages/crm/tests/unit/marketplace/render-home-markdown.spec.ts
@@ -60,7 +60,7 @@ describe("renderHomeMarkdown()", () => {
     assert.match(md, /https:\/\/seldonframe\.com\/marketplace/);
     assert.match(md, /https:\/\/seldonframe\.com\/ai-agents/);
     assert.match(md, /https:\/\/seldonframe\.com\/pricing/);
-    assert.match(md, /https:\/\/seldonframe\.com\/signup/);
+    assert.match(md, /https:\/\/seldonframe\.com\/#hero-form/); // Start-free link enters through the chatbox (2026-07-16)
     // No relative links leak in.
     assert.ok(!/\]\(\/[^/]/.test(md), "must not contain relative markdown links");
   });


### PR DESCRIPTION
## What (Max's call, 2026-07-16 — supersedes the #100 route-by-promise carve-out)

ALL "Start for free" / "Start free" / "Build it free" / "Start building" CTAs now get the same onboarding as the paste-URL/describe chatbox → `/#hero-form` (scroll + focus; cross-page navigations land on the homepage chatbox via the existing hashchange mechanism).

Flipped: nav · FAQ footer · docs · 2 charts pages · claude-brief tool · /home.md links line · `START_HREF` constant (= all ~10 "Start for free" buttons across vs/best/alternative/pricing SEO pages in one line).

Kept on /signup (auth/checkout context, not marketing onboarding): login "New here?" cross-link · marketplace buy-intent (`callbackUrl`) · /pricing "Get started" (plan checkout) · legacy `(marketing)/` dir untouched.

## Verification
- seo + marketplace + landing suites: **1501/1501** in the worktree (render-home-markdown spec updated to pin the new link)
- href-only string edits, each exact-count verified; verify-build gate running, verdict lands as confirmation
- Post-merge smoke: nav CTA on `/` + a vs-page CTA + `/home.md` link line

🤖 Generated with [Claude Code](https://claude.com/claude-code)