### PR TITLE
chore(replay): derive trace types from @seldonframe/reelier 0.2.0 (SF profile = caps/redaction only)

### DIFF
--- a/packages/crm/package.json
+++ b/packages/crm/package.json
@@ -40,7 +40,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@seldonframe/core": "workspace:*",
     "@seldonframe/payments": "workspace:*",
-    "@seldonframe/reelier": "0.1.1",
+    "@seldonframe/reelier": "0.2.0",
     "@stripe/react-stripe-js": "^6.8.0",
     "@stripe/stripe-js": "^9.10.0",
     "@tanstack/react-table": "^8.21.3",

--- a/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
@@ -240,7 +240,16 @@ function emptyFailedRecord(skillName: string, reason: string): ReelierRunRecord 
     finishedAt: now,
     passed: false,
     steps: [],
-    totals: { steps: 0, passed: 0, failed: 0, ms: 0, llmInputTokens: 0, llmOutputTokens: 0 },
+    totals: {
+      steps: 0,
+      passed: 0,
+      unchecked: 0,
+      skipped: 0,
+      failed: 0,
+      ms: 0,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+    },
   };
 }
 

--- a/packages/crm/src/lib/deployments/replay/trace-format.ts
+++ b/packages/crm/src/lib/deployments/replay/trace-format.ts
@@ -1,10 +1,27 @@
 // Deterministic replay — Reelier phase 2c, slice 1 (OBSERVE MODE ONLY).
 //
 // WHAT THIS IS: a small, pure module implementing the Reelier trace-record
-// FORMAT (github.com/seldonframe/reelier) — NOT a dependency on Reelier's
-// code. Slice 1 only ever WRITES records in this shape (a recorder — see
-// ./recorder.ts); nothing here replays a trace. Slice 2 (a future, separate
-// change) is what will read `agent_workflow_traces.records` and compile them.
+// FORMAT (github.com/seldonframe/reelier) — NOT a runtime dependency on
+// Reelier's code (this module imports only TYPES from
+// "@seldonframe/reelier/trace", never any of its functions; ./recorder.ts
+// stays a pure, DB-free, reelier-runtime-free writer). Slice 1 only ever
+// WRITES records in this shape; slice 2 (compile.ts) is what reads
+// `agent_workflow_traces.records` and compiles them via reelier's own
+// compile().
+//
+// TYPES DERIVE FROM THE PACKAGE: TraceRecord (and its per-`t` members below)
+// are aliases of ReelierTraceRecord from "@seldonframe/reelier/trace" — see
+// src/types/reelier.d.ts (the package ships no .d.ts of its own; that file
+// is hand-derived from its dist/trace.js and is this repo's one contract
+// with the format). Deriving here rather than re-declaring the shape means a
+// future reelier trace-format change becomes a TYPE ERROR at this file's
+// import, not silent drift between two independently hand-maintained shapes.
+//
+// SF PROFILE (this repo's own constraints on TOP of the record format, not
+// part of it): the 20k body cap (TRACE_BODY_MAX_CHARS), the 200-record cap
+// (TRACE_MAX_RECORDS), and redaction (redact()/redactString()) below are all
+// SF-only concerns — reelier's own trace format has no opinion on any of
+// them. Kept local and clearly separated from the imported record shapes.
 //
 // Record shapes (seq is monotonic from 0, starting with the one `meta`
 // record; `i` is the call index, monotonic from 0, independent of `seq`):
@@ -16,52 +33,18 @@
 // Everything here is PURE and never throws — an observation-only recorder
 // must never affect (or even risk) the agent turn it is watching alongside.
 
-/** meta must be first (seq 0); every trace opens with exactly one. */
-export type TraceMetaRecord = {
-  t: "meta";
-  seq: number;
-  /** e.g. "email:<deploymentId>" — the running workflow's stable name. */
-  name: string;
-  /** ISO-8601 turn start time. */
-  startedAt: string;
-  /** Tool source names bound into this turn (native + connector), for
-   *  compile-time context — never large, never secret. */
-  wrapped: string[];
-};
+import type { ReelierTraceRecord } from "@seldonframe/reelier/trace";
 
-export type TraceNoteRecord = {
-  t: "note";
-  seq: number;
-  ts: string;
-  text: string;
-};
+/** This repo's trace-record union IS reelier's own trace-record type —
+ *  derived, not re-declared (see header comment). */
+export type TraceRecord = ReelierTraceRecord;
 
-export type TraceCallRecord = {
-  t: "call";
-  seq: number;
-  /** Call index — 0 for the first tool call, 1 for the second, … */
-  i: number;
-  ts: string;
-  tool: string;
-  args: unknown;
-};
-
-export type TraceResultRecord = {
-  t: "result";
-  seq: number;
-  /** Same call index as the matching TraceCallRecord. */
-  i: number;
-  ok: boolean;
-  /** Wall-clock duration of the call, in milliseconds. */
-  ms: number;
-  body: unknown;
-};
-
-export type TraceRecord =
-  | TraceMetaRecord
-  | TraceNoteRecord
-  | TraceCallRecord
-  | TraceResultRecord;
+/** meta must be first (seq 0); every trace opens with exactly one. Narrowed
+ *  from TraceRecord by discriminant — not a separate declaration. */
+export type TraceMetaRecord = Extract<TraceRecord, { t: "meta" }>;
+export type TraceNoteRecord = Extract<TraceRecord, { t: "note" }>;
+export type TraceCallRecord = Extract<TraceRecord, { t: "call" }>;
+export type TraceResultRecord = Extract<TraceRecord, { t: "result" }>;
 
 /** Max chars a single `result.body` (post-redaction, post-serialization) may
  *  occupy in a stored record — matches the token-smart-runtime precedent

--- a/packages/crm/src/types/reelier.d.ts
+++ b/packages/crm/src/types/reelier.d.ts
@@ -1,13 +1,23 @@
-// Ambient type declarations for @seldonframe/reelier@0.1.0 — the published
-// npm package ships compiled JS only (dist/*.js), no .d.ts files (verified
-// against the published tarball: `npm pack @seldonframe/reelier@0.1.0`).
-// These declarations cover ONLY the surface this repo actually calls
-// (compile.ts, skill.ts, runner exports) — they are OUR contract with the
-// package, hand-derived from reading its dist/*.js source (see
-// lib/deployments/replay/compile.ts and lib/deployments/replay/
+// Ambient type declarations for @seldonframe/reelier@0.2.0 — the published
+// npm package still ships compiled JS only (dist/*.js), no .d.ts files
+// (re-verified against the published tarball: `npm pack
+// @seldonframe/reelier@0.2.0` — "files" is ["dist", "README.md", "LICENSE"],
+// no SPEC.md and no *.d.ts). These declarations cover ONLY the surface this
+// repo actually calls (compile.ts, skill.ts, runner exports) — they are OUR
+// contract with the package, hand-derived from reading its dist/*.js source
+// (see lib/deployments/replay/compile.ts and lib/deployments/replay/
 // replay-before-llm.ts for the call sites), not an official types package.
 // A future reelier version may ship real .d.ts files, at which point this
 // file should be deleted rather than kept alongside them.
+//
+// 0.2.0 diff (re-derived from dist/runner.js): RunRecord.totals gained
+// `unchecked` and `skipped` (steps whose outcome is "unchecked"/"skipped" —
+// previously folded into the totals-vs-steps gap; the split is additive,
+// `passed`+`failed` keep their exact 0.1.x meaning) and StepRecord gained
+// an optional `escalationAttempted` (1 or 2, present only once an L1/L2
+// escalation was tried for that step — see attemptEscalation in
+// dist/runner.js). trace.js's record shapes (meta/note/call/result) are
+// byte-identical to 0.1.x.
 
 declare module "@seldonframe/reelier/skill" {
   export type ReelierEffect = "read" | "idempotent-write" | "destructive";
@@ -116,6 +126,10 @@ declare module "@seldonframe/reelier" {
     ms: number;
     failures: string[];
     llm?: { inputTokens: number; outputTokens: number };
+    /** 0.2.0 — 1 or 2, present only when this step's "failed" deterministic
+     *  outcome triggered an L1/L2 escalation attempt (see attemptEscalation
+     *  in dist/runner.js). Absent on any step that never escalated. */
+    escalationAttempted?: 1 | 2;
   };
 
   export type ReelierRunRecord = {
@@ -127,6 +141,13 @@ declare module "@seldonframe/reelier" {
     totals: {
       steps: number;
       passed: number;
+      /** 0.2.0 — count of steps whose outcome is "unchecked" (a step with
+       *  zero asserts that ran without error — reelier's "honest success"
+       *  rule: zero assertions never counts as "passed"). */
+      unchecked: number;
+      /** 0.2.0 — count of steps whose outcome is "skipped" (steps after the
+       *  first divergence in a run, never executed). */
+      skipped: number;
       failed: number;
       ms: number;
       llmInputTokens: number;

--- a/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-before-llm.spec.ts
@@ -59,7 +59,16 @@ function passingRecord(skillName: string, stepCount: number): ReelierRunRecord {
     finishedAt: "2026-07-17T00:00:01.000Z",
     passed: true,
     steps,
-    totals: { steps: stepCount, passed: stepCount, failed: 0, ms: 5 * stepCount, llmInputTokens: 0, llmOutputTokens: 0 },
+    totals: {
+      steps: stepCount,
+      passed: stepCount,
+      unchecked: 0,
+      skipped: 0,
+      failed: 0,
+      ms: 5 * stepCount,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+    },
   };
 }
 
@@ -72,7 +81,7 @@ function divergedRecord(skillName: string): ReelierRunRecord {
     steps: [
       { n: 1, title: "step 1", level: 0, outcome: "failed", ms: 5, failures: ["status == 200 failed: got 500"] },
     ],
-    totals: { steps: 1, passed: 0, failed: 1, ms: 5, llmInputTokens: 0, llmOutputTokens: 0 },
+    totals: { steps: 1, passed: 0, unchecked: 0, skipped: 0, failed: 1, ms: 5, llmInputTokens: 0, llmOutputTokens: 0 },
   };
 }
 

--- a/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
@@ -26,7 +26,7 @@ function passRecord(): ReelierRunRecord {
     finishedAt: "2026-07-17T00:00:01.000Z",
     passed: true,
     steps: [{ n: 1, title: "step", level: 0, outcome: "passed", ms: 1, failures: [] }],
-    totals: { steps: 1, passed: 1, failed: 0, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
+    totals: { steps: 1, passed: 1, unchecked: 0, skipped: 0, failed: 0, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
   };
 }
 
@@ -37,7 +37,7 @@ function divergeRecord(): ReelierRunRecord {
     finishedAt: "2026-07-17T00:00:01.000Z",
     passed: false,
     steps: [{ n: 1, title: "step", level: 0, outcome: "failed", ms: 1, failures: ["boom"] }],
-    totals: { steps: 1, passed: 0, failed: 1, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
+    totals: { steps: 1, passed: 0, unchecked: 0, skipped: 0, failed: 1, ms: 1, llmInputTokens: 0, llmOutputTokens: 0 },
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: workspace:*
         version: link:../payments
       '@seldonframe/reelier':
-        specifier: 0.1.1
-        version: 0.1.1(zod@4.4.3)
+        specifier: 0.2.0
+        version: 0.2.0(zod@4.4.3)
       '@stripe/react-stripe-js':
         specifier: ^6.8.0
         version: 6.8.0(@stripe/stripe-js@9.10.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -2189,8 +2189,8 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@seldonframe/reelier@0.1.1':
-    resolution: {integrity: sha512-15ljFAN4FvweApBVuAG8WlBB4wUUTClZIVp2cs9Q+JB7+QUlyvSWtqojUOfG6nyUVwjymevaP48LXdTiPGc9dg==}
+  '@seldonframe/reelier@0.2.0':
+    resolution: {integrity: sha512-waA6SizBot56bt3Rad7R//Stq8QxIX3zkAgwz7NMkYaaNNUXnvEpmRMo+wFOlK/0KyfzTvQRjfg2SIJW+jB+hg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -8770,7 +8770,7 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@seldonframe/reelier@0.1.1(zod@4.4.3)':
+  '@seldonframe/reelier@0.2.0(zod@4.4.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:


### PR DESCRIPTION
Type-level unification closing the known drift risk: SF's trace-format.ts now derives its record types from @seldonframe/reelier/trace (dep 0.1.1->0.2.0, lockfile confined) so shape drift becomes a compile error instead of silent divergence. SF-only caps/redaction stay local as the documented SF profile. Zero behavior change; fixture updates additive-only.

Found + fixed upstream in the process: the npm package shipped no .d.ts and no SPEC.md (0.2.1 ready, awaiting publish).

verify-build: PASS (201 replay tests, tsc 0-delta, journal unchanged, lockfile confined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)