### PR TITLE
chore(mcp): sync server.json to 1.60.0

### DIFF
--- a/skills/mcp-server/server.json
+++ b/skills/mcp-server/server.json
@@ -7,13 +7,13 @@
     "source": "github",
     "subfolder": "skills/mcp-server"
   },
-  "version": "1.59.2",
+  "version": "1.60.0",
   "websiteUrl": "https://seldonframe.com",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@seldonframe/mcp",
-      "version": "1.59.2",
+      "version": "1.60.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Registry pre-flight: `mcp-publisher publish` requires server.json version == npm-published version (1.60.0). Two-line bump, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)