### PR TITLE
fix(clients-new): credits_exhausted 422 shows the honest message — no more "couldn't read that site"

### DIFF
--- a/docs/learnings/2026-07-16-credits-exhausted-400-mapping.md
+++ b/docs/learnings/2026-07-16-credits-exhausted-400-mapping.md
@@ -56,3 +56,19 @@ semantically-distinct failures under the same status (Anthropic's
 out-of-credits is a 400), so keep ONE shared mapper per provider, test the
 message-based cases, and make every non-retryable reason carry honest
 user-facing copy with the retry affordance suppressed.
+
+## Follow-up (same day, PR #113) — the consumer-surface sweep
+The "separate UI task" deferred above (judgment call 3) was real debt: the
+dashboard's `/clients/new` kept showing "We couldn't read that site. Try a
+different URL" for the same out-of-credits 422, on BOTH its URL and paste
+listeners — a worse lie than /try's, because the operator may be on their
+own BYOK key and the actual fix is funding it. PR #113 made both listeners
+reason-aware (server `message` wins, dedicated fallback copy mentions adding
+Anthropic credits), threaded `message` through `run-create-from-paste.ts`'s
+422, and hoisted the copy into `CREDITS_EXHAUSTED_UI_MESSAGE` in
+`anthropic-error-map.ts` so the two orchestrators share one string.
+
+**Corollary rule:** an error-payload honesty fix isn't done at the payload —
+enumerate every consumer surface of that payload (grep the event/field name
+across `app/`) and sweep them all in the same wave, or file the gap
+explicitly with the exact file:line so the follow-up is mechanical.

--- a/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
@@ -35,6 +35,12 @@ const COPY = {
     invalid_url: "That URL doesn't look right. Check for typos and try again.",
     extraction_failed:
       "We couldn't read that site. Try a different URL — a homepage works best.",
+    // 2026-07-16 — credits_exhausted honesty fix. Out-of-credits is NOT an
+    // unreadable site; the operator here may be on their own BYOK key, so
+    // point at adding Anthropic credits. Server-sent `message` wins; this
+    // line is the fallback when the payload carries none.
+    credits_exhausted:
+      "The Anthropic key powering this build is out of credits. Add credits to your Anthropic account, then try again.",
     workspace_limit_short:
       "You're at your workspace limit. Upgrade to add this client.",
     internal_error:
@@ -278,7 +284,7 @@ export function ClientsNewForm({
 
     es.addEventListener("error", (raw) => {
       const payload = (raw as MessageEvent).data;
-      let data: { code?: number; reason?: string } & Partial<LimitInfo> = {};
+      let data: { code?: number; reason?: string; message?: string } & Partial<LimitInfo> = {};
       try {
         if (typeof payload === "string" && payload.length > 0) {
           data = JSON.parse(payload);
@@ -308,7 +314,14 @@ export function ClientsNewForm({
         return;
       }
       if (data.code === 422) {
-        setErrorBanner(COPY.errors.extraction_failed);
+        // credits_exhausted is a key-funding problem, not a site-reading one —
+        // show the server's honest message (fallback to the dedicated copy)
+        // instead of sending the operator hunting for a "better" URL.
+        setErrorBanner(
+          data.reason === "credits_exhausted"
+            ? data.message || COPY.errors.credits_exhausted
+            : COPY.errors.extraction_failed,
+        );
         return;
       }
       setErrorBanner(COPY.errors.internal_error);
@@ -359,7 +372,7 @@ export function ClientsNewForm({
 
     es.addEventListener("error", (raw) => {
       const payload = (raw as MessageEvent).data;
-      let data: { code?: number; reason?: string } & Partial<LimitInfo> = {};
+      let data: { code?: number; reason?: string; message?: string } & Partial<LimitInfo> = {};
       try {
         if (typeof payload === "string" && payload.length > 0) {
           data = JSON.parse(payload);
@@ -389,7 +402,14 @@ export function ClientsNewForm({
         return;
       }
       if (data.code === 422) {
-        setErrorBanner(COPY.errors.extraction_failed);
+        // credits_exhausted is a key-funding problem, not a site-reading one —
+        // show the server's honest message (fallback to the dedicated copy)
+        // instead of sending the operator hunting for a "better" URL.
+        setErrorBanner(
+          data.reason === "credits_exhausted"
+            ? data.message || COPY.errors.credits_exhausted
+            : COPY.errors.extraction_failed,
+        );
         return;
       }
       setErrorBanner(COPY.errors.internal_error);

--- a/packages/crm/src/lib/web-onboarding/anthropic-error-map.ts
+++ b/packages/crm/src/lib/web-onboarding/anthropic-error-map.ts
@@ -17,6 +17,13 @@ import { WebFetchError } from "./web-fetch-extractor";
 // substring test is the reliable detector.
 const CREDIT_BALANCE_TOO_LOW = /credit balance is too low/i;
 
+// The UI-facing line both SSE orchestrators (run-create-from-url and
+// run-create-from-paste) attach to a credits_exhausted 422. One constant so
+// the two paths can never drift apart — the same copy-drift that let the
+// paste path emit a bare {reason} while the URL path carried a message.
+export const CREDITS_EXHAUSTED_UI_MESSAGE =
+  "The AI account powering this build is out of credits, so retrying won't help right now. If you brought your own Anthropic key, add credits to it — otherwise check back a little later.";
+
 export function mapAnthropicSdkError(err: unknown): WebFetchError {
   const status = (err as { status?: number } | null)?.status;
   const message = err instanceof Error ? err.message : String(err);

--- a/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
@@ -11,6 +11,7 @@
 //   - seedClientContactInAgencyCrm called with sourceUrl: null
 
 import { createSseStream, SSE_RESPONSE_HEADERS } from "./sse";
+import { CREDITS_EXHAUSTED_UI_MESSAGE } from "./anthropic-error-map";
 import type { CreateFullWorkspaceInput, CreateFullWorkspaceResult } from "@/lib/workspace/create-full";
 import type { LimitDecision } from "@/lib/billing/limits";
 import type { ExtractedBusinessFacts } from "./extraction-prompt";
@@ -116,7 +117,16 @@ export async function runCreateFromPaste(input: RunPasteInput): Promise<RunPaste
         facts = await input.deps.extractBusinessFactsFromPaste({ pastedText, byokKey: extraction.key });
       } catch (err: unknown) {
         const reason = (err as { reason?: string }).reason ?? "extraction_failed";
-        sse.error(422, { reason });
+        // 2026-07-16 — credits_exhausted honesty fix (mirrors run-create-from-url):
+        // out-of-credits is non-retryable until credits are added, so the payload
+        // must carry the honest message instead of a bare reason the UI maps to
+        // "We couldn't read that site."
+        sse.error(
+          422,
+          reason === "credits_exhausted"
+            ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
+            : { reason },
+        );
         sse.close();
         return;
       }

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -35,6 +35,7 @@
 
 import { createSseStream, SSE_RESPONSE_HEADERS } from "./sse";
 import { validateCreateFromUrlInput } from "./url-validator";
+import { CREDITS_EXHAUSTED_UI_MESSAGE } from "./anthropic-error-map";
 import type { CreateFullWorkspaceInput, CreateFullWorkspaceResult } from "@/lib/workspace/create-full";
 import type { LimitDecision } from "@/lib/billing/limits";
 import type { ExtractedBusinessFacts } from "./extraction-prompt";
@@ -278,11 +279,7 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
                   "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
               }
             : reason === "credits_exhausted"
-              ? {
-                  reason,
-                  message:
-                    "The AI account powering this build is out of credits, so retrying won't help right now. If you brought your own Anthropic key, add credits to it — otherwise check back a little later.",
-                }
+              ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
               : { reason },
         );
         sse.close();

--- a/packages/crm/tests/unit/web-onboarding/clients-new-form.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/clients-new-form.spec.tsx
@@ -177,4 +177,97 @@ describe("ClientsNewForm", () => {
     assert.ok(screen.getByRole("alert"), "Error banner rendered with role=alert");
     assert.equal(input.value, "https://acme.com", "URL preserved on error");
   });
+
+  // 2026-07-16 — credits_exhausted honesty fix (same class as the /try fix in
+  // PR #112). Out-of-credits is NOT an unreadable site: showing "We couldn't
+  // read that site. Try a different URL" sends the operator hunting for a
+  // better homepage when the real fix is adding credits to the Anthropic key.
+  // The server's 422 payload carries an honest `message` — show it verbatim.
+  test("on 422 credits_exhausted the banner shows the server's honest message, not the extraction copy", async () => {
+    render(<ClientsNewForm />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\//i), {
+      target: { value: "https://acme.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /build workspace/i }));
+
+    const serverMessage =
+      "The AI account powering this build is out of credits, so retrying won't help right now.";
+    const es = FakeEventSource.last;
+    act(() =>
+      es!.fire("error", {
+        code: 422,
+        reason: "credits_exhausted",
+        message: serverMessage,
+      }),
+    );
+
+    const banner = screen.getByRole("alert");
+    assert.ok(
+      banner.textContent!.includes(serverMessage),
+      `banner must show the server message; got: ${banner.textContent}`,
+    );
+    assert.ok(
+      !banner.textContent!.includes("couldn't read that site"),
+      "the extraction_failed copy must NOT appear for credits_exhausted",
+    );
+  });
+
+  test("on 422 credits_exhausted WITHOUT a message the banner falls back to dedicated credits copy", async () => {
+    render(<ClientsNewForm />);
+    fireEvent.change(screen.getByPlaceholderText(/https:\/\//i), {
+      target: { value: "https://acme.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /build workspace/i }));
+
+    const es = FakeEventSource.last;
+    act(() => es!.fire("error", { code: 422, reason: "credits_exhausted" }));
+
+    const banner = screen.getByRole("alert");
+    // The operator here may be on their own BYOK key — the fallback copy must
+    // point at adding credits to their Anthropic key, not at trying a new URL.
+    assert.match(
+      banner.textContent!,
+      /credits/i,
+      "fallback copy must mention credits",
+    );
+    assert.match(
+      banner.textContent!,
+      /anthropic/i,
+      "fallback copy must point at the Anthropic key",
+    );
+    assert.ok(
+      !banner.textContent!.includes("couldn't read that site"),
+      "the extraction_failed copy must NOT appear for credits_exhausted",
+    );
+  });
+
+  test("paste path: on 422 credits_exhausted the banner shows the server's honest message", async () => {
+    render(<ClientsNewForm />);
+    // Switch to the paste tab and submit ≥20 chars (idle-scene's biz minimum).
+    fireEvent.click(screen.getByRole("tab", { name: /no website/i }));
+    fireEvent.change(screen.getByLabelText(/business information/i), {
+      target: { value: "Acme Plumbing in Phoenix, AZ. Drain cleaning. (602) 555-0100." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /build workspace/i }));
+
+    const es = FakeEventSource.last;
+    assert.ok(es, "EventSource was constructed");
+    assert.match(es!.url, /\/api\/v1\/web\/workspaces\/create-from-paste\?/);
+
+    const serverMessage =
+      "The AI account powering this build is out of credits, so retrying won't help right now.";
+    act(() =>
+      es!.fire("error", {
+        code: 422,
+        reason: "credits_exhausted",
+        message: serverMessage,
+      }),
+    );
+
+    const banner = screen.getByRole("alert");
+    assert.ok(
+      banner.textContent!.includes(serverMessage),
+      `paste-path banner must show the server message; got: ${banner.textContent}`,
+    );
+  });
 });

--- a/packages/crm/tests/unit/web-onboarding/run-create-from-paste.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/run-create-from-paste.spec.ts
@@ -1,0 +1,94 @@
+// packages/crm/tests/unit/web-onboarding/run-create-from-paste.spec.ts
+//
+// 2026-07-16 — created for the credits_exhausted honesty fix. The paste
+// orchestrator mirrors run-create-from-url.ts (which has full coverage in
+// route-create-from-url.spec.ts); this spec covers only the paste path's
+// 422 payload contract — the seam that had drifted: run-create-from-url
+// emitted an honest `message` for credits_exhausted while the paste path
+// still emitted a bare `{reason}`, so /clients/new's paste tab showed
+// "We couldn't read that site" for an out-of-credits Anthropic key.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { runCreateFromPaste } from "../../../src/lib/web-onboarding/run-create-from-paste";
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value);
+  }
+  return out;
+}
+
+const validFacts = {
+  business_name: "Acme Plumbing",
+  city: "Phoenix",
+  state: "AZ",
+  phone: "(602) 555-0100",
+  services: ["Drain cleaning"],
+  business_description: "Plumbing in Phoenix.",
+};
+
+const pastedText =
+  "Acme Plumbing in Phoenix, AZ. Drain cleaning and water heaters. Call (602) 555-0100.";
+
+function baseDeps() {
+  return {
+    enforceWorkspaceLimit: async () => ({ allowed: true as const, tier: "workspace" as const }),
+    getOwnedWorkspaceCount: async () => 0,
+    resolveExtractionKey: async () => ({ key: "sk-ant-test" }),
+    extractBusinessFactsFromPaste: async () => validFacts,
+    createFullWorkspace: async () => ({
+      status: "ready" as const,
+      workspace_id: "org-1",
+      slug: "acme-plumbing",
+      public_urls: { home: "https://acme-plumbing.app.seldonframe.com", book: "...", intake: "..." },
+    }),
+    markOperatorOnboarded: async () => {},
+    linkWorkspaceToOperator: async () => ({ ok: true, alreadyOwned: false }),
+    createWebsiteChatbot: async () => ({ ok: true }),
+    seedClientContactInAgencyCrm: async () => ({ ok: true, created: true, contactId: "contact-1" }),
+    seedDefaultOutboundTriggers: async () => undefined,
+    workspaceBaseDomain: "app.seldonframe.com",
+  };
+}
+
+function throwingExtractor(reason: string) {
+  return async () => {
+    const e = new Error("extractor blew up");
+    (e as any).reason = reason;
+    (e as any).name = "WebFetchError";
+    throw e;
+  };
+}
+
+describe("runCreateFromPaste — 422 payload contract", () => {
+  test("credits_exhausted 422 carries an honest non-retryable `message`", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromPaste: throwingExtractor("credits_exhausted") };
+    const sse = await runCreateFromPaste({
+      deps,
+      body: { text: pastedText },
+      sessionUser: { id: "u1", primaryOrgId: "o1" },
+    });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"credits_exhausted".*"message":"/);
+    assert.match(text, /out of credits/i, "the message must say credits ran out, not a generic failure");
+  });
+
+  test("other 422 reasons (e.g. anthropic_unauthorized) carry no `message`", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromPaste: throwingExtractor("anthropic_unauthorized") };
+    const sse = await runCreateFromPaste({
+      deps,
+      body: { text: pastedText },
+      sessionUser: { id: "u1", primaryOrgId: "o1" },
+    });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"anthropic_unauthorized"/);
+    assert.ok(!text.includes('"message"'), "non-credits reasons must stay bare on the paste path");
+  });
+});

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,6 +7,24 @@ with a checkable plan, gets ticked off as it ships, and ends with a review block
 
 ## In flight
 
+### Task — credits_exhausted honesty on /clients/new (2026-07-16, branch claude/zen-sutherland-c96203, extends PR #112)
+
+Problem: clients-new-form.tsx maps EVERY 422 to the extraction_failed copy ("We couldn't
+read that site…") in both SSE error listeners. Since #112 the server emits
+`reason: "credits_exhausted"` + honest `message` on the URL path; the paste path
+(run-create-from-paste.ts:119) still emits bare `{reason}`. Merged #112's branch
+(`claude/intelligent-nightingale-771275`, fast-forward to 59bfa0dee) as the base.
+
+- [ ] RED: extend clients-new-form.spec.tsx — (a) 422 credits_exhausted + message shows
+      server message; (b) no message → dedicated fallback copy mentioning adding credits
+      to their Anthropic key; (c) paste path shows server message too
+- [ ] RED: new run-create-from-paste.spec.ts — credits_exhausted 422 carries honest
+      `message`; other reasons stay bare
+- [ ] GREEN: CREDITS_EXHAUSTED_UI_MESSAGE exported from anthropic-error-map.ts (single
+      source, both run-* files use it) + COPY.errors.credits_exhausted + both listeners
+- [ ] verify-build gate (verify-runner, maker ≠ checker)
+- [ ] Commit + PR (stacked on #112)
+
 ### Task — Agency repositioning of homepage (2026-07-15, branch feat/agency-homepage-positioning)
 
 Max's direction: keep marketing-page structure, reword for AGENCIES; everything true per §1b

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -15,15 +15,22 @@ read that site…") in both SSE error listeners. Since #112 the server emits
 (run-create-from-paste.ts:119) still emits bare `{reason}`. Merged #112's branch
 (`claude/intelligent-nightingale-771275`, fast-forward to 59bfa0dee) as the base.
 
-- [ ] RED: extend clients-new-form.spec.tsx — (a) 422 credits_exhausted + message shows
+- [x] RED: extend clients-new-form.spec.tsx — (a) 422 credits_exhausted + message shows
       server message; (b) no message → dedicated fallback copy mentioning adding credits
-      to their Anthropic key; (c) paste path shows server message too
-- [ ] RED: new run-create-from-paste.spec.ts — credits_exhausted 422 carries honest
-      `message`; other reasons stay bare
-- [ ] GREEN: CREDITS_EXHAUSTED_UI_MESSAGE exported from anthropic-error-map.ts (single
+      to their Anthropic key; (c) paste path shows server message too (all 3 watched fail)
+- [x] RED: new run-create-from-paste.spec.ts — credits_exhausted 422 carries honest
+      `message` (watched fail); other reasons stay bare (guard, green by design)
+- [x] GREEN: CREDITS_EXHAUSTED_UI_MESSAGE exported from anthropic-error-map.ts (single
       source, both run-* files use it) + COPY.errors.credits_exhausted + both listeners
-- [ ] verify-build gate (verify-runner, maker ≠ checker)
-- [ ] Commit + PR (stacked on #112)
+      — 46/46 across the 7 affected suites
+- [x] verify-build gate: PASS via verify-runner (web-onboarding 95/95, tsc delta 0,
+      use-server clean, no migrations, regression grep empty; smoke = post-deploy)
+- [x] Commit fe18a8a68 + PR #113 (stacked on #112 — merge #112 first)
+
+Review: shipped as spec'd; only deviation from minimal-diff was hoisting the message
+string into anthropic-error-map.ts (prevents the exact drift class that caused #112).
+Learnings appended to docs/learnings/2026-07-16-credits-exhausted-400-mapping.md
+(corollary: sweep ALL consumer surfaces of an error payload). ⏳ Max: merge #112 → #113.
 
 ### Task — Agency repositioning of homepage (2026-07-15, branch feat/agency-homepage-positioning)
 


### PR DESCRIPTION
## What

Extends #112 to the operator dashboard. `/clients/new` mapped **every** SSE 422 to the extraction_failed copy ("We couldn't read that site. Try a different URL — a homepage works best.") in both error listeners, so an out-of-credits Anthropic key sent the operator hunting for a "better" homepage.

- **clients-new-form.tsx** — on `code 422` + `reason: "credits_exhausted"`, both listeners (URL + paste) show the server's `data.message`, falling back to a dedicated `COPY.errors.credits_exhausted` line that points BYOK operators at adding credits to their Anthropic key.
- **run-create-from-paste.ts** — the 422 payload now threads the honest message for credits_exhausted (was a bare `{reason}`), matching the URL path.
- **anthropic-error-map.ts** — `CREDITS_EXHAUSTED_UI_MESSAGE` exported once; both orchestrators use it so the copy can never drift between paths again (the same drift class that caused #112's bug).

## Tests

- 3 new `clients-new-form.spec.tsx` cases (FakeEventSource pattern): server message on the URL path, fallback copy when no message, server message on the paste tab.
- New `run-create-from-paste.spec.ts` — 422 payload contract (message for credits_exhausted, bare for other reasons).
- TDD: all four watched fail RED first. 46/46 green across the 7 affected web-onboarding suites; full web-onboarding run 95/95.
- verify-build gate: **PASS** (tsc delta 0, use-server clean, no migrations, regression grep empty; live smoke pending deploy as usual).

## Stacking note

⚠️ **Stacked on #112** — this branch contains #112's commit (`59bfa0dee`) as its base. Merge #112 first (this PR's diff then shrinks to just the dashboard fix), or merge this one and #112 becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)