### PR TITLE
fix(replay): normalize MCP-server prefixes in tool-effect lookup

### DIFF
--- a/packages/crm/src/lib/deployments/replay/tool-effects.ts
+++ b/packages/crm/src/lib/deployments/replay/tool-effects.ts
@@ -120,14 +120,42 @@ const TOOL_EFFECTS: Record<string, Effect> = {
 };
 
 /**
- * Look up a tool's REAL effect from this explicit allowlist. Returns
- * `undefined` for any name not in the map — an unknown tool, NEVER a
- * guess. Callers must treat `undefined` as untrusted (never 'read', never
- * 'idempotent-write') — see replay-before-llm.ts's passesAllReadGate, the
- * only caller with a safety contract riding on this.
+ * Strip any number of leading `<namespace>__` groups off a recorded tool
+ * name. Recorded/traced tool names carry the SAME namespace prefix the
+ * runtime wraps them with before handing them to the model — this
+ * allowlist is keyed by the bare action name, so a lookup on the raw
+ * recorded name always misses:
+ *  - Composio connector tools: `composio__<TOOLKIT_ACTION>` — the fixed
+ *    `composio` namespace (COMPOSIO_TOOL_NAMESPACE in
+ *    lib/integrations/composio/connector.ts), e.g.
+ *    `composio__GMAIL_FETCH_EMAILS`.
+ *  - Generic MCP connector tools: `<serviceName>__<toolName>` — an
+ *    arbitrary per-connector serviceName (lib/agents/mcp/wrap-tool.ts),
+ *    so the namespace itself isn't a fixed string.
+ * Native SF tools (book_appointment, look_up_availability, ...) are never
+ * namespaced and pass through unchanged. Only a `__`-delimited prefix is
+ * stripped — never a fuzzy match — so an unrelated name is returned as-is
+ * and still misses the allowlist (stays UNKNOWN, still destructive by
+ * default).
+ */
+export function normalizeToolName(name: string): string {
+  return name.replace(/^(?:[A-Za-z0-9-]+__)+/, "");
+}
+
+/**
+ * Look up a tool's REAL effect from this explicit allowlist. Tries the
+ * exact recorded name first, then the name with any leading
+ * `<namespace>__` prefix(es) stripped (normalizeToolName) — so a recorded
+ * `composio__GMAIL_FETCH_EMAILS` matches this table's `GMAIL_FETCH_EMAILS`
+ * entry. Returns `undefined` for any name not in the map either way — an
+ * unknown tool, NEVER a guess. Callers must treat `undefined` as untrusted
+ * (never 'read', never 'idempotent-write') — see replay-before-llm.ts's
+ * passesAllReadGate, the only caller with a safety contract riding on this.
  */
 export function effectForTool(name: string): Effect | undefined {
-  return TOOL_EFFECTS[name];
+  const exact = TOOL_EFFECTS[name];
+  if (exact !== undefined) return exact;
+  return TOOL_EFFECTS[normalizeToolName(name)];
 }
 
 /** Total tool names this allowlist explicitly classifies. Exposed for the

--- a/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
@@ -178,6 +178,35 @@ describe("passesAllReadGate — tool-effects allowlist wired in (the search_and_
   });
 });
 
+describe("passesAllReadGate — recorded actionTool names carry an MCP-server prefix", () => {
+  test("an all-read skill whose action tools are composio__-prefixed passes the gate", () => {
+    const skill = {
+      steps: [
+        makeStep({ effect: "read", actionTool: "composio__GMAIL_FETCH_EMAILS" }),
+        makeStep({ n: 2, effect: "read", actionTool: "composio__GMAIL_LIST_LABELS" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+
+  test("a composio__-prefixed destructive send mid-sequence still fails the gate", () => {
+    const skill = {
+      steps: [
+        makeStep({ effect: "read", actionTool: "composio__GMAIL_SEND_EMAIL" }),
+        makeStep({ n: 2, effect: "read", actionTool: "composio__GMAIL_FETCH_EMAILS" }),
+      ],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), false);
+  });
+
+  test("a composio__-prefixed destructive send as the sole/final step still passes (bounded)", () => {
+    const skill = {
+      steps: [makeStep({ effect: "read", actionTool: "composio__GMAIL_SEND_EMAIL" })],
+    } as ReelierSkill;
+    assert.equal(passesAllReadGate(skill), true);
+  });
+});
+
 describe("attemptL0Replay — org-scoped enabled-skill lookup", () => {
   test("skips when no enabled skill exists for this org+deployment", async () => {
     const deps: AttemptL0ReplayDeps = {

--- a/packages/crm/tests/unit/deployments/replay/tool-effects.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/tool-effects.spec.ts
@@ -9,7 +9,12 @@
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
-import { effectForTool, allowlistSize, listToolEffects } from "@/lib/deployments/replay/tool-effects";
+import {
+  effectForTool,
+  allowlistSize,
+  listToolEffects,
+  normalizeToolName,
+} from "@/lib/deployments/replay/tool-effects";
 
 describe("effectForTool — native SF tools", () => {
   test("look_up_availability is read", () => {
@@ -96,6 +101,51 @@ describe("effectForTool — unknown tools", () => {
     assert.equal(effectForTool("search_and_purge"), undefined);
     assert.equal(effectForTool("SOME_RANDOM_TOOLKIT_ACTION"), undefined);
     assert.equal(effectForTool(""), undefined);
+  });
+});
+
+describe("normalizeToolName — MCP-server prefix stripping", () => {
+  test("strips the fixed composio__ namespace", () => {
+    assert.equal(normalizeToolName("composio__GMAIL_FETCH_EMAILS"), "GMAIL_FETCH_EMAILS");
+  });
+
+  test("strips an arbitrary generic-MCP serviceName__ namespace", () => {
+    assert.equal(normalizeToolName("stripe__CREATE_INVOICE"), "CREATE_INVOICE");
+  });
+
+  test("strips repeated/double prefixes", () => {
+    assert.equal(normalizeToolName("composio__gmail__GMAIL_FETCH_EMAILS"), "GMAIL_FETCH_EMAILS");
+  });
+
+  test("unprefixed native tool names pass through unchanged", () => {
+    assert.equal(normalizeToolName("book_appointment"), "book_appointment");
+  });
+
+  test("empty string passes through unchanged", () => {
+    assert.equal(normalizeToolName(""), "");
+  });
+});
+
+describe("effectForTool — recorded names carrying an MCP-server prefix", () => {
+  test("a composio__-prefixed read tool classifies as read", () => {
+    assert.equal(effectForTool("composio__GMAIL_FETCH_EMAILS"), "read");
+  });
+
+  test("a composio__-prefixed destructive tool classifies as destructive", () => {
+    assert.equal(effectForTool("composio__GMAIL_SEND_EMAIL"), "destructive");
+  });
+
+  test("an unknown tool name under a prefix still returns undefined, never a guess", () => {
+    assert.equal(effectForTool("composio__SOME_RANDOM_TOOLKIT_ACTION"), undefined);
+  });
+
+  test("a double-prefixed name is still resolved via normalization", () => {
+    assert.equal(effectForTool("composio__gmail__GMAIL_SEND_EMAIL"), "destructive");
+  });
+
+  test("unprefixed names classify exactly as before", () => {
+    assert.equal(effectForTool("book_appointment"), "destructive");
+    assert.equal(effectForTool("look_up_availability"), "read");
   });
 });
 


### PR DESCRIPTION
## What

Production traces record tool names with MCP-server prefixes (`composio__GMAIL_FETCH_EMAILS`; generic connectors use `<serviceName>__<toolName>` per wrap-tool.ts) but the effect allowlist keys are unprefixed — so every prefixed lookup missed, every step classified destructive, and the replay gate could never pass (fail-safe but permanently dark). Found by compiling the FIRST real production trace.

Fix: `normalizeToolName()` strips repeated `<ns>__` groups; `effectForTool` tries exact match first, then normalized. Unknown names still return undefined → destructive (gate stays fail-safe). Gate + ops CLI inherit via `effectForTool`.

Companion fix landed in the reelier package (`fbf7f3a`, 0.1.1): token-based classification with destructive-wins precedence + expanded destructive verb set (independent reviewer caught a P1 in the first version — `execute_query` classifying read — fixed and re-APPROVED empirically).

## Verification

- Independent adversarial review: **APPROVE** (exact-first prevents collision loosening; no native key contains `__`; P2 hardening note tracked: scope the normalize fallback to known prefixes or document global-uniqueness assumption for generic-MCP connectors)
- verify-build: **PASS** — 114 tests incl. 10 new prefix tests, tsc 0 new errors, journal unchanged, regression grep empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)