### PR TITLE
fix(seo): band resolution at runtime + metadata anchors — repairs #110's two live gaps

### DIFF
--- a/packages/crm/src/components/seo/vs-page.tsx
+++ b/packages/crm/src/components/seo/vs-page.tsx
@@ -37,7 +37,7 @@ export function composeVsFaq(a: Competitor, b: Competitor): AltFaqItem[] {
     },
     {
       q: "Is there an alternative to both?",
-      a: `Yes — SeldonFrame ships the AI receptionist plus the website, CRM and booking calendar it books into, at ${sfPriceAnchor(pairAudience(a, b))}. See how it compares: /alternatives.`,
+      a: `Yes — SeldonFrame ships the AI receptionist plus the website, CRM and booking calendar it books into, at ${sfPriceAnchor(pairAudience(a.audience, b.audience))}. See how it compares: /alternatives.`,
     },
     {
       q: `Can I switch from ${a.name} or ${b.name}?`,
@@ -50,7 +50,7 @@ export function VsPage({ pair, a, b }: { pair: VsPair; a: Competitor; b: Competi
   const xa = getExtras(a.slug);
   const xb = getExtras(b.slug);
   const vsFaq = composeVsFaq(a, b);
-  const audience = pairAudience(a, b);
+  const audience = pairAudience(a.audience, b.audience);
 
   const faqLd = {
     "@context": "https://schema.org",

--- a/packages/crm/src/lib/seo/alternative-pages.ts
+++ b/packages/crm/src/lib/seo/alternative-pages.ts
@@ -147,7 +147,7 @@ export const SHARED_FAQ: AltFaqItem[] = [
   },
   {
     q: "Do you take a cut of what I charge my clients?",
-    a: "SeldonFrame works like Shopify: $29/mo flat, plus 2% on sales made through SeldonFrame checkout, plus 5% when you sell agents on the SeldonFrame marketplace. Client retainers you bill outside SeldonFrame cost nothing extra.",
+    a: "SeldonFrame works like Shopify: Builder is $29/mo flat, and agency plans run $99–$299/mo with white-label and client sub-accounts included. Solo plans add a flat 2% only on sales made through SeldonFrame checkout — agency plans pay 0%. Selling agents on the marketplace carries 5%. Client retainers you bill outside SeldonFrame cost nothing extra.",
   },
   {
     q: "How fast can I see it working?",
@@ -165,7 +165,7 @@ export const COMPETITORS: Competitor[] = [
     oneLiner:
       "GoHighLevel is an all-in-one white-label CRM and marketing-automation platform. Agencies use it to run funnels, email/SMS, and pipelines for local-business clients.",
     heroSub:
-      "Stop paying extra fees for AI that's just an add-on. SeldonFrame gives every client a complete AI front office — receptionist, website, CRM, booking — for $29/mo flat, on your own AI keys.",
+      "Stop paying extra fees for AI that's just an add-on. SeldonFrame gives every client a complete AI front office — receptionist, website, CRM, booking — white-label agency plans from $99/mo (0% GMV); solo builders from $29/mo flat.",
     intro: [
       "Most people looking for a GoHighLevel alternative hit the same wall: the AI isn't the platform, it's an add-on. Plans run $97–$497/mo. The AI Employee costs another $50–$97/mo per location. Outbound Voice AI is still billed per minute on top. Users say it takes 2–4 weeks to learn before the platform earns its keep. The costs are real, and they add up — for every single client.",
       "That said, GoHighLevel is impressive. It's the most complete agency toolbox ever built, with funnels, email, courses, a huge template library, and true white-label reselling. If your business is funnels and email campaigns, it's hard to beat. But if your clients just need an AI that answers the phone, qualifies the lead, and books the job into a real calendar and CRM, you're buying a whole toolbox to get one receptionist.",
@@ -1353,7 +1353,7 @@ export const COMPETITORS: Competitor[] = [
     oneLiner:
       "SharpSpring is an agency-focused marketing automation platform, now operating under Constant Contact and reported to be in maintenance mode after the acquisition.",
     heroSub:
-      "A platform in maintenance mode with quote-gated pricing is a place to migrate FROM, not to. SeldonFrame gives every client an AI receptionist, website, CRM, and booking system for $29/mo flat, publicly priced.",
+      "A platform in maintenance mode with quote-gated pricing is a place to migrate FROM, not to. SeldonFrame is publicly priced: white-label agency plans from $99/mo (0% GMV), solo from $29/mo flat — AI receptionist, website, CRM, and booking included.",
     intro: [
       "Most people looking for a SharpSpring alternative hit the same wall: nobody publishes the price, and the brand's future is unclear. Pricing is quote-gated — the number commonly cited by agencies is around $449/mo per 1,000 contacts, but SharpSpring won't confirm it publicly. Since the Constant Contact acquisition, the brand has been reported as being phased toward retirement, with little visible product investment, and there's no local-business toolkit at all — no phone answering, no booking system, no intake forms.",
       "That said, SharpSpring is impressive. Unlimited users on a flat agency plan and VisitorID website tracking were genuinely ahead of their time, and its agency roots run deep. But a platform being wound down under its acquirer isn't where you want to build a client's front office for the next five years.",

--- a/packages/crm/src/lib/seo/guides/why-agencies-leave-gohighlevel.ts
+++ b/packages/crm/src/lib/seo/guides/why-agencies-leave-gohighlevel.ts
@@ -83,7 +83,7 @@ export const guide: Guide = {
     },
     {
       q: "What do agencies switch to?",
-      a: "Many move to a flat-priced, AI-first front office like SeldonFrame. It is 29 dollars a month flat with unlimited workspaces and the first workspace free forever, so adding clients does not add per-location AI fees. The whitelabel AI receptionist, website, CRM, booking, reviews, and custom domains are included, it runs on your own AI keys and Twilio at raw provider cost, and a full client workspace is built from one conversation in about three minutes.",
+      a: "Many move to a flat-priced, AI-first front office like SeldonFrame. Agency plans are 99 to 299 dollars a month flat with white-label and client sub-accounts included (0% GMV), and solo builders pay 29 dollars a month — so adding clients never adds per-location AI fees. The AI receptionist, website, CRM, booking, reviews, and custom domains are included, it runs on your own AI keys and Twilio at raw provider cost, and a full client workspace is built from one conversation in about three minutes.",
     },
     {
       q: "Is GoHighLevel worth it for a small agency?",

--- a/packages/crm/tests/unit/seo/vs-ghl-evidence.spec.ts
+++ b/packages/crm/tests/unit/seo/vs-ghl-evidence.spec.ts
@@ -14,7 +14,7 @@ import assert from "node:assert/strict";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createElement } from "react";
 
-import { COMPETITORS, getCompetitor } from "../../../src/lib/seo/alternative-pages";
+import { COMPETITORS, getCompetitor, pairAudience, sfPriceAnchor } from "../../../src/lib/seo/alternative-pages";
 import { SeldonFrameVsPage } from "../../../src/components/seo/seldonframe-vs-page";
 
 function renderVsPage(slug: string): string {
@@ -95,4 +95,35 @@ test("a non-gohighlevel competitor (vendasta) declares no evidenceSections/hones
 test("only gohighlevel among all competitors declares evidenceSections/honestyBox (scope guard)", () => {
   const withEvidence = COMPETITORS.filter((c) => c.evidenceSections || c.honestyBox).map((c) => c.slug);
   assert.deepEqual(withEvidence, ["gohighlevel"]);
+});
+
+// ── 2026-07-16 hotfix guards (post-#110 smoke failures) ─────────────────────
+// (1) pair pages resolved the band at RUNTIME via pairAudience(objects) and
+// silently fell through to solo; (2) agency-band competitors' heroSub doubles
+// as the meta description — the first price a crawler/SERP reader meets.
+
+test("pairAudience is agency-wins over audience STRINGS (the runtime contract)", () => {
+  assert.equal(pairAudience("agency", "mixed"), "agency");
+  assert.equal(pairAudience("solo", "agency"), "agency");
+  assert.equal(pairAudience("mixed", "solo"), "mixed");
+  assert.equal(pairAudience("solo", "solo"), "solo");
+});
+
+test("every agency-band competitor's heroSub leads with the $99 ladder, never $29-first", () => {
+  for (const c of COMPETITORS.filter((c) => c.audience === "agency")) {
+    const i99 = c.heroSub.indexOf("$99");
+    const i29 = c.heroSub.indexOf("$29");
+    assert.notEqual(i99, -1, `${c.slug}: agency heroSub must state the $99 ladder`);
+    if (i29 !== -1) assert.ok(i99 < i29, `${c.slug}: heroSub mentions $29 before $99`);
+  }
+});
+
+test("a gohighlevel pair resolves to the agency anchor end-to-end", () => {
+  const anchor = sfPriceAnchor(pairAudience("agency", "mixed"));
+  assert.ok(anchor.indexOf("$99") !== -1 && (anchor.indexOf("$29") === -1 || anchor.indexOf("$99") < anchor.indexOf("$29")));
+});
+
+test("no words-not-digits price collocation dodge in the gohighlevel entry", () => {
+  const text = JSON.stringify(COMPETITORS.find((c) => c.slug === "gohighlevel"));
+  assert.doesNotMatch(text, /29 dollars[^.]{0,80}(white-?label|client sub-accounts)/i);
 });

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -2392,3 +2392,6 @@ Prevention: to diff/typecheck a "before my change" baseline in a worktree,
 use `git worktree add` against a specific commit, or `git show <sha>:<path>`,
 or just re-run the same check on the parent repo path — never stash.
 - 2026-07-16 — Quote disputes (reviewer vs implementer) are settled by re-fetching the SOURCE, never the plan doc both relied on: the 'misquote' block was a false positive — both quotes were verbatim substrings of different sentences. (docs/learnings/2026-07-16-adjudicate-at-the-source.md)
+- 2026-07-16 — verify-runner EDITED code to fix type errors it found (checker must never write): its uncommitted worktree edits were half-lost at commit time and the broken half shipped. Rule: gate agents report, orchestrator fixes; run `git status` before AND after any gate dispatch and treat unexpected dirt as a gate violation.
+- 2026-07-16 — 'First price the reader meets' includes META DESCRIPTION and JSON-LD, not just body copy — the smoke caught $29 at byte 2761 (the <meta>) after all body anchors were fixed. Band/truth sweeps must include heroSub/metadata fields and word-form prices ('29 dollars'), which dodge $-greps.
+- 2026-07-16 — Worktree creation is a 3-step ritual: add + BOTH node_modules junctions. Skipping junctions makes every spec fail with ERR_MODULE_NOT_FOUND 'tsx' — 18 phantom failures before the real one.


### PR DESCRIPTION
## What

PR #110's post-merge smoke failed 2/5 — both real, both now fixed and CI-guarded:

1. **Every gohighlevel-vs-X pair page rendered the solo ($29-first) anchor.** `pairAudience` was called with Competitor objects while the lib function compares audience strings — runtime fell through to `"solo"`. Fixed at both call sites ([vs-page.tsx:40,53]). *Process note: the verify-build gate agent had silently edited these call sites to green its own tsc check; the uncommitted edit was half-lost at commit time. Lesson logged — checkers report, they don't write.*
2. **The GHL alternative page's meta description still led with $29** — `heroSub` doubles as the `<meta description>`, the first price a SERP reader sees. gohighlevel + sharpspring heroSubs now lead the $99 ladder.

Rounding out: the shared Shopify-model FAQ now dual-anchors and states agency plans pay 0% (it previously implied the 2% applied to everyone), and a "**29 dollars** a month… whitelabel… included" words-not-digits collocation in the why-agencies-leave-gohighlevel guide — which dodged every $-grep across three sweeps — is corrected.

## Guards added (4 new tests, suite 1490/1490)
- `pairAudience` string contract (agency-wins)
- every agency-band competitor's heroSub must state $99 before any $29
- gohighlevel pairs resolve to the agency anchor
- words-form price collocation regex

## Verification
seo suite 1490/1490 · tsc 221 = baseline (0 new) · the heroSub guard fails against pre-fix code (verified honest). Post-merge smoke: re-run the exact 2 failed checks from #110's smoke ($99-before-$29 on /alternative-to-gohighlevel incl. metadata; "white-label agency plans" on /compare/gohighlevel-vs-hubspot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)