### PR TITLE
feat(seo): indexation consolidation — gate ai-agents 160→16 pairs, compare 56→33

### DIFF
--- a/packages/crm/src/app/(public)/ai-agents/[job]/for/[vertical]/page.tsx
+++ b/packages/crm/src/app/(public)/ai-agents/[job]/for/[vertical]/page.tsx
@@ -9,9 +9,10 @@
 // ADDITIVE: no migration, no DB — pure registry → static HTML.
 
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import {
-  allJobVerticalPairs,
+  KEPT_PAIRS,
+  isKeptPair,
   getJob,
   getVertical,
   composePageCopy,
@@ -20,9 +21,11 @@ import { AgentPage } from "@/components/seo/agent-page";
 
 type RouteParams = { params: Promise<{ job: string; vertical: string }> };
 
-/** Statically pre-render one page per (job, vertical) pair. */
+/** Statically pre-render only the kept (job, vertical) pairs — see
+ *  KEPT_PAIRS (indexation consolidation, 2026-07-17). Every other valid
+ *  pair still resolves at request time and 301s to its job hub. */
 export function generateStaticParams(): { job: string; vertical: string }[] {
-  return allJobVerticalPairs();
+  return KEPT_PAIRS;
 }
 
 export async function generateMetadata({ params }: RouteParams): Promise<Metadata> {
@@ -35,6 +38,7 @@ export async function generateMetadata({ params }: RouteParams): Promise<Metadat
   } catch {
     return { title: "Agent not found — SeldonFrame" };
   }
+  if (!isKeptPair(job.slug, vertical.slug)) permanentRedirect(`/ai-agents/${job.slug}`);
   const copy = composePageCopy(job, vertical);
   const canonical = `/ai-agents/${job.slug}/for/${vertical.slug}`;
   return {
@@ -66,5 +70,6 @@ export default async function AgentJobVerticalPage({ params }: RouteParams) {
   } catch {
     notFound();
   }
+  if (!isKeptPair(job.slug, vertical.slug)) permanentRedirect(`/ai-agents/${job.slug}`);
   return <AgentPage job={job} vertical={vertical} />;
 }

--- a/packages/crm/src/app/(public)/compare/[pair]/page.tsx
+++ b/packages/crm/src/app/(public)/compare/[pair]/page.tsx
@@ -7,10 +7,10 @@
 //     VS_PAIRS registry, ending in the SeldonFrame both-worlds answer (VsPage).
 // Additive: no DB.
 import type { Metadata } from "next";
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { VsPage } from "@/components/seo/vs-page";
 import { SeldonFrameVsPage } from "@/components/seo/seldonframe-vs-page";
-import { VS_PAIRS, getVsPair, vsSlug } from "@/lib/seo/alternative-pages-extras";
+import { VS_PAIRS, getVsPair, vsSlug, isKeptVsPair } from "@/lib/seo/alternative-pages-extras";
 import { COMPETITORS, getCompetitor, LAST_UPDATED, type Competitor } from "@/lib/seo/alternative-pages";
 import { buildOgUrl, shortPrice } from "@/lib/seo/og-card";
 
@@ -31,7 +31,7 @@ function resolveSfVs(pairSlug: string): Competitor | null {
 export function generateStaticParams(): { pair: string }[] {
   return [
     ...COMPETITORS.map((c) => ({ pair: `${SF_VS_PREFIX}${c.slug}` })),
-    ...VS_PAIRS.map((p) => ({ pair: vsSlug(p) })),
+    ...VS_PAIRS.map((p) => vsSlug(p)).filter(isKeptVsPair).map((pair) => ({ pair })),
   ];
 }
 
@@ -59,6 +59,9 @@ export async function generateMetadata({ params }: RouteParams): Promise<Metadat
   } catch {
     return { title: "Comparison not found — SeldonFrame" };
   }
+  // Folded third-party pair (indexation consolidation, 2026-07-17) — 301 to
+  // the /alternatives hub; seldonframe-vs-* pairs never reach this branch.
+  if (!isKeptVsPair(pairSlug)) permanentRedirect("/alternatives");
   const { a, b } = resolved;
   const title = `${a.name} vs ${b.name}: What You Need to Know (${LAST_UPDATED}) — SeldonFrame`;
   const description = `${a.name} vs ${b.name}, honestly compared: pricing, AI receptionist, whitelabel and the business system behind the agent — plus the both-worlds option.`;
@@ -84,5 +87,6 @@ export default async function ComparePairPage({ params }: RouteParams) {
   } catch {
     notFound();
   }
+  if (!isKeptVsPair(pairSlug)) permanentRedirect("/alternatives");
   return <VsPage pair={resolved.pair} a={resolved.a} b={resolved.b} />;
 }

--- a/packages/crm/src/app/ai-agents/listing.md/route.ts
+++ b/packages/crm/src/app/ai-agents/listing.md/route.ts
@@ -19,7 +19,7 @@
 // via the pure renderers. 404 when the job (or named vertical) doesn't resolve,
 // mirroring the HTML page's notFound().
 
-import { getJob, getVertical } from "@/lib/seo/agent-pages";
+import { getJob, getVertical, isKeptPair } from "@/lib/seo/agent-pages";
 import {
   renderAiAgentJobMarkdown,
   renderAiAgentJobVerticalMarkdown,
@@ -46,6 +46,11 @@ export function GET(req: Request): Response {
       vertical = getVertical(verticalSlug);
     } catch {
       return notFoundMd(`/ai-agents/${jobSlug}/for/${verticalSlug}`);
+    }
+    // Folded pair (indexation consolidation, 2026-07-17) — 301 the Markdown
+    // twin to the job hub's, mirroring the HTML page's permanentRedirect.
+    if (!isKeptPair(job.slug, vertical.slug)) {
+      return Response.redirect(new URL(`/ai-agents/${job.slug}.md`, req.url), 308);
     }
   }
 

--- a/packages/crm/src/app/compare/activecampaign-vs-klaviyo.md/route.ts
+++ b/packages/crm/src/app/compare/activecampaign-vs-klaviyo.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/activecampaign-vs-klaviyo.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/activecampaign-vs-klaviyo.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/activecampaign-vs-klaviyo.md" });
-  const { pair, a, b } = getVsPair("activecampaign-vs-klaviyo");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/activecampaign-vs-klaviyo>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/clickfunnels-vs-kartra.md/route.ts
+++ b/packages/crm/src/app/compare/clickfunnels-vs-kartra.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/clickfunnels-vs-kartra.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/clickfunnels-vs-kartra.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/clickfunnels-vs-kartra.md" });
-  const { pair, a, b } = getVsPair("clickfunnels-vs-kartra");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/clickfunnels-vs-kartra>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-activecampaign.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-activecampaign.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-activecampaign.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-activecampaign.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-activecampaign.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-activecampaign");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-activecampaign>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-clickfunnels.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-clickfunnels.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-clickfunnels.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-clickfunnels.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-clickfunnels.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-clickfunnels");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-clickfunnels>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-hubspot.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-hubspot.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-hubspot.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-hubspot.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-hubspot.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-hubspot");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-hubspot>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-kartra.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-kartra.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-kartra.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-kartra.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-kartra.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-kartra");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-kartra>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-keap.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-keap.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-keap.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-keap.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-keap.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-keap");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-keap>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-salesforce.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-salesforce.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-salesforce.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-salesforce.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-salesforce.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-salesforce");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-salesforce>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-sharpspring.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-sharpspring.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-sharpspring.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-sharpspring.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-sharpspring.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-sharpspring");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-sharpspring>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-vendasta.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-vendasta.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-vendasta.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-vendasta.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-vendasta.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-vendasta");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-vendasta>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/gohighlevel-vs-zoho.md/route.ts
+++ b/packages/crm/src/app/compare/gohighlevel-vs-zoho.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/gohighlevel-vs-zoho.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/gohighlevel-vs-zoho.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/gohighlevel-vs-zoho.md" });
-  const { pair, a, b } = getVsPair("gohighlevel-vs-zoho");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/gohighlevel-vs-zoho>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/hubspot-vs-activecampaign.md/route.ts
+++ b/packages/crm/src/app/compare/hubspot-vs-activecampaign.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/hubspot-vs-activecampaign.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/hubspot-vs-activecampaign.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/hubspot-vs-activecampaign.md" });
-  const { pair, a, b } = getVsPair("hubspot-vs-activecampaign");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/hubspot-vs-activecampaign>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/hubspot-vs-clickfunnels.md/route.ts
+++ b/packages/crm/src/app/compare/hubspot-vs-clickfunnels.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/hubspot-vs-clickfunnels.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/hubspot-vs-clickfunnels.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/hubspot-vs-clickfunnels.md" });
-  const { pair, a, b } = getVsPair("hubspot-vs-clickfunnels");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/hubspot-vs-clickfunnels>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/hubspot-vs-salesforce.md/route.ts
+++ b/packages/crm/src/app/compare/hubspot-vs-salesforce.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/hubspot-vs-salesforce.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/hubspot-vs-salesforce.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/hubspot-vs-salesforce.md" });
-  const { pair, a, b } = getVsPair("hubspot-vs-salesforce");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/hubspot-vs-salesforce>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/kartra-vs-gohighlevel.md/route.ts
+++ b/packages/crm/src/app/compare/kartra-vs-gohighlevel.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/kartra-vs-gohighlevel.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/kartra-vs-gohighlevel.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/kartra-vs-gohighlevel.md" });
-  const { pair, a, b } = getVsPair("kartra-vs-gohighlevel");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/kartra-vs-gohighlevel>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/podium-vs-goodcall.md/route.ts
+++ b/packages/crm/src/app/compare/podium-vs-goodcall.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/podium-vs-goodcall.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/podium-vs-goodcall.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/podium-vs-goodcall.md" });
-  const { pair, a, b } = getVsPair("podium-vs-goodcall");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/podium-vs-goodcall>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/salesforce-vs-zoho.md/route.ts
+++ b/packages/crm/src/app/compare/salesforce-vs-zoho.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/salesforce-vs-zoho.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/salesforce-vs-zoho.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/salesforce-vs-zoho.md" });
-  const { pair, a, b } = getVsPair("salesforce-vs-zoho");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/salesforce-vs-zoho>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/smith-ai-vs-goodcall.md/route.ts
+++ b/packages/crm/src/app/compare/smith-ai-vs-goodcall.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/smith-ai-vs-goodcall.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/smith-ai-vs-goodcall.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/smith-ai-vs-goodcall.md" });
-  const { pair, a, b } = getVsPair("smith-ai-vs-goodcall");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/smith-ai-vs-goodcall>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/stammer-ai-vs-synthflow.md/route.ts
+++ b/packages/crm/src/app/compare/stammer-ai-vs-synthflow.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/stammer-ai-vs-synthflow.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/stammer-ai-vs-synthflow.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/stammer-ai-vs-synthflow.md" });
-  const { pair, a, b } = getVsPair("stammer-ai-vs-synthflow");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/stammer-ai-vs-synthflow>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/synthflow-vs-retell-ai.md/route.ts
+++ b/packages/crm/src/app/compare/synthflow-vs-retell-ai.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/synthflow-vs-retell-ai.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/synthflow-vs-retell-ai.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/synthflow-vs-retell-ai.md" });
-  const { pair, a, b } = getVsPair("synthflow-vs-retell-ai");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/synthflow-vs-retell-ai>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/synthflow-vs-vapi.md/route.ts
+++ b/packages/crm/src/app/compare/synthflow-vs-vapi.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/synthflow-vs-vapi.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/synthflow-vs-vapi.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/synthflow-vs-vapi.md" });
-  const { pair, a, b } = getVsPair("synthflow-vs-vapi");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/synthflow-vs-vapi>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/voiceflow-vs-botpress.md/route.ts
+++ b/packages/crm/src/app/compare/voiceflow-vs-botpress.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/voiceflow-vs-botpress.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/voiceflow-vs-botpress.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/voiceflow-vs-botpress.md" });
-  const { pair, a, b } = getVsPair("voiceflow-vs-botpress");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/voiceflow-vs-botpress>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/compare/zoho-vs-hubspot.md/route.ts
+++ b/packages/crm/src/app/compare/zoho-vs-hubspot.md/route.ts
@@ -1,19 +1,8 @@
-// /compare/zoho-vs-hubspot.md — Markdown twin of the head-to-head page.
-import { getVsPair } from "@/lib/seo/alternative-pages-extras";
-import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
-import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
-
+// /compare/zoho-vs-hubspot.md — folded pair (indexation consolidation, 2026-07-17): 308
+// to the /alternatives hub, mirroring the HTML page's permanentRedirect. See
+// docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md.
 export const dynamic = "force-dynamic";
 
 export function GET(req: Request): Response {
-  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/zoho-vs-hubspot.md" });
-  const { pair, a, b } = getVsPair("zoho-vs-hubspot");
-  const md = renderVsMarkdown(pair, a, b);
-  return new Response(md, {
-    headers: {
-      "Content-Type": "text/markdown; charset=utf-8",
-      Link: '<https://www.seldonframe.com/compare/zoho-vs-hubspot>; rel="alternate"; type="text/html"',
-      "Cache-Control": "public, max-age=300, s-maxage=3600",
-    },
-  });
+  return Response.redirect(new URL("/alternatives", req.url), 308);
 }

--- a/packages/crm/src/app/sitemap.ts
+++ b/packages/crm/src/app/sitemap.ts
@@ -13,9 +13,9 @@
 
 import type { MetadataRoute } from "next";
 import { isRecordToAgentOn } from "@/lib/recordings/policy";
-import { AGENT_JOBS, allJobVerticalPairs } from "@/lib/seo/agent-pages";
+import { AGENT_JOBS, KEPT_PAIRS } from "@/lib/seo/agent-pages";
 import { COMPETITORS } from "@/lib/seo/alternative-pages";
-import { VS_PAIRS, vsSlug } from "@/lib/seo/alternative-pages-extras";
+import { VS_PAIRS, vsSlug, isKeptVsPair } from "@/lib/seo/alternative-pages-extras";
 import { allBestSlugs } from "@/lib/seo/best-pages";
 import { allGuideSlugs } from "@/lib/seo/guides";
 import { allBlogSlugs } from "@/lib/seo/blog";
@@ -64,8 +64,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // Tier-2: job × vertical (the long tail).
-  for (const { job, vertical } of allJobVerticalPairs()) {
+  // Tier-2: job × vertical (the long tail) — only the kept pairs (indexation
+  // consolidation, 2026-07-17); folded pairs 301 and must not be sitemapped.
+  for (const { job, vertical } of KEPT_PAIRS) {
     entries.push({
       url: `${base}/ai-agents/${job}/for/${vertical}`,
       lastModified: now,
@@ -150,10 +151,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // Head-to-head comparison pages (/compare/<a>-vs-<b>).
+  // Head-to-head comparison pages (/compare/<a>-vs-<b>) — only the kept
+  // third-party pairs (indexation consolidation, 2026-07-17); folded pairs
+  // 301 to /alternatives and must not be sitemapped.
   for (const pair of VS_PAIRS) {
+    const slug = vsSlug(pair);
+    if (!isKeptVsPair(slug)) continue;
     entries.push({
-      url: `${base}/compare/${vsSlug(pair)}`,
+      url: `${base}/compare/${slug}`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.7,

--- a/packages/crm/src/lib/seo/agent-pages.ts
+++ b/packages/crm/src/lib/seo/agent-pages.ts
@@ -798,7 +798,10 @@ export function relatedJobsForVertical(currentJobSlug: string, limit = 5): Agent
   return AGENT_JOBS.filter((j) => j.slug !== currentJobSlug).slice(0, limit);
 }
 
-/** Every (job, vertical) pair — the Tier-2 route param source. */
+/** Every (job, vertical) pair — the full matrix (160 pairs). Kept as the
+ *  inventory source (spec assertions, the markdown-resolution fallback); the
+ *  routes/sitemap use `KEPT_PAIRS` below to decide what actually gets a
+ *  standalone page. */
 export function allJobVerticalPairs(): { job: string; vertical: string }[] {
   const pairs: { job: string; vertical: string }[] = [];
   for (const job of AGENT_JOBS) {
@@ -807,6 +810,38 @@ export function allJobVerticalPairs(): { job: string; vertical: string }[] {
     }
   }
   return pairs;
+}
+
+// ─── indexation consolidation (2026-07-17) ────────────────────────────────────
+// See docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md — of the 160
+// job×vertical pairs only ~71 ever got a search impression and ~10 got
+// meaningful ones, so Google was rationing crawl budget across mostly-empty
+// pages. These 16 are the ones with real organic traction (or, for
+// missed-call-text-back/for/barbers, real campaign traffic) and stay as
+// standalone pages; every other pair 301s to its job hub, which gains a
+// "by industry" section reusing the same vertical copy so nothing is lost.
+export const KEPT_PAIRS: { job: string; vertical: string }[] = [
+  { job: "google-review-agent", vertical: "real-estate" },
+  { job: "google-review-agent", vertical: "med-spas" },
+  { job: "google-review-agent", vertical: "roofers" },
+  { job: "google-review-agent", vertical: "barbers" },
+  { job: "google-review-agent", vertical: "auto-repair" },
+  { job: "google-review-agent", vertical: "cleaning" },
+  { job: "google-review-agent", vertical: "chiropractors" },
+  { job: "google-review-agent", vertical: "dentists" },
+  { job: "missed-call-text-back", vertical: "barbers" },
+  { job: "missed-call-text-back", vertical: "restaurants" },
+  { job: "missed-call-text-back", vertical: "dentists" },
+  { job: "missed-call-text-back", vertical: "roofers" },
+  { job: "missed-call-text-back", vertical: "med-spas" },
+  { job: "missed-call-text-back", vertical: "garage-door" },
+  { job: "ai-receptionist", vertical: "auto-repair" },
+  { job: "ai-receptionist", vertical: "real-estate" },
+];
+
+/** Whether a (job, vertical) pair keeps its standalone page. Pure — no DB. */
+export function isKeptPair(job: string, vertical: string): boolean {
+  return KEPT_PAIRS.some((p) => p.job === job && p.vertical === vertical);
 }
 
 // ─── copy composition (the GEO answer-page engine) ─────────────────────────────

--- a/packages/crm/src/lib/seo/alternative-pages-extras.ts
+++ b/packages/crm/src/lib/seo/alternative-pages-extras.ts
@@ -828,3 +828,25 @@ export function getVsPair(slug: string): { pair: VsPair; a: Competitor; b: Compe
   if (!pair) throw new Error(`Unknown vs pair: ${slug}`);
   return { pair, a: getCompetitor(pair.a), b: getCompetitor(pair.b) };
 }
+
+// ─── indexation consolidation (2026-07-17) ────────────────────────────────────
+// See docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md — of the 30
+// third-party VS_PAIRS, 3 months of GSC data show clicks on only these 7; the
+// other ~23 have 0 clicks and Google treats a mismatched-topic 301 as a
+// soft-404, which is the intended outcome for them. The 26 seldonframe-vs-*
+// pages (COMPETITORS, alternative-pages.ts) are bottom-funnel and untouched —
+// this allowlist governs ONLY the third-party VS_PAIRS family.
+export const KEPT_VS_SLUGS: string[] = [
+  "chatbase-vs-voiceflow",
+  "chatbase-vs-botpress",
+  "gohighlevel-vs-linktree",
+  "gohighlevel-vs-klaviyo",
+  "keap-vs-activecampaign",
+  "klaviyo-vs-hubspot",
+  "vapi-vs-retell-ai",
+];
+
+/** Whether a third-party `/compare/<a>-vs-<b>` pair keeps its standalone page. */
+export function isKeptVsPair(slug: string): boolean {
+  return KEPT_VS_SLUGS.includes(slug);
+}


### PR DESCRIPTION
## Why

255 of 650 known pages are not indexed (154 = Google refusing to crawl). The `ai-agents` family alone emits 160 URLs (10 jobs × 16 verticals) of which only ~10 ever earned meaningful impressions; third-party `compare` pairs earned 0 clicks in 3 months. Domain-level crawl rationing is gating every future content play.

Full plan + GSC/PostHog evidence: `docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md` (approved by Max 2026-07-17).

## What

- **`KEPT_PAIRS` allowlist** (16 job×vertical pairs) in `lib/seo/agent-pages.ts`; `generateStaticParams` + sitemap emit only those. Folded pairs `permanentRedirect` to their job hub. Shared `listing.md` twin route gated identically.
- **`KEPT_VS_SLUGS` allowlist** (7 third-party pairs) in `lib/seo/alternative-pages-extras.ts`; folded pairs `permanentRedirect('/alternatives')`. All 26 `seldonframe-vs-*` pages untouched.
- **23 folded compare `.md` twin routes** rewritten to serve only a 308 → `/alternatives` (consistent fold across HTML and LLM-crawler surfaces).
- **No data deleted** — emission gated only; per-vertical copy is reused by the PR 2 job-hub sections.
- Sitemap: **−167 URLs** (~650 → ~490 known).

⚠️ Deliberately kept: `/ai-agents/missed-call-text-back/for/barbers` — GSC shows only 25 impressions but PostHog shows 137 visitors/30d of campaign traffic.

## Verification

Independent verify-runner gate: **PASS** — 1518 unit tests green; tsc delta clean (single pre-existing `copilot/turn` error confirmed on main); use-server hygiene clean; no migrations; regression grep empty. Behavioral invariants verified from the diff: kept pairs still statically generated, folded ai-agents pairs redirect to their own job hub, exactly 23 `.md` routes touched (none of the 7 kept), sitemap changes scoped to the two families.

Post-deploy smoke (will run after merge): kept pair 200s, folded pair 308s on both `.html` and `.md` surfaces, sitemap URL-count delta.

## Follow-up (PR 2, next)

Internal-link wave: footer "Pricing guides" group, `alternative-to-X ↔ X-pricing ↔ compare` triangle, job-hub "by industry" sections, and removing the 23 folded pairs from `/alternatives` + `llms.txt` (until then those links 301 back to the hub — harmless round-trip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)