### PR TITLE
feat(seo+agencies): GHL evidence slices — ownership block + $99-vs-$497 table, vs-GHL evidence sections + honesty box, PostHog query pack

### DIFF
--- a/docs/learnings/2026-07-16-adjudicate-at-the-source.md
+++ b/docs/learnings/2026-07-16-adjudicate-at-the-source.md
@@ -1,0 +1,18 @@
+# Adjudicate quote conflicts at the source, not the intermediate doc
+
+## The problem, in one line
+Two parallel implementers quoted the same GoHighLevel help article with different words on two public pages; the reviewer blocked one as a "misquote presented as the vendor's own words" — but its only evidence was our research plan doc, an intermediate artifact.
+
+## The approach
+1. Recognize the conflict class: implementer A claimed it live-fetched the article and the plan doc's quote wasn't an exact substring; implementer B trusted the plan doc; the reviewer trusted the plan doc too. Three parties, one shared upstream source nobody in the dispute had just read.
+2. Fetch the live source (the GHL help article) and extract every candidate sentence character-for-character.
+3. Result: the article contains BOTH sentences — each quote was a verbatim substring of a different sentence. No misquote existed; the reviewer's block was a false positive created by verifying against a summary instead of the source.
+4. Fix what the conflict revealed anyway: the spec pinned the quote string but could never catch fidelity drift, so document each quote's provenance (full source sentence + fetch date + "re-verify at the source if this string changes") next to the pinned constant.
+
+## Judgment calls
+- Did NOT "apply the reviewer's fix" reflexively — swapping A's true quote for B's would have shipped a correct page while leaving the false belief (that A misquoted) on the record, and destroyed useful variety (two different verbatim sentences on two surfaces is stronger evidence, not weaker).
+- Did NOT force both surfaces onto one quote for "consistency" — consistency between quotes is not a virtue when both are independently true and serve different framings.
+- DID keep the reviewer's other findings (color drift, missing rel) — one false positive doesn't discredit a review.
+
+## The reusable rule, one line
+When two claims about a source disagree — including a reviewer vs an implementer — the tiebreaker is always a fresh fetch of the source itself, never the intermediate document either party relied on.

--- a/docs/strategy/posthog-persona-split-queries-2026-07-16.md
+++ b/docs/strategy/posthog-persona-split-queries-2026-07-16.md
@@ -1,0 +1,109 @@
+# PostHog persona-split query pack — 2026-07-16
+
+**Purpose:** settle the open bet behind the agency homepage flip (PR #100, 2026-07-15): does homepage
+traffic/conversion actually skew agency-operator, or SMB-owner? Kill threshold set at flip time:
+signups −20% over 14 days with no compensating rise in builds→claims ⇒ revert (one commit).
+
+**Why now:** since PR #106 (2026-07-16), EVERY free-start CTA funnels through one entry —
+the hero chatbox (`/#hero-form`) — so the funnel below is clean for the first time.
+
+**Project:** 497925 (events proxied via `/ingest`). Instrumentation available today: `$pageview`,
+`$autocapture`, `share_card_viewed`, `activation_step_completed` (server), MCP/LLM analytics events.
+No hero-submit custom event exists yet (see "recommended event" at the bottom) — the funnel uses
+destination pageviews as the submit proxy, which is accurate because the chatbox always navigates:
+URL tab → `/try?url=…` · describe tab → `/signup?intent=build` → `/clients/new`.
+
+> Run these in PostHog → SQL (HogQL). Adjust the host filter if www/app hosts are split in your data.
+> Or authorize the PostHog connector in claude.ai connector settings and Claude can run + chart them.
+
+---
+
+## Query A — Persona mix of homepage visitors (no new instrumentation)
+
+Classifies each person who viewed `/` in the window by the OTHER intent pages they touched:
+agency-intent (`/agencies`, `/compare/*`, `/sell`, agency guides) vs smb-intent (calculators,
+`/best/*`, charts). People touching neither = "unclassified" (expect a big bucket; the split of
+the classified tail is the signal).
+
+```sql
+WITH person_paths AS (
+  SELECT person_id,
+         groupArray(DISTINCT properties.$pathname) AS paths
+  FROM events
+  WHERE event = '$pageview'
+    AND timestamp > now() - INTERVAL 14 DAY
+  GROUP BY person_id
+)
+SELECT
+  multiIf(
+    arrayExists(p -> p LIKE '/agencies%' OR p LIKE '/compare/%' OR p LIKE '/sell%'
+                  OR p LIKE '/guides/%agency%' OR p LIKE '/guides/white-label%', paths), 'agency-intent',
+    arrayExists(p -> p LIKE '/tools/%calculator%' OR p LIKE '/best/%' OR p LIKE '/charts/%', paths), 'smb-intent',
+    'unclassified') AS persona,
+  count() AS visitors
+FROM person_paths
+WHERE arrayExists(p -> p = '/', paths)
+GROUP BY persona ORDER BY visitors DESC
+```
+
+**Read it as:** if agency-intent ≫ smb-intent among classified homepage visitors, the hero bet is
+confirmed on traffic. (Conversion is Query B.)
+
+## Query B — THE funnel: homepage → chatbox → build → claim/signup (persona-split)
+
+Create as a **Funnel insight** (UI) — steps:
+1. `$pageview` where pathname = `/`
+2. `$pageview` where pathname = `/try` **OR** (pathname = `/signup` AND `$current_url` contains `intent=build`)  ← chatbox submit proxy
+3. `$pageview` where pathname starts with `/claim` **OR** pathname starts with `/clients/new`
+4. `activation_step_completed` (any)
+
+Conversion window 14 days; breakdown by the persona cohorts from Query A (save A's two branches as
+Cohorts first: "agency-intent visitors" / "smb-intent visitors"). The persona whose funnel converts
+deeper is the persona the homepage should keep speaking to.
+
+## Query C — Kill-threshold monitor (the −20% tripwire)
+
+Weekly trend, compare the 14 days BEFORE 2026-07-15 (pre-#100) against after:
+
+```sql
+SELECT toStartOfWeek(timestamp) AS wk,
+  countIf(event='$pageview' AND properties.$pathname='/signup')                            AS signup_views,
+  countIf(event='$pageview' AND properties.$pathname='/try')                               AS anon_builds_started,
+  countIf(event='$pageview' AND properties.$pathname='/signup'
+          AND properties.$current_url LIKE '%intent=build%')                               AS describe_builds,
+  countIf(event='$pageview' AND properties.$pathname LIKE '/claim%')                       AS claims
+FROM events
+WHERE timestamp > now() - INTERVAL 6 WEEK
+GROUP BY wk ORDER BY wk
+```
+
+**Tripwire:** signup_views down >20% vs pre-flip weeks AND (anon_builds_started + describe_builds +
+claims) NOT up ⇒ revert the hero persona (one commit, PR #100's H1). Otherwise the flip stands.
+
+## Query D — Which CTA labels actually feed the chatbox (post-#106)
+
+```sql
+SELECT properties.$pathname AS page,
+       coalesce(properties.$el_text, extract(properties.elements_chain, 'text="([^"]*)"')) AS cta_label,
+       count() AS clicks
+FROM events
+WHERE event = '$autocapture'
+  AND timestamp > now() - INTERVAL 14 DAY
+  AND properties.elements_chain LIKE '%#hero-form%'
+GROUP BY page, cta_label
+ORDER BY clicks DESC LIMIT 30
+```
+
+Tells you which button ("Start for free" nav vs "Build it free" hero vs pricing-grid CTA…) and which
+page actually sends people into the chatbox — i.e., where copy iterations pay.
+
+---
+
+## Recommended follow-up event (one line, big precision win)
+
+`marketing-hero.tsx` submit handler: `posthog.capture("hero_form_submitted", { tab, hasValue: true })`
+— replaces the pageview proxy in Query B step 2 and separates "landed on /try by link" from "typed
+and submitted". Not required for the queries above to be directional.
+
+**Refresh discipline:** re-run A+B after 14 days of post-#106 data (from 2026-07-30) before making
+any persona call — today's data is mid-transition.

--- a/packages/crm/src/app/(public)/agencies/page.tsx
+++ b/packages/crm/src/app/(public)/agencies/page.tsx
@@ -12,6 +12,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { MarketingNav } from "@/components/landing/marketing-nav";
 import { MarketingAgencyMath } from "@/components/landing/marketing-agency-math";
+import { MarketingAgencyOwnership } from "@/components/landing/marketing-agency-ownership";
 import { MarketingFooter } from "@/components/landing/marketing-footer";
 
 export const metadata: Metadata = {
@@ -30,6 +31,7 @@ export default function AgenciesPage() {
       <MarketingNav />
       <main id="main-content" className="pt-[100px]">
         <MarketingAgencyMath />
+        <MarketingAgencyOwnership />
 
         {/* Guides for agency builders — cross-links into the supply-side content library. */}
         <section aria-label="Guides for agency builders" className="border-t border-[rgba(34,29,23,.08)] px-5 py-16 md:px-8 lg:px-12">

--- a/packages/crm/src/components/landing/marketing-agency-ownership.tsx
+++ b/packages/crm/src/components/landing/marketing-agency-ownership.tsx
@@ -37,8 +37,8 @@ export function MarketingAgencyOwnership() {
         {/* Ownership block */}
         <div className="grid grid-cols-1 items-start gap-10 min-[900px]:grid-cols-[1.1fr_.9fr] min-[900px]:gap-14">
           <div>
-            <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#059669]">
-              <span className="h-px w-4 bg-[#059669]" aria-hidden />
+            <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#1F2B24]">
+              <span className="h-px w-4 bg-[#1F2B24]" aria-hidden />
               No lock-in
             </div>
             <h2 className="mt-3.5 text-[clamp(27px,4.2vw,40px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#221D17]">
@@ -77,8 +77,8 @@ export function MarketingAgencyOwnership() {
 
         {/* $99-vs-$497 comparison table */}
         <div className="mt-16 md:mt-20">
-          <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#059669]">
-            <span className="h-px w-4 bg-[#059669]" aria-hidden />
+          <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#1F2B24]">
+            <span className="h-px w-4 bg-[#1F2B24]" aria-hidden />
             The math, side by side
           </div>
           <h3 className="mt-3.5 max-w-[36ch] text-[clamp(22px,3vw,30px)] font-[500] leading-[1.15] tracking-[-0.02em] text-[#221D17]">
@@ -108,7 +108,7 @@ export function MarketingAgencyOwnership() {
                   <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
                     Resell under your brand
                   </th>
-                  <td className="px-5 py-4 font-[600] text-[#059669]">$99/mo (included)</td>
+                  <td className="px-5 py-4 font-[600] text-[#1F2B24]">$99/mo (included)</td>
                   <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">
                     requires $497/mo Agency Pro (SaaS Mode)
                   </td>
@@ -135,7 +135,7 @@ export function MarketingAgencyOwnership() {
                   <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
                     Cut of what you resell
                   </th>
-                  <td className="px-5 py-4 font-[600] text-[#059669]">0% GMV on agency plans</td>
+                  <td className="px-5 py-4 font-[600] text-[#1F2B24]">0% GMV on agency plans</td>
                   <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">&mdash;</td>
                 </tr>
               </tbody>

--- a/packages/crm/src/components/landing/marketing-agency-ownership.tsx
+++ b/packages/crm/src/components/landing/marketing-agency-ownership.tsx
@@ -1,0 +1,156 @@
+// packages/crm/src/components/landing/marketing-agency-ownership.tsx
+//
+// Added 2026-07-16 per docs/strategy/ghl-pain-messaging-plan-2026-07-16.md
+// (§B — "/agencies — lead with ownership + the math story"). Two blocks:
+//
+// 1. Ownership block — the never-taxes/no-lock-in pitch, anchored to
+//    GoHighLevel's own help-center article on website export (the
+//    strongest verified pain: vendor's own docs, not a third-party claim).
+// 2. The $99-vs-$497 comparison table — SF Agency Starter vs GHL SaaS
+//    Mode + white-label mobile add-on + metered usage.
+//
+// Server component (no interactivity needed) — sibling to
+// MarketingAgencyMath, reusing its warm paper section pattern (this one
+// sits on the page's paper background rather than the dark forest block,
+// so it reads as a distinct "proof" section right after the pitch+math).
+//
+// PHRASING GUARDS (do not relax — see plan doc "prohibited claims" list):
+// - "no supported export" — never "zero data egress" or "resellers don't
+//   own their data" (both refuted).
+// - GHL's fees are PUBLISHED in its own docs — never "hidden fees".
+// - The white-label mobile app cell must read as an honest gap ("web
+//   portal, your domain"), never implied parity with a mobile app SF
+//   does not have.
+
+import Link from "next/link";
+
+const GHL_EXPORT_HELP_URL =
+  "https://help.gohighlevel.com/support/solutions/articles/155000007342";
+
+export function MarketingAgencyOwnership() {
+  return (
+    <section
+      aria-label="Ownership and pricing vs. GoHighLevel"
+      className="border-t border-[rgba(34,29,23,.08)] bg-[#F6F2EA] px-5 py-20 md:px-8 md:py-28 lg:px-12"
+    >
+      <div className="mx-auto max-w-[1120px]">
+        {/* Ownership block */}
+        <div className="grid grid-cols-1 items-start gap-10 min-[900px]:grid-cols-[1.1fr_.9fr] min-[900px]:gap-14">
+          <div>
+            <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#059669]">
+              <span className="h-px w-4 bg-[#059669]" aria-hidden />
+              No lock-in
+            </div>
+            <h2 className="mt-3.5 text-[clamp(27px,4.2vw,40px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#221D17]">
+              Own everything.{" "}
+              <em className="font-[Newsreader,Georgia,serif] font-normal not-italic text-[rgba(34,29,23,.6)]">
+                Leave anytime.
+              </em>
+            </h2>
+            <p className="mt-4 max-w-[54ch] text-[15.5px] leading-[1.55] text-[rgba(34,29,23,.72)]">
+              SeldonFrame is open source (AGPL-3.0) — run it on our cloud or self-host it yourself.
+              Every client site, agent, CRM record, and piece of content your agency builds exports
+              any time: contacts and deals as JSON, agents as portable configs, sites as their own
+              hosted pages. There&rsquo;s no claim step, no export request, no waiting on us. A public
+              Docker image exists for the day you want to run it entirely on your own infrastructure.
+            </p>
+          </div>
+
+          <blockquote className="rounded-[20px] border border-[rgba(34,29,23,.1)] bg-white px-7 py-6 shadow-[0_1px_2px_rgba(34,29,23,.04),0_20px_44px_rgba(34,29,23,.06)]">
+            <p className="m-0 text-[15px] italic leading-[1.6] text-[#221D17]">
+              GoHighLevel&rsquo;s own help center: HighLevel &ldquo;
+              <Link
+                href={GHL_EXPORT_HELP_URL}
+                target="_blank"
+                rel="nofollow noopener"
+                className="not-italic underline decoration-[rgba(34,29,23,.3)] underline-offset-2 hover:decoration-[#221D17]"
+              >
+                does not support exporting websites in a way that allows them to be managed
+              </Link>
+              &rdquo; outside its platform — no supported export.
+            </p>
+            <p className="m-0 mt-3 text-[11.5px] uppercase tracking-[0.08em] text-[rgba(34,29,23,.45)]">
+              GoHighLevel help center, accessed July 2026
+            </p>
+          </blockquote>
+        </div>
+
+        {/* $99-vs-$497 comparison table */}
+        <div className="mt-16 md:mt-20">
+          <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[#059669]">
+            <span className="h-px w-4 bg-[#059669]" aria-hidden />
+            The math, side by side
+          </div>
+          <h3 className="mt-3.5 max-w-[36ch] text-[clamp(22px,3vw,30px)] font-[500] leading-[1.15] tracking-[-0.02em] text-[#221D17]">
+            Reselling under your own brand, priced honestly
+          </h3>
+          <p className="mt-2 max-w-[60ch] text-[13.5px] leading-[1.55] text-[rgba(34,29,23,.6)]">
+            Per GoHighLevel&rsquo;s published pricing, July 2026.
+          </p>
+
+          <div className="mt-6 overflow-x-auto rounded-[18px] border border-[rgba(34,29,23,.1)] bg-white">
+            <table className="w-full min-w-[640px] border-collapse text-left text-[14px]">
+              <thead>
+                <tr className="border-b border-[rgba(34,29,23,.1)]">
+                  <th scope="col" className="px-5 py-4 font-[600] text-[rgba(34,29,23,.55)]">
+                    &nbsp;
+                  </th>
+                  <th scope="col" className="px-5 py-4 font-[600] text-[#221D17]">
+                    SeldonFrame Agency Starter
+                  </th>
+                  <th scope="col" className="px-5 py-4 font-[600] text-[#221D17]">
+                    GoHighLevel
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-[rgba(34,29,23,.08)]">
+                  <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
+                    Resell under your brand
+                  </th>
+                  <td className="px-5 py-4 font-[600] text-[#059669]">$99/mo (included)</td>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">
+                    requires $497/mo Agency Pro (SaaS Mode)
+                  </td>
+                </tr>
+                <tr className="border-b border-[rgba(34,29,23,.08)]">
+                  <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
+                    White-label client access
+                  </th>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">web portal, your domain — included</td>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">white-label mobile app: +$497/mo add-on</td>
+                </tr>
+                <tr className="border-b border-[rgba(34,29,23,.08)]">
+                  <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
+                    Usage
+                  </th>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">
+                    flat — no per-email/SMS platform meter (BYOK / BYO-Twilio at provider cost)
+                  </td>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">
+                    metered per email ($0.675/1k) + per SMS segment + per voice minute
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row" className="px-5 py-4 font-[500] text-[rgba(34,29,23,.7)]">
+                    Cut of what you resell
+                  </th>
+                  <td className="px-5 py-4 font-[600] text-[#059669]">0% GMV on agency plans</td>
+                  <td className="px-5 py-4 text-[rgba(34,29,23,.72)]">&mdash;</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-3 max-w-[70ch] text-[12px] leading-[1.5] text-[rgba(34,29,23,.45)]">
+            GoHighLevel&rsquo;s fees are published in its own pricing and support docs, not hidden —
+            we&rsquo;re just laying them next to ours. It also offers mitigations at the $497 tier
+            (bring-your-own SMTP, usage rebilling with markup) that narrow this gap; we&rsquo;re
+            comparing what each plan includes at its own price, not claiming GoHighLevel is
+            deceptive about it.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/crm/src/components/seo/seldonframe-vs-page.tsx
+++ b/packages/crm/src/components/seo/seldonframe-vs-page.tsx
@@ -194,7 +194,7 @@ export function SeldonFrameVsPage({ competitor }: { competitor: Competitor }): R
                   >
                     {`"${sec.quote.text}"`}
                     <div style={{ marginTop: 6, fontSize: 12.5, fontStyle: "normal", fontWeight: 600 }}>
-                      <a href={sec.quote.href} className="sf-link" style={{ color: MKT.green, textDecoration: "underline" }}>
+                      <a href={sec.quote.href} rel="nofollow noopener" className="sf-link" style={{ color: MKT.green, textDecoration: "underline" }}>
                         {sec.quote.source}
                       </a>
                       {" — accessed July 2026"}

--- a/packages/crm/src/components/seo/seldonframe-vs-page.tsx
+++ b/packages/crm/src/components/seo/seldonframe-vs-page.tsx
@@ -164,6 +164,79 @@ export function SeldonFrameVsPage({ competitor }: { competitor: Competitor }): R
           />
         </section>
 
+        {/* ── EVIDENCE-ORDERED DEEP-DIVE SECTIONS (OPTIONAL — only present when
+            the competitor supplies evidenceSections; every other competitor
+            page is unaffected) ── */}
+        {c.evidenceSections && c.evidenceSections.length > 0 ? (
+          <section style={{ padding: "34px 0 8px" }}>
+            <h2 style={H2}>{`${c.name}, evidence first`}</h2>
+            {c.evidenceSections.map((sec) => (
+              <div key={sec.title} style={{ marginTop: 22, maxWidth: 760 }}>
+                <h3 style={{ margin: 0, fontSize: 18.5, fontWeight: 800 }}>{sec.title}</h3>
+                {sec.paragraphs.map((p, i) => (
+                  <p key={i} style={{ margin: "10px 0 0", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.78)" }}>
+                    {emphasize(p)}
+                  </p>
+                ))}
+                {sec.quote ? (
+                  <blockquote
+                    style={{
+                      margin: "12px 0 0",
+                      padding: "12px 18px",
+                      borderLeft: `3px solid ${MKT.green}`,
+                      background: MKT.green10,
+                      borderRadius: "0 10px 10px 0",
+                      fontSize: 14.5,
+                      lineHeight: 1.6,
+                      fontStyle: "italic",
+                      color: "rgba(34,29,23,0.82)",
+                    }}
+                  >
+                    {`"${sec.quote.text}"`}
+                    <div style={{ marginTop: 6, fontSize: 12.5, fontStyle: "normal", fontWeight: 600 }}>
+                      <a href={sec.quote.href} className="sf-link" style={{ color: MKT.green, textDecoration: "underline" }}>
+                        {sec.quote.source}
+                      </a>
+                      {" — accessed July 2026"}
+                    </div>
+                  </blockquote>
+                ) : null}
+                {sec.contrast ? (
+                  <p style={{ margin: "10px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.7)" }}>
+                    <strong style={{ color: MKT.green }}>SeldonFrame: </strong>
+                    {emphasize(sec.contrast)}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </section>
+        ) : null}
+
+        {/* ── HONESTY BOX (OPTIONAL — the never-lies proof) ── */}
+        {c.honestyBox ? (
+          <section style={{ padding: "20px 0 8px" }}>
+            <div
+              style={{
+                border: `1.5px solid ${MKT.ink10}`,
+                borderRadius: 16,
+                padding: "20px 24px",
+                background: "rgba(255,255,255,0.6)",
+                maxWidth: 760,
+              }}
+            >
+              <h3 style={{ margin: 0, fontSize: 16.5, fontWeight: 800 }}>{c.honestyBox.title}</h3>
+              <ul style={{ margin: "12px 0 0", padding: 0, listStyle: "none" }}>
+                {c.honestyBox.items.map((item) => (
+                  <li key={item} style={{ fontSize: 14, lineHeight: 1.6, color: "rgba(34,29,23,0.75)", marginBottom: 8 }}>
+                    <span style={{ color: MKT.green, fontWeight: 800, marginRight: 8 }}>✓</span>
+                    {emphasize(item)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        ) : null}
+
         {/* ── THE TWO CONTENDERS ── */}
         <section className="sf-sfvs-cards" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16, padding: "10px 0 8px" }}>
           <div style={{ border: "1.5px solid rgba(31, 43, 36,0.4)", borderRadius: 16, padding: "22px 24px", background: "rgba(31, 43, 36,0.05)" }}>

--- a/packages/crm/src/lib/seo/alternative-pages.ts
+++ b/packages/crm/src/lib/seo/alternative-pages.ts
@@ -16,6 +16,31 @@ export const LAST_UPDATED = "July 2026";
 export type AltFaqItem = { q: string; a: string };
 export type SwitchReason = { title: string; body: string };
 
+/** A single evidence-ordered section on the /compare/seldonframe-vs-<slug>
+ *  page — OPTIONAL, competitor-specific, and rendered by
+ *  components/seo/seldonframe-vs-page.tsx only when a competitor supplies
+ *  `evidenceSections`. Every claim must trace to a primary/attributed source
+ *  (see docs/strategy/ghl-pain-messaging-plan-2026-07-16.md for the pattern);
+ *  no competitor other than the one populating this field is affected. */
+export type EvidenceSection = {
+  /** Section heading, e.g. "The lock-in: no supported export". */
+  title: string;
+  /** Body paragraphs, rendered in order. */
+  paragraphs: string[];
+  /** Optional short, attributed verbatim quote from the competitor's own
+   *  material (kept under 15 words per copyright/never-lies discipline). */
+  quote?: { text: string; source: string; href: string };
+  /** The honest SF contrast sentence closing out the section. */
+  contrast?: string;
+};
+
+/** The visually distinct "what they get right / what's true for everyone"
+ *  callout — the never-lies proof. OPTIONAL; renders only when present. */
+export type HonestyBox = {
+  title: string;
+  items: string[];
+};
+
 export type Competitor = {
   /** URL slug: /alternative-to-<slug> */
   slug: string;
@@ -47,6 +72,13 @@ export type Competitor = {
   /** Honest "choose them if…" sentence. */
   whenTheyWin: string;
   faq: AltFaqItem[];
+  /** OPTIONAL — evidence-ordered deep-dive sections for the vs-page (used
+   *  only by gohighlevel as of 2026-07-16; every other competitor omits this
+   *  and renders byte-identically to before). Order in the array is render
+   *  order — strongest evidence first. */
+  evidenceSections?: EvidenceSection[];
+  /** OPTIONAL — the honesty-box callout (used only by gohighlevel). */
+  honestyBox?: HonestyBox;
 };
 
 /** SeldonFrame's side of the comparison table — identical on every page. */
@@ -139,6 +171,56 @@ export const COMPETITORS: Competitor[] = [
         a: "Yes. Client workspaces, a branded client portal, and custom domains are included starting at $99/mo — not locked behind a $497/mo tier.",
       },
     ],
+    evidenceSections: [
+      {
+        title: "The lock-in: no supported export",
+        paragraphs: [
+          "GoHighLevel's own help center is explicit about what happens if you ever want to leave: your funnel and website pages don't come with you. The article's own words:",
+          "Sub-account transfers off an agency's master account are agency-initiated only, and white-label sub-accounts can't transfer at all — integrations, phone numbers, and email senders sever the moment a sub-account moves.",
+        ],
+        quote: {
+          text: "does not provide tools, guidance, or support for copying, hosting, or maintaining",
+          source: "GoHighLevel help center, article 155000007342",
+          href: "https://help.gohighlevel.com/support/solutions/articles/155000007342",
+        },
+        contrast:
+          "SeldonFrame is AGPL-3.0 open source and self-hostable — every workspace exports as JSON, and nothing about leaving requires the vendor's help.",
+      },
+      {
+        title: "The complexity: a real learning curve",
+        paragraphs: [
+          "GoHighLevel's own G2 review base tells a consistent story: Learning Curve (141 mentions), Steep Learning Curve (90), and Not Intuitive (56) — 287 grouped mentions in G2's AI-tallied cons summary as of July 2026 (directional, since categories can overlap). Capterra's aggregate ease-of-use sub-score sits at 3.7/5, the lowest of its rated categories. Reviewers report implementations commonly taking 2–4 weeks to get running.",
+        ],
+        contrast:
+          "A SeldonFrame workspace — site, CRM, booking calendar, intake, and the AI agent — is generated from one conversation in about 3 minutes.",
+      },
+      {
+        title: "The pricing stack",
+        paragraphs: [
+          "GoHighLevel's published pricing page (per GoHighLevel's pricing page, July 2026) lists a $97/$297/$497 monthly ladder. SaaS Mode — reselling the platform under your own brand — requires the $497/mo tier, and white-label mobile branding is a separate $497/mo add-on on any tier. On top of the subscription, usage is metered by default: $0.675 per 1,000 LC emails, per-segment SMS, and per-minute voice, drawn from an auto-refilling wallet on the agency's card. Add-ons stack further: $97/mo per sub-account for the AI Employee, $297/mo for HIPAA (which can't be disabled once purchased), and $500/mo for premium support.",
+          "These numbers are published in GoHighLevel's own support docs — they're just absent from the top-level marketing pages. To GoHighLevel's credit, there are real mitigations: agencies can bring their own SMTP to cut email costs, and usage rebilling with markup becomes available on the $497 tier.",
+        ],
+        contrast:
+          "SeldonFrame's agency tiers are flat — $99/$199/$299/mo, whitelabel and client portal included, 0% GMV fee on agency tiers, and AI/telephony run on your own keys at provider cost. The marketplace's 5% fee only ever applies to marketplace transactions, never to the subscription tier.",
+      },
+      {
+        title: "Reliability, as reviewers report it",
+        paragraphs: [
+          "Individual reviewers report real incidents: a 30–45-day phone outage described in a G2 review dated 2026-06-29; misfired workflow emails sent to the wrong recipients; and a status-page feature request that's stayed open on GoHighLevel's own community board since April 2023. These are reviewer reports, not a claim that GoHighLevel is broadly unreliable — see the honesty box below for the aggregate rating.",
+        ],
+        contrast:
+          "Rather than generalize from anyone's outages, SeldonFrame sells its own never-lies machinery directly: grounded responses, an enforced read-back before anything is booked, guardrails, and automatic evals on every agent.",
+      },
+    ],
+    honestyBox: {
+      title: "What GoHighLevel gets right — and what's true for everyone",
+      items: [
+        "GoHighLevel rates 4.2/5 on Capterra and 4.6/5 on G2 in aggregate — the complaints above are real but are the minority voice, not the average experience.",
+        "Its fees are published in its own support documentation; nothing here is a hidden or secret charge.",
+        "A2P 10DLC carrier registration delays apply to every SMS platform, SeldonFrame included — this isn't a GoHighLevel-specific problem.",
+        "For a large team that wants one all-in-one platform with a huge template ecosystem and is willing to invest the ramp-up time, GoHighLevel is a legitimate, well-reviewed choice.",
+      ],
+    },
   },
   {
     slug: "vapi",

--- a/packages/crm/tests/unit/landing/marketing-agency-ownership.spec.ts
+++ b/packages/crm/tests/unit/landing/marketing-agency-ownership.spec.ts
@@ -43,6 +43,11 @@ const GHL_EXPORT_HELP_URL =
 
 // The verbatim quote embedded in the component — must stay <=15 words and
 // must be a substring of the article text confirmed in the plan doc.
+// Source-verified 2026-07-16 against the live article (last updated 2026-02-10):
+// full sentence = "HighLevel does not support exporting websites in a way that allows
+// them to be managed or edited outside the HighLevel platform." The vs-GHL page
+// quotes a DIFFERENT verbatim sentence from the same article (the external-hosting
+// one) — both are true; re-verify against the source if either string changes.
 const VERBATIM_QUOTE =
   "does not support exporting websites in a way that allows them to be managed";
 

--- a/packages/crm/tests/unit/landing/marketing-agency-ownership.spec.ts
+++ b/packages/crm/tests/unit/landing/marketing-agency-ownership.spec.ts
@@ -1,0 +1,104 @@
+// Snapshot-shape tests for MarketingAgencyOwnership.
+//
+// 2026-07-16 addition per docs/strategy/ghl-pain-messaging-plan-2026-07-16.md
+// (§B "/agencies — lead with ownership + the math story"). Pins:
+// - the GHL help-center link href (verified export article)
+// - the verbatim quote (<=15 words) from that article
+// - the "July 2026" datestamp on the pricing table
+// - $99 and $497 both present (the comparison anchors)
+// - absence of prohibited claims from the plan doc's refuted-claims list
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { MarketingAgencyOwnership } from "../../../src/components/landing/marketing-agency-ownership";
+
+type AnyEl = { props?: Record<string, unknown>; type?: unknown };
+
+function flatten(node: unknown, acc: AnyEl[] = []): AnyEl[] {
+  if (!node || typeof node !== "object") return acc;
+  const el = node as AnyEl;
+  acc.push(el);
+  const children = el.props?.children;
+  if (Array.isArray(children)) for (const c of children) flatten(c, acc);
+  else if (children) flatten(children, acc);
+  return acc;
+}
+
+// JSON.stringify-safe serializer (mirrors marketing-faq.spec.ts / marketing-pricing.spec.ts).
+function safeText(node: unknown): string {
+  const seen = new WeakSet<object>();
+  return JSON.stringify(node, (_key, value) => {
+    if (typeof value === "function") return undefined;
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value as object)) return "[Circular]";
+      seen.add(value as object);
+    }
+    return value;
+  });
+}
+
+const GHL_EXPORT_HELP_URL =
+  "https://help.gohighlevel.com/support/solutions/articles/155000007342";
+
+// The verbatim quote embedded in the component — must stay <=15 words and
+// must be a substring of the article text confirmed in the plan doc.
+const VERBATIM_QUOTE =
+  "does not support exporting websites in a way that allows them to be managed";
+
+const PROHIBITED = /hidden fee|secret fee|zero data egress|don't own their data|doesn't own their data/i;
+
+describe("MarketingAgencyOwnership — ownership block + $99-vs-$497 table", () => {
+  test("links to the GHL export help-center article with rel=nofollow noopener", () => {
+    const result = MarketingAgencyOwnership();
+    const links = flatten(result).filter(
+      (el) => (el.props as { href?: string })?.href === GHL_EXPORT_HELP_URL,
+    );
+    assert.equal(links.length, 1, "expected exactly one link to the GHL export help article");
+    const props = links[0].props as { rel?: string; target?: string };
+    assert.equal(props.rel, "nofollow noopener");
+    assert.equal(props.target, "_blank");
+  });
+
+  test("the verbatim GHL quote is present and stays under 15 words", () => {
+    const wordCount = VERBATIM_QUOTE.trim().split(/\s+/).length;
+    assert.ok(wordCount <= 15, `quote must be <=15 words, got ${wordCount}`);
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.ok(text.includes(VERBATIM_QUOTE), "verbatim quote missing from rendered output");
+  });
+
+  test("attributes the quote to the GHL help center, dated July 2026", () => {
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.match(text, /GoHighLevel help center, accessed July 2026/);
+  });
+
+  test("the pricing table is datestamped and carries $99 + $497", () => {
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.match(text, /per GoHighLevel.s published pricing, July 2026/i);
+    assert.match(text, /\$99\/mo/);
+    assert.match(text, /\$497\/mo/);
+  });
+
+  test("the white-label mobile cell states an honest gap, not parity", () => {
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.match(text, /web portal, your domain/i);
+    assert.match(text, /white-label mobile app: \+\$497\/mo add-on/i);
+  });
+
+  test("says 'no supported export', never the refuted/prohibited phrasings", () => {
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.match(text, /no supported export/i);
+    assert.doesNotMatch(text, PROHIBITED);
+  });
+
+  test("0% GMV framed about SF alone; GHL cell is a neutral dash, not implying GHL takes a cut", () => {
+    const result = MarketingAgencyOwnership();
+    const text = safeText(result);
+    assert.match(text, /0% GMV on agency plans/);
+  });
+});

--- a/packages/crm/tests/unit/seo/vs-ghl-evidence.spec.ts
+++ b/packages/crm/tests/unit/seo/vs-ghl-evidence.spec.ts
@@ -1,0 +1,98 @@
+// TDD guardrail for the 2026-07-16 vs-GoHighLevel evidence-ordered upgrade
+// (docs/strategy/ghl-pain-messaging-plan-2026-07-16.md). Pins:
+//  - the gohighlevel entry's optional evidenceSections + honestyBox render on
+//    /compare/seldonframe-vs-gohighlevel, lock-in FIRST, with the help-center
+//    quote + link + datestamp and the honesty-box aggregate ratings + A2P line
+//  - the prohibited-claims list (per the plan doc) is absent from the
+//    rendered page
+//  - the optional-fields design means every OTHER competitor renders with
+//    zero drift (no evidence sections, no honesty box) — the no-fields-no-
+//    change proof
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+
+import { COMPETITORS, getCompetitor } from "../../../src/lib/seo/alternative-pages";
+import { SeldonFrameVsPage } from "../../../src/components/seo/seldonframe-vs-page";
+
+function renderVsPage(slug: string): string {
+  const competitor = getCompetitor(slug);
+  return renderToStaticMarkup(createElement(SeldonFrameVsPage, { competitor }) as any);
+}
+
+const PROHIBITED = /hidden fee|secret fee|zero data egress|don't own their data|\$2k|2,000\/mo/i;
+const SMS_PROVISIONING_COMPARISON = /weeks? (to|for) (get|provision).{0,20}(number|sms)/i;
+
+test("gohighlevel entry declares evidenceSections with lock-in FIRST", () => {
+  const c = getCompetitor("gohighlevel");
+  assert.ok(c.evidenceSections && c.evidenceSections.length >= 4, "expected at least 4 evidence sections");
+  const titles = c.evidenceSections!.map((s) => s.title);
+  assert.match(titles[0], /lock-in/i, `first evidence section should be lock-in, got: ${titles[0]}`);
+});
+
+test("gohighlevel evidenceSections carry the help-center quote + link + datestamp", () => {
+  const c = getCompetitor("gohighlevel");
+  const lockIn = c.evidenceSections!.find((s) => /lock-in/i.test(s.title));
+  assert.ok(lockIn?.quote, "lock-in section missing a quote");
+  assert.equal(lockIn!.quote!.href, "https://help.gohighlevel.com/support/solutions/articles/155000007342");
+  assert.ok(lockIn!.quote!.text.split(/\s+/).length <= 15, "quote exceeds 15 words");
+  assert.ok(lockIn!.quote!.text.length > 0);
+});
+
+test("/compare/seldonframe-vs-gohighlevel renders the evidence sections, lock-in first, before the honesty box", () => {
+  const html = renderVsPage("gohighlevel");
+  const lockInIdx = html.search(/lock-in/i);
+  const complexityIdx = html.search(/complexity|learning curve/i);
+  const pricingStackIdx = html.search(/pricing stack/i);
+  const reliabilityIdx = html.search(/reliability, as reviewers report/i);
+  const honestyIdx = html.search(/What GoHighLevel gets right/i);
+
+  assert.ok(lockInIdx > -1, "lock-in section not rendered");
+  assert.ok(complexityIdx > lockInIdx, "complexity section should render after lock-in");
+  assert.ok(pricingStackIdx > complexityIdx, "pricing-stack section should render after complexity");
+  assert.ok(reliabilityIdx > pricingStackIdx, "reliability section should render after pricing-stack");
+  assert.ok(honestyIdx > reliabilityIdx, "honesty box should render after all evidence sections");
+});
+
+test("/compare/seldonframe-vs-gohighlevel renders the honesty box with both aggregate ratings and the A2P line", () => {
+  const html = renderVsPage("gohighlevel");
+  assert.match(html, /4\.6\/5/);
+  assert.match(html, /4\.2\/5/);
+  assert.match(html, /A2P 10DLC carrier registration delays apply to every SMS platform/i);
+});
+
+test("/compare/seldonframe-vs-gohighlevel absolutely never contains a prohibited claim", () => {
+  const html = renderVsPage("gohighlevel");
+  assert.doesNotMatch(html, PROHIBITED, "prohibited phrase leaked into the GHL vs-page");
+});
+
+test("/compare/seldonframe-vs-gohighlevel never compares SMS/phone provisioning time against SeldonFrame", () => {
+  const html = renderVsPage("gohighlevel");
+  assert.doesNotMatch(html, SMS_PROVISIONING_COMPARISON, "SMS-provisioning-time comparison leaked into the GHL vs-page");
+});
+
+test("the help-center link is rendered as an anchor on the page", () => {
+  const html = renderVsPage("gohighlevel");
+  assert.match(html, /href="https:\/\/help\.gohighlevel\.com\/support\/solutions\/articles\/155000007342"/);
+});
+
+// ─── no-drift proof: at least one other competitor is byte-identical to the
+// pre-upgrade shape (no evidenceSections/honestyBox fields → no new markup) ──
+
+test("a non-gohighlevel competitor (vendasta) declares no evidenceSections/honestyBox and renders none", () => {
+  const c = getCompetitor("vendasta");
+  assert.equal(c.evidenceSections, undefined);
+  assert.equal(c.honestyBox, undefined);
+
+  const html = renderVsPage("vendasta");
+  assert.doesNotMatch(html, /What GoHighLevel gets right/i);
+  assert.doesNotMatch(html, /evidence first/i);
+  assert.doesNotMatch(html, PROHIBITED);
+});
+
+test("only gohighlevel among all competitors declares evidenceSections/honestyBox (scope guard)", () => {
+  const withEvidence = COMPETITORS.filter((c) => c.evidenceSections || c.honestyBox).map((c) => c.slug);
+  assert.deepEqual(withEvidence, ["gohighlevel"]);
+});

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2391,3 +2391,4 @@ left in the stack — never touch/drop a stash you didn't push yourself.
 Prevention: to diff/typecheck a "before my change" baseline in a worktree,
 use `git worktree add` against a specific commit, or `git show <sha>:<path>`,
 or just re-run the same check on the parent repo path — never stash.
+- 2026-07-16 — Quote disputes (reviewer vs implementer) are settled by re-fetching the SOURCE, never the plan doc both relied on: the 'misquote' block was a false positive — both quotes were verbatim substrings of different sentences. (docs/learnings/2026-07-16-adjudicate-at-the-source.md)


### PR DESCRIPTION
## What (the two big slices from the GHL pain research, Max-approved 2026-07-16)

All claims trace to `docs/strategy/ghl-pain-messaging-plan-2026-07-16.md` (deep-research verified: 99 agents, 23 claims confirmed 3-vote adversarial, 2 refuted-and-prohibited).

### 1. /agencies — ownership block + comparison table (`marketing-agency-ownership.tsx`, new)
- **"Own everything. Leave anytime."** — AGPL-3.0, self-host or cloud, JSON export — anchored to GoHighLevel's own help article stating websites can't be exported (14-word verbatim quote, linked `rel="nofollow noopener"`, "accessed July 2026")
- **The table**: SF Agency Starter $99/mo (reselling + white-label + portal included, 0% GMV) vs GHL $497/mo SaaS Mode + $497/mo white-label mobile add-on + per-email/SMS/minute meters — datestamped "per GoHighLevel's published pricing, July 2026", with GHL's mitigations honestly stated (BYO-SMTP, $497-tier rebilling)

### 2. /compare/seldonframe-vs-gohighlevel — evidence-ordered sections + honesty box
- New OPTIONAL `evidenceSections`/`honestyBox` fields on `Competitor` — populated **only** for gohighlevel; every other comparison page renders byte-identically (no-drift test on vendasta + scope-guard test pinning `["gohighlevel"]` as sole carrier)
- Evidence order = evidence strength: **lock-in** (GHL's own doc, quoted verbatim) → **complexity** (287 grouped G2 mentions, attributed 2–4-week implementations) → **pricing stack** ("published in GHL's own support docs — absent from marketing pages", never "hidden") → **reliability** (dated reviewer reports only, inside the honest aggregate)
- **Honesty box**: GHL's real 4.2/4.6 ratings · fees are published · A2P delays bind every SMS platform including us · "GHL is a legitimate choice" for the right buyer — the never-lies proof no competitor page has

### 3. PostHog persona-split query pack (`docs/strategy/`)
4 paste-ready HogQL queries (persona mix · single-entry funnel post-#106 · the −20% kill-threshold monitor · CTA attribution). Re-run from 2026-07-30 for clean post-#106 data.

## Verification
- Independent reviewer: SHIP-WITH-FIXES → all applied. Its "misquote" block was **resolved by re-fetching GHL's live article**: both implementers' quotes are verbatim substrings of two different sentences in the same source (provenance now documented in the spec). Real fixes: 6× retired emerald → forest green; `rel` on the competitor quote link; `$2k` added to the prohibited-phrase regex
- verify-build gate: **PASS** — 16/16 new specs + seo suite 1483/1483; tsc 0 new (364 baseline); use-server clean; no migrations; regression grep empty; deployed-main baseline routes 200
- New specs enforce the prohibited-claims list in CI: `/hidden fee|secret fee|zero data egress|don't own their data|\$2k/` can never reappear on these surfaces, and no SMS-provisioning comparison can be added unnoticed

## Follow-ups (non-blocking)
- Markdown twin (`/compare/seldonframe-vs-gohighlevel.md`) doesn't carry the new sections — parity slice if wanted
- Optional `hero_form_submitted` capture (one line) would sharpen funnel step 2 in the query pack

Post-merge smoke: `/agencies` (quote + table + datestamp), `/compare/seldonframe-vs-gohighlevel` (lock-in first + honesty box), one other /compare page unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)