### PR TITLE
feat(replay): tool-effect allowlist + anchored query-param redaction + replay-ops CLI

### DIFF
--- a/packages/crm/scripts/replay-ops.ts
+++ b/packages/crm/scripts/replay-ops.ts
@@ -1,11 +1,18 @@
 // Deterministic replay — ops CLI for the trace -> skill -> enable loop
 // (Reelier phase 2c). This is OPS TOOLING run by the platform owner with
-// direct DB env — NOT an in-app admin surface. `list-traces` / `list-skills`
-// deliberately allow cross-org listing (no logged-in org to scope to; a
-// human with direct DB access already has that reach) — every other
-// command that TOUCHES a specific row (`show-trace`, `compile`, `enable`,
-// `disable`) still scopes/derives its org from that row's own org_id, never
-// from an argument a caller could spoof.
+// direct DB env — NOT an in-app admin surface. There is no logged-in org to
+// scope anything to here; direct DB access IS the authorization boundary,
+// same as running SQL by hand. Per command:
+//   - `list-traces` / `list-skills`: intentionally cross-org (no filter
+//     unless `--org`/`--deployment` is passed).
+//   - `compile`: looks up the trace row by id, then derives orgId +
+//     deploymentId FROM that row and passes them into compileSkillFromTrace
+//     (which enforces its own org-scoped WHERE) — so a compile always
+//     targets the trace's OWN org, never an argument a caller could spoof.
+//   - `enable` / `disable`: act by skillId ALONE (no org check at all) —
+//     the operator running this script with direct DB env is already
+//     trusted with every row in the database, so there is no org boundary
+//     left to enforce.
 //
 // Usage (from packages/crm):
 //   pnpm tsx scripts/replay-ops.ts list-traces [--org <id>] [--deployment <id>] [--limit N]

--- a/packages/crm/scripts/replay-ops.ts
+++ b/packages/crm/scripts/replay-ops.ts
@@ -1,0 +1,366 @@
+// Deterministic replay — ops CLI for the trace -> skill -> enable loop
+// (Reelier phase 2c). This is OPS TOOLING run by the platform owner with
+// direct DB env — NOT an in-app admin surface. `list-traces` / `list-skills`
+// deliberately allow cross-org listing (no logged-in org to scope to; a
+// human with direct DB access already has that reach) — every other
+// command that TOUCHES a specific row (`show-trace`, `compile`, `enable`,
+// `disable`) still scopes/derives its org from that row's own org_id, never
+// from an argument a caller could spoof.
+//
+// Usage (from packages/crm):
+//   pnpm tsx scripts/replay-ops.ts list-traces [--org <id>] [--deployment <id>] [--limit N]
+//   pnpm tsx scripts/replay-ops.ts show-trace <traceId>
+//   pnpm tsx scripts/replay-ops.ts compile <traceId>
+//   pnpm tsx scripts/replay-ops.ts list-skills [--deployment <id>]
+//   pnpm tsx scripts/replay-ops.ts enable <skillId>
+//   pnpm tsx scripts/replay-ops.ts disable <skillId>
+//
+// DB-connection pattern mirrors scripts/validate-brain-v2.ts: load
+// .env(.local) candidates via dotenv (override:false — never clobbers an
+// already-exported env var), then hard-fail with a clear message (never a
+// raw stack trace) if DATABASE_URL still isn't set.
+import path from "node:path";
+import { config as loadDotenv } from "dotenv";
+
+function loadEnvironment() {
+  const cwd = process.cwd();
+  const parent = path.resolve(cwd, "..");
+  const grandParent = path.resolve(cwd, "..", "..");
+  const candidates = [
+    path.join(cwd, ".env.local"),
+    path.join(cwd, ".env"),
+    path.join(parent, ".env.local"),
+    path.join(parent, ".env"),
+    path.join(grandParent, ".env.local"),
+    path.join(grandParent, ".env"),
+    path.join(cwd, "packages", "crm", ".env"),
+    path.join(cwd, "packages", "crm", ".env.local"),
+  ];
+  for (const envPath of Array.from(new Set(candidates))) {
+    loadDotenv({ path: envPath, override: false });
+  }
+}
+
+type Args = {
+  command: string | undefined;
+  positional: string[];
+  flags: Record<string, string>;
+};
+
+function parseArgs(argv: string[]): Args {
+  const [command, ...rest] = argv;
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i++) {
+    const tok = rest[i];
+    if (tok.startsWith("--")) {
+      const name = tok.slice(2);
+      const next = rest[i + 1];
+      if (next !== undefined && !next.startsWith("--")) {
+        flags[name] = next;
+        i++;
+      } else {
+        flags[name] = "true";
+      }
+    } else {
+      positional.push(tok);
+    }
+  }
+  return { command, positional, flags };
+}
+
+function truncate(value: unknown, max = 120): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str === undefined) return "undefined";
+  return str.length > max ? `${str.slice(0, max)}…` : str;
+}
+
+/** True iff `err` is a Postgres unique-constraint violation (code 23505).
+ *  Same check as lib/agents/lifecycle/supervised-run.ts's
+ *  isUniqueViolationError / lib/agents/message-trigger-storage-drizzle.ts's
+ *  isUniqueViolation — reimplemented locally (not imported) because those
+ *  modules' own contracts are about a different domain (supervised runs /
+ *  message triggers); this is a one-line, dependency-free check. */
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return (err as { code?: string }).code === "23505";
+}
+
+async function cmdListTraces(flags: Record<string, string>) {
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { and, eq, desc } = await import("drizzle-orm");
+
+  const conditions = [];
+  if (flags.org) conditions.push(eq(agentWorkflowTraces.orgId, flags.org));
+  if (flags.deployment) conditions.push(eq(agentWorkflowTraces.deploymentId, flags.deployment));
+  const limit = flags.limit ? Number.parseInt(flags.limit, 10) : 25;
+
+  let query = db
+    .select({
+      id: agentWorkflowTraces.id,
+      orgId: agentWorkflowTraces.orgId,
+      deploymentId: agentWorkflowTraces.deploymentId,
+      kind: agentWorkflowTraces.kind,
+      ok: agentWorkflowTraces.ok,
+      callCount: agentWorkflowTraces.callCount,
+      createdAt: agentWorkflowTraces.createdAt,
+    })
+    .from(agentWorkflowTraces)
+    .orderBy(desc(agentWorkflowTraces.createdAt))
+    .limit(Number.isFinite(limit) && limit > 0 ? limit : 25);
+
+  if (conditions.length > 0) {
+    query = query.where(and(...conditions)) as typeof query;
+  }
+
+  const rows = await query;
+  if (rows.length === 0) {
+    console.log("No traces found.");
+    return;
+  }
+  console.log(`${rows.length} trace(s):\n`);
+  for (const row of rows) {
+    console.log(
+      `${row.id}  org=${row.orgId}  deployment=${row.deploymentId ?? "-"}  kind=${row.kind}  ok=${row.ok}  calls=${row.callCount}  ${row.createdAt.toISOString()}`,
+    );
+  }
+}
+
+async function cmdShowTrace(traceId: string | undefined) {
+  if (!traceId) {
+    console.error("usage: show-trace <traceId>");
+    process.exitCode = 1;
+    return;
+  }
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { redact } = await import("@/lib/deployments/replay/trace-format");
+  const { eq } = await import("drizzle-orm");
+  const [row] = await db
+    .select()
+    .from(agentWorkflowTraces)
+    .where(eq(agentWorkflowTraces.id, traceId))
+    .limit(1);
+  if (!row) {
+    console.error(`trace not found: ${traceId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`trace ${row.id}`);
+  console.log(`  org: ${row.orgId}`);
+  console.log(`  deployment: ${row.deploymentId ?? "-"}`);
+  console.log(`  kind: ${row.kind}  ok: ${row.ok}  calls: ${row.callCount}`);
+  console.log(`  started: ${row.startedAt.toISOString()}  finished: ${row.finishedAt.toISOString()}`);
+  console.log("");
+
+  // Belt-and-suspenders: re-redact on the way OUT too, in case this row
+  // predates a redaction fix (e.g. the query-param masking added alongside
+  // this CLI) — a trace written before a hardening pass must never leak a
+  // secret through `show-trace` just because it slipped past write-time
+  // redaction.
+  const records = Array.isArray(row.records) ? row.records : [];
+  for (const rec of records as Array<Record<string, unknown>>) {
+    const safe = redact(rec) as Record<string, unknown>;
+    if (safe.t === "note") {
+      console.log(`  [${safe.seq}] note: ${truncate(safe.text, 200)}`);
+    } else if (safe.t === "call") {
+      console.log(`  [${safe.seq}] call#${safe.i} ${safe.tool}  args=${truncate(safe.args)}`);
+    } else if (safe.t === "result") {
+      console.log(`  [${safe.seq}] result#${safe.i} ok=${safe.ok} ms=${safe.ms}  body=${truncate(safe.body)}`);
+    } else if (safe.t === "meta") {
+      console.log(`  [${safe.seq}] meta name=${safe.name} wrapped=${truncate(safe.wrapped)}`);
+    } else {
+      // A 'replay-run' (ReelierRunRecord) row — not a TraceRecord[] shape.
+      // Print it redacted-whole rather than assuming per-record fields.
+      console.log(`  ${truncate(safe)}`);
+    }
+  }
+}
+
+async function cmdCompile(traceId: string | undefined) {
+  if (!traceId) {
+    console.error("usage: compile <traceId>");
+    process.exitCode = 1;
+    return;
+  }
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { compileSkillFromTrace } = await import("@/lib/deployments/replay/compile");
+  const { effectForTool } = await import("@/lib/deployments/replay/tool-effects");
+  const { eq } = await import("drizzle-orm");
+
+  const [row] = await db
+    .select({
+      id: agentWorkflowTraces.id,
+      orgId: agentWorkflowTraces.orgId,
+      deploymentId: agentWorkflowTraces.deploymentId,
+    })
+    .from(agentWorkflowTraces)
+    .where(eq(agentWorkflowTraces.id, traceId))
+    .limit(1);
+  if (!row) {
+    console.error(`trace not found: ${traceId}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!row.deploymentId) {
+    console.error(`trace ${traceId} has no deployment_id — nothing to compile a skill against`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = await compileSkillFromTrace(row.orgId, row.deploymentId, traceId);
+  if (!result) {
+    console.error(`compile failed: trace ${traceId} not found under its own org/deployment scope`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`draft skill id: ${result.skillRow.id}  (status: ${result.skillRow.status})`);
+  console.log("");
+  console.log("--- skill_md ---");
+  console.log(result.skillRow.skillMd);
+  console.log("--- end skill_md ---");
+
+  const nonReadSteps = result.compiled.steps.filter((s) => effectForTool(s.tool) !== "read");
+  if (nonReadSteps.length > 0) {
+    console.log("");
+    console.log(
+      `WARNING: ${nonReadSteps.length} step(s) use a tool NOT allowlisted 'read' — the replay gate will only ` +
+        `ever run this skill if ALL of these are the SINGLE FINAL step:`,
+    );
+    for (const s of nonReadSteps) {
+      const known = effectForTool(s.tool);
+      const label = known ? known : "UNKNOWN (not in tool-effects.ts allowlist — treated as destructive)";
+      console.log(`  step ${s.n} "${s.title}": tool=${s.tool} -> ${label}`);
+    }
+  }
+}
+
+async function cmdListSkills(flags: Record<string, string>) {
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const { eq, desc } = await import("drizzle-orm");
+
+  let query = db
+    .select({
+      id: replaySkills.id,
+      deploymentId: replaySkills.deploymentId,
+      name: replaySkills.name,
+      status: replaySkills.status,
+      healCount: replaySkills.healCount,
+      lastReplayAt: replaySkills.lastReplayAt,
+    })
+    .from(replaySkills)
+    .orderBy(desc(replaySkills.createdAt));
+
+  if (flags.deployment) {
+    query = query.where(eq(replaySkills.deploymentId, flags.deployment)) as typeof query;
+  }
+
+  const rows = await query;
+  if (rows.length === 0) {
+    console.log("No skills found.");
+    return;
+  }
+  console.log(`${rows.length} skill(s):\n`);
+  for (const row of rows) {
+    console.log(
+      `${row.id}  deployment=${row.deploymentId}  name=${row.name ?? "-"}  status=${row.status}  heals=${row.healCount}  lastReplay=${row.lastReplayAt ? row.lastReplayAt.toISOString() : "-"}`,
+    );
+  }
+}
+
+async function setSkillStatus(skillId: string | undefined, status: "enabled" | "disabled") {
+  if (!skillId) {
+    console.error(`usage: ${status === "enabled" ? "enable" : "disable"} <skillId>`);
+    process.exitCode = 1;
+    return;
+  }
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const { eq } = await import("drizzle-orm");
+
+  const [skill] = await db
+    .select({ id: replaySkills.id, deploymentId: replaySkills.deploymentId, status: replaySkills.status })
+    .from(replaySkills)
+    .where(eq(replaySkills.id, skillId))
+    .limit(1);
+  if (!skill) {
+    console.error(`skill not found: ${skillId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await db
+      .update(replaySkills)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(replaySkills.id, skillId));
+    console.log(`${skillId}: ${skill.status} -> ${status}  (deployment ${skill.deploymentId})`);
+  } catch (err) {
+    if (status === "enabled" && isUniqueViolation(err)) {
+      console.error(
+        `cannot enable ${skillId}: another skill is already enabled for deployment ${skill.deploymentId} ` +
+          `(replay_skills_one_enabled_per_deployment_idx — at most one enabled skill per deployment). ` +
+          `Disable the currently-enabled skill first, then retry.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  loadEnvironment();
+
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "No database configured: DATABASE_URL is not set. Load .env/.env.local (or export DATABASE_URL) before running replay-ops.",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const { command, positional, flags } = parseArgs(process.argv.slice(2));
+
+  switch (command) {
+    case "list-traces":
+      await cmdListTraces(flags);
+      break;
+    case "show-trace":
+      await cmdShowTrace(positional[0]);
+      break;
+    case "compile":
+      await cmdCompile(positional[0]);
+      break;
+    case "list-skills":
+      await cmdListSkills(flags);
+      break;
+    case "enable":
+      await setSkillStatus(positional[0], "enabled");
+      break;
+    case "disable":
+      await setSkillStatus(positional[0], "disabled");
+      break;
+    default:
+      console.error(
+        "usage: replay-ops.ts <list-traces|show-trace|compile|list-skills|enable|disable> [args]\n\n" +
+          "  list-traces [--org <id>] [--deployment <id>] [--limit N]\n" +
+          "  show-trace <traceId>\n" +
+          "  compile <traceId>\n" +
+          "  list-skills [--deployment <id>]\n" +
+          "  enable <skillId>\n" +
+          "  disable <skillId>",
+      );
+      process.exitCode = command ? 1 : 0;
+  }
+}
+
+main().catch((err) => {
+  console.error("replay-ops failed:", err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
@@ -32,7 +32,8 @@ import type {
   ReelierRunRecord,
   ReelierTool,
 } from "@seldonframe/reelier";
-import type { ReelierSkill } from "@seldonframe/reelier/skill";
+import type { ReelierSkill, ReelierSkillStep } from "@seldonframe/reelier/skill";
+import { effectForTool } from "./tool-effects";
 
 export type AttemptL0ReplayInput = {
   orgId: string;
@@ -64,14 +65,37 @@ export type AttemptL0ReplayResult =
 type EnabledSkillRow = { id: string; skillMd: string };
 
 /**
+ * A step's TRUSTED effect for gate purposes. Consults tool-effects.ts's
+ * explicit allowlist FIRST — SF's own hand-classified truth about the tool's
+ * real side effect, keyed by name. Only when the allowlist has never heard
+ * of the tool (an unknown/third-party/typo'd name) does the compiled skill's
+ * own `effect:` line get a say — and even then it is trusted ONLY when it
+ * says 'destructive' (the safe direction); an unknown tool claiming 'read'
+ * or 'idempotent-write' in skill_md text is never believed, because that
+ * text came from reelier's verb-prefix heuristic over the tool NAME, not
+ * from anything SF actually verified (this is the `search_and_purge`
+ * attack: a destructive tool whose name happens to parse as a read verb).
+ * Net effect: an unknown tool is ALWAYS treated as destructive here — it can
+ * only ever occupy the gate's single bounded final-step slot, exactly like a
+ * genuinely destructive allowlisted tool.
+ */
+function trustedEffect(step: ReelierSkillStep): ReelierSkill["steps"][number]["effect"] {
+  const known = effectForTool(step.actionTool);
+  if (known !== undefined) return known;
+  return "destructive";
+}
+
+/**
  * v1 replay gate: at most one non-read step, and it must be the LAST step.
  * Zero non-read steps (a pure-read skill) also passes trivially. An empty
- * skill (no steps) never passes — nothing to replay.
+ * skill (no steps) never passes — nothing to replay. "Non-read" here is the
+ * ALLOWLIST-trusted effect (trustedEffect above), never skill_md's raw
+ * `effect:` line directly.
  */
 export function passesAllReadGate(skill: ReelierSkill): boolean {
   if (skill.steps.length === 0) return false;
   const lastIdx = skill.steps.length - 1;
-  return skill.steps.every((step, idx) => step.effect === "read" || idx === lastIdx);
+  return skill.steps.every((step, idx) => trustedEffect(step) === "read" || idx === lastIdx);
 }
 
 /** Injectable I/O — defaults to real DB reads / reelier calls (kept out of

--- a/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
@@ -67,17 +67,17 @@ type EnabledSkillRow = { id: string; skillMd: string };
 /**
  * A step's TRUSTED effect for gate purposes. Consults tool-effects.ts's
  * explicit allowlist FIRST — SF's own hand-classified truth about the tool's
- * real side effect, keyed by name. Only when the allowlist has never heard
- * of the tool (an unknown/third-party/typo'd name) does the compiled skill's
- * own `effect:` line get a say — and even then it is trusted ONLY when it
- * says 'destructive' (the safe direction); an unknown tool claiming 'read'
- * or 'idempotent-write' in skill_md text is never believed, because that
+ * real side effect, keyed by name. When the allowlist has never heard of the
+ * tool (an unknown/third-party/typo'd name), the result is UNCONDITIONALLY
+ * 'destructive' — the compiled skill's own `effect:` line is never consulted
+ * for an unknown tool, not even to check whether it says 'destructive'. That
  * text came from reelier's verb-prefix heuristic over the tool NAME, not
- * from anything SF actually verified (this is the `search_and_purge`
- * attack: a destructive tool whose name happens to parse as a read verb).
- * Net effect: an unknown tool is ALWAYS treated as destructive here — it can
- * only ever occupy the gate's single bounded final-step slot, exactly like a
- * genuinely destructive allowlisted tool.
+ * from anything SF actually verified (this is the `search_and_purge` attack:
+ * a destructive tool whose name happens to parse as a read verb), so it gets
+ * zero influence on the gate either way. Net effect: an unknown tool is
+ * ALWAYS treated as destructive here — it can only ever occupy the gate's
+ * single bounded final-step slot, exactly like a genuinely destructive
+ * allowlisted tool.
  */
 function trustedEffect(step: ReelierSkillStep): ReelierSkill["steps"][number]["effect"] {
   const known = effectForTool(step.actionTool);

--- a/packages/crm/src/lib/deployments/replay/tool-effects.ts
+++ b/packages/crm/src/lib/deployments/replay/tool-effects.ts
@@ -1,0 +1,144 @@
+// Deterministic replay — Reelier phase 2c, ops hardening. An EXPLICIT
+// allowlist of SF's own known tool names -> their REAL side effect, read
+// from this codebase (not inferred from a name/verb heuristic).
+//
+// WHY THIS EXISTS: replay-before-llm.ts's passesAllReadGate previously
+// trusted a compiled skill's own `effect:` line verbatim — text produced by
+// reelier's compiler from a verb-prefix heuristic over the tool NAME (e.g.
+// "get_*"/"list_*"/"search_*" -> read). A hypothetical tool named
+// `search_and_purge` would classify as 'read' under that heuristic even
+// though it deletes data — the gate would then treat it as safe to replay
+// anywhere in the sequence, not just as the bounded final step. This module
+// is the fix: SF's OWN tools are classified here, by hand, from reading
+// their actual execute() bodies (see the two maps below) — never from their
+// name. Any tool NOT in this map is UNKNOWN, and effectForTool returns
+// undefined for it; the caller (replay-before-llm.ts) must treat undefined
+// as "never read, never idempotent-write" — i.e. destructive by default —
+// so an unknown tool can only ever appear as the gate's single bounded
+// final step, exactly like a genuinely destructive one, regardless of what
+// the compiled skill_md's text claims about it.
+import type { ReelierEffect } from "@seldonframe/reelier/skill";
+
+export type Effect = ReelierEffect;
+
+/**
+ * Native agent tools — lib/agents/tools.ts's ALL_TOOLS plus the opt-in
+ * draft_for_approval capability tool (never in ALL_TOOLS itself, appended by
+ * getToolsForCapabilities only when the DRAFT_FOR_APPROVAL_CAPABILITY is
+ * requested). Classified by reading each tool's execute():
+ *  - look_up_availability / find_my_existing_appointment / get_quote_range:
+ *    pure reads off calendar/blueprint state, no DB write.
+ *  - provide_faq_answer: pure in-memory search over blueprint.faq, no I/O.
+ *  - escalate_to_human: writes portal_messages + activities rows only — an
+ *    internal CRM record, no external send (no email/SMS call site).
+ *  - draft_for_approval: creates an inert agent_action_drafts row awaiting a
+ *    human's approval (the never-fail-compile precedent) — nothing external
+ *    happens until a human acts on it separately.
+ *  - book_appointment / reschedule_appointment / cancel_appointment: commit
+ *    a real booking change (create/move/cancel a calendar commitment).
+ *  - take_message: sends a REAL operator SMS via sendSmsFromApi (Twilio) —
+ *    an external send, even though the recipient is the operator's own team
+ *    rather than the caller.
+ */
+const NATIVE_TOOL_EFFECTS: Record<string, Effect> = {
+  look_up_availability: "read",
+  find_my_existing_appointment: "read",
+  provide_faq_answer: "read",
+  get_quote_range: "read",
+  escalate_to_human: "idempotent-write",
+  draft_for_approval: "idempotent-write",
+  book_appointment: "destructive",
+  reschedule_appointment: "destructive",
+  cancel_appointment: "destructive",
+  take_message: "destructive",
+};
+
+/**
+ * Composio-connector tools — the curated default allowlist per toolkit
+ * (lib/integrations/composio/catalog.ts's DEFAULT_TOOLS_BY_TOOLKIT). Slugs
+ * follow Composio's own `{TOOLKIT}_{ACTION}` convention. Classified by each
+ * action's documented behavior, not by the SEND/CREATE/LIST prefix alone:
+ *  - *_SEND_EMAIL, *_SEND_MESSAGE, *_CREATE_EVENT (calendar — typically
+ *    emails attendees an invite), *_CREATE_INVOICE (issues a real invoice):
+ *    a real external send / booking / financial document. destructive.
+ *  - *_FETCH_*, *_LIST_*, *_FIND_*, *_SEARCH_*, *_GET_*, *_QUERY_*,
+ *    *_DOWNLOAD_*: read-only lookups.
+ *  - *_CREATE_EMAIL_DRAFT, *_ADD_LABEL_*, *_MODIFY_*_LABELS, *_CREATE_LABEL,
+ *    *_CREATE_FILE, *_CREATE_PAGE, *_CREATE_CONTACT, *_CREATE_DEAL,
+ *    *_CREATE_CUSTOMER, *_BATCH_MOVE_MESSAGES, *_UPDATE_EMAIL_MESSAGE: a
+ *    mutation confined to the connected account/workspace itself (labels,
+ *    drafts, CRM/file records) — never a message or document reaching a
+ *    third party. idempotent-write.
+ */
+const COMPOSIO_TOOL_EFFECTS: Record<string, Effect> = {
+  // Gmail
+  GMAIL_SEND_EMAIL: "destructive",
+  GMAIL_FETCH_EMAILS: "read",
+  GMAIL_CREATE_EMAIL_DRAFT: "idempotent-write",
+  GMAIL_ADD_LABEL_TO_EMAIL: "idempotent-write",
+  GMAIL_MODIFY_THREAD_LABELS: "idempotent-write",
+  GMAIL_LIST_LABELS: "read",
+  GMAIL_CREATE_LABEL: "idempotent-write",
+  // Google Calendar
+  GOOGLECALENDAR_CREATE_EVENT: "destructive",
+  GOOGLECALENDAR_FIND_FREE_SLOTS: "read",
+  GOOGLECALENDAR_FIND_EVENT: "read",
+  GOOGLECALENDAR_LIST_EVENTS: "read",
+  // Google Drive
+  GOOGLEDRIVE_FIND_FILE: "read",
+  GOOGLEDRIVE_CREATE_FILE: "idempotent-write",
+  GOOGLEDRIVE_DOWNLOAD_FILE: "read",
+  // Slack
+  SLACK_SEND_MESSAGE: "destructive",
+  SLACK_LIST_CHANNELS: "read",
+  SLACK_FETCH_CONVERSATION_HISTORY: "read",
+  // Notion
+  NOTION_CREATE_PAGE: "idempotent-write",
+  NOTION_SEARCH: "read",
+  NOTION_QUERY_DATABASE: "read",
+  // HubSpot
+  HUBSPOT_CREATE_CONTACT: "idempotent-write",
+  HUBSPOT_SEARCH_CONTACTS: "read",
+  HUBSPOT_CREATE_DEAL: "idempotent-write",
+  // QuickBooks
+  QUICKBOOKS_CREATE_INVOICE: "destructive",
+  QUICKBOOKS_CREATE_CUSTOMER: "idempotent-write",
+  QUICKBOOKS_LIST_INVOICES: "read",
+  // Outlook
+  OUTLOOK_SEND_EMAIL: "destructive",
+  OUTLOOK_LIST_MESSAGES: "read",
+  OUTLOOK_CALENDAR_CREATE_EVENT: "destructive",
+  OUTLOOK_CALENDAR_GET_SCHEDULE: "read",
+  OUTLOOK_LIST_MAIL_FOLDERS: "read",
+  OUTLOOK_BATCH_MOVE_MESSAGES: "idempotent-write",
+  OUTLOOK_UPDATE_EMAIL_MESSAGE: "idempotent-write",
+};
+
+const TOOL_EFFECTS: Record<string, Effect> = {
+  ...NATIVE_TOOL_EFFECTS,
+  ...COMPOSIO_TOOL_EFFECTS,
+};
+
+/**
+ * Look up a tool's REAL effect from this explicit allowlist. Returns
+ * `undefined` for any name not in the map — an unknown tool, NEVER a
+ * guess. Callers must treat `undefined` as untrusted (never 'read', never
+ * 'idempotent-write') — see replay-before-llm.ts's passesAllReadGate, the
+ * only caller with a safety contract riding on this.
+ */
+export function effectForTool(name: string): Effect | undefined {
+  return TOOL_EFFECTS[name];
+}
+
+/** Total tool names this allowlist explicitly classifies. Exposed for the
+ *  ops CLI + tests — not itself load-bearing on the gate. */
+export function allowlistSize(): number {
+  return Object.keys(TOOL_EFFECTS).length;
+}
+
+/** The full name -> Effect map, read-only. Exposed for the ops CLI's
+ *  `compile` warning line (flagging any compiled step whose tool isn't
+ *  allowlisted 'read') without duplicating this table elsewhere. */
+export function listToolEffects(): ReadonlyArray<[string, Effect]> {
+  return Object.entries(TOOL_EFFECTS);
+}

--- a/packages/crm/src/lib/deployments/replay/trace-format.ts
+++ b/packages/crm/src/lib/deployments/replay/trace-format.ts
@@ -94,10 +94,21 @@ const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g;
  *  whole in a single string field (`?api_key=abc123&x=1`) or an
  *  obviously form-encoded body (`token=abc123&foo=bar`). Independent of
  *  SECRET_KEY_NAME_RE below, which only fires on actual JSON object keys —
- *  this one fires on TEXT embedded inside a string value. Deliberately the
- *  same shape-agnostic policy as SECRET_KEY_NAME_RE: match on the NAME,
- *  never on the value's shape (a token/key/code can look like anything). */
-const QUERY_PARAM_NAME_RE = /token|secret|key|password|auth|signature|sig|code/i;
+ *  this one fires on TEXT embedded inside a string value.
+ *
+ *  NOT the same matching policy as SECRET_KEY_NAME_RE (that one is a bare
+ *  substring test — `/token|secret|.../i.test(k)` — appropriate for a JSON
+ *  key name, which is rarely an English word). A query-param name embedded
+ *  in arbitrary URL/body text is far more likely to collide with an
+ *  ordinary word, so this pattern is ANCHORED: each short token
+ *  (key/auth/authorization/signature/sig/code) must match the param name as
+ *  a whole word or a `_`/`-`-delimited compound at the END of the name
+ *  (`(?:^|[_-])TOKEN$`), never as a bare substring anywhere. That's what
+ *  keeps `api_key`/`access_token`/`public_key`/`auth_code` masked while
+ *  `monkey`/`donkey`/`design`/`author`/`barcode` (which merely CONTAIN one
+ *  of those tokens mid-word) pass through untouched. */
+const QUERY_PARAM_NAME_RE =
+  /(?:^|[_-])(?:api[_-]?key|access[_-]?token|key|token|secret|password|auth|authorization|signature|sig|code)$/i;
 /** Matches one `name=value` pair, anchored so it only fires on an ACTUAL
  *  `name=value` occurrence — preceded by start-of-string, `?`, `&`,
  *  whitespace, or a quote (never mid-word, so a bare sentence containing

--- a/packages/crm/src/lib/deployments/replay/trace-format.ts
+++ b/packages/crm/src/lib/deployments/replay/trace-format.ts
@@ -89,6 +89,33 @@ const BASIC_AUTH_RE = /Basic\s+[A-Za-z0-9+/=]{8,}/gi;
 const GOOGLE_OAUTH_RE = /\bya29\.[A-Za-z0-9._-]{10,}/g;
 /** Matches a JWT-shaped string (three dot-separated base64url segments). */
 const JWT_RE = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{4,}/g;
+/** Query-param / form-field NAME pattern whose VALUE is masked when found as
+ *  a `name=value` occurrence inside any plain string — e.g. a URL stored
+ *  whole in a single string field (`?api_key=abc123&x=1`) or an
+ *  obviously form-encoded body (`token=abc123&foo=bar`). Independent of
+ *  SECRET_KEY_NAME_RE below, which only fires on actual JSON object keys —
+ *  this one fires on TEXT embedded inside a string value. Deliberately the
+ *  same shape-agnostic policy as SECRET_KEY_NAME_RE: match on the NAME,
+ *  never on the value's shape (a token/key/code can look like anything). */
+const QUERY_PARAM_NAME_RE = /token|secret|key|password|auth|signature|sig|code/i;
+/** Matches one `name=value` pair, anchored so it only fires on an ACTUAL
+ *  `name=value` occurrence — preceded by start-of-string, `?`, `&`,
+ *  whitespace, or a quote (never mid-word, so a bare sentence containing
+ *  "key" never matches — there's no `=`). The value runs until the next
+ *  `&`, whitespace, quote, or angle bracket, so only THAT param's value is
+ *  replaced and the rest of the URL/body (other params, the path, etc.)
+ *  passes through untouched. */
+const QUERY_PARAM_PAIR_RE = /(^|[?&\s"'])([A-Za-z0-9_.\-]+)=([^&\s"'<>]*)/g;
+
+/** Mask query-param / form-field VALUES by NAME inside a plain string. Pure;
+ *  never throws (a plain regex replace over a string can't throw). */
+function redactQueryParams(value: string): string {
+  return value.replace(QUERY_PARAM_PAIR_RE, (match, prefix: string, name: string, val: string) => {
+    if (!val || !QUERY_PARAM_NAME_RE.test(name)) return match;
+    return `${prefix}${name}=«redacted»`;
+  });
+}
+
 /** Object keys whose STRING value is masked outright (never pattern-matched
  *  — a token/secret/password field can hold any shape, not just the shapes
  *  above), when the value is long enough to plausibly be a real credential
@@ -103,18 +130,23 @@ const SECRET_KEY_NAME_MIN_LENGTH = 8;
  *
  *  NOTE — this is defense-in-depth, not a guarantee: it catches the KNOWN
  *  shapes above (Anthropic/OpenAI-style keys, Bearer/Basic auth headers,
- *  Google OAuth tokens, JWTs) plus a key-name heuristic (see
- *  SECRET_KEY_NAME_RE in redact() below) — an arbitrary connector's own
- *  bespoke credential shape, embedded in a plain string under an
- *  innocuous-looking field name, can still slip through. Treat this as one
- *  layer, not the only layer, of the "never store a live secret" contract. */
+ *  Google OAuth tokens, JWTs), a URL-query-param / form-field NAME
+ *  heuristic (QUERY_PARAM_NAME_RE — masks `?api_key=...`-shaped values by
+ *  param name, e.g. a callback/webhook URL stored whole in a string field),
+ *  plus a JSON-object key-name heuristic (see SECRET_KEY_NAME_RE in
+ *  redact() below) — an arbitrary connector's own bespoke credential shape,
+ *  embedded in a plain string under an innocuous-looking field name, can
+ *  still slip through. Treat this as one layer, not the only layer, of the
+ *  "never store a live secret" contract. */
 function redactString(value: string): string {
-  return value
-    .replace(SECRET_KEY_RE, "[redacted]")
-    .replace(BEARER_RE, "Bearer [redacted]")
-    .replace(BASIC_AUTH_RE, "Basic [redacted]")
-    .replace(GOOGLE_OAUTH_RE, "[redacted]")
-    .replace(JWT_RE, "[redacted]");
+  return redactQueryParams(
+    value
+      .replace(SECRET_KEY_RE, "[redacted]")
+      .replace(BEARER_RE, "Bearer [redacted]")
+      .replace(BASIC_AUTH_RE, "Basic [redacted]")
+      .replace(GOOGLE_OAUTH_RE, "[redacted]")
+      .replace(JWT_RE, "[redacted]"),
+  );
 }
 
 /**

--- a/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
@@ -78,13 +78,21 @@ function divergedRecord(skillName: string): ReelierRunRecord {
 
 describe("passesAllReadGate — v1 policy", () => {
   test("all-read skill passes", () => {
-    const skill = { steps: [makeStep({ effect: "read" }), makeStep({ n: 2, effect: "read" })] } as ReelierSkill;
+    const skill = {
+      steps: [
+        makeStep({ effect: "read", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "read", actionTool: "look_up_availability" }),
+      ],
+    } as ReelierSkill;
     assert.equal(passesAllReadGate(skill), true);
   });
 
   test("read steps followed by ONE final non-read step passes", () => {
     const skill = {
-      steps: [makeStep({ effect: "read" }), makeStep({ n: 2, effect: "idempotent-write" })],
+      steps: [
+        makeStep({ effect: "read", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "idempotent-write" }),
+      ],
     } as ReelierSkill;
     assert.equal(passesAllReadGate(skill), true);
   });
@@ -116,6 +124,57 @@ describe("passesAllReadGate — v1 policy", () => {
 
   test("an empty skill (no steps) never passes", () => {
     assert.equal(passesAllReadGate({ steps: [] } as unknown as ReelierSkill), false);
+  });
+});
+
+describe("passesAllReadGate — tool-effects allowlist wired in (the search_and_purge attack)", () => {
+  test("an ALLOWLISTED destructive tool declared 'read' in skill_md is NOT trusted — gate fails when it isn't the last step", () => {
+    // book_appointment is allowlisted 'destructive' (tool-effects.ts). A
+    // compiler bug or a hand-edited skill_md could still claim effect:'read'
+    // for it — the allowlist must win over that text.
+    const skill = {
+      steps: [
+        makeStep({ effect: "read", actionTool: "book_appointment" }),
+        makeStep({ n: 2, effect: "read", actionTool: "look_up_availability" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), false);
+  });
+
+  test("an UNKNOWN tool declared 'read' in skill_md is NEVER trusted — gate fails even though skill_md says read (the literal attack)", () => {
+    // A hypothetical tool like `search_and_purge` isn't in the allowlist at
+    // all. Under the OLD gate (trusting skill_md's effect line directly),
+    // this would have passed as 'read' anywhere in the sequence — exactly
+    // reelier's verb-prefix heuristic misclassifying a destructive tool
+    // because its name starts with "search". The allowlist forces any
+    // UNKNOWN tool to 'destructive', so it can only ever be the bounded
+    // final step, never a mid-sequence "read".
+    const skill = {
+      steps: [
+        makeStep({ effect: "read", actionTool: "search_and_purge" }),
+        makeStep({ n: 2, effect: "read", actionTool: "look_up_availability" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), false);
+  });
+
+  test("an UNKNOWN tool as the sole/final step still passes (bounded exactly like a known-destructive final step)", () => {
+    const skill = {
+      steps: [makeStep({ effect: "read", actionTool: "search_and_purge" })],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+
+  test("an allowlisted read tool passes even when skill_md's own effect line disagrees", () => {
+    // look_up_availability is allowlisted 'read' — trusted regardless of
+    // what skill_md's (untrusted) effect line claims.
+    const skill = {
+      steps: [
+        makeStep({ effect: "destructive", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "read", actionTool: "look_up_availability" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
   });
 });
 

--- a/packages/crm/tests/unit/deployments/replay/tool-effects.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/tool-effects.spec.ts
@@ -1,0 +1,117 @@
+// Deterministic replay — ops hardening. Unit tests for the explicit
+// tool-effect allowlist (lib/deployments/replay/tool-effects.ts). The
+// safety-critical property is exercised end-to-end (through
+// passesAllReadGate) in replay-before-llm.spec.ts's "search_and_purge
+// attack" describe block — these tests cover the module's own contract in
+// isolation: known tools classify correctly, unknown tools return
+// undefined (never a guess).
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { effectForTool, allowlistSize, listToolEffects } from "@/lib/deployments/replay/tool-effects";
+
+describe("effectForTool — native SF tools", () => {
+  test("look_up_availability is read", () => {
+    assert.equal(effectForTool("look_up_availability"), "read");
+  });
+
+  test("find_my_existing_appointment is read", () => {
+    assert.equal(effectForTool("find_my_existing_appointment"), "read");
+  });
+
+  test("provide_faq_answer is read", () => {
+    assert.equal(effectForTool("provide_faq_answer"), "read");
+  });
+
+  test("get_quote_range is read", () => {
+    assert.equal(effectForTool("get_quote_range"), "read");
+  });
+
+  test("escalate_to_human is idempotent-write (internal CRM rows only, no external send)", () => {
+    assert.equal(effectForTool("escalate_to_human"), "idempotent-write");
+  });
+
+  test("draft_for_approval is idempotent-write (inert until a human approves)", () => {
+    assert.equal(effectForTool("draft_for_approval"), "idempotent-write");
+  });
+
+  test("book_appointment / reschedule_appointment / cancel_appointment are destructive", () => {
+    assert.equal(effectForTool("book_appointment"), "destructive");
+    assert.equal(effectForTool("reschedule_appointment"), "destructive");
+    assert.equal(effectForTool("cancel_appointment"), "destructive");
+  });
+
+  test("take_message is destructive (sends a real operator SMS via Twilio)", () => {
+    assert.equal(effectForTool("take_message"), "destructive");
+  });
+});
+
+describe("effectForTool — Composio connector tools", () => {
+  test("GMAIL_SEND_EMAIL and OUTLOOK_SEND_EMAIL are destructive (send-class)", () => {
+    assert.equal(effectForTool("GMAIL_SEND_EMAIL"), "destructive");
+    assert.equal(effectForTool("OUTLOOK_SEND_EMAIL"), "destructive");
+  });
+
+  test("SLACK_SEND_MESSAGE is destructive (posts externally)", () => {
+    assert.equal(effectForTool("SLACK_SEND_MESSAGE"), "destructive");
+  });
+
+  test("calendar CREATE_EVENT actions are destructive (books, typically invites attendees)", () => {
+    assert.equal(effectForTool("GOOGLECALENDAR_CREATE_EVENT"), "destructive");
+    assert.equal(effectForTool("OUTLOOK_CALENDAR_CREATE_EVENT"), "destructive");
+  });
+
+  test("QUICKBOOKS_CREATE_INVOICE is destructive (issues a real invoice)", () => {
+    assert.equal(effectForTool("QUICKBOOKS_CREATE_INVOICE"), "destructive");
+  });
+
+  test("fetch/list/find/search/get/query/download actions are read", () => {
+    assert.equal(effectForTool("GMAIL_FETCH_EMAILS"), "read");
+    assert.equal(effectForTool("GMAIL_LIST_LABELS"), "read");
+    assert.equal(effectForTool("GOOGLECALENDAR_FIND_EVENT"), "read");
+    assert.equal(effectForTool("NOTION_SEARCH"), "read");
+    assert.equal(effectForTool("HUBSPOT_SEARCH_CONTACTS"), "read");
+    assert.equal(effectForTool("QUICKBOOKS_LIST_INVOICES"), "read");
+    assert.equal(effectForTool("OUTLOOK_CALENDAR_GET_SCHEDULE"), "read");
+    assert.equal(effectForTool("NOTION_QUERY_DATABASE"), "read");
+    assert.equal(effectForTool("GOOGLEDRIVE_DOWNLOAD_FILE"), "read");
+  });
+
+  test("account-internal mutations (drafts, labels, CRM/file records) are idempotent-write", () => {
+    assert.equal(effectForTool("GMAIL_CREATE_EMAIL_DRAFT"), "idempotent-write");
+    assert.equal(effectForTool("GMAIL_ADD_LABEL_TO_EMAIL"), "idempotent-write");
+    assert.equal(effectForTool("NOTION_CREATE_PAGE"), "idempotent-write");
+    assert.equal(effectForTool("HUBSPOT_CREATE_CONTACT"), "idempotent-write");
+    assert.equal(effectForTool("HUBSPOT_CREATE_DEAL"), "idempotent-write");
+    assert.equal(effectForTool("QUICKBOOKS_CREATE_CUSTOMER"), "idempotent-write");
+    assert.equal(effectForTool("OUTLOOK_BATCH_MOVE_MESSAGES"), "idempotent-write");
+    assert.equal(effectForTool("OUTLOOK_UPDATE_EMAIL_MESSAGE"), "idempotent-write");
+    assert.equal(effectForTool("GOOGLEDRIVE_CREATE_FILE"), "idempotent-write");
+  });
+});
+
+describe("effectForTool — unknown tools", () => {
+  test("an unknown/typo'd/hypothetical tool name returns undefined, never a guess", () => {
+    assert.equal(effectForTool("search_and_purge"), undefined);
+    assert.equal(effectForTool("SOME_RANDOM_TOOLKIT_ACTION"), undefined);
+    assert.equal(effectForTool(""), undefined);
+  });
+});
+
+describe("allowlistSize / listToolEffects", () => {
+  test("allowlistSize matches the number of entries listToolEffects returns", () => {
+    assert.equal(allowlistSize(), listToolEffects().length);
+  });
+
+  test("allowlist has a non-trivial number of classified tools", () => {
+    assert.ok(allowlistSize() >= 30, `expected >= 30 classified tools, got ${allowlistSize()}`);
+  });
+
+  test("every listed effect is one of the three valid ReelierEffect values", () => {
+    const valid = new Set(["read", "idempotent-write", "destructive"]);
+    for (const [name, effect] of listToolEffects()) {
+      assert.ok(valid.has(effect), `${name} has invalid effect ${effect}`);
+    }
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
@@ -134,6 +134,58 @@ describe("redact — secret-shaped strings never reach storage", () => {
   });
 });
 
+describe("redact — query-param / form-field VALUES masked by param NAME", () => {
+  test("masks an api_key query-param value, leaves other params alone", () => {
+    const out = redact("https://example.com/cb?api_key=abc123&x=1") as string;
+    assert.ok(!out.includes("abc123"));
+    assert.ok(out.includes("api_key=«redacted»"));
+    assert.ok(out.includes("x=1"));
+  });
+
+  test("utm_source (and other non-secret-shaped param names) are left untouched", () => {
+    const url = "https://example.com/?utm_source=google&utm_medium=cpc";
+    assert.equal(redact(url), url);
+  });
+
+  test("multiple secret-shaped params in the same string are all masked", () => {
+    const out = redact("?token=abc&secret=def&public=1") as string;
+    assert.ok(!out.includes("=abc"));
+    assert.ok(!out.includes("=def"));
+    assert.ok(out.includes("token=«redacted»"));
+    assert.ok(out.includes("secret=«redacted»"));
+    assert.ok(out.includes("public=1"));
+  });
+
+  test("a value containing URL-safe special characters is masked in full, rest of the URL preserved", () => {
+    const out = redact("https://x.test/cb?api_key=abc-123_ABC.xyz%3D&ok=1") as string;
+    assert.ok(!out.includes("abc-123_ABC.xyz%3D"));
+    assert.ok(out.includes("api_key=«redacted»"));
+    assert.ok(out.startsWith("https://x.test/cb?"));
+    assert.ok(out.includes("ok=1"));
+  });
+
+  test("a plain sentence containing the word 'key' with no '=' is left untouched", () => {
+    const sentence = "the key to success is hard work, not luck";
+    assert.equal(redact(sentence), sentence);
+  });
+
+  test("a form-encoded body's first pair (no leading ? or &) is still masked by name", () => {
+    const out = redact("token=abc123&foo=bar") as string;
+    assert.ok(!out.includes("abc123"));
+    assert.ok(out.includes("token=«redacted»"));
+    assert.ok(out.includes("foo=bar"));
+  });
+
+  test("recurses into nested objects — a URL string field inside an object is redacted the same way", () => {
+    const out = redact({ webhookUrl: "https://hooks.example.com/x?signature=deadbeef1234&id=9" }) as {
+      webhookUrl: string;
+    };
+    assert.ok(!out.webhookUrl.includes("deadbeef1234"));
+    assert.ok(out.webhookUrl.includes("signature=«redacted»"));
+    assert.ok(out.webhookUrl.includes("id=9"));
+  });
+});
+
 describe("capTraceBody — per-record truncation with an explicit marker", () => {
   test("small body passes through unchanged", () => {
     const body = { ok: true, id: "x" };

--- a/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/trace-format.spec.ts
@@ -184,6 +184,25 @@ describe("redact — query-param / form-field VALUES masked by param NAME", () =
     assert.ok(out.webhookUrl.includes("signature=«redacted»"));
     assert.ok(out.webhookUrl.includes("id=9"));
   });
+
+  test("param names that merely CONTAIN a secret-shaped token mid-word are left untouched (anchored, not substring)", () => {
+    // monkey/donkey contain "key" but don't END in it at a word/compound
+    // boundary; design/assignment contain "sig" mid-word; barcode contains
+    // "code" but not as a `_`/`-`-delimited (or whole-name) suffix; author
+    // contains "auth" as a prefix, not the whole name.
+    const url =
+      "https://example.com/?monkey=1&donkey=2&design=blue&barcode=abc123&author=jane&assignment=42&x=1";
+    assert.equal(redact(url), url);
+  });
+
+  test("public_key and auth_code (compound, `_`-delimited) are still masked — the anchoring keeps compounds, not just bare names", () => {
+    const out = redact("?public_key=abc123&auth_code=xyz789&id=1") as string;
+    assert.ok(!out.includes("abc123"));
+    assert.ok(!out.includes("xyz789"));
+    assert.ok(out.includes("public_key=«redacted»"));
+    assert.ok(out.includes("auth_code=«redacted»"));
+    assert.ok(out.includes("id=1"));
+  });
 });
 
 describe("capTraceBody — per-record truncation with an explicit marker", () => {


### PR DESCRIPTION
## What

Hardening + ops follow-up to #129 (all behind the live SF_DETERMINISTIC_REPLAY flag; no migrations, no new deps, no route changes):

- **Tool-effect allowlist** (`replay/tool-effects.ts`): 43 tools (10 native + 33 Composio) explicitly classified read / idempotent-write / destructive from their actual implementations. The replay gate now consults the allowlist FIRST; an unknown tool is unconditionally treated as destructive — a skill_md `effect:` line has zero influence on the gate. Closes the reviewer's `search_and_purge` attack class (literal test included).
- **Anchored query-param redaction**: `?api_key=...`, `access_token`, `auth_code` etc. masked by param NAME with word-boundary anchoring — `monkey`/`barcode`/`design`/`utm_source` untouched (negative tests included). Write-path only, as always.
- **`scripts/replay-ops.ts`**: the owner CLI for the trace→skill loop — `list-traces`, `show-trace` (re-redacts on read), `compile <traceId>` (prints full draft skill_md + warns on non-read steps), `list-skills`, `enable`/`disable` (surfaces the one-enabled-per-deployment unique violation cleanly).

## Verification

- Independent adversarial review: **APPROVE** — allowlist-wins invariant traced in code + tested; 8+ classifications spot-checked against real execute() bodies (no mutating tool classified read); 3 P2 precision nits found and swept in `771bd2a33` (anchored regex + two honest-comment fixes)
- verify-build: **PASS** — 68 tests green, tsc baseline-delta zero, use-server clean, journal unchanged, regression grep empty, lockfile untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)