### PR TITLE
feat(distribution): Claude Code plugin + marketplace — one-command install for the SF MCP (+ reflect listed)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,21 @@
 {
-  "$schema": "https://claude.ai/schemas/marketplace.json",
   "name": "seldonframe",
-  "owner": { "name": "SeldonFrame", "url": "https://www.seldonframe.com" },
+  "owner": { "name": "SeldonFrame", "email": "maximehoule100@gmail.com" },
+  "description": "SeldonFrame plugins — build, deploy, and sell AI agents from your IDE",
   "plugins": [
     {
       "name": "seldonframe",
-      "source": "./",
-      "description": "Build, deploy, and sell AI agents for local-service businesses — from your IDE. One command creates a live hosted workspace: website, booking page, intake form, CRM, and an AI receptionist, in about 3 minutes. First workspace free, no key required.",
-      "author": { "name": "SeldonFrame", "url": "https://www.seldonframe.com" },
-      "homepage": "https://seldonframe.com",
-      "repository": "https://github.com/seldonframe/seldonframe",
-      "license": "MIT",
-      "keywords": ["mcp", "ai-agents", "crm", "website-builder", "booking", "small-business"]
+      "source": "./integrations/claude-plugin",
+      "description": "The SeldonFrame MCP, one install: build a real hosted workspace (website, booking, CRM, AI agent) from a sentence. First workspace free, no API key.",
+      "category": "productivity",
+      "tags": ["agents", "crm", "business", "mcp", "voice"]
+    },
+    {
+      "name": "reflect",
+      "source": { "source": "github", "repo": "seldonframe/reflect" },
+      "description": "Your AI argues before it answers — five-step decision loop built from Bezos's letters, Musk's algorithm, and Farnam Street's mental models.",
+      "category": "productivity",
+      "tags": ["decision-making", "mental-models", "anti-sycophancy"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ The open-source platform that gives your coding agent the primitives real produc
 claude mcp add seldonframe -- npx -y @seldonframe/mcp
 ```
 
+Or as an auto-updating Claude Code plugin:
+
+```
+/plugin marketplace add seldonframe/seldonframe
+/plugin install seldonframe@seldonframe
+```
+
 ```
 > Build me an AI receptionist for an HVAC company in New Orleans.
 
@@ -160,6 +167,13 @@ One npm package — [`@seldonframe/mcp`](https://www.npmjs.com/package/@seldonfr
 
 ```bash
 claude mcp add seldonframe -- npx -y @seldonframe/mcp
+```
+
+Or as a plugin (auto-updates, one-liner via the marketplace):
+
+```
+/plugin marketplace add seldonframe/seldonframe
+/plugin install seldonframe@seldonframe
 ```
 
 </details>

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "seldonframe",
+  "description": "Build, deploy, and sell AI agents from your IDE. One install connects the SeldonFrame MCP: describe a business and get a real hosted workspace — website, booking page, intake form, CRM, and an AI agent — on its own subdomain. First workspace is free, no API key needed.",
+  "author": { "name": "SeldonFrame" },
+  "homepage": "https://seldonframe.com",
+  "repository": "https://github.com/seldonframe/seldonframe",
+  "license": "MIT",
+  "keywords": ["agents", "crm", "business-os", "voice", "booking", "mcp"]
+}

--- a/integrations/claude-plugin/.mcp.json
+++ b/integrations/claude-plugin/.mcp.json
@@ -1,0 +1,6 @@
+{
+  "seldonframe": {
+    "command": "npx",
+    "args": ["-y", "@seldonframe/mcp"]
+  }
+}


### PR DESCRIPTION
New distribution rail, zero runtime surface:

- `.claude-plugin/marketplace.json` at repo root → `/plugin marketplace add seldonframe/seldonframe`
- `integrations/claude-plugin/` → the `seldonframe` plugin: bundles `@seldonframe/mcp` (verified live on npm, v1.60.0) via plugin `.mcp.json` — install = MCP connected, keyless first-run intact
- marketplace also lists `reflect` (github source seldonframe/reflect, its own plugin manifests shipped `ca990ae`) — cross-traffic between the repos in both directions
- README: plugin install lines added beside the existing `claude mcp add` snippet (quickstart + Claude Code details block)

Schemas per official plugins-reference docs (self-hosted single-repo marketplace pattern; version omitted = auto-update per commit). Same playbook as the approved ChatGPT plugin, applied to Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)