### PR TITLE
feat(replay): slice 2 — compile traces to skills + L0 replay-before-LLM (Reelier 2c)

### DIFF
--- a/packages/crm/drizzle/0075_replay_skills.sql
+++ b/packages/crm/drizzle/0075_replay_skills.sql
@@ -1,0 +1,36 @@
+-- packages/crm/drizzle/0075_replay_skills.sql
+-- Deterministic replay — Reelier phase 2c, slice 2. Adds:
+--   1. `agent_workflow_traces.kind` — 'trace' (slice 1, default) vs
+--      'replay-run' (an L0 replay attempt's RunRecord, slice 2).
+--   2. `replay_skills` — compiled-from-trace SKILL.md rows, at most one
+--      'enabled' per deployment (partial unique index).
+--
+-- HAND-WRITTEN (house rule: never drizzle-kit generate in this repo).
+-- Additive only + idempotent (IF NOT EXISTS / CREATE ... IF NOT EXISTS) so a
+-- re-run after an out-of-band apply is a no-op. Mirrors 0074's style.
+
+ALTER TABLE "agent_workflow_traces"
+  ADD COLUMN IF NOT EXISTS "kind" text NOT NULL DEFAULT 'trace';
+
+CREATE TABLE IF NOT EXISTS "replay_skills" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "deployment_id" uuid NOT NULL REFERENCES "deployments"("id") ON DELETE CASCADE,
+  "name" text,
+  "skill_md" text NOT NULL,
+  "status" text NOT NULL DEFAULT 'draft',
+  "source_trace_id" uuid REFERENCES "agent_workflow_traces"("id") ON DELETE SET NULL,
+  "heal_count" integer NOT NULL DEFAULT 0,
+  "last_replay_at" timestamp with time zone,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+
+-- At most one ENABLED skill per deployment — replay-before-llm.ts's
+-- org-scoped lookup assumes "the" enabled skill, singular.
+CREATE UNIQUE INDEX IF NOT EXISTS "replay_skills_one_enabled_per_deployment_idx"
+  ON "replay_skills" ("deployment_id")
+  WHERE "status" = 'enabled';
+
+CREATE INDEX IF NOT EXISTS "replay_skills_org_deployment_idx"
+  ON "replay_skills" ("org_id", "deployment_id");

--- a/packages/crm/drizzle/meta/_journal.json
+++ b/packages/crm/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1784000000000,
       "tag": "0074_agent_workflow_traces",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1784100000000,
+      "tag": "0075_replay_skills",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crm/package.json
+++ b/packages/crm/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@seldonframe/core": "workspace:*",
     "@seldonframe/payments": "workspace:*",
+    "@seldonframe/reelier": "0.1.0",
     "@stripe/react-stripe-js": "^6.3.0",
     "@stripe/stripe-js": "^9.5.0",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/crm/src/db/schema/agent-workflow-traces.ts
+++ b/packages/crm/src/db/schema/agent-workflow-traces.ts
@@ -1,15 +1,19 @@
-// agent_workflow_traces — deterministic replay, Reelier phase 2c slice 1
-// (OBSERVE MODE ONLY). One row per email-triggered deployed-agent turn,
-// recorded ONLY when SF_DETERMINISTIC_REPLAY=1 (lib/web-build/policy.ts's
+// agent_workflow_traces — deterministic replay, Reelier phase 2c. One row per
+// email-triggered deployed-agent turn (kind='trace', slice 1) OR one row per
+// L0 replay attempt (kind='replay-run', slice 2) — recorded ONLY when
+// SF_DETERMINISTIC_REPLAY=1 (lib/web-build/policy.ts's
 // isDeterministicReplayOn). Dark by default; zero rows written when off.
 //
-// WHAT THIS IS: the raw material slice 2 (a future, separate change) will
-// compile into Reelier replays. This slice only ever WRITES — nothing reads
-// or replays `records` yet.
+// Slice 1 wrote 'trace' rows only (raw material for the compiler). Slice 2
+// adds the compiler (lib/deployments/replay/compile.ts, reading a 'trace'
+// row into a replay_skills.skill_md) and the L0 replayer
+// (lib/deployments/replay/replay-before-llm.ts, writing a 'replay-run' row
+// per attempt) — see AgentWorkflowTraceKind below for the two shapes.
 //
-// `records` is a jsonb array shaped by lib/deployments/replay/trace-format.ts
-// (the Reelier trace-record FORMAT — this repo has no npm dependency on
-// Reelier's code, only matches its record contract).
+// `records` is a jsonb value shaped per `kind` — see AgentWorkflowTraceRecords
+// below (this repo has no npm dependency on Reelier's trace FORMAT itself,
+// only matches its record contract; it DOES depend on @seldonframe/reelier
+// for the runner/compiler, which is where ReelierRunRecord comes from).
 //
 // FAIL-SOFT BY CONTRACT: the writer (lib/deployments/replay/persist.ts)
 // NEVER throws into the agent turn it observed — mirrors agent-run-receipts.ts's
@@ -33,8 +37,19 @@ import {
 import { organizations } from "./organizations";
 import { deployments } from "./deployments";
 import type { TraceRecord } from "@/lib/deployments/replay/trace-format";
+import type { ReelierRunRecord } from "@seldonframe/reelier";
 
 export type AgentWorkflowTraceTriggerKind = "email";
+
+/** Reelier phase 2c slice 2 — a row is either an OBSERVE-MODE trace (`kind:
+ *  'trace'`, `records` a TraceRecord[] in seq order, unchanged from slice 1)
+ *  or an L0 REPLAY run (`kind: 'replay-run'`, `records` the reelier
+ *  RunRecord the replay attempt produced — see
+ *  lib/deployments/replay/replay-before-llm.ts). Default 'trace' so every
+ *  slice-1 row (and every insert that doesn't pass `kind`) keeps its
+ *  existing meaning unchanged. */
+export type AgentWorkflowTraceKind = "trace" | "replay-run";
+export type AgentWorkflowTraceRecords = TraceRecord[] | ReelierRunRecord;
 
 export const agentWorkflowTraces = pgTable(
   "agent_workflow_traces",
@@ -54,6 +69,10 @@ export const agentWorkflowTraces = pgTable(
      *  enum) so a later slice (sms/schedule) needs no migration to add a
      *  new kind, mirroring agent_run_receipts.trigger_kind's convention. */
     triggerKind: text("trigger_kind").$type<AgentWorkflowTraceTriggerKind>().notNull(),
+    /** Reelier phase 2c slice 2 (migration 0075) — 'trace' (default, slice 1
+     *  behavior unchanged) or 'replay-run' (an L0 replay attempt's
+     *  RunRecord). See AgentWorkflowTraceKind above. */
+    kind: text("kind").$type<AgentWorkflowTraceKind>().notNull().default("trace"),
     /** The Gmail messageId / dedup key that identified this run. Nullable —
      *  not every trigger carries one (mirrors composio-event-dispatch.ts's
      *  fail-open-on-missing-id contract). */
@@ -66,7 +85,7 @@ export const agentWorkflowTraces = pgTable(
      *  meta first (seq 0), then note/call/result records in seq order.
      *  Already redacted + per-record capped by the recorder before this row
      *  is ever written (see trace-format.ts's redact()/capTraceBody()). */
-    records: jsonb("records").$type<TraceRecord[]>().notNull().default([]),
+    records: jsonb("records").$type<AgentWorkflowTraceRecords>().notNull().default([]),
     inputTokens: integer("input_tokens").notNull().default(0),
     outputTokens: integer("output_tokens").notNull().default(0),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/packages/crm/src/db/schema/index.ts
+++ b/packages/crm/src/db/schema/index.ts
@@ -54,6 +54,8 @@ export * from "./agent-action-drafts";
 export * from "./agent-run-receipts";
 // Deterministic replay — Reelier phase 2c slice 1 (observe mode only).
 export * from "./agent-workflow-traces";
+// Deterministic replay — Reelier phase 2c slice 2 (compile + L0 replay).
+export * from "./replay-skills";
 // May 1, 2026 — Measurement Layers 2 + 3.
 export * from "./seldonframe-events";
 export * from "./brain-outcomes";

--- a/packages/crm/src/db/schema/replay-skills.ts
+++ b/packages/crm/src/db/schema/replay-skills.ts
@@ -1,0 +1,81 @@
+// replay_skills — deterministic replay, Reelier phase 2c slice 2. One row
+// per COMPILED skill (a SKILL.md source, compiled from a stored
+// agent_workflow_traces row by lib/deployments/replay/compile.ts's
+// compileSkillFromTrace). A skill always starts `status: 'draft'` —
+// compileSkillFromTrace NEVER auto-enables (review-before-save: enabling is
+// a human act, for now via SQL/ops — no UI in this slice).
+//
+// At most ONE 'enabled' skill per deployment (the partial unique index
+// below) — lib/deployments/replay/replay-before-llm.ts's org-scoped lookup
+// relies on this to make "the deployment's enabled skill" unambiguous.
+//
+// Org-scoped: every read/write is scoped by org_id (L-04, security
+// invariant) — mirrors agent_workflow_traces.ts's contract exactly.
+// deployment_id is NOT NULL + ON DELETE CASCADE (unlike
+// agent_workflow_traces.deployment_id, which is nullable-on-delete): a
+// compiled skill has no meaning detached from the deployment it replays
+// against, so it's deleted with its deployment rather than orphaned.
+import { sql } from "drizzle-orm";
+import {
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { organizations } from "./organizations";
+import { deployments } from "./deployments";
+import { agentWorkflowTraces } from "./agent-workflow-traces";
+
+export type ReplaySkillStatus = "draft" | "enabled" | "disabled";
+
+export const replaySkills = pgTable(
+  "replay_skills",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    deploymentId: uuid("deployment_id")
+      .notNull()
+      .references(() => deployments.id, { onDelete: "cascade" }),
+    /** The compiled trace's own meta name (e.g. "email:<deploymentId>"), or
+     *  a later human rename — free text, no uniqueness constraint. */
+    name: text("name"),
+    /** The full SKILL.md source (frontmatter + step blocks) — reelier's
+     *  renderSkillMd output verbatim. Never mutated in place by this slice
+     *  (no L1/L2 escalation write-back yet — heal_count stays 0). */
+    skillMd: text("skill_md").notNull(),
+    status: text("status").$type<ReplaySkillStatus>().notNull().default("draft"),
+    /** The trace this skill was compiled from — ON DELETE SET NULL (a
+     *  skill outlives the trace row it was derived from; the trace is
+     *  provenance, not a dependency). */
+    sourceTraceId: uuid("source_trace_id").references(() => agentWorkflowTraces.id, {
+      onDelete: "set null",
+    }),
+    /** Count of successful L1/L2 escalation heals written back to this
+     *  skill. Always 0 in slice 2 (L0-only replay — no escalation ladder
+     *  wired yet); the column exists now so a future escalation slice needs
+     *  no migration. */
+    healCount: integer("heal_count").notNull().default(0),
+    /** Set only after a PASSED L0 replay run (replay-before-llm.ts) — never
+     *  touched by a skipped or diverged attempt. */
+    lastReplayAt: timestamp("last_replay_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    // At most one ENABLED skill per deployment — the replay-before-llm
+    // lookup assumes "the" enabled skill, singular.
+    uniqueIndex("replay_skills_one_enabled_per_deployment_idx")
+      .on(table.deploymentId)
+      .where(sql`status = 'enabled'`),
+    index("replay_skills_org_deployment_idx").on(table.orgId, table.deploymentId),
+  ],
+);
+
+export type ReplaySkillRow = typeof replaySkills.$inferSelect;
+export type NewReplaySkillRow = typeof replaySkills.$inferInsert;

--- a/packages/crm/src/lib/deployments/composio-event-dispatch-deps.ts
+++ b/packages/crm/src/lib/deployments/composio-event-dispatch-deps.ts
@@ -20,6 +20,12 @@ import {
 } from "@/lib/deployments/store";
 import { writeRunReceipt } from "@/lib/agent-receipts/write";
 import type { DispatchComposioEventDeps } from "@/lib/deployments/composio-event-dispatch";
+// Deterministic replay — Reelier phase 2c slice 2. Precondition fix (review
+// item 3): this was a per-dispatch `await import(...)` inside runAgenticTurn
+// — a pure policy-flag check has no reason to pay a dynamic-import cost on
+// every single run. Static, top-level, same as every other policy import in
+// this file's sibling deps modules.
+import { isDeterministicReplayOn } from "@/lib/web-build/policy";
 
 /** Build the production deps for dispatchComposioEventToDeployments.
  *  `claimRun`/`releaseClaim` wire the verify-gate fix-wave atomic
@@ -56,38 +62,14 @@ export function buildDispatchComposioEventDeps(): DispatchComposioEventDeps {
       const { getAIClient } = await import("@/lib/ai/client");
       const { runStatelessAgentTurn } = await import("@/lib/agents/stateless-turn");
 
-      // Deterministic replay — Reelier phase 2c slice 1 (OBSERVE MODE ONLY).
-      // Dark unless SF_DETERMINISTIC_REPLAY=1: when off, `recorder` stays
-      // undefined, `wrapToolCall` is never passed to runStatelessAgentTurn,
-      // and no new code path executes beyond this boolean check.
-      const { isDeterministicReplayOn } = await import("@/lib/web-build/policy");
+      // Deterministic replay — Reelier phase 2c. Dark unless
+      // SF_DETERMINISTIC_REPLAY=1: when off, neither the observe-mode
+      // recorder (slice 1) nor the L0 replay-before-LLM seam (slice 2)
+      // executes beyond this boolean check — runTurn() below is called
+      // directly, byte-for-byte the pre-slice-1 code path.
       const replayOn = isDeterministicReplayOn({
         SF_DETERMINISTIC_REPLAY: process.env.SF_DETERMINISTIC_REPLAY,
       });
-      let recorder: import("@/lib/deployments/replay/recorder").TraceRecorder | undefined;
-      const turnStartedAt = new Date();
-      if (replayOn) {
-        try {
-          const { TraceRecorder } = await import("@/lib/deployments/replay/recorder");
-          recorder = new TraceRecorder({
-            name: `email:${deploymentId}`,
-            startedAt: turnStartedAt.toISOString(),
-            // Native tool names aren't known until getToolsForCapabilities
-            // resolves inside runStatelessAgentTurn — this slice records the
-            // capability allowlist instead (a stable, cheap proxy for
-            // "what was bound"), never the resolved tool-name list.
-            wrapped: blueprint.capabilities ?? [],
-          });
-        } catch (err) {
-          // Recorder construction must never affect the turn — fall through
-          // with recorder left undefined (no tracing this run).
-          console.warn(
-            "[composio-event-dispatch-deps] TraceRecorder construction failed:",
-            err instanceof Error ? err.message : String(err),
-          );
-          recorder = undefined;
-        }
-      }
 
       const resolution = await getAIClient({ orgId });
       if (!resolution.client) {
@@ -95,6 +77,12 @@ export function buildDispatchComposioEventDeps(): DispatchComposioEventDeps {
         // (Task 1) — this is now an observable receipt reason ("no LLM key
         // configured") instead of a silent generic error; mirrors
         // runActionOnlyTurn's no_llm_key fail-soft, just no longer mute.
+        // NOTE: this check runs BEFORE the L0 replay attempt below — a
+        // deployment with a working enabled skill but no LLM key still
+        // fails here today. Decoupling replay from the LLM-key requirement
+        // is a documented future improvement, not this slice's scope (the
+        // brief places replay "before running the agentic turn", not before
+        // the org/LLM preconditions the turn itself already required).
         return { ok: false, errorMessage: "no LLM key configured" };
       }
 
@@ -130,87 +118,178 @@ export function buildDispatchComposioEventDeps(): DispatchComposioEventDeps {
         }
       }
 
-      // Agent receipts slice (Task 2a) — collect a secret-safe tool-call
-      // trail via the SAME onToolEvent seam the supervised-run action log
-      // uses (stateless-turn.ts: `line` is already a summarized, no-secrets
-      // gloss — never the raw tool input/output). Only "result" events are
-      // kept (start events would double the list with no extra info).
-      const toolCalls: Array<{ tool: string; ok: boolean; note?: string }> = [];
-
-      const turn = await runStatelessAgentTurn({
-        orgId,
-        orgSlug: org.slug,
-        orgName: org.name ?? "your business",
-        soul:
-          org.soul && typeof org.soul === "object"
-            ? (org.soul as Parameters<typeof runStatelessAgentTurn>[0]["soul"])
-            : null,
-        timezone: org.timezone ?? "UTC",
-        blueprint,
-        voiceProfileNote,
-        messages: [
-          {
-            role: "user",
-            content:
-              "You have a new email in your inbox. Check it and triage it using your tools (label, draft a reply if appropriate).",
-          },
-        ],
-        testMode: false,
-        client: resolution.client,
-        onToolEvent: (event) => {
-          if (event.phase !== "result") return;
-          toolCalls.push({ tool: event.tool, ok: event.ok === true, note: event.line });
-        },
-        // Deterministic replay — only passed when recording is on; every
-        // other caller/run leaves this undefined (identical unwrapped path).
-        wrapToolCall: recorder
-          ? (tool, args, run) => recorder!.wrapCall(tool, args, run)
-          : undefined,
-      });
-
-      // Deterministic replay — persist ONE row for this run, success or
-      // failure, best-effort (writeWorkflowTrace never throws). Runs after
-      // the turn resolves so recording never delays or blocks the turn
-      // itself; a persistence failure is swallowed inside the writer.
-      if (recorder) {
-        try {
-          const { writeWorkflowTrace } = await import("@/lib/deployments/replay/persist");
-          const { extractMessageId } = await import(
-            "@/lib/deployments/composio-event-dispatch"
-          );
-          await writeWorkflowTrace({
-            orgId,
-            deploymentId,
-            triggerKind: "email",
-            triggerKey: extractMessageId(payload ?? {}),
-            startedAt: turnStartedAt,
-            finishedAt: new Date(),
-            ok: turn.ok === true,
-            callCount: recorder.callCount,
-            records: recorder.finish(),
-            // No token metering path exists on this turn result yet — store
-            // 0 rather than inventing a new one (slice 1 scope).
-            inputTokens: 0,
-            outputTokens: 0,
-          });
-        } catch (err) {
-          console.warn(
-            "[composio-event-dispatch-deps] deterministic-replay persist failed (fail-soft, run continues):",
-            err instanceof Error ? err.message : String(err),
-          );
+      // The normal agentic-turn path (unchanged from slice 1 apart from
+      // being wrapped in a closure) — invoked directly when replay is off,
+      // and by replayOrTurn (only on a replay skip/diverge) when it's on.
+      const runTurn = async (): Promise<{
+        ok: boolean;
+        toolCalls?: Array<{ tool: string; ok: boolean; note?: string }>;
+        replyText?: string;
+        errorMessage?: string;
+      }> => {
+        // Deterministic replay — Reelier phase 2c slice 1 (OBSERVE MODE
+        // ONLY). Precondition fix (review item 3, "guarded Date
+        // construction") — turnStartedAt is only ever read inside the
+        // `if (replayOn)`/`if (recorder)` blocks below, so it's now only
+        // constructed when actually needed (was unconditional before).
+        let recorder: import("@/lib/deployments/replay/recorder").TraceRecorder | undefined;
+        let turnStartedAt: Date | undefined;
+        if (replayOn) {
+          turnStartedAt = new Date();
+          try {
+            const { TraceRecorder } = await import("@/lib/deployments/replay/recorder");
+            recorder = new TraceRecorder({
+              name: `email:${deploymentId}`,
+              startedAt: turnStartedAt.toISOString(),
+              // Native tool names aren't known until getToolsForCapabilities
+              // resolves inside runStatelessAgentTurn — this slice records the
+              // capability allowlist instead (a stable, cheap proxy for
+              // "what was bound"), never the resolved tool-name list.
+              wrapped: blueprint.capabilities ?? [],
+            });
+          } catch (err) {
+            // Recorder construction must never affect the turn — fall through
+            // with recorder left undefined (no tracing this run).
+            console.warn(
+              "[composio-event-dispatch-deps] TraceRecorder construction failed:",
+              err instanceof Error ? err.message : String(err),
+            );
+            recorder = undefined;
+          }
         }
+
+        // Agent receipts slice (Task 2a) — collect a secret-safe tool-call
+        // trail via the SAME onToolEvent seam the supervised-run action log
+        // uses (stateless-turn.ts: `line` is already a summarized, no-secrets
+        // gloss — never the raw tool input/output). Only "result" events are
+        // kept (start events would double the list with no extra info).
+        const toolCalls: Array<{ tool: string; ok: boolean; note?: string }> = [];
+
+        const turn = await runStatelessAgentTurn({
+          orgId,
+          orgSlug: org.slug,
+          orgName: org.name ?? "your business",
+          soul:
+            org.soul && typeof org.soul === "object"
+              ? (org.soul as Parameters<typeof runStatelessAgentTurn>[0]["soul"])
+              : null,
+          timezone: org.timezone ?? "UTC",
+          blueprint,
+          voiceProfileNote,
+          messages: [
+            {
+              role: "user",
+              content:
+                "You have a new email in your inbox. Check it and triage it using your tools (label, draft a reply if appropriate).",
+            },
+          ],
+          testMode: false,
+          client: resolution.client!,
+          onToolEvent: (event) => {
+            if (event.phase !== "result") return;
+            toolCalls.push({ tool: event.tool, ok: event.ok === true, note: event.line });
+          },
+          // Deterministic replay — only passed when recording is on; every
+          // other caller/run leaves this undefined (identical unwrapped path).
+          wrapToolCall: recorder
+            ? (tool, args, run) => recorder!.wrapCall(tool, args, run)
+            : undefined,
+        });
+
+        // Deterministic replay — persist ONE row for this run, success or
+        // failure, best-effort (writeWorkflowTrace never throws). Runs after
+        // the turn resolves so recording never delays or blocks the turn
+        // itself; a persistence failure is swallowed inside the writer.
+        if (recorder && turnStartedAt) {
+          try {
+            const { writeWorkflowTrace } = await import("@/lib/deployments/replay/persist");
+            const { extractMessageId } = await import(
+              "@/lib/deployments/composio-event-dispatch"
+            );
+            await writeWorkflowTrace({
+              orgId,
+              deploymentId,
+              triggerKind: "email",
+              triggerKey: extractMessageId(payload ?? {}),
+              startedAt: turnStartedAt,
+              finishedAt: new Date(),
+              ok: turn.ok === true,
+              callCount: recorder.callCount,
+              records: recorder.finish(),
+              // No token metering path exists on this turn result yet — store
+              // 0 rather than inventing a new one (slice 1 scope).
+              inputTokens: 0,
+              outputTokens: 0,
+            });
+          } catch (err) {
+            console.warn(
+              "[composio-event-dispatch-deps] deterministic-replay persist failed (fail-soft, run continues):",
+              err instanceof Error ? err.message : String(err),
+            );
+          }
+        }
+
+        return {
+          ok: turn.ok === true,
+          toolCalls,
+          replyText: turn.ok === true ? turn.reply : undefined,
+          // Agent truth slice (Task 1) — the turn's own diagnostic (e.g.
+          // "[runtime error] anthropic 401: invalid x-api-key") when it
+          // failed. Unscrubbed here — writeRunReceipt's deriveReceiptSummary
+          // scrubs before it's ever persisted.
+          errorMessage: turn.ok === false ? turn.message : undefined,
+        };
+      };
+
+      if (!replayOn) {
+        return runTurn();
       }
 
-      return {
-        ok: turn.ok === true,
-        toolCalls,
-        replyText: turn.ok === true ? turn.reply : undefined,
-        // Agent truth slice (Task 1) — the turn's own diagnostic (e.g.
-        // "[runtime error] anthropic 401: invalid x-api-key") when it
-        // failed. Unscrubbed here — writeRunReceipt's deriveReceiptSummary
-        // scrubs before it's ever persisted.
-        errorMessage: turn.ok === false ? turn.message : undefined,
-      };
+      // Deterministic replay — Reelier phase 2c slice 2. Try a deterministic
+      // L0 skill replay BEFORE the agentic turn; only falls through to
+      // runTurn() on a skip (no enabled skill / gate refused) or a
+      // divergence (an assert failed mid-replay).
+      const { replayOrTurn } = await import("@/lib/deployments/replay/replay-or-turn");
+      const { attemptL0Replay, markReplaySkillReplayed } = await import(
+        "@/lib/deployments/replay/replay-before-llm"
+      );
+      const { writeWorkflowTrace } = await import("@/lib/deployments/replay/persist");
+      const { extractMessageId } = await import("@/lib/deployments/composio-event-dispatch");
+
+      return replayOrTurn(
+        {
+          attemptL0Replay,
+          runTurn,
+          // Persist ONE agent_workflow_traces row (kind:'replay-run') for
+          // any non-skipped attempt (pass OR diverge) — see the design's D
+          // section. Best-effort; writeWorkflowTrace itself never throws.
+          persistReplayRun: async (replay) => {
+            if (replay.kind === "skipped") return;
+            await writeWorkflowTrace({
+              orgId,
+              deploymentId,
+              triggerKind: "email",
+              triggerKey: extractMessageId(payload ?? {}),
+              startedAt: new Date(replay.record.startedAt),
+              finishedAt: new Date(replay.record.finishedAt),
+              ok: replay.kind === "passed",
+              callCount: replay.record.steps.length,
+              records: replay.record,
+              kind: "replay-run",
+              inputTokens: 0,
+              outputTokens: 0,
+            });
+          },
+          markSkillReplayed: markReplaySkillReplayed,
+        },
+        {
+          orgId,
+          deploymentId,
+          orgSlug: org.slug,
+          timezone: org.timezone ?? "UTC",
+          blueprint,
+        },
+      );
     },
   };
 }

--- a/packages/crm/src/lib/deployments/replay/compile.ts
+++ b/packages/crm/src/lib/deployments/replay/compile.ts
@@ -1,0 +1,155 @@
+// Deterministic replay — Reelier phase 2c, slice 2. compileSkillFromTrace:
+// read one org-scoped `agent_workflow_traces` row (kind:'trace', slice 1's
+// raw material) and compile it into a `replay_skills` row (status:'draft')
+// via @seldonframe/reelier's OWN compiler (compile()/renderSkillMd() —
+// deterministic, zero LLM calls, per the package's own design notes).
+//
+// NEVER auto-enables: every compiled skill starts `status: 'draft'` —
+// enabling is a human act (for now via SQL/ops; no UI in this slice). This
+// mirrors the never-fail-compile precedent (agent_action_drafts: a compiled
+// artifact PREPARES work it may not execute without review).
+//
+// Org-scoped: the trace lookup is WHERE org_id = $orgId AND deployment_id =
+// $deploymentId AND id = $traceId — a caller can never compile a trace that
+// belongs to a different org OR a different deployment than the one it
+// asked for (L-04 security invariant).
+//
+// SHAPE ADAPTER: reelier's compile() expects each `result` record's `body`
+// to be an MCP CallToolResult ({content:[{type:"text",text}], isError}) —
+// that's the shape ITS OWN recorder (an MCP proxy) produces. Our recorder
+// (./recorder.ts) wraps SF's native tool execute() results directly (a raw
+// JS value, already redacted/capped by trace-format.ts) — a different shape
+// by construction (we never proxy MCP). toReelierRecords() below bridges
+// that gap the same way the L0 replay tool bridge does for the reverse
+// direction (replay-before-llm.ts): wrap our raw body as reelier's own
+// mcp-tool.js would have produced it, so compile()'s dataflow recovery
+// (JSON.parse(obs.body)) works exactly as it does on a reelier-native trace.
+
+import { compile, renderSkillMd } from "@seldonframe/reelier/compile";
+import type { ReelierCompileResult } from "@seldonframe/reelier/compile";
+import type { ReelierTraceRecord } from "@seldonframe/reelier/trace";
+import type { TraceRecord } from "./trace-format";
+import type { NewReplaySkillRow, ReplaySkillRow } from "@/db/schema/replay-skills";
+
+/** Adapt our TraceRecord[] into reelier's own trace-record shape for
+ *  compile(): identical for meta/note/call records (our TraceRecord type
+ *  was built to match reelier's record contract exactly — see
+ *  trace-format.ts's header comment); only `result.body` differs, wrapped
+ *  here into the MCP CallToolResult shape compile()'s
+ *  mcpResultToObservation() expects. Pure; never throws (JSON.stringify of
+ *  an already-capped/redacted value can only fail on a circular structure,
+ *  which capTraceBody already ruled out before this ever reaches storage —
+ *  still guarded defensively). */
+export function toReelierRecords(records: TraceRecord[]): ReelierTraceRecord[] {
+  return records.map((r): ReelierTraceRecord => {
+    if (r.t !== "result") return r;
+    let text: string;
+    try {
+      text = JSON.stringify(r.body ?? null) ?? "null";
+    } catch {
+      text = JSON.stringify({ error: "unserializable trace body" });
+    }
+    return {
+      t: "result",
+      seq: r.seq,
+      i: r.i,
+      ok: r.ok,
+      ms: r.ms,
+      body: { content: [{ type: "text", text }], isError: !r.ok },
+    };
+  });
+}
+
+export type CompileSkillFromTraceResult = {
+  skillRow: ReplaySkillRow;
+  compiled: ReelierCompileResult;
+};
+
+/** Injectable I/O — defaults to real `@/db` reads/writes (kept out of the
+ *  top-level import graph so this module stays test-friendly). */
+export type CompileSkillFromTraceDeps = {
+  loadTrace?: (
+    orgId: string,
+    deploymentId: string,
+    traceId: string,
+  ) => Promise<{ id: string; records: TraceRecord[] } | null>;
+  insertSkill?: (row: NewReplaySkillRow) => Promise<ReplaySkillRow>;
+};
+
+async function defaultLoadTrace(
+  orgId: string,
+  deploymentId: string,
+  traceId: string,
+): Promise<{ id: string; records: TraceRecord[] } | null> {
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { and, eq } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ id: agentWorkflowTraces.id, records: agentWorkflowTraces.records })
+    .from(agentWorkflowTraces)
+    .where(
+      and(
+        eq(agentWorkflowTraces.id, traceId),
+        eq(agentWorkflowTraces.orgId, orgId),
+        eq(agentWorkflowTraces.deploymentId, deploymentId),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  // A 'trace' row's records are always a TraceRecord[] (never a RunRecord —
+  // that shape only exists on kind:'replay-run' rows, which this lookup
+  // doesn't filter for by kind but SHOULD never be passed a replay-run id in
+  // practice; a caller compiling a replay-run id will just get a compile()
+  // that finds no calls, an honest empty/near-empty skill rather than a
+  // crash — Array.isArray guards the cast).
+  const records = Array.isArray(row.records) ? (row.records as TraceRecord[]) : [];
+  return { id: row.id, records };
+}
+
+async function defaultInsertSkill(row: NewReplaySkillRow): Promise<ReplaySkillRow> {
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const [inserted] = await db.insert(replaySkills).values(row).returning();
+  return inserted;
+}
+
+/**
+ * Compile one org-scoped trace into a draft replay_skills row. Returns
+ * `null` when the trace isn't found (wrong id, or belongs to a different
+ * org/deployment — the org-scoped WHERE clause makes these indistinguishable
+ * on purpose, mirroring every other org-scoped lookup in this codebase: a
+ * caller never learns whether a resource exists in ANOTHER org). Throws on a
+ * genuine compile/insert failure — unlike the recorder/persist modules, this
+ * is a synchronous, human-triggered action (not an observation hook riding
+ * along a live agent turn), so fail-LOUD is correct here: a caller (ops
+ * script / future admin action) needs to know compilation failed rather than
+ * silently getting nothing.
+ */
+export async function compileSkillFromTrace(
+  orgId: string,
+  deploymentId: string,
+  traceId: string,
+  deps?: CompileSkillFromTraceDeps,
+): Promise<CompileSkillFromTraceResult | null> {
+  const loadTrace = deps?.loadTrace ?? defaultLoadTrace;
+  const insertSkill = deps?.insertSkill ?? defaultInsertSkill;
+
+  const trace = await loadTrace(orgId, deploymentId, traceId);
+  if (!trace) return null;
+
+  const reelierRecords = toReelierRecords(trace.records);
+  const compiled = compile(reelierRecords);
+  const skillMd = renderSkillMd(compiled, `trace:${traceId}`);
+
+  const row: NewReplaySkillRow = {
+    orgId,
+    deploymentId,
+    name: compiled.name,
+    skillMd,
+    status: "draft",
+    sourceTraceId: trace.id,
+  };
+
+  const skillRow = await insertSkill(row);
+  return { skillRow, compiled };
+}

--- a/packages/crm/src/lib/deployments/replay/persist.ts
+++ b/packages/crm/src/lib/deployments/replay/persist.ts
@@ -13,10 +13,11 @@
 // with a throwing insert.
 
 import type {
+  AgentWorkflowTraceKind,
+  AgentWorkflowTraceRecords,
   AgentWorkflowTraceTriggerKind,
   NewAgentWorkflowTraceRow,
 } from "@/db/schema/agent-workflow-traces";
-import type { TraceRecord } from "./trace-format";
 
 export type WriteWorkflowTraceInput = {
   orgId: string;
@@ -30,7 +31,13 @@ export type WriteWorkflowTraceInput = {
   finishedAt: Date;
   ok: boolean;
   callCount: number;
-  records: TraceRecord[];
+  /** A TraceRecord[] (kind:'trace', default) or a reelier RunRecord
+   *  (kind:'replay-run') — see AgentWorkflowTraceKind. */
+  records: AgentWorkflowTraceRecords;
+  /** Slice 2 — 'trace' (default, slice 1 behavior unchanged) or
+   *  'replay-run' (an L0 replay attempt's RunRecord; see
+   *  replay-before-llm.ts). */
+  kind?: AgentWorkflowTraceKind;
   /** Slice 1 rule: populate from whatever the turn already exposes; store 0
    *  when unavailable rather than inventing a new metering path. */
   inputTokens?: number;
@@ -68,6 +75,7 @@ export async function writeWorkflowTrace(
       orgId: input.orgId,
       deploymentId: input.deploymentId ?? null,
       triggerKind: input.triggerKind,
+      kind: input.kind ?? "trace",
       triggerKey: input.triggerKey ?? null,
       startedAt: input.startedAt,
       finishedAt: input.finishedAt,

--- a/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
@@ -1,0 +1,313 @@
+// Deterministic replay — Reelier phase 2c, slice 2. attemptL0Replay: try to
+// satisfy a deployment's turn with a deterministic L0 skill replay BEFORE
+// ever constructing an LLM turn. Called from
+// composio-event-dispatch-deps.ts (via replay-or-turn.ts), only when
+// SF_DETERMINISTIC_REPLAY=1.
+//
+// v1 SCOPE, deliberately narrow:
+//   - maxLevel 0 ONLY — zero LLM calls, by construction (reelier's own
+//     contract: `--max-level 0` never constructs an `llm` client).
+//   - allowDestructive false — a `destructive`-effect step always refuses
+//     inside the runner regardless of our own gate below (belt + suspenders).
+//   - vars: {} — no input-variable mapping from the event payload in v1; an
+//     unresolved `{{var}}` in a skill throws inside reelier's fillTemplate,
+//     which the runner already turns into a normal step failure → diverge.
+//     Nothing special to implement here for that case.
+//
+// HARD SAFETY — never send email/SMS twice: if replay executes some steps
+// then diverges, the caller (replay-or-turn.ts) falls back to a FRESH
+// agentic turn. Steps already executed during a diverged replay may have had
+// real effects — reads are safe to repeat, a write is not. MITIGATE (v1
+// policy, not a general solution): only attempt replay when the skill's
+// steps are ALL effect 'read' except AT MOST ONE FINAL non-read step
+// (passesAllReadGate below). This does not eliminate the risk on that one
+// final step (if ITS assert fails after the tool call already ran, the
+// write already happened and the fallback turn may repeat it) — it only
+// BOUNDS the exposure to a single step instead of an arbitrary prefix. That
+// residual risk is accepted for v1 and must be revisited before this gate is
+// loosened (e.g. before mid-sequence writes are ever allowed).
+import type { AgentBlueprint } from "@/db/schema/agents";
+import type { ToolExecuteContext } from "@/lib/agents/tools";
+import type {
+  ReelierRunRecord,
+  ReelierTool,
+} from "@seldonframe/reelier";
+import type { ReelierSkill } from "@seldonframe/reelier/skill";
+
+export type AttemptL0ReplayInput = {
+  orgId: string;
+  deploymentId: string;
+  orgSlug: string;
+  timezone: string;
+  blueprint: AgentBlueprint;
+};
+
+export type AttemptL0ReplaySkippedResult = { kind: "skipped"; reason: string };
+export type AttemptL0ReplayDivergedResult = {
+  kind: "diverged";
+  skillId: string;
+  record: ReelierRunRecord;
+  failures: string[];
+};
+export type AttemptL0ReplayPassedResult = {
+  kind: "passed";
+  skillId: string;
+  record: ReelierRunRecord;
+  toolCalls: Array<{ tool: string; ok: boolean; note?: string }>;
+  replyText?: string;
+};
+export type AttemptL0ReplayResult =
+  | AttemptL0ReplaySkippedResult
+  | AttemptL0ReplayDivergedResult
+  | AttemptL0ReplayPassedResult;
+
+type EnabledSkillRow = { id: string; skillMd: string };
+
+/**
+ * v1 replay gate: at most one non-read step, and it must be the LAST step.
+ * Zero non-read steps (a pure-read skill) also passes trivially. An empty
+ * skill (no steps) never passes — nothing to replay.
+ */
+export function passesAllReadGate(skill: ReelierSkill): boolean {
+  if (skill.steps.length === 0) return false;
+  const lastIdx = skill.steps.length - 1;
+  return skill.steps.every((step, idx) => step.effect === "read" || idx === lastIdx);
+}
+
+/** Injectable I/O — defaults to real DB reads / reelier calls (kept out of
+ *  the top-level import graph so this module stays test-friendly). */
+export type AttemptL0ReplayDeps = {
+  loadEnabledSkill?: (orgId: string, deploymentId: string) => Promise<EnabledSkillRow | null>;
+  buildTools?: (input: AttemptL0ReplayInput) => Promise<Record<string, ReelierTool>>;
+  parseSkill?: (source: string) => Promise<ReelierSkill>;
+  runSkill?: (
+    skill: ReelierSkill,
+    options: import("@seldonframe/reelier").ReelierRunSkillOptions,
+  ) => Promise<ReelierRunRecord>;
+};
+
+async function defaultLoadEnabledSkill(
+  orgId: string,
+  deploymentId: string,
+): Promise<EnabledSkillRow | null> {
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const { and, eq } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ id: replaySkills.id, skillMd: replaySkills.skillMd })
+    .from(replaySkills)
+    .where(
+      and(
+        eq(replaySkills.orgId, orgId),
+        eq(replaySkills.deploymentId, deploymentId),
+        eq(replaySkills.status, "enabled"),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+async function defaultParseSkill(source: string): Promise<ReelierSkill> {
+  const { parseSkill } = await import("@seldonframe/reelier/skill");
+  return parseSkill(source);
+}
+
+async function defaultRunSkillImpl(
+  skill: ReelierSkill,
+  options: import("@seldonframe/reelier").ReelierRunSkillOptions,
+): Promise<ReelierRunRecord> {
+  const { runSkill } = await import("@seldonframe/reelier");
+  return runSkill(skill, options);
+}
+
+/**
+ * Bridge SF's resolved agent tools (getToolsForCapabilities — the SAME
+ * resolution stateless-turn.ts uses, but invoked here WITHOUT ever starting
+ * an LLM turn) into a reelier Tool registry. Mapping mirrors reelier's own
+ * mcp-tool.js contract: status 200 on success / 500 on a thrown error,
+ * headers always {} (not an HTTP tool), body the JSON text of the raw
+ * result (so `json.<path>` asserts/binds parse it directly, same as a
+ * reelier-native MCP tool's text-content body).
+ */
+async function defaultBuildTools(
+  input: AttemptL0ReplayInput,
+): Promise<Record<string, ReelierTool>> {
+  const { getToolsForCapabilities } = await import("@/lib/agents/tools");
+  const tools = await getToolsForCapabilities(input.blueprint.capabilities, {
+    orgId: input.orgId,
+    connectors: input.blueprint.connectors,
+  });
+
+  const ctx: ToolExecuteContext = {
+    orgId: input.orgId,
+    orgSlug: input.orgSlug,
+    // No real conversation exists for an L0 replay run — stable sentinels,
+    // distinct from stateless-turn.ts's "template-test" sentinel so a
+    // replay run is never mistaken for a template test in any downstream
+    // log/read.
+    agentId: input.deploymentId,
+    conversationId: `replay-l0:${input.deploymentId}`,
+    // Real execution, not sandboxed — an L0 replay run performs the SAME
+    // real actions the recorded trace did (gated to at most one write step
+    // by the all-read policy above).
+    testMode: false,
+    timezone: input.timezone || undefined,
+  };
+
+  const registry: Record<string, ReelierTool> = {};
+  for (const tool of tools) {
+    registry[tool.name] = {
+      // Unused by the runner itself (it only consults the SKILL step's own
+      // declared `effect`, not the Tool registry entry's — confirmed by
+      // reelier's own mcp-tool.js comment). Present only to satisfy the
+      // registry's shape.
+      effect: "destructive",
+      async run(args: unknown) {
+        try {
+          const result = await tool.execute(args, ctx);
+          return { status: 200, headers: {}, body: JSON.stringify(result ?? null) };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return { status: 500, headers: {}, body: JSON.stringify({ error: message }) };
+        }
+      },
+    };
+  }
+  return registry;
+}
+
+function emptyFailedRecord(skillName: string, reason: string): ReelierRunRecord {
+  const now = new Date().toISOString();
+  return {
+    skill: skillName,
+    startedAt: now,
+    finishedAt: now,
+    passed: false,
+    steps: [],
+    totals: { steps: 0, passed: 0, failed: 0, ms: 0, llmInputTokens: 0, llmOutputTokens: 0 },
+  };
+}
+
+/**
+ * Try to satisfy this deployment's turn via a deterministic L0 skill replay.
+ * FAIL-OPEN BY CONTRACT: never throws — any unexpected error anywhere in
+ * this path degrades to `{kind:"skipped", reason}` so the caller always
+ * falls back to the normal agentic turn. The ONLY way this returns
+ * `kind:"passed"` is a clean, zero-LLM, all-assertions-held replay.
+ */
+export async function attemptL0Replay(
+  input: AttemptL0ReplayInput,
+  deps?: AttemptL0ReplayDeps,
+): Promise<AttemptL0ReplayResult> {
+  try {
+    const loadEnabledSkill = deps?.loadEnabledSkill ?? defaultLoadEnabledSkill;
+    const buildTools = deps?.buildTools ?? defaultBuildTools;
+    const parseSkillFn = deps?.parseSkill ?? defaultParseSkill;
+    const runSkillFn = deps?.runSkill ?? defaultRunSkillImpl;
+
+    const skillRow = await loadEnabledSkill(input.orgId, input.deploymentId);
+    if (!skillRow) return { kind: "skipped", reason: "no enabled skill for this deployment" };
+
+    let skill: ReelierSkill;
+    try {
+      skill = await parseSkillFn(skillRow.skillMd);
+    } catch (err) {
+      return {
+        kind: "skipped",
+        reason: `skill parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    if (!passesAllReadGate(skill)) {
+      return {
+        kind: "skipped",
+        reason:
+          "all-read gate refused: skill has a non-read step that isn't the last step (or has zero steps) — v1 policy only replays skills whose writes are confined to a single final step",
+      };
+    }
+
+    let tools: Record<string, ReelierTool>;
+    try {
+      tools = await buildTools(input);
+    } catch (err) {
+      return {
+        kind: "skipped",
+        reason: `tool bridge failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    let record: ReelierRunRecord;
+    try {
+      record = await runSkillFn(skill, {
+        tools,
+        allowDestructive: false,
+        maxLevel: 0,
+        // NEVER write .reelier/runs/<name>.jsonl — this repo persists its
+        // OWN run record (agent_workflow_traces, kind:'replay-run'), and a
+        // serverless deploy has no durable local filesystem to write to
+        // anyway.
+        dryRun: true,
+        vars: {},
+      });
+    } catch (err) {
+      // A thrown runSkill (rather than a clean per-step divergence) is
+      // treated identically to a divergence — fail-open, fall back.
+      return {
+        kind: "diverged",
+        skillId: skillRow.id,
+        record: emptyFailedRecord(skill.name, "runSkill threw"),
+        failures: [err instanceof Error ? err.message : String(err)],
+      };
+    }
+
+    if (!record.passed) {
+      return {
+        kind: "diverged",
+        skillId: skillRow.id,
+        record,
+        failures: record.steps.flatMap((s) => s.failures),
+      };
+    }
+
+    // Replay PASSES (every step passed/unchecked, none failed) — skip the
+    // agentic turn entirely. toolCalls carries a `replay-l0` tag in `note`
+    // so the run receipt (written by the orchestrator from this return
+    // value, same seam every other run uses) is honestly labeled without
+    // needing a new receipt field.
+    const toolCalls = record.steps.map((stepRecord, idx) => ({
+      tool: skill.steps[idx]?.actionTool ?? stepRecord.title,
+      ok: true,
+      note: `replay-l0: ${stepRecord.title}`,
+    }));
+
+    return { kind: "passed", skillId: skillRow.id, record, toolCalls, replyText: undefined };
+  } catch (err) {
+    // Belt-and-suspenders: this function must NEVER throw into its caller.
+    return {
+      kind: "skipped",
+      reason: `unexpected error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/** Mark a skill's `last_replay_at` after a PASSED replay run. Org-scoped
+ *  implicitly via `skillId` (the row was already loaded org-scoped by
+ *  loadEnabledSkill above — this is a targeted update by primary key, not a
+ *  fresh lookup). FAIL-SOFT — a bookkeeping-only write must never affect the
+ *  (already-returned) replay result. */
+export async function markReplaySkillReplayed(skillId: string): Promise<void> {
+  try {
+    const { db } = await import("@/db");
+    const { replaySkills } = await import("@/db/schema/replay-skills");
+    const { eq } = await import("drizzle-orm");
+    await db
+      .update(replaySkills)
+      .set({ lastReplayAt: new Date(), updatedAt: new Date() })
+      .where(eq(replaySkills.id, skillId));
+  } catch (err) {
+    console.warn(
+      "[deployments/replay/replay-before-llm] markReplaySkillReplayed failed (fail-soft):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/packages/crm/src/lib/deployments/replay/replay-or-turn.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-or-turn.ts
@@ -1,0 +1,80 @@
+// Deterministic replay — Reelier phase 2c, slice 2. replayOrTurn: the pure,
+// DI'd decision seam between "try an L0 replay" and "run the normal agentic
+// turn" — factored out of composio-event-dispatch-deps.ts's runAgenticTurn
+// SOLELY so this decision is unit-testable without touching Postgres /
+// Anthropic (that file's own header claims it's "the only place that
+// touches" those — this module still delegates every DB/LLM-touching step to
+// injected functions, so the claim stays true; this file itself is DB/LLM-
+// free). Smallest additive refactor that makes "replay-pass skips the
+// agentic turn" and "divergence falls back to it" independently provable.
+//
+// Contract: `deps.runTurn` (the real agentic turn, incl. its own trace
+// recording) is invoked IF AND ONLY IF the replay attempt did not cleanly
+// pass — `kind: "skipped"` (no enabled skill / gate refused / bridge
+// failed) or `kind: "diverged"` both fall through to it. `kind: "passed"`
+// returns immediately WITHOUT ever calling `deps.runTurn` — the agentic
+// turn (and therefore any LLM spend) is never constructed for a successful
+// replay.
+import type { AttemptL0ReplayInput, AttemptL0ReplayResult } from "./replay-before-llm";
+
+export type ReplayOrTurnResult = {
+  ok: boolean;
+  toolCalls?: Array<{ tool: string; ok: boolean; note?: string }>;
+  replyText?: string;
+  errorMessage?: string;
+};
+
+export type ReplayOrTurnDeps = {
+  attemptL0Replay: (input: AttemptL0ReplayInput) => Promise<AttemptL0ReplayResult>;
+  /** The normal agentic turn (runStatelessAgentTurn + its own trace
+   *  recording), invoked only on a replay skip/diverge. */
+  runTurn: () => Promise<ReplayOrTurnResult>;
+  /** Persist ONE agent_workflow_traces row (kind:'replay-run') for any
+   *  non-skipped replay attempt (pass OR diverge — see the module's D
+   *  section). No-op'd by the caller when `replay.kind === "skipped"`
+   *  (nothing ran, nothing to persist) — replayOrTurn enforces that by only
+   *  calling this for pass/diverge. Must itself be fail-soft (never throw);
+   *  a throw here is still caught defensively below. */
+  persistReplayRun: (replay: AttemptL0ReplayResult) => Promise<void>;
+  /** Bookkeeping-only — called ONLY after a PASSED replay. Fail-soft. */
+  markSkillReplayed: (skillId: string) => Promise<void>;
+};
+
+export async function replayOrTurn(
+  deps: ReplayOrTurnDeps,
+  input: AttemptL0ReplayInput,
+): Promise<ReplayOrTurnResult> {
+  const replay = await deps.attemptL0Replay(input);
+
+  if (replay.kind === "skipped") {
+    return deps.runTurn();
+  }
+
+  // pass OR diverge — both are a real, recorded replay attempt.
+  try {
+    await deps.persistReplayRun(replay);
+  } catch (err) {
+    console.warn(
+      "[deployments/replay/replay-or-turn] persistReplayRun failed (fail-soft):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+
+  if (replay.kind === "passed") {
+    try {
+      await deps.markSkillReplayed(replay.skillId);
+    } catch (err) {
+      console.warn(
+        "[deployments/replay/replay-or-turn] markSkillReplayed failed (fail-soft):",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    return { ok: true, toolCalls: replay.toolCalls, replyText: replay.replyText };
+  }
+
+  // diverged — fall back to the normal agentic turn. The fallback's own
+  // result (ok/toolCalls/replyText/errorMessage) is the user-visible
+  // result; the failed replay attempt is invisible to the end user beyond
+  // its own persisted 'replay-run' row.
+  return deps.runTurn();
+}

--- a/packages/crm/src/lib/deployments/replay/trace-format.ts
+++ b/packages/crm/src/lib/deployments/replay/trace-format.ts
@@ -83,19 +83,52 @@ export const TRACE_MAX_RECORDS = 200;
 const SECRET_KEY_RE = /\bsk-[A-Za-z0-9_-]{10,}/g;
 /** Matches an Authorization-header-shaped bearer token. */
 const BEARER_RE = /Bearer\s+\S{8,}/gi;
+/** Matches an Authorization-header-shaped Basic credential (base64-ish). */
+const BASIC_AUTH_RE = /Basic\s+[A-Za-z0-9+/=]{8,}/gi;
+/** Matches a Google OAuth access token (`ya29.…`). */
+const GOOGLE_OAUTH_RE = /\bya29\.[A-Za-z0-9._-]{10,}/g;
+/** Matches a JWT-shaped string (three dot-separated base64url segments). */
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g;
+/** Object keys whose STRING value is masked outright (never pattern-matched
+ *  — a token/secret/password field can hold any shape, not just the shapes
+ *  above), when the value is long enough to plausibly be a real credential
+ *  rather than e.g. a boolean-ish "yes"/short label. */
+const SECRET_KEY_NAME_RE = /token|secret|password|api[_-]?key|authorization/i;
+/** Minimum length for a key-name-matched value to be masked — short strings
+ *  under a secret-shaped key name (e.g. `{tokenType: "bearer"}`) are almost
+ *  certainly not the secret itself. */
+const SECRET_KEY_NAME_MIN_LENGTH = 8;
 
-/** Redact secret-shaped substrings from a plain string. Pure; never throws. */
+/** Redact secret-shaped substrings from a plain string. Pure; never throws.
+ *
+ *  NOTE — this is defense-in-depth, not a guarantee: it catches the KNOWN
+ *  shapes above (Anthropic/OpenAI-style keys, Bearer/Basic auth headers,
+ *  Google OAuth tokens, JWTs) plus a key-name heuristic (see
+ *  SECRET_KEY_NAME_RE in redact() below) — an arbitrary connector's own
+ *  bespoke credential shape, embedded in a plain string under an
+ *  innocuous-looking field name, can still slip through. Treat this as one
+ *  layer, not the only layer, of the "never store a live secret" contract. */
 function redactString(value: string): string {
-  return value.replace(SECRET_KEY_RE, "[redacted]").replace(BEARER_RE, "Bearer [redacted]");
+  return value
+    .replace(SECRET_KEY_RE, "[redacted]")
+    .replace(BEARER_RE, "Bearer [redacted]")
+    .replace(BASIC_AUTH_RE, "Basic [redacted]")
+    .replace(GOOGLE_OAUTH_RE, "[redacted]")
+    .replace(JWT_RE, "[redacted]");
 }
 
 /**
  * Deep-redact secret-shaped strings out of an arbitrary JSON-ish value
  * (tool args or a tool result body) before it is ever stored. Walks
- * objects/arrays; non-string primitives pass through unchanged. Guards
- * against cycles/excessive depth with a max-depth cutoff (returns a fixed
- * marker past the cutoff rather than recursing forever or throwing).
- * Pure; never throws — any unexpected shape degrades to a safe marker.
+ * objects/arrays; non-string primitives pass through unchanged. At each
+ * object key, a string value under a secret-shaped KEY NAME (token / secret /
+ * password / api[_-]?key / authorization, case-insensitive) is masked
+ * outright — independent of whether its shape matches one of the known
+ * patterns above — since a "secret" or "password" field can hold literally
+ * any string. Guards against cycles/excessive depth with a max-depth cutoff
+ * (returns a fixed marker past the cutoff rather than recursing forever or
+ * throwing). Pure; never throws — any unexpected shape degrades to a safe
+ * marker.
  */
 export function redact(value: unknown, depth = 0): unknown {
   if (depth > 12) return "[redact: max depth exceeded]";
@@ -105,6 +138,14 @@ export function redact(value: unknown, depth = 0): unknown {
     if (Array.isArray(value)) return value.map((v) => redact(v, depth + 1));
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (
+        typeof v === "string" &&
+        v.length >= SECRET_KEY_NAME_MIN_LENGTH &&
+        SECRET_KEY_NAME_RE.test(k)
+      ) {
+        out[k] = "[redacted]";
+        continue;
+      }
       out[k] = redact(v, depth + 1);
     }
     return out;
@@ -150,7 +191,10 @@ export function makeNoteRecord(input: { seq: number; ts: string; text: string })
   return { t: "note", seq: input.seq, ts: input.ts, text: input.text };
 }
 
-/** Build a `call` record — args are redacted before storage. */
+/** Build a `call` record — args are redacted THEN cap'd before storage,
+ *  mirroring makeResultRecord's contract exactly (a runaway call args
+ *  payload — e.g. a bulk connector operation — must not bloat a trace row
+ *  any more than a runaway result body can). */
 export function makeCallRecord(input: {
   seq: number;
   i: number;
@@ -164,7 +208,7 @@ export function makeCallRecord(input: {
     i: input.i,
     ts: input.ts,
     tool: input.tool,
-    args: redact(input.args),
+    args: capTraceBody(redact(input.args)),
   };
 }
 

--- a/packages/crm/src/types/reelier.d.ts
+++ b/packages/crm/src/types/reelier.d.ts
@@ -1,0 +1,167 @@
+// Ambient type declarations for @seldonframe/reelier@0.1.0 — the published
+// npm package ships compiled JS only (dist/*.js), no .d.ts files (verified
+// against the published tarball: `npm pack @seldonframe/reelier@0.1.0`).
+// These declarations cover ONLY the surface this repo actually calls
+// (compile.ts, skill.ts, runner exports) — they are OUR contract with the
+// package, hand-derived from reading its dist/*.js source (see
+// lib/deployments/replay/compile.ts and lib/deployments/replay/
+// replay-before-llm.ts for the call sites), not an official types package.
+// A future reelier version may ship real .d.ts files, at which point this
+// file should be deleted rather than kept alongside them.
+
+declare module "@seldonframe/reelier/skill" {
+  export type ReelierEffect = "read" | "idempotent-write" | "destructive";
+
+  export type ReelierSkillStep = {
+    n: number;
+    title: string;
+    intent: string;
+    actionTool: string;
+    actionArgs: unknown;
+    asserts: string[];
+    binds: string[];
+    effect: ReelierEffect;
+    line: number;
+  };
+
+  export type ReelierSkill = {
+    name: string;
+    description: string;
+    steps: ReelierSkillStep[];
+    preamble: string;
+    trailing: string;
+  };
+
+  export class SkillParseError extends Error {}
+
+  export function parseSkill(source: string): ReelierSkill;
+}
+
+declare module "@seldonframe/reelier/trace" {
+  export type ReelierTraceRecord =
+    | { t: "meta"; seq: number; name: string; startedAt: string; wrapped: string[] }
+    | { t: "note"; seq: number; ts: string; text: string }
+    | { t: "call"; seq: number; i: number; ts: string; tool: string; args: unknown }
+    | { t: "result"; seq: number; i: number; ok: boolean; ms: number; body: unknown };
+
+  export function parseTraceLines(source: string): ReelierTraceRecord[];
+  export function formatTrace(records: ReelierTraceRecord[]): string[];
+}
+
+declare module "@seldonframe/reelier/compile" {
+  import type { ReelierEffect } from "@seldonframe/reelier/skill";
+  import type { ReelierTraceRecord } from "@seldonframe/reelier/trace";
+
+  export type ReelierOpenQuestion = { stepN?: number; text: string };
+
+  export type ReelierCompiledStep = {
+    n: number;
+    title: string;
+    intent: string;
+    tool: string;
+    args: unknown;
+    asserts: string[];
+    binds: string[];
+    effect: ReelierEffect;
+  };
+
+  export type ReelierCompileResult = {
+    name: string;
+    steps: ReelierCompiledStep[];
+    openQuestions: ReelierOpenQuestion[];
+    stats: {
+      steps: number;
+      asserts: number;
+      binds: number;
+      effects: Record<ReelierEffect, number>;
+    };
+  };
+
+  /** Deterministic trace -> CompileResult. Zero LLM calls. */
+  export function compile(records: ReelierTraceRecord[]): ReelierCompileResult;
+  /** Render a CompileResult as a SKILL.md source string. */
+  export function renderSkillMd(result: ReelierCompileResult, traceFileName: string): string;
+}
+
+declare module "@seldonframe/reelier" {
+  import type { ReelierEffect, ReelierSkill } from "@seldonframe/reelier/skill";
+
+  /** The runner's Tool -> Observation contract (mcp-tool.js's own mapping:
+   *  status 200 on success / 500 on isError-or-thrown, headers always {} for
+   *  a non-HTTP tool, body the JSON text of the result). */
+  export type ReelierObservation = {
+    status: number;
+    headers: Record<string, string>;
+    body: string;
+  };
+
+  export type ReelierToolRunCtx = { allowDestructive: boolean };
+
+  /** A registry entry the runner dispatches `step.actionTool` against.
+   *  `effect` is carried for documentation only — the runner's executeStep
+   *  consults `step.effect` (the SKILL's own declared effect), never
+   *  `Tool.effect` (confirmed by reelier's own mcp-tool.js comment). */
+  export type ReelierTool = {
+    effect: ReelierEffect;
+    run(args: unknown, ctx: ReelierToolRunCtx): Promise<ReelierObservation>;
+  };
+
+  export type ReelierStepOutcome = "passed" | "failed" | "unchecked" | "skipped";
+
+  export type ReelierStepRecord = {
+    n: number;
+    title: string;
+    level: number;
+    outcome: ReelierStepOutcome;
+    ms: number;
+    failures: string[];
+    llm?: { inputTokens: number; outputTokens: number };
+  };
+
+  export type ReelierRunRecord = {
+    skill: string;
+    startedAt: string;
+    finishedAt: string;
+    passed: boolean;
+    steps: ReelierStepRecord[];
+    totals: {
+      steps: number;
+      passed: number;
+      failed: number;
+      ms: number;
+      llmInputTokens: number;
+      llmOutputTokens: number;
+    };
+  };
+
+  export type ReelierLlmClient = unknown;
+
+  export type ReelierRunSkillOptions = {
+    cwd?: string;
+    tools?: Record<string, ReelierTool>;
+    allowDestructive?: boolean;
+    vars?: Record<string, unknown>;
+    /** When true, skip the append-only `.reelier/runs/<name>.jsonl` write —
+     *  REQUIRED for any serverless/production caller (this repo always
+     *  passes true; see replay-before-llm.ts). */
+    dryRun?: boolean;
+    /** 0 = pure deterministic replay, zero LLM calls, by construction. This
+     *  repo's v1 replay-before-LLM seam only ever passes 0. */
+    maxLevel?: number;
+    llm?: ReelierLlmClient;
+    llmModel?: string;
+    llmL2Model?: string;
+    skillPath?: string;
+    onStep?: (
+      record: ReelierStepRecord,
+      filled: { tool: string; args: unknown },
+    ) => void;
+  };
+
+  export function runSkill(
+    skill: ReelierSkill,
+    options?: ReelierRunSkillOptions,
+  ): Promise<ReelierRunRecord>;
+
+  export function fillTemplate(value: unknown, bindings: Record<string, unknown>): unknown;
+}

--- a/packages/crm/tests/unit/deployments/replay/compile.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/compile.spec.ts
@@ -1,0 +1,167 @@
+// Deterministic replay — Reelier phase 2c slice 2. compileSkillFromTrace:
+// org-scoped lookup + reelier's OWN compile()/renderSkillMd() round-trip
+// against a realistic stored-records fixture (create_note -> get_note, with
+// a dataflow bind between them). Verifies (a) the org/deployment-scoped
+// lookup never leaks a trace from a different org/deployment, (b) the
+// compiled skill always starts status:'draft', and (c) the shape adapter
+// (toReelierRecords) preserves enough structure for reelier's dataflow
+// recovery to actually find the create_note -> get_note bind.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  compileSkillFromTrace,
+  toReelierRecords,
+  type CompileSkillFromTraceDeps,
+} from "@/lib/deployments/replay/compile";
+import { parseSkill } from "@seldonframe/reelier/skill";
+import {
+  makeMetaRecord,
+  makeNoteRecord,
+  makeCallRecord,
+  makeResultRecord,
+  type TraceRecord,
+} from "@/lib/deployments/replay/trace-format";
+
+const ORG = "org_1";
+const DEPLOYMENT = "dep_1";
+const TRACE_ID = "trace_1";
+
+/** create_note("hello") -> {noteId: "n_42"}; get_note({noteId: "n_42"}) ->
+ *  {found: true} — a realistic two-step trace with a dataflow dependency
+ *  (get_note's arg is the value create_note's result produced). */
+function fixtureRecords(): TraceRecord[] {
+  return [
+    makeMetaRecord({ name: "email:dep_1", startedAt: "2026-07-17T00:00:00.000Z", wrapped: ["gmail"] }),
+    makeNoteRecord({ seq: 1, ts: "2026-07-17T00:00:00.100Z", text: "Creating a note for this email" }),
+    makeCallRecord({ seq: 2, i: 0, ts: "2026-07-17T00:00:00.200Z", tool: "create_note", args: { body: "hello" } }),
+    makeResultRecord({ seq: 3, i: 0, ok: true, ms: 12, body: { noteId: "n_42" } }),
+    makeNoteRecord({ seq: 4, ts: "2026-07-17T00:00:00.300Z", text: "Confirming the note was written" }),
+    makeCallRecord({ seq: 5, i: 1, ts: "2026-07-17T00:00:00.400Z", tool: "get_note", args: { noteId: "n_42" } }),
+    makeResultRecord({ seq: 6, i: 1, ok: true, ms: 8, body: { found: true } }),
+  ];
+}
+
+function fakeDeps(records: TraceRecord[]): CompileSkillFromTraceDeps & {
+  insertedRows: unknown[];
+} {
+  const insertedRows: unknown[] = [];
+  return {
+    insertedRows,
+    loadTrace: async (orgId, deploymentId, traceId) => {
+      if (orgId !== ORG || deploymentId !== DEPLOYMENT || traceId !== TRACE_ID) return null;
+      return { id: traceId, records };
+    },
+    insertSkill: async (row) => {
+      insertedRows.push(row);
+      return {
+        id: "skill_1",
+        orgId: row.orgId,
+        deploymentId: row.deploymentId,
+        name: row.name ?? null,
+        skillMd: row.skillMd,
+        status: row.status ?? "draft",
+        sourceTraceId: row.sourceTraceId ?? null,
+        healCount: 0,
+        lastReplayAt: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as never;
+    },
+  };
+}
+
+describe("toReelierRecords — shape adapter", () => {
+  test("wraps a result body into the MCP CallToolResult shape compile() expects", () => {
+    const out = toReelierRecords([
+      makeResultRecord({ seq: 0, i: 0, ok: true, ms: 1, body: { noteId: "n_42" } }),
+    ]);
+    const rec = out[0] as { t: "result"; body: { content: Array<{ type: string; text: string }>; isError: boolean } };
+    assert.equal(rec.t, "result");
+    assert.equal(rec.body.isError, false);
+    assert.equal(rec.body.content[0].type, "text");
+    assert.deepEqual(JSON.parse(rec.body.content[0].text), { noteId: "n_42" });
+  });
+
+  test("a failed result sets isError true", () => {
+    const out = toReelierRecords([
+      makeResultRecord({ seq: 0, i: 0, ok: false, ms: 1, body: { error: "boom" } }),
+    ]);
+    const rec = out[0] as { body: { isError: boolean } };
+    assert.equal(rec.body.isError, true);
+  });
+
+  test("meta/note/call records pass through unchanged", () => {
+    const meta = makeMetaRecord({ name: "n", startedAt: "t", wrapped: [] });
+    const note = makeNoteRecord({ seq: 1, ts: "t", text: "hi" });
+    const call = makeCallRecord({ seq: 2, i: 0, ts: "t", tool: "x", args: {} });
+    const out = toReelierRecords([meta, note, call]);
+    assert.deepEqual(out, [meta, note, call]);
+  });
+});
+
+describe("compileSkillFromTrace — org-scoped lookup", () => {
+  test("returns null when the trace belongs to a different org", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace("org_OTHER", DEPLOYMENT, TRACE_ID, deps);
+    assert.equal(result, null);
+    assert.equal(deps.insertedRows.length, 0);
+  });
+
+  test("returns null when the trace belongs to a different deployment", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace(ORG, "dep_OTHER", TRACE_ID, deps);
+    assert.equal(result, null);
+  });
+
+  test("returns null for an unknown trace id", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace(ORG, DEPLOYMENT, "trace_UNKNOWN", deps);
+    assert.equal(result, null);
+  });
+});
+
+describe("compileSkillFromTrace — round-trip against a realistic fixture", () => {
+  test("compiles a draft skill whose SKILL.md round-trips through reelier's OWN parseSkill", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace(ORG, DEPLOYMENT, TRACE_ID, deps);
+    assert.ok(result);
+    assert.equal(result!.skillRow.status, "draft");
+    assert.equal(result!.skillRow.sourceTraceId, TRACE_ID);
+    assert.equal(deps.insertedRows.length, 1);
+
+    // The real reelier parser must accept our compiler's own output verbatim.
+    const parsed = parseSkill(result!.skillRow.skillMd);
+    assert.equal(parsed.steps.length, 2);
+    assert.equal(parsed.steps[0].actionTool, "create_note");
+    assert.equal(parsed.steps[1].actionTool, "get_note");
+  });
+
+  test("recovers the create_note -> get_note dataflow bind (noteId)", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace(ORG, DEPLOYMENT, TRACE_ID, deps);
+    assert.ok(result);
+    const step1 = result!.compiled.steps[0];
+    const step2 = result!.compiled.steps[1];
+    // Step 1 (create_note) gets a bind extracting json.noteId from its own
+    // result, PLUS the "is set" assert reelier's compiler always pairs with
+    // a fresh bind.
+    assert.ok(step1.binds.some((b) => b.includes("json.noteId")));
+    assert.ok(step1.asserts.some((a) => a.includes("json.noteId is set")));
+    // Step 2 (get_note)'s literal "n_42" arg is replaced with the bound
+    // variable — never the baked-in literal — so replay always uses the
+    // FRESH value produced at run time.
+    const argsJson = JSON.stringify(step2.args);
+    assert.ok(!argsJson.includes("n_42"));
+    assert.ok(/\{\{\w+\}\}/.test(argsJson));
+  });
+
+  test("both steps get a success assert (status == 200) since both results were ok", async () => {
+    const deps = fakeDeps(fixtureRecords());
+    const result = await compileSkillFromTrace(ORG, DEPLOYMENT, TRACE_ID, deps);
+    for (const step of result!.compiled.steps) {
+      assert.ok(step.asserts.some((a) => a === "status == 200"));
+    }
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/persist.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/persist.spec.ts
@@ -59,6 +59,28 @@ describe("writeWorkflowTrace — happy path", () => {
     assert.deepEqual(row.records, records);
   });
 
+  test("kind defaults to 'trace' when not specified (slice 2)", async () => {
+    let inserted: unknown = null;
+    await writeWorkflowTrace(baseInput(), {
+      insert: async (row) => {
+        inserted = row;
+      },
+    });
+    const row = inserted as Record<string, unknown>;
+    assert.equal(row.kind, "trace");
+  });
+
+  test("kind:'replay-run' passes through when specified", async () => {
+    let inserted: unknown = null;
+    await writeWorkflowTrace(baseInput({ kind: "replay-run" }), {
+      insert: async (row) => {
+        inserted = row;
+      },
+    });
+    const row = inserted as Record<string, unknown>;
+    assert.equal(row.kind, "replay-run");
+  });
+
   test("null deploymentId / triggerKey pass through as null (not undefined)", async () => {
     let inserted: unknown = null;
     await writeWorkflowTrace(baseInput({ deploymentId: null, triggerKey: null }), {

--- a/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
@@ -1,0 +1,286 @@
+// Deterministic replay — Reelier phase 2c slice 2. attemptL0Replay: DI'd
+// unit tests covering the org-scoped enabled-skill lookup, the all-read
+// gate, a clean PASS, and a DIVERGE — all with fake reelier calls (no real
+// parseSkill/runSkill import needed for most of these; passesAllReadGate IS
+// exercised against real ReelierSkill-shaped fixtures).
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  attemptL0Replay,
+  passesAllReadGate,
+  type AttemptL0ReplayDeps,
+  type AttemptL0ReplayInput,
+} from "@/lib/deployments/replay/replay-before-llm";
+import type { ReelierSkill } from "@seldonframe/reelier/skill";
+import type { ReelierRunRecord } from "@seldonframe/reelier";
+
+const ORG = "org_1";
+const DEPLOYMENT = "dep_1";
+
+function baseInput(): AttemptL0ReplayInput {
+  return {
+    orgId: ORG,
+    deploymentId: DEPLOYMENT,
+    orgSlug: "acme",
+    timezone: "America/Toronto",
+    blueprint: { capabilities: [] } as never,
+  };
+}
+
+function makeStep(overrides: Partial<ReelierSkill["steps"][number]> = {}): ReelierSkill["steps"][number] {
+  return {
+    n: 1,
+    title: "step",
+    intent: "do a thing",
+    actionTool: "get_note",
+    actionArgs: {},
+    asserts: [],
+    binds: [],
+    effect: "read",
+    line: 1,
+    ...overrides,
+  };
+}
+
+function passingRecord(skillName: string, stepCount: number): ReelierRunRecord {
+  const steps = Array.from({ length: stepCount }, (_, i) => ({
+    n: i + 1,
+    title: `step ${i + 1}`,
+    level: 0,
+    outcome: "passed" as const,
+    ms: 5,
+    failures: [],
+  }));
+  return {
+    skill: skillName,
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: true,
+    steps,
+    totals: { steps: stepCount, passed: stepCount, failed: 0, ms: 5 * stepCount, llmInputTokens: 0, llmOutputTokens: 0 },
+  };
+}
+
+function divergedRecord(skillName: string): ReelierRunRecord {
+  return {
+    skill: skillName,
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: false,
+    steps: [
+      { n: 1, title: "step 1", level: 0, outcome: "failed", ms: 5, failures: ["status == 200 failed: got 500"] },
+    ],
+    totals: { steps: 1, passed: 0, failed: 1, ms: 5, llmInputTokens: 0, llmOutputTokens: 0 },
+  };
+}
+
+describe("passesAllReadGate — v1 policy", () => {
+  test("all-read skill passes", () => {
+    const skill = { steps: [makeStep({ effect: "read" }), makeStep({ n: 2, effect: "read" })] } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+
+  test("read steps followed by ONE final non-read step passes", () => {
+    const skill = {
+      steps: [makeStep({ effect: "read" }), makeStep({ n: 2, effect: "idempotent-write" })],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+
+  test("a single write-only step (last==only) passes", () => {
+    const skill = { steps: [makeStep({ effect: "destructive" })] } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+
+  test("a non-read step BEFORE the last step fails the gate", () => {
+    const skill = {
+      steps: [
+        makeStep({ effect: "idempotent-write" }),
+        makeStep({ n: 2, effect: "read" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), false);
+  });
+
+  test("two non-read steps fails the gate", () => {
+    const skill = {
+      steps: [
+        makeStep({ effect: "idempotent-write" }),
+        makeStep({ n: 2, effect: "destructive" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), false);
+  });
+
+  test("an empty skill (no steps) never passes", () => {
+    assert.equal(passesAllReadGate({ steps: [] } as unknown as ReelierSkill), false);
+  });
+});
+
+describe("attemptL0Replay — org-scoped enabled-skill lookup", () => {
+  test("skips when no enabled skill exists for this org+deployment", async () => {
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => null,
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "skipped");
+  });
+
+  test("passes the exact orgId + deploymentId through to the lookup (never a different org's skill)", async () => {
+    let seenArgs: [string, string] | null = null;
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async (orgId, deploymentId) => {
+        seenArgs = [orgId, deploymentId];
+        return null;
+      },
+    };
+    await attemptL0Replay(baseInput(), deps);
+    assert.deepEqual(seenArgs, [ORG, DEPLOYMENT]);
+  });
+});
+
+describe("attemptL0Replay — all-read gate wired into the attempt", () => {
+  test("a mixed-effect skill (non-read before last) is skipped WITHOUT ever calling runSkill", async () => {
+    const skill: ReelierSkill = {
+      name: "mixed",
+      description: "d",
+      steps: [
+        makeStep({ effect: "idempotent-write" }),
+        makeStep({ n: 2, effect: "read" }),
+      ],
+      preamble: "",
+      trailing: "",
+    };
+    let runSkillCalled = false;
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "irrelevant" }),
+      parseSkill: async () => skill,
+      runSkill: async () => {
+        runSkillCalled = true;
+        return passingRecord("mixed", 2);
+      },
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "skipped");
+    assert.equal(runSkillCalled, false);
+  });
+});
+
+describe("attemptL0Replay — PASS", () => {
+  test("a clean replay returns kind:'passed' with toolCalls tagged replay-l0", async () => {
+    const skill: ReelierSkill = {
+      name: "all-read",
+      description: "d",
+      steps: [makeStep({ effect: "read", actionTool: "get_note" })],
+      preamble: "",
+      trailing: "",
+    };
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "irrelevant" }),
+      parseSkill: async () => skill,
+      buildTools: async () => ({}),
+      runSkill: async () => passingRecord("all-read", 1),
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "passed");
+    if (result.kind === "passed") {
+      assert.equal(result.skillId, "skill_1");
+      assert.equal(result.toolCalls.length, 1);
+      assert.equal(result.toolCalls[0].tool, "get_note");
+      assert.ok(result.toolCalls[0].note?.includes("replay-l0"));
+    }
+  });
+
+  test("runSkill is called with maxLevel:0, allowDestructive:false, dryRun:true", async () => {
+    const skill: ReelierSkill = {
+      name: "s",
+      description: "d",
+      steps: [makeStep({ effect: "read" })],
+      preamble: "",
+      trailing: "",
+    };
+    let seenOptions: unknown = null;
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "x" }),
+      parseSkill: async () => skill,
+      buildTools: async () => ({}),
+      runSkill: async (_skill, options) => {
+        seenOptions = options;
+        return passingRecord("s", 1);
+      },
+    };
+    await attemptL0Replay(baseInput(), deps);
+    const opts = seenOptions as { maxLevel?: number; allowDestructive?: boolean; dryRun?: boolean };
+    assert.equal(opts.maxLevel, 0);
+    assert.equal(opts.allowDestructive, false);
+    assert.equal(opts.dryRun, true);
+  });
+});
+
+describe("attemptL0Replay — DIVERGE / throw", () => {
+  test("a failed run record returns kind:'diverged' with failures collected", async () => {
+    const skill: ReelierSkill = {
+      name: "s",
+      description: "d",
+      steps: [makeStep({ effect: "read" })],
+      preamble: "",
+      trailing: "",
+    };
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "x" }),
+      parseSkill: async () => skill,
+      buildTools: async () => ({}),
+      runSkill: async () => divergedRecord("s"),
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "diverged");
+    if (result.kind === "diverged") {
+      assert.equal(result.skillId, "skill_1");
+      assert.ok(result.failures.length > 0);
+    }
+  });
+
+  test("a thrown runSkill is treated as a diverge, never propagates", async () => {
+    const skill: ReelierSkill = {
+      name: "s",
+      description: "d",
+      steps: [makeStep({ effect: "read" })],
+      preamble: "",
+      trailing: "",
+    };
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "x" }),
+      parseSkill: async () => skill,
+      buildTools: async () => ({}),
+      runSkill: async () => {
+        throw new Error("network blew up");
+      },
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "diverged");
+  });
+
+  test("a throwing loadEnabledSkill degrades to skipped, never throws (fail-open)", async () => {
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => {
+        throw new Error("db down");
+      },
+    };
+    await assert.doesNotReject(attemptL0Replay(baseInput(), deps));
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "skipped");
+  });
+
+  test("an unparseable skill_md is skipped, not thrown", async () => {
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: "skill_1", skillMd: "not a skill" }),
+      parseSkill: async () => {
+        throw new Error("Frontmatter fence never closed");
+      },
+    };
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "skipped");
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
@@ -1,0 +1,146 @@
+// Deterministic replay — Reelier phase 2c slice 2. replayOrTurn: the DI'd
+// decision seam proving the two safety-critical behaviors the design
+// requires — a PASSED replay skips the agentic turn entirely (spy: runTurn
+// never called), and a DIVERGED/skipped replay falls back to it (turn
+// called, its result is the user-visible result).
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { replayOrTurn, type ReplayOrTurnDeps } from "@/lib/deployments/replay/replay-or-turn";
+import type { AttemptL0ReplayInput, AttemptL0ReplayResult } from "@/lib/deployments/replay/replay-before-llm";
+import type { ReelierRunRecord } from "@seldonframe/reelier";
+
+const INPUT: AttemptL0ReplayInput = {
+  orgId: "org_1",
+  deploymentId: "dep_1",
+  orgSlug: "acme",
+  timezone: "UTC",
+  blueprint: {} as never,
+};
+
+function passRecord(): ReelierRunRecord {
+  return {
+    skill: "s",
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: true,
+    steps: [{ n: 1, title: "step", level: 0, outcome: "passed", ms: 1, failures: [] }],
+    totals: { steps: 1, passed: 1, failed: 0, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
+  };
+}
+
+function divergeRecord(): ReelierRunRecord {
+  return {
+    skill: "s",
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: false,
+    steps: [{ n: 1, title: "step", level: 0, outcome: "failed", ms: 1, failures: ["boom"] }],
+    totals: { steps: 1, passed: 0, failed: 1, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
+  };
+}
+
+function baseDeps(overrides: Partial<ReplayOrTurnDeps> = {}): {
+  deps: ReplayOrTurnDeps;
+  runTurnCalled: { count: number };
+  persisted: AttemptL0ReplayResult[];
+  markedSkillIds: string[];
+} {
+  const runTurnCalled = { count: 0 };
+  const persisted: AttemptL0ReplayResult[] = [];
+  const markedSkillIds: string[] = [];
+  const deps: ReplayOrTurnDeps = {
+    attemptL0Replay: async () => ({ kind: "skipped", reason: "no skill" }),
+    runTurn: async () => {
+      runTurnCalled.count++;
+      return { ok: true, replyText: "turn ran" };
+    },
+    persistReplayRun: async (replay) => {
+      persisted.push(replay);
+    },
+    markSkillReplayed: async (skillId) => {
+      markedSkillIds.push(skillId);
+    },
+    ...overrides,
+  };
+  return { deps, runTurnCalled, persisted, markedSkillIds };
+}
+
+describe("replayOrTurn — replay PASS skips the agentic turn", () => {
+  test("runTurn is NEVER called when replay passes", async () => {
+    const { deps, runTurnCalled } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "passed",
+        skillId: "skill_1",
+        record: passRecord(),
+        toolCalls: [{ tool: "get_note", ok: true, note: "replay-l0: step" }],
+        replyText: undefined,
+      }),
+    });
+    const result = await replayOrTurn(deps, INPUT);
+    assert.equal(runTurnCalled.count, 0);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.toolCalls, [{ tool: "get_note", ok: true, note: "replay-l0: step" }]);
+  });
+
+  test("a passed replay persists the run record AND marks the skill replayed", async () => {
+    const { deps, persisted, markedSkillIds } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "passed",
+        skillId: "skill_1",
+        record: passRecord(),
+        toolCalls: [],
+        replyText: undefined,
+      }),
+    });
+    await replayOrTurn(deps, INPUT);
+    assert.equal(persisted.length, 1);
+    assert.equal(persisted[0].kind, "passed");
+    assert.deepEqual(markedSkillIds, ["skill_1"]);
+  });
+});
+
+describe("replayOrTurn — DIVERGE falls back to the agentic turn", () => {
+  test("runTurn IS called on a divergence, and its result is the user-visible result", async () => {
+    const { deps, runTurnCalled } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "diverged",
+        skillId: "skill_1",
+        record: divergeRecord(),
+        failures: ["boom"],
+      }),
+    });
+    const result = await replayOrTurn(deps, INPUT);
+    assert.equal(runTurnCalled.count, 1);
+    assert.equal(result.ok, true);
+    assert.equal(result.replyText, "turn ran");
+  });
+
+  test("a divergence persists the failed run record but never marks the skill replayed", async () => {
+    const { deps, persisted, markedSkillIds } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "diverged",
+        skillId: "skill_1",
+        record: divergeRecord(),
+        failures: ["boom"],
+      }),
+    });
+    await replayOrTurn(deps, INPUT);
+    assert.equal(persisted.length, 1);
+    assert.equal(persisted[0].kind, "diverged");
+    assert.equal(markedSkillIds.length, 0);
+  });
+});
+
+describe("replayOrTurn — skipped falls back WITHOUT persisting a run record", () => {
+  test("runTurn IS called and nothing is persisted when replay was skipped (no enabled skill)", async () => {
+    const { deps, runTurnCalled, persisted } = baseDeps({
+      attemptL0Replay: async () => ({ kind: "skipped", reason: "no enabled skill" }),
+    });
+    const result = await replayOrTurn(deps, INPUT);
+    assert.equal(runTurnCalled.count, 1);
+    assert.equal(persisted.length, 0);
+    assert.equal(result.replyText, "turn ran");
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/replay-skills-schema.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-skills-schema.spec.ts
@@ -1,0 +1,120 @@
+// Deterministic replay — Reelier phase 2c slice 2. replay_skills schema +
+// migration 0075 shape checks — mirrors tests/unit/workflow-approvals-schema
+// .spec.ts's pattern (Drizzle schemas don't run SQL in unit tests; verify
+// the inferred TS shape + cross-check the hand-written migration SQL
+// against it, since this repo hand-writes migrations rather than
+// drizzle-kit generating them — the two can silently drift).
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { replaySkills } from "@/db/schema/replay-skills";
+import type { ReplaySkillRow, NewReplaySkillRow, ReplaySkillStatus } from "@/db/schema/replay-skills";
+import { agentWorkflowTraces } from "@/db/schema/agent-workflow-traces";
+
+describe("replay_skills — table shape", () => {
+  test("exports a Drizzle PgTable", () => {
+    assert.equal(typeof replaySkills, "object");
+    assert.ok(replaySkills);
+  });
+
+  test("columns: identifiers + org/deployment scope", () => {
+    assert.ok("id" in replaySkills);
+    assert.ok("orgId" in replaySkills);
+    assert.ok("deploymentId" in replaySkills);
+  });
+
+  test("columns: skill content + lifecycle", () => {
+    assert.ok("name" in replaySkills);
+    assert.ok("skillMd" in replaySkills);
+    assert.ok("status" in replaySkills);
+    assert.ok("sourceTraceId" in replaySkills);
+    assert.ok("healCount" in replaySkills);
+    assert.ok("lastReplayAt" in replaySkills);
+    assert.ok("createdAt" in replaySkills);
+    assert.ok("updatedAt" in replaySkills);
+  });
+
+  test("ReplaySkillStatus has the 3 expected values (draft/enabled/disabled)", () => {
+    const all: ReplaySkillStatus[] = ["draft", "enabled", "disabled"];
+    assert.equal(all.length, 3);
+  });
+
+  test("ReplaySkillRow / NewReplaySkillRow type exports round-trip a draft row", () => {
+    const row: ReplaySkillRow = {
+      id: "00000000-0000-4000-8000-000000000001",
+      orgId: "00000000-0000-4000-8000-000000000002",
+      deploymentId: "00000000-0000-4000-8000-000000000003",
+      name: "email:dep_1",
+      skillMd: "---\nname: x\n---\n",
+      status: "draft",
+      sourceTraceId: null,
+      healCount: 0,
+      lastReplayAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    assert.equal(row.status, "draft");
+
+    const insert: NewReplaySkillRow = {
+      orgId: row.orgId,
+      deploymentId: row.deploymentId,
+      skillMd: row.skillMd,
+    };
+    assert.equal(insert.deploymentId, row.deploymentId);
+  });
+
+  test("barrel re-export wires replay_skills into the db schema bundle", async () => {
+    const schemaBarrel = await import("@/db/schema");
+    assert.ok(
+      "replaySkills" in schemaBarrel,
+      "replay_skills must be re-exported via the schema barrel so drizzle config picks it up",
+    );
+  });
+});
+
+describe("agent_workflow_traces — kind column (slice 2 addition)", () => {
+  test("kind column exists on the schema", () => {
+    assert.ok("kind" in agentWorkflowTraces);
+  });
+});
+
+describe("migration 0075 — SQL matches the Drizzle schema's constraints", () => {
+  const migrationSql = readFileSync(
+    path.join(__dirname, "../../../../drizzle/0075_replay_skills.sql"),
+    "utf8",
+  );
+
+  test("adds agent_workflow_traces.kind with default 'trace'", () => {
+    assert.match(migrationSql, /ALTER TABLE "agent_workflow_traces"/);
+    assert.match(migrationSql, /ADD COLUMN IF NOT EXISTS "kind" text NOT NULL DEFAULT 'trace'/);
+  });
+
+  test("creates replay_skills with deployment_id NOT NULL + ON DELETE CASCADE", () => {
+    assert.match(migrationSql, /CREATE TABLE IF NOT EXISTS "replay_skills"/);
+    assert.match(
+      migrationSql,
+      /"deployment_id" uuid NOT NULL REFERENCES "deployments"\("id"\) ON DELETE CASCADE/,
+    );
+  });
+
+  test("creates the partial UNIQUE index enforcing at most one enabled skill per deployment", () => {
+    assert.match(
+      migrationSql,
+      /CREATE UNIQUE INDEX IF NOT EXISTS "replay_skills_one_enabled_per_deployment_idx"\s*\n\s*ON "replay_skills" \("deployment_id"\)\s*\n\s*WHERE "status" = 'enabled'/,
+    );
+  });
+
+  test("status defaults to 'draft' at the SQL level, matching the schema's compileSkillFromTrace contract (never auto-enabled)", () => {
+    assert.match(migrationSql, /"status" text NOT NULL DEFAULT 'draft'/);
+  });
+
+  test("source_trace_id references agent_workflow_traces ON DELETE SET NULL", () => {
+    assert.match(
+      migrationSql,
+      /"source_trace_id" uuid REFERENCES "agent_workflow_traces"\("id"\) ON DELETE SET NULL/,
+    );
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
@@ -81,6 +81,57 @@ describe("redact — secret-shaped strings never reach storage", () => {
   test("a short-looking token that doesn't match either shape is left alone", () => {
     assert.equal(redact("hello world"), "hello world");
   });
+
+  test("masks a Basic auth header inside a plain string", () => {
+    const out = redact("Authorization: Basic dXNlcjpwYXNzd29yZA==") as string;
+    assert.ok(!out.includes("dXNlcjpwYXNzd29yZA=="));
+    assert.ok(out.includes("Basic [redacted]"));
+  });
+
+  test("masks a Google OAuth (ya29.) access token", () => {
+    const out = redact("token: ya29.a0ARrdaM_veryLongOpaqueTokenValue123456") as string;
+    assert.ok(!out.includes("ya29.a0ARrdaM_veryLongOpaqueTokenValue123456"));
+    assert.ok(out.includes("[redacted]"));
+  });
+
+  test("masks a JWT-shaped string", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const out = redact(`bearer token is ${jwt}`) as string;
+    assert.ok(!out.includes(jwt));
+    assert.ok(out.includes("[redacted]"));
+  });
+
+  test("masks a string value under a secret-shaped KEY NAME, regardless of shape", () => {
+    const out = redact({
+      apiKey: "totally-plain-looking-value-not-a-known-shape",
+      api_key: "another-plain-value-1234",
+      password: "hunter22222",
+      Authorization: "custom-scheme xyz123abc456",
+      unrelatedField: "totally-plain-looking-value-not-a-known-shape",
+    }) as Record<string, string>;
+    assert.equal(out.apiKey, "[redacted]");
+    assert.equal(out.api_key, "[redacted]");
+    assert.equal(out.password, "[redacted]");
+    assert.equal(out.Authorization, "[redacted]");
+    // The SAME value under a non-secret-shaped key name is left untouched —
+    // the key-name mask only fires on the key, never on the value's shape.
+    assert.equal(out.unrelatedField, "totally-plain-looking-value-not-a-known-shape");
+  });
+
+  test("a short value under a secret-shaped key name is left alone (too short to plausibly be a real credential)", () => {
+    const out = redact({ tokenType: "bearer" }) as Record<string, string>;
+    assert.equal(out.tokenType, "bearer");
+  });
+
+  test("a non-secret key with an ordinary value is never touched", () => {
+    const out = redact({ contactName: "Jordan Rivera", note: "call back tomorrow" }) as Record<
+      string,
+      string
+    >;
+    assert.equal(out.contactName, "Jordan Rivera");
+    assert.equal(out.note, "call back tomorrow");
+  });
 });
 
 describe("capTraceBody — per-record truncation with an explicit marker", () => {
@@ -101,6 +152,22 @@ describe("capTraceBody — per-record truncation with an explicit marker", () =>
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     assert.equal(capTraceBody(circular), "[trace body was not serializable]");
+  });
+});
+
+describe("makeCallRecord — args are cap'd like a result body", () => {
+  test("oversized args are truncated with the same __truncated marker as a result body", () => {
+    const bigArgs = { payload: "x".repeat(TRACE_BODY_MAX_CHARS * 2) };
+    const call = makeCallRecord({ seq: 1, i: 0, ts: "t1", tool: "BULK_UPSERT", args: bigArgs });
+    const out = call.args as { __truncated: boolean; preview: string; originalLength: number };
+    assert.equal(out.__truncated, true);
+    assert.ok(out.preview.length <= TRACE_BODY_MAX_CHARS);
+    assert.ok(out.originalLength > TRACE_BODY_MAX_CHARS);
+  });
+
+  test("small args pass through unchanged (still redacted)", () => {
+    const call = makeCallRecord({ seq: 1, i: 0, ts: "t1", tool: "GMAIL_SEND_EMAIL", args: { to: "a@b.com" } });
+    assert.deepEqual(call.args, { to: "a@b.com" });
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       '@seldonframe/payments':
         specifier: workspace:*
         version: link:../payments
+      '@seldonframe/reelier':
+        specifier: 0.1.0
+        version: 0.1.0(zod@4.3.6)
       '@stripe/react-stripe-js':
         specifier: ^6.3.0
         version: 6.3.0(@stripe/stripe-js@9.5.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1514,6 +1517,16 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
@@ -2070,6 +2083,11 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@seldonframe/reelier@0.1.0':
+    resolution: {integrity: sha512-aF7QzNBooL4PMf08PmxFLnZuSLUeyZeY7rdZgwW4kNHM6Pl94VYcr7o8EozZhtepf8tT02/0v0fpx+XxPs0uMg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -3540,10 +3558,6 @@ packages:
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
-
-  content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
-    engines: {node: '>=18'}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -5656,9 +5670,6 @@ packages:
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -8121,6 +8132,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.9)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.1(express@5.2.1)
+      hono: 4.12.9
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -8659,6 +8692,14 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@seldonframe/reelier@0.1.0(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
 
   '@sindresorhus/is@7.2.0': {}
 
@@ -10179,11 +10220,11 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10425,8 +10466,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-disposition@1.0.1: {}
-
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -10556,6 +10595,10 @@ snapshots:
       ms: 2.0.0
 
   debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -11240,11 +11283,11 @@ snapshots:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.2
-      content-disposition: 1.0.1
+      content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -11258,7 +11301,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -11385,7 +11428,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12568,8 +12611,6 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
-  path-to-regexp@8.3.0: {}
-
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
@@ -13028,11 +13069,11 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13125,7 +13166,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1


### PR DESCRIPTION
## What

Slice 2 of the Reelier integration, behind the already-live `SF_DETERMINISTIC_REPLAY` flag:

- **Preconditions closed** (slice-1 review P2s): redaction broadened (Basic auth, ya29., JWT, key-name masking), call args capped like result bodies, policy check static-imported
- **Compile**: `replay_skills` table (migration 0075, one-enabled-per-deployment partial unique index) + `compileSkillFromTrace` using the published `@seldonframe/reelier@0.1.0` compiler; skills always land as **draft** — enabling is a human act
- **L0 replay-before-LLM**: for a deployment with an enabled skill, replay runs deterministically (maxLevel 0, no LLM constructed, allowDestructive false) — pass → agentic turn skipped, receipt tagged `replay-l0`, 0 tokens; any divergence/failure → **fail-open** to the normal agentic turn
- **Double-effect safety**: replay only attempted when all steps are effect `read` except at most one final step (conservative v1 gate, documented)

Merging this is behaviorally inert until a skill row is manually enabled — nothing is enabled yet.

## Verification

- Independent adversarial review: **Ship** — 10/10 hard invariants verified against source (fail-open construction, all-read gate incl. unparseable-skill handling, org-scoping, no-LLM path, migration exactness), 0 P0/P1, 4 P2 hardening notes tracked
- verify-build: **PASS** — 79 replay tests green, tsc baseline-delta clean, journal idx 52 consistent, regression grep empty, lockfile confined to reelier+mcp-sdk (+benign dedupes)
- Bonus root-cause fix: corrupted zod package in shared node_modules repaired (was breaking the stateless-turn spec family repo-wide)

## Tracked P2s (pre-loosening preconditions)

- SF-side tool-effect allowlist before the all-read gate is ever relaxed (verb-prefix heuristic is the current guarantee)
- URL-query-param secrets still pass redaction (documented defense-in-depth gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)