### PR TITLE
feat(seo): internal-link wave — pricing footer, competitor triangle, by-industry hubs

### DIFF
--- a/packages/crm/src/app/(public)/alternatives/page.tsx
+++ b/packages/crm/src/app/(public)/alternatives/page.tsx
@@ -7,7 +7,7 @@ import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/mark
 import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { COMPETITORS, LAST_UPDATED, getCompetitor } from "@/lib/seo/alternative-pages";
-import { VS_PAIRS, vsSlug } from "@/lib/seo/alternative-pages-extras";
+import { VS_PAIRS, vsSlug, isKeptVsPair } from "@/lib/seo/alternative-pages-extras";
 
 export const metadata: Metadata = {
   title: "SeldonFrame vs the alternatives — honest comparisons for agencies & builders",
@@ -15,6 +15,11 @@ export const metadata: Metadata = {
     "How SeldonFrame compares to GoHighLevel, HubSpot, ActiveCampaign, ClickFunnels, Vapi, Podium and more — plus HighLevel head-to-heads: AI receptionist, website, CRM and booking at $29/mo flat.",
   alternates: { canonical: "/alternatives" },
 };
+
+// Folded third-party pairs 301 to this very page (indexation consolidation,
+// 2026-07-17) — listing them here would just be a dead click, so only the
+// kept pairs are linked.
+const KEPT_VS_PAIRS = VS_PAIRS.filter((p) => isKeptVsPair(vsSlug(p)));
 
 export default function AlternativesHubPage(): ReactElement {
   return (
@@ -99,7 +104,7 @@ export default function AlternativesHubPage(): ReactElement {
           Comparing two tools against each other? These break down the real trade-off — and what to do when you need what both do.
         </p>
         <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 18 }}>
-          {VS_PAIRS.map((p) => (
+          {KEPT_VS_PAIRS.map((p) => (
             <Link
               key={vsSlug(p)}
               href={`/compare/${vsSlug(p)}`}

--- a/packages/crm/src/app/(public)/tools/google-review-link-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/google-review-link-generator/page.tsx
@@ -10,6 +10,7 @@ import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { GoogleReviewLinkGenerator } from "@/components/seo/google-review-link-generator";
 import { buildOgUrl } from "@/lib/seo/og-card";
+import { keptVerticalsForJob } from "@/lib/seo/agent-pages";
 
 /** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
  *  text, so strip tags before embedding in the schema. */
@@ -60,6 +61,8 @@ const FAQ = [
   },
 ];
 
+const REVIEW_AGENT_VERTICALS = keptVerticalsForJob("google-review-agent");
+
 export default function GoogleReviewLinkGeneratorPage(): ReactElement {
   const faqLd = {
     "@context": "https://schema.org",
@@ -105,6 +108,27 @@ export default function GoogleReviewLinkGeneratorPage(): ReactElement {
             biggest lever isn't asking more — it's <strong>removing friction</strong> from the ask. A direct link or a QR
             code on a receipt turns a 2-minute chore into a <strong>10-second tap</strong>.
           </p>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Put this on autopilot</h2>
+          <p style={{ margin: "0 0 16px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)", maxWidth: 660 }}>
+            This tool builds the link. The <strong>Google Review Agent</strong> sends it automatically — at the perfect
+            moment after every finished job, with a follow-up if there's no response, and it catches unhappy customers
+            privately first. Built for:
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {REVIEW_AGENT_VERTICALS.map((v) => (
+              <Link
+                key={v.slug}
+                href={`/ai-agents/google-review-agent/for/${v.slug}`}
+                className="sf-link"
+                style={{ fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.7)", border: `1px solid ${MKT.ink10}`, borderRadius: 999, padding: "7px 14px", textDecoration: "none", background: "rgba(255,255,255,0.5)" }}
+              >
+                {`Review agent for ${v.plural}`}
+              </Link>
+            ))}
+          </div>
         </section>
 
         <section style={{ padding: "40px 0 0" }}>

--- a/packages/crm/src/app/llms.txt/route.ts
+++ b/packages/crm/src/app/llms.txt/route.ts
@@ -7,9 +7,9 @@
 //
 // Served as text/markdown at /llms.txt.
 
-import { AGENT_JOBS, VERTICALS } from "@/lib/seo/agent-pages";
+import { AGENT_JOBS, VERTICALS, KEPT_PAIRS, getJob, getVertical } from "@/lib/seo/agent-pages";
 import { COMPETITORS, getCompetitor } from "@/lib/seo/alternative-pages";
-import { VS_PAIRS, vsSlug } from "@/lib/seo/alternative-pages-extras";
+import { VS_PAIRS, vsSlug, isKeptVsPair } from "@/lib/seo/alternative-pages-extras";
 import { BEST_PAGES, bestSlug, getBestPage, midSentence } from "@/lib/seo/best-pages";
 import { allGuideSlugs, getGuide } from "@/lib/seo/guides";
 import { allBlogSlugs, getBlogArticle } from "@/lib/seo/blog";
@@ -64,18 +64,18 @@ export async function GET(req: Request): Promise<Response> {
   }
   lines.push("");
 
-  // Tier-2: a representative sample of job × vertical pages (the long tail is
-  // enumerated in sitemap.xml; here we list a focused, useful subset per job so
-  // the file stays scannable while still revealing the vertical pattern).
-  lines.push("## AI agents by industry (examples)");
+  // Tier-2: only the KEPT job × vertical pages (indexation consolidation,
+  // 2026-07-17) — every other pair now 301s to its job hub, so listing them
+  // here would just send the crawler through a redirect. The full long tail
+  // (kept pairs only) is enumerated in sitemap.xml.
+  lines.push("## AI agents by industry");
   lines.push("");
-  const sampleVerticals = VERTICALS.slice(0, 6);
-  for (const job of AGENT_JOBS) {
-    for (const v of sampleVerticals) {
-      lines.push(
-        `- [${job.name} for ${v.plural}](${base}/ai-agents/${job.slug}/for/${v.slug}): ${job.name} tailored for ${v.plural}.`,
-      );
-    }
+  for (const { job: jobSlug, vertical: verticalSlug } of KEPT_PAIRS) {
+    const job = getJob(jobSlug);
+    const v = getVertical(verticalSlug);
+    lines.push(
+      `- [${job.name} for ${v.plural}](${base}/ai-agents/${jobSlug}/for/${verticalSlug}): ${job.name} tailored for ${v.plural}.`,
+    );
   }
   lines.push("");
 
@@ -93,7 +93,9 @@ export async function GET(req: Request): Promise<Response> {
   for (const c of COMPETITORS) {
     lines.push(`- [${c.name} pricing breakdown](${base}/${c.slug}-pricing): plans, the costs that stack on top, and what you'll actually pay.`);
   }
-  for (const p of VS_PAIRS) {
+  // Only the kept third-party pairs (indexation consolidation, 2026-07-17) —
+  // the other ~23 now 301 to /alternatives.
+  for (const p of VS_PAIRS.filter((pair) => isKeptVsPair(vsSlug(pair)))) {
     lines.push(
       `- [${getCompetitor(p.a).name} vs ${getCompetitor(p.b).name}](${base}/compare/${vsSlug(p)}): ${p.angle}`,
     );
@@ -210,7 +212,7 @@ export async function GET(req: Request): Promise<Response> {
   lines.push(`- [AI agent library](${base}/ai-agents): every stat-backed agent answer page.`);
   lines.push(`- [Pricing](${base}/pricing): plans and what a workspace costs.`);
   lines.push(
-    `- Full URL list: ${base}/sitemap.xml lists every agent page (all ${AGENT_JOBS.length} jobs × ${VERTICALS.length} industries).`,
+    `- Full URL list: ${base}/sitemap.xml lists every agent page (${AGENT_JOBS.length} job hubs, each covering all ${VERTICALS.length} industries, plus the ${KEPT_PAIRS.length} by-industry pages with real search traffic).`,
   );
   lines.push("");
 

--- a/packages/crm/src/components/landing/marketing-footer.tsx
+++ b/packages/crm/src/components/landing/marketing-footer.tsx
@@ -1,9 +1,15 @@
 // packages/crm/src/components/landing/marketing-footer.tsx
 //
 // Redesign 2026-06-18 — warm light aesthetic.
-// Six-column footer on md+ (brand + 5 link columns incl. the Compare/Free-tools
-// SEO mesh, PostPlanify-style). Paper-soft background, warm ink typography.
-// Dual CTA strip above the columns — SMB + agency paths.
+// Seven-column footer on md+ (brand + 6 link columns incl. the Compare/Free-tools/
+// Pricing-guides SEO mesh, PostPlanify-style). Paper-soft background, warm ink
+// typography. Dual CTA strip above the columns — SMB + agency paths.
+//
+// 2026-07-17: added the "Pricing guides" column (indexation-consolidation
+// Part 1c — the homepage/footer previously linked zero pricing pages despite
+// */-pricing being the best-performing SEO family). No pricing hub/index page
+// exists to headline the column (only the SF-owned /pricing page, which is a
+// different page), so there is no "All pricing breakdowns →" link here.
 
 import Link from "next/link";
 
@@ -74,6 +80,17 @@ const COLUMNS: readonly Column[] = [
     ],
   },
   {
+    heading: "Pricing guides",
+    links: [
+      { label: "Podium Pricing", href: "/podium-pricing" },
+      { label: "Linktree Pricing", href: "/linktree-pricing" },
+      { label: "Kartra Pricing", href: "/kartra-pricing" },
+      { label: "Voiceflow Pricing", href: "/voiceflow-pricing" },
+      { label: "Durable Pricing", href: "/durable-pricing" },
+      { label: "Synthflow Pricing", href: "/synthflow-pricing" },
+    ],
+  },
+  {
     heading: "Company",
     links: [
       { label: "Contact", href: "mailto:hello@seldonframe.com" },
@@ -95,7 +112,7 @@ export function MarketingFooter() {
 
       <div className="mx-auto max-w-[1120px]">
         {/* Brand block */}
-        <div className="grid grid-cols-1 gap-10 md:grid-cols-[1.4fr_repeat(5,1fr)] md:gap-8">
+        <div className="grid grid-cols-1 gap-10 md:grid-cols-[1.4fr_repeat(6,1fr)] md:gap-8">
           <div className="flex max-w-[340px] flex-col gap-5">
             <Link href="/" aria-label="SeldonFrame — home" className="inline-flex items-center">
               <BrandMark size={22} />

--- a/packages/crm/src/components/seo/agent-page.tsx
+++ b/packages/crm/src/components/seo/agent-page.tsx
@@ -34,6 +34,9 @@ import {
   composePageCopy,
   deployHrefFor,
   relatedJobsForVertical,
+  keptVerticalsForJob,
+  isKeptPair,
+  VERTICALS,
   type AgentJob,
   type Vertical,
 } from "@/lib/seo/agent-pages";
@@ -55,6 +58,20 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
   const steps = job.howItWorks;
   const related = relatedJobsForVertical(job.slug, 5);
   const verticalLabel = vertical ? vertical.plural : "your business";
+  // Review-agent cluster (PR 2, Part 1c): on a kept google-review-agent Tier-2
+  // page, cross-link the tool that builds the review link this agent sends,
+  // plus the other kept verticals for the SAME job (siblings) — every folded
+  // pair already redirects before this component renders, so `vertical` here
+  // is always a kept one when it's present.
+  const reviewAgentSiblings =
+    vertical && job.slug === "google-review-agent"
+      ? keptVerticalsForJob(job.slug).filter((v) => v.slug !== vertical.slug)
+      : [];
+  // Job-hub "by industry" section (PR 2, Part 1c — the consolidation payoff):
+  // Tier-1 only. Kept verticals link to their standalone page; folded verticals
+  // render their composed copy inline so the content lives on the hub instead
+  // of vanishing with the page.
+  const byIndustry = !vertical ? VERTICALS : [];
   // The public `.md` twin of THIS page (Tier-1 or Tier-2) — pointed at by the
   // visually-hidden Markdown pointer for the human-pastes-URL-into-an-LLM flow.
   const markdownHref = vertical
@@ -348,6 +365,97 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
           </div>
         </section>
 
+        {/* ── REVIEW-AGENT CLUSTER: tool + sibling-vertical cross-links (Tier-2, google-review-agent only) ── */}
+        {reviewAgentSiblings.length > 0 ? (
+          <section style={SECTION}>
+            <h2 style={{ ...H2, marginBottom: 4 }}>Built the link? Put the ask on autopilot</h2>
+            <p style={{ margin: "0 0 18px", fontSize: 14.5, color: "rgba(34,29,23,0.55)" }}>
+              This agent sends the ask automatically — no manual texting required.
+            </p>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+              <Link
+                href="/tools/google-review-link-generator"
+                className="sf-link"
+                style={{ fontSize: 13.5, fontWeight: 600, color: MKT.green, border: "1px solid rgba(31, 43, 36,0.35)", borderRadius: 999, padding: "7px 14px", textDecoration: "none", background: "rgba(31, 43, 36,0.06)" }}
+              >
+                Build the review link (free tool) →
+              </Link>
+              {reviewAgentSiblings.map((v) => (
+                <Link
+                  key={v.slug}
+                  href={`/ai-agents/google-review-agent/for/${v.slug}`}
+                  className="sf-link"
+                  style={{ fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.7)", border: "1px solid rgba(34,29,23,0.10)", borderRadius: 999, padding: "7px 14px", textDecoration: "none", background: "rgba(255,255,255,0.5)" }}
+                >
+                  {`For ${v.plural}`}
+                </Link>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* ── BY INDUSTRY (Tier-1 hub only — the consolidation payoff): kept
+             verticals link out, folded verticals render their composed copy
+             inline so the content lives on the hub instead of vanishing. ── */}
+        {byIndustry.length > 0 ? (
+          <section style={SECTION}>
+            <h2 style={H2}>{`${job.name} by industry`}</h2>
+            <p style={{ margin: "-6px 0 20px", fontSize: 15, color: "rgba(34,29,23,0.6)", maxWidth: 640 }}>
+              How this agent shows up for the trades that ask about it most.
+            </p>
+            <div className="sf-ap-industry">
+              {byIndustry.map((v) => {
+                const kept = isKeptPair(job.slug, v.slug);
+                if (kept) {
+                  return (
+                    <Link
+                      key={v.slug}
+                      href={`/ai-agents/${job.slug}/for/${v.slug}`}
+                      className="sf-cardhover"
+                      style={{
+                        textDecoration: "none",
+                        color: MKT.ink,
+                        background: "#fff",
+                        border: "1px solid rgba(34,29,23,0.10)",
+                        borderRadius: 14,
+                        padding: 16,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: 12,
+                        boxShadow: "0 1px 2px rgba(34,29,23,0.04)",
+                      }}
+                    >
+                      <div style={{ fontWeight: 700, fontSize: 15.5 }}>{v.plural}</div>
+                      <span style={{ color: MKT.green, flex: "none", display: "flex" }}>
+                        <MarketplaceIcon name="arrowRight" size={16} />
+                      </span>
+                    </Link>
+                  );
+                }
+                const vCopy = composePageCopy(job, v);
+                return (
+                  <div
+                    key={v.slug}
+                    style={{
+                      background: "#fff",
+                      border: "1px solid rgba(34,29,23,0.10)",
+                      borderRadius: 14,
+                      padding: 16,
+                      boxShadow: "0 1px 2px rgba(34,29,23,0.04)",
+                    }}
+                  >
+                    <div style={{ fontWeight: 700, fontSize: 15.5, marginBottom: 6 }}>{v.plural}</div>
+                    <p style={{ margin: 0, fontSize: 13.5, lineHeight: 1.55, color: "rgba(34,29,23,0.68)" }}>
+                      {firstSentences(vCopy.intro, 2)}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
+
         {/* ── FLYWHEEL: "more agents for [vertical]" cross-links ── */}
         {related.length > 0 ? (
           <section style={SECTION}>
@@ -445,6 +553,7 @@ const AGENT_PAGE_CSS = `
   .sf-agentpage,.sf-agentpage *{min-width:0}
   .sf-ap-main{max-width:920px}
   .sf-ap-related{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+  .sf-ap-industry{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
   .sf-ap-howit{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px}
   .sf-ap-works{display:flex;flex-wrap:wrap;gap:10px}
   .sf-ap-stepcard{transition:transform .2s cubic-bezier(0.22,1,0.36,1),box-shadow .2s,border-color .2s}
@@ -460,6 +569,7 @@ const AGENT_PAGE_CSS = `
     .sf-ap-h1{font-size:32px !important;line-height:1.08 !important}
     .sf-ap-stat{font-size:18px !important}
     .sf-ap-related{grid-template-columns:1fr}
+    .sf-ap-industry{grid-template-columns:1fr}
     .sf-ap-howit{grid-template-columns:1fr}
   }
   @media (prefers-reduced-motion:reduce){
@@ -495,4 +605,13 @@ function aOrAnLower(name: string): string {
 /** Pick a representative surface icon for a related-agent card. */
 function surfaceIconFor(job: AgentJob) {
   return SURFACE_META[job.surfaces[0]].icon;
+}
+
+/** The first `n` sentences of already-composed copy (splitting on ". ") — no
+ *  new writing, just trims composePageCopy's intro down to a hub-card-sized
+ *  blurb for the "by industry" section (PR 2, Part 1c). */
+function firstSentences(text: string, n: number): string {
+  const parts = text.split(". ");
+  if (parts.length <= n) return text;
+  return `${parts.slice(0, n).join(". ")}.`;
 }

--- a/packages/crm/src/components/seo/alternative-page.tsx
+++ b/packages/crm/src/components/seo/alternative-page.tsx
@@ -15,6 +15,7 @@ import { MarketplaceNav, MarketplaceFooter, SeldonFrameMark } from "@/components
 import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
 import { MarkdownPointer } from "@/components/seo/markdown-pointer";
+import { CompetitorCrossLinks } from "@/components/seo/competitor-crosslinks";
 import { TldrBox } from "@/components/seo/tldr-box";
 import { FrontOfficeFlow } from "@/components/seo/front-office-flow";
 import { BuildWidget } from "@/components/seo/build-widget";
@@ -277,6 +278,12 @@ export function AlternativePage({ competitor }: { competitor: Competitor }): Rea
               <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }}>{item.a}</p>
             </details>
           ))}
+        </section>
+
+        {/* ── THIS COMPETITOR, EVERYWHERE (the pricing/compare triangle) ── */}
+        <section style={{ padding: "30px 0 8px" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 20, fontWeight: 800, letterSpacing: "-0.01em" }}>{`More on ${c.name}`}</h2>
+          <CompetitorCrossLinks slug={c.slug} current="alternative" />
         </section>
 
         {/* ── MORE COMPARISONS (flywheel) ── */}

--- a/packages/crm/src/components/seo/competitor-crosslinks.tsx
+++ b/packages/crm/src/components/seo/competitor-crosslinks.tsx
@@ -1,0 +1,71 @@
+// The per-competitor "triangle" cross-link block — indexation consolidation
+// Part 1c (docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md).
+// Three surfaces exist per competitor: /alternative-to-<slug>, /<slug>-pricing,
+// and /compare/seldonframe-vs-<slug>. All three already render from ONE shared
+// template each (alternative-page.tsx, pricing-page.tsx, seldonframe-vs-page.tsx
+// — no per-competitor page files to edit), so this single component, told which
+// surface it's rendering on, links to whichever OTHER surfaces exist for that
+// competitor. `pricing` is the only optional leg: /<slug>-pricing only exists
+// for competitors present in BOTH lib/seo/alternative-pages.ts (COMPETITORS,
+// 26 slugs) AND lib/seo/competitor-pricing.ts (PRICING, 25 slugs) — every
+// PRICING slug has a matching COMPETITOR, but "claude-projects" has no pricing
+// page (an alternative-to-only comparison, no vendor pricing page to break down).
+
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { PRICING } from "@/lib/seo/competitor-pricing";
+
+export type CompetitorSurface = "alternative" | "pricing" | "compare";
+
+const PILL_STYLE = {
+  fontSize: 13.5,
+  fontWeight: 600,
+  color: "rgba(34,29,23,0.7)",
+  border: `1px solid ${MKT.ink10}`,
+  borderRadius: 999,
+  padding: "7px 14px",
+  textDecoration: "none",
+  background: "rgba(255,255,255,0.5)",
+} as const;
+
+/** Whether `/<slug>-pricing` exists (i.e. the slug is in the PRICING registry). */
+export function hasCompetitorPricing(slug: string): boolean {
+  return PRICING.some((p) => p.slug === slug);
+}
+
+/**
+ * Renders a link to each of the OTHER two triangle surfaces for `slug` (never
+ * back to `current`), skipping `pricing` when the competitor has no pricing
+ * page. Returns null when there's nothing else to link (shouldn't happen in
+ * practice — every competitor has at least 2 of the 3 surfaces).
+ */
+export function CompetitorCrossLinks({
+  slug,
+  current,
+}: {
+  slug: string;
+  current: CompetitorSurface;
+}): ReactElement | null {
+  const c = getCompetitor(slug);
+  const candidates: { surface: CompetitorSurface; href: string; label: string }[] = [
+    { surface: "alternative", href: `/alternative-to-${slug}`, label: `${c.name} switching guide` },
+    { surface: "pricing", href: `/${slug}-pricing`, label: `${c.name} pricing breakdown` },
+    { surface: "compare", href: `/compare/seldonframe-vs-${slug}`, label: `SeldonFrame vs ${c.name}` },
+  ];
+  const targets = candidates.filter(
+    (t) => t.surface !== current && (t.surface !== "pricing" || hasCompetitorPricing(slug)),
+  );
+  if (targets.length === 0) return null;
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+      {targets.map((t) => (
+        <Link key={t.surface} href={t.href} className="sf-link" style={PILL_STYLE}>
+          {`${t.label} →`}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/seldonframe-vs-page.tsx
+++ b/packages/crm/src/components/seo/seldonframe-vs-page.tsx
@@ -19,6 +19,7 @@ import { MarkdownPointer } from "@/components/seo/markdown-pointer";
 import { TldrBox } from "@/components/seo/tldr-box";
 import { FrontOfficeFlow } from "@/components/seo/front-office-flow";
 import { PricingSourceLine } from "@/components/seo/alternative-page";
+import { hasCompetitorPricing } from "@/components/seo/competitor-crosslinks";
 import { BuildWidget } from "@/components/seo/build-widget";
 import { AuthorByline, articleLd } from "@/components/seo/author-byline";
 import { monthYearToIso } from "@/lib/seo/month-iso";
@@ -450,6 +451,15 @@ export function SeldonFrameVsPage({ competitor }: { competitor: Competitor }): R
             >
               {`Prefer the switching guide? Full ${c.name} alternative breakdown →`}
             </Link>
+            {hasCompetitorPricing(c.slug) ? (
+              <Link
+                href={`/${c.slug}-pricing`}
+                className="sf-link"
+                style={{ fontSize: 13.5, fontWeight: 600, color: MKT.green, border: `1px solid rgba(31, 43, 36,0.35)`, borderRadius: 999, padding: "7px 14px", textDecoration: "none", background: "rgba(31, 43, 36,0.06)" }}
+              >
+                {`${c.name} pricing breakdown →`}
+              </Link>
+            ) : null}
             {crossLinks.map((o) => (
               <Link
                 key={o.slug}

--- a/packages/crm/src/lib/seo/agent-pages.ts
+++ b/packages/crm/src/lib/seo/agent-pages.ts
@@ -844,6 +844,12 @@ export function isKeptPair(job: string, vertical: string): boolean {
   return KEPT_PAIRS.some((p) => p.job === job && p.vertical === vertical);
 }
 
+/** The kept verticals for one job, in registry order — the sibling set a kept
+ *  Tier-2 page cross-links to (PR 2, Part 1c "review-agent cluster"). Pure. */
+export function keptVerticalsForJob(jobSlug: string): Vertical[] {
+  return KEPT_PAIRS.filter((p) => p.job === jobSlug).map((p) => getVertical(p.vertical));
+}
+
 // ─── copy composition (the GEO answer-page engine) ─────────────────────────────
 
 export type ComposedPageCopy = {

--- a/packages/crm/tests/unit/integrations/llm-key-dialog.spec.tsx
+++ b/packages/crm/tests/unit/integrations/llm-key-dialog.spec.tsx
@@ -19,6 +19,12 @@ import type { SaveLlmKeyResult } from "../../../src/lib/integrations/llm/actions
 
 afterEach(() => cleanup());
 
+// testing-library's default asyncUtilTimeout is 1s, which is too tight for
+// base-ui's Dialog mount/unmount cycle when CI runs the whole suite in
+// parallel (`node --test` fans specs across every core). The assertions below
+// still prove the same contract — they just tolerate a loaded machine.
+const WAIT = { timeout: 5000 } as const;
+
 describe("<LlmKeyDialog>", () => {
   test("renders the Anthropic key field when open", () => {
     render(<LlmKeyDialog open={true} onOpenChange={() => {}} action={async () => ({ ok: true, provider: "anthropic" })} />);
@@ -49,7 +55,7 @@ describe("<LlmKeyDialog>", () => {
 
     await waitFor(() => {
       assert.equal(openState, false, "dialog should close on success");
-    });
+    }, WAIT);
     assert.equal(savedCalled, true, "onSaved should fire on success");
   });
 
@@ -79,7 +85,7 @@ describe("<LlmKeyDialog>", () => {
         screen.getAllByText(/anthropic keys start with sk-ant-/i).length > 0,
         "error message not shown",
       );
-    });
+    }, WAIT);
     assert.equal(openState, true, "dialog must stay open on error — no silent close");
   });
 
@@ -109,7 +115,7 @@ describe("<LlmKeyDialog>", () => {
 
     await waitFor(() => {
       assert.ok(screen.getAllByText(/anthropic keys start with sk-ant-/i).length > 0);
-    });
+    }, WAIT);
 
     // Close without saving via the dialog's own close control — the same
     // onOpenChange(false) path Escape/overlay-click drive internally.
@@ -117,7 +123,7 @@ describe("<LlmKeyDialog>", () => {
 
     await waitFor(() => {
       assert.equal(screen.queryAllByLabelText(/anthropic api key/i).length, 0, "dialog should be closed");
-    });
+    }, WAIT);
 
     fireEvent.click(screen.getByRole("button", { name: /reopen/i }));
 


### PR DESCRIPTION
## Why

Part 1c of the SEO sprint (`docs/strategy/seo/2026-07-17-indexation-consolidation-plan.md`), stacked on #124 (merged).

The homepage is the only page with real authority (avg position 3.3) and the footer linked **zero** pricing pages — yet `*-pricing` is the best-performing family (avg position 23) while `/best/` is the worst (position 47). This routes authority to the pages that can actually use it, and completes the consolidation by absorbing the folded pages' copy into their job hubs.

## What

- **Footer "Pricing guides" column** — podium, linktree, kartra, voiceflow, durable, synthflow.
- **Competitor triangle** — new shared `CompetitorCrossLinks` component wiring `alternative-to-X ↔ X-pricing ↔ compare/seldonframe-vs-X`. Join = 25 of 26 competitors; `claude-projects` has no pricing page and is gated out by `hasCompetitorPricing()`. (`pricing-page.tsx` already linked both legs — untouched.)
- **Review-agent cluster** — the google-review-link-generator tool page (149 impressions) links the 8 kept vertical pages; each links back + to its siblings.
- **"By industry" hub sections** — `/ai-agents/[job]` hubs render all 16 verticals: kept ones link out, **folded ones render their copy inline**. This is the consolidation payoff — #124's folded content now lives on the hub instead of vanishing.
- **Link hygiene** — `/alternatives` and `llms.txt` filtered to kept pairs (they were still listing all 30 folded compare pairs and an unfiltered vertical sample).

## Verification

Independent verify-runner: all six standard checks pass (tsc delta 0 — the single `copilot/turn` error is pre-existing on main; use-server clean; no migrations; regression grep empty) and all six behavioral invariants confirmed from the diff: no folded page is linked anywhere, folded verticals render inline without links, the triangle only renders legs that exist, the 6 footer targets all resolve, the 8 vertical links all point to kept pairs, and the new `.sf-ap-industry` grid copies the proven `.sf-ap-related` mobile-collapse pattern.

Preview smoke + footer layout check at 1280/768/375px done on this PR's deployment before merge.

## Known pre-existing issue (not fixed here)

`/alternatives` maps all 26 COMPETITORS to `/<slug>-pricing` links, but only 25 have pricing pages — `claude-projects` is a dead link. Predates this work and is outside the plan's guardrails; flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)