### PR TITLE
feat(replay): Ledger v1 — org-scoped receipts dashboard (/replay)

### DIFF
--- a/.superpowers/sdd/replay-ledger-page-report.md
+++ b/.superpowers/sdd/replay-ledger-page-report.md
@@ -1,0 +1,106 @@
+# Replay Ledger v1 — build report
+
+## Files changed
+
+- `packages/crm/src/lib/deployments/replay/ledger-queries.ts` (NEW) — org-scoped read queries + pure summary/shaping functions
+- `packages/crm/tests/unit/deployments/replay/ledger-queries.spec.ts` (NEW) — unit tests for the above
+- `packages/crm/src/app/(dashboard)/replay/page.tsx` (NEW) — the Replay Ledger dashboard page
+- `packages/crm/src/components/layout/nav-config.ts` (edited) — added a "Replay" nav entry, indented under Agents
+
+No other files were touched. `replay-before-llm.ts`, `replay-or-turn.ts`, and any claims module were left untouched per the concurrent gate-v2 work warning.
+
+## What changed, per file
+
+### `ledger-queries.ts`
+Three read surfaces, each split into (a) a pure compute/shape function taking already-loaded rows, and (b) an async DI wrapper that does the actual `@/db` read — mirroring `persist.ts`/`compile.ts`'s `defaultInsert`/`defaultLoadTrace` pattern (lazy dynamic imports, injectable `deps`):
+
+- `computeLedgerSummary(rows, agentTurnCount) → LedgerSummary` / `getLedgerSummary(orgId, deps?)` — folds `agent_workflow_traces` rows (both `kind`s) into: `tracesRecorded` (count of `kind='trace'`), `replayRunsTotal`/`replayRunsOk`/`replayRunsFailed` (count of `kind='replay-run'` split by `ok`), `llmTurnsAvoided` (= `replayRunsOk` — see honesty note below), `stepsPassed`/`stepsUnchecked`/`stepsSkipped`/`stepsFailed` (summed from each replay-run row's `records.totals`, kept as separate fields — never merged), `totalReplayMs` (summed `records.totals.ms`), `agentTurnCount` (a separate `agent_run_receipts` count query, the turn-count denominator), `lastActivityAt` (max `createdAt` across all rows).
+- `getLedgerSkillRows(orgId, deps?) → LedgerSkillRow[]` — reads `replay_skills` left-joined to `deployments` for `clientName`, ordered by `updatedAt desc`; carries `name`, `status`, `triggerFilter`, `healCount`, `lastReplayAt`, `sourceTraceId` (provenance).
+- `toLedgerRecentRun(row)` / `getLedgerRecentRuns(orgId, deps?, limit = 20)` — reads the last 20 `agent_workflow_traces` rows (both kinds, left-joined to `deployments`), shapes each into `{ kind, ok, callCount (trace rows), stepTotals (replay-run rows, `null` for trace rows) }`.
+
+Every DB-touching function takes `orgId` as its first argument, filters `WHERE org_id = $orgId`, and never reads it from anywhere else — the caller (the page) resolves it from `getOrgId()` (session-derived).
+
+**Honesty-rule enforcement in code:** `llmTurnsAvoided` is documented in the file header as structurally true (not an estimate) because `attemptL0Replay`'s own contract in `replay-before-llm.ts` states a passed replay "skip[s] the agentic turn entirely" — so every `ok=true` replay-run row IS one avoided turn. No token/dollar math is derived anywhere in this file (trace `input_tokens`/`output_tokens` are never read).
+
+### `page.tsx`
+Server component, `dynamic = "force-dynamic"`. Auth: `getOrgId()` + `redirect("/login")` if absent, matching `approvals/page.tsx` and `agents/runs/page.tsx`. Renders regardless of `SF_DETERMINISTIC_REPLAY` (reads history only; the flag only gates writes).
+
+- Header: "Replay Ledger"
+- 4 KPI cards (styling lifted from the reskinned `studio/agents/activity/page.tsx` — `rounded-2xl border bg-card`, tone-tinted icon chip, big number, sublabel):
+  - **Replays** — `replayRunsTotal`, sublabel "N ok · N failed"
+  - **LLM turns avoided** — `llmTurnsAvoided`, sublabel "ok replay runs"
+  - **Steps verified** — `stepsPassed` ONLY, sublabel "N unchecked · N failed" (never merged into the headline number)
+  - **Traces recorded** — `tracesRecorded`, sublabel "last activity <date>" when available
+- Compiled-skills table: name, deployment, status chip (enabled=green/draft=grey/disabled=amber), trigger filter (human-readable from `TriggerFilter`, or "every event"), heal count, last replayed (or "never")
+- Recent-runs table (last 20): when, kind (trace/replay), deployment, outcome chip (ok=green/failed=red), and per-run step-outcome chips for replay-run rows (passed=green, unchecked=amber, skipped=neutral (only shown if >0), failed=red) — trace rows show `N call(s)` instead since they have no step totals
+- Empty state (zero traces AND zero replay runs): "No replay activity yet — traces appear when SF_DETERMINISTIC_REPLAY is on and agents run."
+
+### `nav-config.ts`
+Added one `NavItem` (`{ href: "/replay", label: "Replay", icon: "BookOpen", indent: true }`) to the "agency" (default) session's first/untitled group, indented under Agents alongside Automations — same nesting precedent as the existing Automations sub-item. Only the `agency` branch was touched; `operator-portal` and `inside-client-workspace` sessions are unaffected (Replay Ledger is an agency-operator surface for v1).
+
+## Nav decision
+
+Nav IS config-driven (`components/layout/nav-config.ts`'s `buildNavGroups`), so I added a real entry rather than skipping. Placed as an indented sub-item under "Agents" (same pattern as "Automations") in the `agency` session branch only, since the ledger surfaces agent reliability data for the builder-operator, not the sub-tenant/client-workspace views.
+
+## Summary cards — what they show from the real current data model
+
+- `agent_workflow_traces` currently has rows only where `SF_DETERMINISTIC_REPLAY=1` was on when the turn ran (fail-soft, dark by default) — so on most orgs today the page renders the empty state.
+- Where rows exist: `kind='trace'` rows are the slice-1 observe-mode captures (one per email-triggered turn); `kind='replay-run'` rows are slice-2 L0 replay attempts, each carrying a `ReelierRunRecord` with `totals: {steps, passed, unchecked, skipped, failed, ms, llmInputTokens, llmOutputTokens}`.
+- `input_tokens`/`output_tokens` on the trace row itself are documented as 0-populated in the schema comment — this page never reads them, and no dollar/savings figure exists anywhere in the code.
+- "LLM turns avoided" reads directly as `replayRunsOk` — a structural count, traceable row-by-row back to `agent_workflow_traces WHERE kind='replay-run' AND ok=true`.
+
+## Test results (verbatim tail)
+
+New spec, run in isolation:
+```
+▶ computeLedgerSummary — pure math over fixture rows
+  ✔ empty input yields all-zero summary with agentTurnCount passed through (0.7287ms)
+  ✔ counts legacy kind='trace' rows separately from replay-run rows (0.121ms)
+  ✔ llmTurnsAvoided = count of ok=true replay-run rows, never an estimate (0.1848ms)
+  ✔ lastActivityAt is the max createdAt across all rows regardless of kind (0.688ms)
+  ✔ a replay-run row whose records blob isn't a RunRecord contributes 0 step totals (never throws) (0.1144ms)
+✔ computeLedgerSummary — pure math over fixture rows (2.7677ms)
+▶ toLedgerRecentRun — pure shaping
+  ✔ kind='trace' row carries callCount, stepTotals null (0.1417ms)
+  ✔ kind='replay-run' row carries stepTotals from records.totals (1.5707ms)
+✔ toLedgerRecentRun — pure shaping (1.8591ms)
+▶ getLedgerSummary — org-scoped DI wrapper
+  ✔ calls both fetch fns with the caller's orgId (0.23ms)
+✔ getLedgerSummary — org-scoped DI wrapper (0.3337ms)
+▶ getLedgerSkillRows — org-scoped DI wrapper
+  ✔ calls fetchSkillRows with the caller's orgId and passes rows through (0.1447ms)
+✔ getLedgerSkillRows — org-scoped DI wrapper (0.1938ms)
+▶ getLedgerRecentRuns — org-scoped DI wrapper
+  ✔ calls fetchRecentRunRows with the caller's orgId and the default limit (0.1933ms)
+  ✔ shapes fetched rows through toLedgerRecentRun (0.097ms)
+✔ getLedgerRecentRuns — org-scoped DI wrapper (0.3749ms)
+ℹ tests 11
+ℹ suites 5
+ℹ pass 11
+ℹ fail 0
+```
+
+Full `tests/unit/deployments/replay/*.spec.ts` (46 suites, 164 tests): 163 pass, 1 pre-existing failure unrelated to this change (`compile.spec.ts` fails with `Cannot find module '@seldonframe/reelier/compile'` — confirmed via `git stash` that this fails identically on the pre-change tree; the package isn't even present under the repo root's `node_modules/@seldonframe`, an environment gap, not something this task introduced).
+
+`tests/unit/layout/nav-config.spec.ts` (42 tests): 41 pass, 1 pre-existing failure unrelated to this change (`'SF Admin'` vs `'Seldon Admin'` label mismatch — confirmed via `git stash` it fails identically pre-change). My added nav item does not touch the `inside-client-workspace`/`operator-portal` branches those other 41 tests cover, and the `agency`-branch pinned-baseline test (in the `enabledModules` describe block) is unaffected since it exercises a different session branch.
+
+`npx tsc --noEmit`: 247 errors both before and after my change (identical count, confirmed via `git stash` diff) — zero new errors from `ledger-queries.ts`, `page.tsx`, or `nav-config.ts` (none of the 247 lines reference those files).
+
+`pnpm check:use-server` (via `bash scripts/check-use-server.sh src`): `✓ All 'use server' files export only async functions / types.` — exit 0, clean.
+
+## Deviations from the plan and why
+
+- **Worktree had no `node_modules`** at session start (both root and `packages/crm`). Recreated the junctions to the main repo's `node_modules` (per the "Worktree typecheck method" memory note that junctions vanish and must be re-verified) before any test/tsc could run. This is environment setup, not a plan deviation.
+- **"Source" column on skill rows**: the plan said "name, status, trigger_filter, heal_count, last_replay_at, source" — I read "source" as `sourceTraceId` (the trace a skill was compiled from, per the schema's own doc comment calling it "provenance"). Exposed as `sourceTraceId` in the query/type layer; the page table doesn't render a dedicated "Source" column in v1 (kept the table to 6 columns matching the plan's other fields) — this is a minor cut, easy to add a column for later if wanted.
+- **Agent-turn count**: used `agent_run_receipts` (one row per agent RUN attempt, org-scoped, already exists) as the "agent-turn count for the same deployments" denominator, per the plan's own phrasing ("for the same deployments" — I scoped it to the same `org_id`, which agent_run_receipts already ties to; a stricter same-deployment-id-set join was possible but would have required intersecting with the trace rows' deployment ids, adding a second data dependency for a number that's shown only as a summary sublabel context, not a headline card in this v1). Flagging this as the one place I made a scoping call rather than a literal deployment-id-set join — happy to tighten if the deployment-id-exact semantics matter later.
+- Page-level tests: skipped per the plan's own fallback ("otherwise skip page tests and say so") — no existing pattern for testing a Next.js server-component page directly in this repo's harness; route render is left to live smoke.
+
+## Open risks
+
+- Zero-row state is the common case today (flag is dark by default) — the empty state is the only thing most operators will see until `SF_DETERMINISTIC_REPLAY` is flipped and skills get compiled/enabled. Worth a live smoke once there's real data in a workspace.
+- The two pre-existing test failures (`compile.spec.ts` module resolution, `nav-config.spec.ts` label mismatch) are NOT fixed by this task — flagging so they aren't mistaken for regressions introduced here.
+- No pagination on the skills table or recent-runs list beyond the existing 20-row cap on runs — fine for v1 scale, would need a "load more" if a single deployment accumulates many replay-run rows.
+
+## Worktree
+
+`C:\Users\maxim\CascadeProjects\Seldon Frame\.claude\worktrees\agent-a7958eef4f08afcc5`, branch `feat/replay-ledger-page`, based on `origin/main` at `1d5241c5f`. Not pushed, no PR opened, per instructions.

--- a/packages/crm/src/app/(dashboard)/replay/page.tsx
+++ b/packages/crm/src/app/(dashboard)/replay/page.tsx
@@ -21,7 +21,7 @@
 // rounded-2xl cards, emerald/amber/red outcome chips.
 
 import { redirect } from "next/navigation";
-import { BookOpen, CheckCircle2, ListChecks, Zap } from "lucide-react";
+import { BookOpen, Bot, CheckCircle2, ListChecks, Zap } from "lucide-react";
 
 import { getOrgId } from "@/lib/auth/helpers";
 import {
@@ -93,11 +93,11 @@ function EmptyState() {
 
 function SummaryCards({ summary }: { summary: LedgerSummary }) {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
       <KpiTile
         label="Replays"
         value={summary.replayRunsTotal}
-        sublabel={`${summary.replayRunsOk} ok · ${summary.replayRunsFailed} failed`}
+        sublabel={`${summary.replayRunsOk} ok · ${summary.replayRunsFailed} failed · ${formatMs(summary.totalReplayMs)} total replay time`}
         icon={<Zap className="size-[18px]" />}
         tone="info"
       />
@@ -108,10 +108,23 @@ function SummaryCards({ summary }: { summary: LedgerSummary }) {
         icon={<CheckCircle2 className="size-[18px]" />}
         tone="positive"
       />
+      {/* Agent turns (LLM) — the replay-vs-agent side-by-side is the ledger's
+          whole point: this is the count of agent_run_receipts rows (every
+          push/schedule/event RUN attempt) for the org, the denominator
+          llmTurnsAvoided is measured against. Fetched by getLedgerSummary
+          already; this card is what surfaces it (previously computed but
+          never rendered). */}
+      <KpiTile
+        label="Agent turns (LLM)"
+        value={summary.agentTurnCount}
+        sublabel="agent_run_receipts, all triggers"
+        icon={<Bot className="size-[18px]" />}
+        tone="info"
+      />
       <KpiTile
         label="Steps verified"
         value={summary.stepsPassed}
-        sublabel={`${summary.stepsUnchecked} unchecked · ${summary.stepsFailed} failed`}
+        sublabel={`${summary.stepsUnchecked} unchecked · ${summary.stepsSkipped} skipped · ${summary.stepsFailed} failed`}
         icon={<ListChecks className="size-[18px]" />}
         tone="neutral"
       />
@@ -197,6 +210,7 @@ function SkillsTable({ rows }: { rows: LedgerSkillRow[] }) {
               <th className="px-5 py-3 font-medium">Trigger filter</th>
               <th className="px-5 py-3 font-medium">Heals</th>
               <th className="px-5 py-3 font-medium">Last replayed</th>
+              <th className="px-5 py-3 font-medium">Source</th>
             </tr>
           </thead>
           <tbody>
@@ -217,6 +231,9 @@ function SkillsTable({ rows }: { rows: LedgerSkillRow[] }) {
                 <td className="px-5 py-3 text-muted-foreground">{row.healCount}</td>
                 <td className="px-5 py-3 text-muted-foreground">
                   {row.lastReplayAt ? formatWhen(row.lastReplayAt) : "never"}
+                </td>
+                <td className="px-5 py-3 font-mono text-xs text-muted-foreground">
+                  {formatSource(row.sourceTraceId)}
                 </td>
               </tr>
             ))}
@@ -332,6 +349,14 @@ function OutcomeChip({
   );
 }
 
+/** The compiled skill's source trace — provenance only (sourceTraceId is
+ *  ON DELETE SET NULL, so a deleted trace shows "trace deleted" rather than
+ *  a dead link). Shows a truncated id, never a full uuid (visual noise). */
+function formatSource(sourceTraceId: string | null): string {
+  if (!sourceTraceId) return "manual / trace deleted";
+  return `trace:${sourceTraceId.slice(0, 8)}`;
+}
+
 function formatTriggerFilter(filter: LedgerSkillRow["triggerFilter"]): string {
   if (!filter) return "every event";
   const parts: string[] = [];
@@ -339,6 +364,12 @@ function formatTriggerFilter(filter: LedgerSkillRow["triggerFilter"]): string {
   if (filter.senderContains) parts.push(`sender contains "${filter.senderContains}"`);
   if (filter.subjectContains) parts.push(`subject contains "${filter.subjectContains}"`);
   return parts.length > 0 ? parts.join(", ") : "every event";
+}
+
+/** Human-readable duration from a summed ms figure — e.g. "1.2s", "340ms". */
+function formatMs(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 /** A compact, locale-stable "when" — e.g. "Jun 26, 14:32". */

--- a/packages/crm/src/app/(dashboard)/replay/page.tsx
+++ b/packages/crm/src/app/(dashboard)/replay/page.tsx
@@ -1,0 +1,352 @@
+// Replay Ledger v1 — /replay (server, read-only).
+//
+// The org-scoped receipts dashboard for deterministic replay (Reelier phase
+// 2c): what has been recorded (agent_workflow_traces) and what has been
+// compiled + replayed (replay_skills / replay-run rows). Renders regardless
+// of SF_DETERMINISTIC_REPLAY — the flag only gates WRITING new rows; this
+// page always reads whatever history already exists.
+//
+// HONESTY RULE (hard): every number on this page is a direct measured
+// count/sum from ledger-queries.ts — no dollar figures, no estimated
+// savings. "LLM turns avoided" = count of ok=true replay-run rows, which is
+// structurally true (see ledger-queries.ts header), not an estimate.
+// "Steps verified" shows PASSED only; unchecked is a separate figure, never
+// merged into it.
+//
+// Auth: same org-session guard as sibling dashboard pages (approvals/page.tsx,
+// agents/runs/page.tsx) — getOrgId() + redirect to /login when absent.
+//
+// Styling mirrors the reskinned studio/agents/activity page: animate-page-enter
+// shell, text-page-title header, KPI-tile grid on --card/--border tokens,
+// rounded-2xl cards, emerald/amber/red outcome chips.
+
+import { redirect } from "next/navigation";
+import { BookOpen, CheckCircle2, ListChecks, Zap } from "lucide-react";
+
+import { getOrgId } from "@/lib/auth/helpers";
+import {
+  getLedgerSummary,
+  getLedgerSkillRows,
+  getLedgerRecentRuns,
+  type LedgerSummary,
+  type LedgerSkillRow,
+  type LedgerRecentRun,
+} from "@/lib/deployments/replay/ledger-queries";
+import type { ReplaySkillStatus } from "@/db/schema/replay-skills";
+
+export const dynamic = "force-dynamic";
+
+export default async function ReplayLedgerPage() {
+  const orgId = await getOrgId();
+  if (!orgId) redirect("/login");
+
+  const [summary, skillRows, recentRuns] = await Promise.all([
+    getLedgerSummary(orgId),
+    getLedgerSkillRows(orgId),
+    getLedgerRecentRuns(orgId),
+  ]);
+
+  const hasAnyActivity = summary.tracesRecorded > 0 || summary.replayRunsTotal > 0;
+
+  return (
+    <section className="animate-page-enter space-y-6">
+      <div>
+        <h1 className="text-page-title">Replay Ledger</h1>
+        <p className="text-label text-muted-foreground">
+          The receipts for deterministic replay — every recorded turn and every
+          L0 replay attempt, measured directly from stored rows. No estimates,
+          no dollar figures.
+        </p>
+      </div>
+
+      {!hasAnyActivity ? (
+        <EmptyState />
+      ) : (
+        <>
+          <SummaryCards summary={summary} />
+          <SkillsTable rows={skillRows} />
+          <RecentRunsList runs={recentRuns} />
+        </>
+      )}
+    </section>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-border bg-card p-8 text-center shadow-(--shadow-xs)">
+      <span
+        className="mx-auto inline-flex size-10 items-center justify-center rounded-xl bg-primary/10 text-primary"
+        aria-hidden
+      >
+        <BookOpen className="size-5" />
+      </span>
+      <h2 className="mt-3 text-base font-semibold text-foreground">
+        No replay activity yet
+      </h2>
+      <p className="mx-auto mt-1 max-w-md text-sm text-muted-foreground">
+        Traces appear when SF_DETERMINISTIC_REPLAY is on and agents run.
+      </p>
+    </div>
+  );
+}
+
+function SummaryCards({ summary }: { summary: LedgerSummary }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <KpiTile
+        label="Replays"
+        value={summary.replayRunsTotal}
+        sublabel={`${summary.replayRunsOk} ok · ${summary.replayRunsFailed} failed`}
+        icon={<Zap className="size-[18px]" />}
+        tone="info"
+      />
+      <KpiTile
+        label="LLM turns avoided"
+        value={summary.llmTurnsAvoided}
+        sublabel="ok replay runs"
+        icon={<CheckCircle2 className="size-[18px]" />}
+        tone="positive"
+      />
+      <KpiTile
+        label="Steps verified"
+        value={summary.stepsPassed}
+        sublabel={`${summary.stepsUnchecked} unchecked · ${summary.stepsFailed} failed`}
+        icon={<ListChecks className="size-[18px]" />}
+        tone="neutral"
+      />
+      <KpiTile
+        label="Traces recorded"
+        value={summary.tracesRecorded}
+        sublabel={summary.lastActivityAt ? `last activity ${formatWhen(summary.lastActivityAt)}` : undefined}
+        icon={<BookOpen className="size-[18px]" />}
+        tone="neutral"
+      />
+    </div>
+  );
+}
+
+function KpiTile({
+  label,
+  value,
+  sublabel,
+  icon,
+  tone,
+}: {
+  label: string;
+  value: number;
+  sublabel?: string;
+  icon: React.ReactNode;
+  tone: "positive" | "info" | "caution" | "neutral";
+}) {
+  const toneChip =
+    tone === "positive"
+      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+      : tone === "info"
+        ? "bg-primary/10 text-primary"
+        : tone === "caution"
+          ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+          : "bg-muted text-muted-foreground";
+  return (
+    <div className="rounded-2xl border border-border bg-card p-4 shadow-(--shadow-xs)">
+      <span
+        className={`inline-flex size-9 items-center justify-center rounded-xl ${toneChip}`}
+        aria-hidden
+      >
+        {icon}
+      </span>
+      <div className="mt-3 text-2xl font-semibold tracking-tight text-foreground">
+        {value.toLocaleString("en-US")}
+      </div>
+      <div className="mt-0.5 text-xs text-muted-foreground">{label}</div>
+      {sublabel ? (
+        <div className="mt-0.5 text-[11px] text-muted-foreground/80">{sublabel}</div>
+      ) : null}
+    </div>
+  );
+}
+
+const SKILL_STATUS_STYLES: Record<ReplaySkillStatus, string> = {
+  enabled: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  draft: "border-muted-foreground/30 bg-muted text-muted-foreground",
+  disabled: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
+};
+
+function SkillsTable({ rows }: { rows: LedgerSkillRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div>
+        <h2 className="text-card-title text-foreground">Compiled skills</h2>
+        <div className="mt-2 rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted-foreground shadow-(--shadow-xs)">
+          No skills compiled yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-card-title text-foreground">Compiled skills</h2>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-(--shadow-xs)">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/30 text-left text-[11px] uppercase tracking-wide text-muted-foreground">
+              <th className="px-5 py-3 font-medium">Skill</th>
+              <th className="px-5 py-3 font-medium">Deployment</th>
+              <th className="px-5 py-3 font-medium">Status</th>
+              <th className="px-5 py-3 font-medium">Trigger filter</th>
+              <th className="px-5 py-3 font-medium">Heals</th>
+              <th className="px-5 py-3 font-medium">Last replayed</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id} className="border-b border-border align-top last:border-0 hover:bg-muted/30">
+                <td className="px-5 py-3 font-medium text-foreground">{row.name ?? "—"}</td>
+                <td className="px-5 py-3 text-muted-foreground">{row.deploymentName ?? row.deploymentId}</td>
+                <td className="px-5 py-3">
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${SKILL_STATUS_STYLES[row.status]}`}
+                  >
+                    {row.status}
+                  </span>
+                </td>
+                <td className="px-5 py-3 text-xs text-muted-foreground">
+                  {formatTriggerFilter(row.triggerFilter)}
+                </td>
+                <td className="px-5 py-3 text-muted-foreground">{row.healCount}</td>
+                <td className="px-5 py-3 text-muted-foreground">
+                  {row.lastReplayAt ? formatWhen(row.lastReplayAt) : "never"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function RecentRunsList({ runs }: { runs: LedgerRecentRun[] }) {
+  if (runs.length === 0) {
+    return (
+      <div>
+        <h2 className="text-card-title text-foreground">Recent runs</h2>
+        <div className="mt-2 rounded-2xl border border-border bg-card p-6 text-center text-sm text-muted-foreground shadow-(--shadow-xs)">
+          No runs yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-card-title text-foreground">Recent runs</h2>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-(--shadow-xs)">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted/30 text-left text-[11px] uppercase tracking-wide text-muted-foreground">
+              <th className="px-5 py-3 font-medium">When</th>
+              <th className="px-5 py-3 font-medium">Kind</th>
+              <th className="px-5 py-3 font-medium">Deployment</th>
+              <th className="px-5 py-3 font-medium">Outcome</th>
+              <th className="px-5 py-3 font-medium">Steps</th>
+            </tr>
+          </thead>
+          <tbody>
+            {runs.map((run) => (
+              <tr key={run.id} className="border-b border-border align-top last:border-0 hover:bg-muted/30">
+                <td className="whitespace-nowrap px-5 py-3 font-mono text-xs text-muted-foreground">
+                  {formatWhen(run.createdAt)}
+                </td>
+                <td className="px-5 py-3 uppercase text-muted-foreground">
+                  {run.kind === "replay-run" ? "replay" : "trace"}
+                </td>
+                <td className="px-5 py-3 text-muted-foreground">{run.deploymentName ?? run.deploymentId ?? "—"}</td>
+                <td className="px-5 py-3">
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+                      run.ok
+                        ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+                        : "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400"
+                    }`}
+                  >
+                    {run.ok ? "ok" : "failed"}
+                  </span>
+                </td>
+                <td className="px-5 py-3">
+                  {run.stepTotals ? (
+                    <StepOutcomeChips totals={run.stepTotals} />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">{run.callCount} call(s)</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+/** Per-run step outcome chips — passed / unchecked / failed kept as SEPARATE
+ *  visual counters, never merged into a single "verified" figure. Skipped
+ *  only renders when > 0 (a zero-skipped run stays uncluttered). */
+function StepOutcomeChips({
+  totals,
+}: {
+  totals: { passed: number; unchecked: number; skipped: number; failed: number };
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <OutcomeChip label="passed" value={totals.passed} tone="positive" />
+      <OutcomeChip label="unchecked" value={totals.unchecked} tone="caution" />
+      {totals.skipped > 0 ? <OutcomeChip label="skipped" value={totals.skipped} tone="neutral" /> : null}
+      <OutcomeChip label="failed" value={totals.failed} tone="negative" />
+    </div>
+  );
+}
+
+function OutcomeChip({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: "positive" | "caution" | "negative" | "neutral";
+}) {
+  const toneClass =
+    tone === "positive"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400"
+      : tone === "caution"
+        ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400"
+        : tone === "negative"
+          ? "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-400"
+          : "border-muted-foreground/30 bg-muted text-muted-foreground";
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${toneClass}`}>
+      {value} {label}
+    </span>
+  );
+}
+
+function formatTriggerFilter(filter: LedgerSkillRow["triggerFilter"]): string {
+  if (!filter) return "every event";
+  const parts: string[] = [];
+  if (filter.senderEndsWith) parts.push(`sender ends with "${filter.senderEndsWith}"`);
+  if (filter.senderContains) parts.push(`sender contains "${filter.senderContains}"`);
+  if (filter.subjectContains) parts.push(`subject contains "${filter.subjectContains}"`);
+  return parts.length > 0 ? parts.join(", ") : "every event";
+}
+
+/** A compact, locale-stable "when" — e.g. "Jun 26, 14:32". */
+function formatWhen(date: Date): string {
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/packages/crm/src/components/layout/nav-config.ts
+++ b/packages/crm/src/components/layout/nav-config.ts
@@ -306,6 +306,11 @@ export function buildNavGroups(input: BuildNavInput): NavGroup[] {
         { href: "/dashboard", label: "Home", icon: "Home" },
         { href: "/studio/agents", label: "Agents", icon: "Bot" },
         { href: "/automations", label: "Automations", icon: "Zap", indent: true },
+        // Replay Ledger (2026-07-18) — the org-scoped receipts dashboard for
+        // deterministic replay (agent_workflow_traces + replay_skills).
+        // Indented under Agents like Automations: a reliability surface for
+        // the same agents, not a new top-level noun.
+        { href: "/replay", label: "Replay", icon: "BookOpen", indent: true },
       ]),
     },
     {

--- a/packages/crm/src/lib/deployments/replay/ledger-queries.ts
+++ b/packages/crm/src/lib/deployments/replay/ledger-queries.ts
@@ -1,0 +1,330 @@
+// Replay Ledger v1 — org-scoped READ queries backing the /replay dashboard
+// page (packages/crm/src/app/(dashboard)/replay/page.tsx).
+//
+// HONEST-DATA CONTRACT: every number this module returns is a direct
+// count/sum over stored rows (agent_workflow_traces / replay_skills /
+// agent_run_receipts) — never an estimate, never a dollar figure. In
+// particular "LLM turns avoided" = count(kind='replay-run' AND ok=true).
+// That is not an estimate: attemptL0Replay's own contract
+// (replay-before-llm.ts — "Replay PASSES ... skip the agentic turn
+// entirely") means every ok=true replay-run row structurally replaced
+// exactly one agentic turn that would otherwise have run. Trace token
+// fields (input_tokens/output_tokens) are currently 0-populated
+// (agent-workflow-traces.ts) — this module never derives a savings/cost
+// figure from them.
+//
+// Every exported read function takes `orgId` as an explicit argument,
+// resolved by the CALLER from the server-side session (getOrgId()) —
+// never from a route param or request body (L-04 security invariant). This
+// file only READS; it never touches gate-v2's execution path
+// (replay-before-llm.ts / replay-or-turn.ts / the claims module).
+//
+// DI pattern mirrors persist.ts / compile.ts in this same directory: each
+// public function accepts an optional `deps` with an injectable fetch fn
+// (default: a lazy `@/db` read, kept out of the top-level import graph so
+// this module stays test-friendly). The actual math/shaping is split into
+// separate PURE functions (computeLedgerSummary, toLedgerRecentRun) so unit
+// tests can feed fixture rows directly without a DB.
+
+import type {
+  AgentWorkflowTraceKind,
+  AgentWorkflowTraceRecords,
+} from "@/db/schema/agent-workflow-traces";
+import type { ReplaySkillStatus } from "@/db/schema/replay-skills";
+import type { TriggerFilter } from "./trigger-filter";
+import type { ReelierRunRecord } from "@seldonframe/reelier";
+
+/** Narrow AgentWorkflowTraceRecords (TraceRecord[] | ReelierRunRecord) to the
+ *  replay-run shape. Pure; never throws. */
+function isReelierRunRecord(records: AgentWorkflowTraceRecords): records is ReelierRunRecord {
+  return !!records && typeof records === "object" && !Array.isArray(records) && "totals" in records;
+}
+
+// ---------------------------------------------------------------------------
+// Summary — the honest headline cards
+// ---------------------------------------------------------------------------
+
+export type LedgerTraceRow = {
+  id: string;
+  kind: AgentWorkflowTraceKind;
+  ok: boolean;
+  callCount: number;
+  records: AgentWorkflowTraceRecords;
+  createdAt: Date;
+};
+
+export type LedgerSummary = {
+  /** Count of kind='trace' rows — the raw observe-mode material. */
+  tracesRecorded: number;
+  /** Count of kind='replay-run' rows — every L0 replay attempt. */
+  replayRunsTotal: number;
+  replayRunsOk: number;
+  replayRunsFailed: number;
+  /** = replayRunsOk. See header — each ok=true replay-run row structurally
+   *  replaced one agentic turn; never an estimate. */
+  llmTurnsAvoided: number;
+  /** Summed across replay-run rows' `records.totals` — kept SEPARATE from
+   *  stepsUnchecked (never merged into one "verified" figure; unchecked ≠
+   *  passed). */
+  stepsPassed: number;
+  stepsUnchecked: number;
+  stepsSkipped: number;
+  stepsFailed: number;
+  /** Summed `records.totals.ms` across replay-run rows. */
+  totalReplayMs: number;
+  /** Count of agent_run_receipts rows for the org — the agentic-turn
+   *  denominator replay runs are measured against. */
+  agentTurnCount: number;
+  lastActivityAt: Date | null;
+};
+
+/** Pure: fold already-loaded trace rows (+ the separately-counted org
+ *  agent-turn total) into the honest summary shape. No I/O, no estimation. */
+export function computeLedgerSummary(rows: LedgerTraceRow[], agentTurnCount: number): LedgerSummary {
+  const summary: LedgerSummary = {
+    tracesRecorded: 0,
+    replayRunsTotal: 0,
+    replayRunsOk: 0,
+    replayRunsFailed: 0,
+    llmTurnsAvoided: 0,
+    stepsPassed: 0,
+    stepsUnchecked: 0,
+    stepsSkipped: 0,
+    stepsFailed: 0,
+    totalReplayMs: 0,
+    agentTurnCount,
+    lastActivityAt: null,
+  };
+
+  for (const row of rows) {
+    if (row.kind === "trace") {
+      summary.tracesRecorded += 1;
+    } else if (row.kind === "replay-run") {
+      summary.replayRunsTotal += 1;
+      if (row.ok) {
+        summary.replayRunsOk += 1;
+      } else {
+        summary.replayRunsFailed += 1;
+      }
+      if (isReelierRunRecord(row.records)) {
+        const totals = row.records.totals;
+        summary.stepsPassed += totals.passed ?? 0;
+        summary.stepsUnchecked += totals.unchecked ?? 0;
+        summary.stepsSkipped += totals.skipped ?? 0;
+        summary.stepsFailed += totals.failed ?? 0;
+        summary.totalReplayMs += totals.ms ?? 0;
+      }
+    }
+    if (!summary.lastActivityAt || row.createdAt > summary.lastActivityAt) {
+      summary.lastActivityAt = row.createdAt;
+    }
+  }
+
+  summary.llmTurnsAvoided = summary.replayRunsOk;
+  return summary;
+}
+
+export type LedgerSummaryDeps = {
+  fetchTraceRows?: (orgId: string) => Promise<LedgerTraceRow[]>;
+  fetchAgentTurnCount?: (orgId: string) => Promise<number>;
+};
+
+async function defaultFetchTraceRows(orgId: string): Promise<LedgerTraceRow[]> {
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { eq } = await import("drizzle-orm");
+  return db
+    .select({
+      id: agentWorkflowTraces.id,
+      kind: agentWorkflowTraces.kind,
+      ok: agentWorkflowTraces.ok,
+      callCount: agentWorkflowTraces.callCount,
+      records: agentWorkflowTraces.records,
+      createdAt: agentWorkflowTraces.createdAt,
+    })
+    .from(agentWorkflowTraces)
+    .where(eq(agentWorkflowTraces.orgId, orgId));
+}
+
+async function defaultFetchAgentTurnCount(orgId: string): Promise<number> {
+  const { db } = await import("@/db");
+  const { agentRunReceipts } = await import("@/db/schema/agent-run-receipts");
+  const { eq, sql } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(agentRunReceipts)
+    .where(eq(agentRunReceipts.orgId, orgId));
+  return row?.count ?? 0;
+}
+
+/** Org-scoped summary read. `orgId` must come from the server-side session
+ *  (getOrgId()), never a request param — see header. */
+export async function getLedgerSummary(orgId: string, deps?: LedgerSummaryDeps): Promise<LedgerSummary> {
+  const fetchTraceRows = deps?.fetchTraceRows ?? defaultFetchTraceRows;
+  const fetchAgentTurnCount = deps?.fetchAgentTurnCount ?? defaultFetchAgentTurnCount;
+  const [rows, agentTurnCount] = await Promise.all([
+    fetchTraceRows(orgId),
+    fetchAgentTurnCount(orgId),
+  ]);
+  return computeLedgerSummary(rows, agentTurnCount);
+}
+
+// ---------------------------------------------------------------------------
+// Per-skill rows
+// ---------------------------------------------------------------------------
+
+export type LedgerSkillRow = {
+  id: string;
+  deploymentId: string;
+  deploymentName: string | null;
+  name: string | null;
+  status: ReplaySkillStatus;
+  triggerFilter: TriggerFilter | null;
+  healCount: number;
+  lastReplayAt: Date | null;
+  /** The trace this skill was compiled from — provenance only, `null` when
+   *  the source trace has since been deleted (ON DELETE SET NULL). */
+  sourceTraceId: string | null;
+  createdAt: Date;
+};
+
+export type LedgerSkillRowsDeps = {
+  fetchSkillRows?: (orgId: string) => Promise<LedgerSkillRow[]>;
+};
+
+async function defaultFetchSkillRows(orgId: string): Promise<LedgerSkillRow[]> {
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const { deployments } = await import("@/db/schema/deployments");
+  const { eq, desc } = await import("drizzle-orm");
+  return db
+    .select({
+      id: replaySkills.id,
+      deploymentId: replaySkills.deploymentId,
+      deploymentName: deployments.clientName,
+      name: replaySkills.name,
+      status: replaySkills.status,
+      triggerFilter: replaySkills.triggerFilter,
+      healCount: replaySkills.healCount,
+      lastReplayAt: replaySkills.lastReplayAt,
+      sourceTraceId: replaySkills.sourceTraceId,
+      createdAt: replaySkills.createdAt,
+    })
+    .from(replaySkills)
+    .leftJoin(deployments, eq(replaySkills.deploymentId, deployments.id))
+    .where(eq(replaySkills.orgId, orgId))
+    .orderBy(desc(replaySkills.updatedAt));
+}
+
+/** Org-scoped skill-row read. `orgId` must come from the server-side session
+ *  — see header. */
+export async function getLedgerSkillRows(orgId: string, deps?: LedgerSkillRowsDeps): Promise<LedgerSkillRow[]> {
+  const fetchSkillRows = deps?.fetchSkillRows ?? defaultFetchSkillRows;
+  return fetchSkillRows(orgId);
+}
+
+// ---------------------------------------------------------------------------
+// Recent runs — last N mixed-kind rows
+// ---------------------------------------------------------------------------
+
+export const LEDGER_RECENT_RUNS_LIMIT = 20;
+
+export type LedgerRecentRunStepTotals = {
+  steps: number;
+  passed: number;
+  unchecked: number;
+  skipped: number;
+  failed: number;
+  ms: number;
+};
+
+export type LedgerRecentRun = {
+  id: string;
+  kind: AgentWorkflowTraceKind;
+  deploymentId: string | null;
+  deploymentName: string | null;
+  ok: boolean;
+  createdAt: Date;
+  /** kind='trace' rows: the raw tool-call count for that turn. */
+  callCount: number;
+  /** kind='replay-run' rows only: the reelier RunRecord's step totals.
+   *  `null` for kind='trace' rows (they carry callCount instead) and for a
+   *  replay-run row whose records blob doesn't parse as a RunRecord. */
+  stepTotals: LedgerRecentRunStepTotals | null;
+};
+
+export type LedgerRecentRunSourceRow = {
+  id: string;
+  kind: AgentWorkflowTraceKind;
+  deploymentId: string | null;
+  deploymentName: string | null;
+  ok: boolean;
+  callCount: number;
+  records: AgentWorkflowTraceRecords;
+  createdAt: Date;
+};
+
+/** Pure: shape one raw trace row into the recent-run summary view used by
+ *  the page. No I/O. */
+export function toLedgerRecentRun(row: LedgerRecentRunSourceRow): LedgerRecentRun {
+  const stepTotals =
+    row.kind === "replay-run" && isReelierRunRecord(row.records)
+      ? {
+          steps: row.records.totals.steps ?? 0,
+          passed: row.records.totals.passed ?? 0,
+          unchecked: row.records.totals.unchecked ?? 0,
+          skipped: row.records.totals.skipped ?? 0,
+          failed: row.records.totals.failed ?? 0,
+          ms: row.records.totals.ms ?? 0,
+        }
+      : null;
+  return {
+    id: row.id,
+    kind: row.kind,
+    deploymentId: row.deploymentId,
+    deploymentName: row.deploymentName,
+    ok: row.ok,
+    createdAt: row.createdAt,
+    callCount: row.callCount,
+    stepTotals,
+  };
+}
+
+export type LedgerRecentRunsDeps = {
+  fetchRecentRunRows?: (orgId: string, limit: number) => Promise<LedgerRecentRunSourceRow[]>;
+};
+
+async function defaultFetchRecentRunRows(orgId: string, limit: number): Promise<LedgerRecentRunSourceRow[]> {
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { deployments } = await import("@/db/schema/deployments");
+  const { eq, desc } = await import("drizzle-orm");
+  return db
+    .select({
+      id: agentWorkflowTraces.id,
+      kind: agentWorkflowTraces.kind,
+      deploymentId: agentWorkflowTraces.deploymentId,
+      deploymentName: deployments.clientName,
+      ok: agentWorkflowTraces.ok,
+      callCount: agentWorkflowTraces.callCount,
+      records: agentWorkflowTraces.records,
+      createdAt: agentWorkflowTraces.createdAt,
+    })
+    .from(agentWorkflowTraces)
+    .leftJoin(deployments, eq(agentWorkflowTraces.deploymentId, deployments.id))
+    .where(eq(agentWorkflowTraces.orgId, orgId))
+    .orderBy(desc(agentWorkflowTraces.createdAt))
+    .limit(limit);
+}
+
+/** Org-scoped recent-runs read (default cap: LEDGER_RECENT_RUNS_LIMIT).
+ *  `orgId` must come from the server-side session — see header. */
+export async function getLedgerRecentRuns(
+  orgId: string,
+  deps?: LedgerRecentRunsDeps,
+  limit: number = LEDGER_RECENT_RUNS_LIMIT,
+): Promise<LedgerRecentRun[]> {
+  const fetchRecentRunRows = deps?.fetchRecentRunRows ?? defaultFetchRecentRunRows;
+  const rows = await fetchRecentRunRows(orgId, limit);
+  return rows.map(toLedgerRecentRun);
+}

--- a/packages/crm/tests/unit/deployments/replay/ledger-queries.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/ledger-queries.spec.ts
@@ -181,6 +181,47 @@ describe("computeLedgerSummary — pure math over fixture rows", () => {
     assert.equal(summary.replayRunsOk, 1);
     assert.equal(summary.stepsPassed, 0);
   });
+
+  test("a legacy RunRecord with `totals` but missing unchecked/skipped fields folds those as 0 via ?? 0 (never undefined/NaN)", () => {
+    // Simulates an older reelier RunRecord shape (pre-unchecked/skipped totals
+    // fields) landing in a stored row — the ?? 0 fallback in computeLedgerSummary
+    // must degrade honestly rather than propagate `undefined` into a sum.
+    const legacyRecord = {
+      skill: "email:dep_1",
+      startedAt: "2026-07-17T00:00:00.000Z",
+      finishedAt: "2026-07-17T00:00:01.000Z",
+      passed: true,
+      steps: [],
+      totals: {
+        steps: 2,
+        passed: 2,
+        // unchecked / skipped intentionally OMITTED — legacy shape.
+        failed: 0,
+        ms: 50,
+        llmInputTokens: 0,
+        llmOutputTokens: 0,
+      },
+    } as unknown as ReelierRunRecord;
+    const rows: LedgerTraceRow[] = [
+      {
+        id: "r1",
+        kind: "replay-run",
+        ok: true,
+        callCount: 0,
+        records: legacyRecord,
+        createdAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+    ];
+    const summary = computeLedgerSummary(rows, 0);
+    assert.equal(summary.stepsPassed, 2);
+    assert.equal(summary.stepsUnchecked, 0);
+    assert.equal(summary.stepsSkipped, 0);
+    assert.equal(summary.stepsFailed, 0);
+    assert.equal(summary.totalReplayMs, 50);
+    // No NaN/undefined ever leaks into the summary.
+    assert.equal(Number.isFinite(summary.stepsUnchecked), true);
+    assert.equal(Number.isFinite(summary.stepsSkipped), true);
+  });
 });
 
 describe("toLedgerRecentRun — pure shaping", () => {

--- a/packages/crm/tests/unit/deployments/replay/ledger-queries.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/ledger-queries.spec.ts
@@ -1,0 +1,302 @@
+// Replay Ledger v1 — unit tests for ledger-queries.ts.
+//
+// Two layers, mirroring persist.spec.ts's style:
+//   1. Pure math/shaping (computeLedgerSummary / toLedgerRecentRun) tested
+//      directly against fixture rows — no DB, no DI.
+//   2. The DI wrappers (getLedgerSummary / getLedgerSkillRows /
+//      getLedgerRecentRuns) tested at spy level: assert the injected fetch
+//      fn is called with the caller's orgId (the org-scoping contract),
+//      same level persist.spec asserts writeWorkflowTrace's insert args.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeLedgerSummary,
+  toLedgerRecentRun,
+  getLedgerSummary,
+  getLedgerSkillRows,
+  getLedgerRecentRuns,
+  LEDGER_RECENT_RUNS_LIMIT,
+  type LedgerTraceRow,
+  type LedgerRecentRunSourceRow,
+} from "@/lib/deployments/replay/ledger-queries";
+import type { ReelierRunRecord } from "@seldonframe/reelier";
+
+const ORG = "org_1";
+
+function passingRunRecord(overrides: Partial<ReelierRunRecord["totals"]> = {}): ReelierRunRecord {
+  return {
+    skill: "email:dep_1",
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: true,
+    steps: [],
+    totals: {
+      steps: 3,
+      passed: 2,
+      unchecked: 1,
+      skipped: 0,
+      failed: 0,
+      ms: 120,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+      ...overrides,
+    },
+  };
+}
+
+function failingRunRecord(): ReelierRunRecord {
+  return {
+    skill: "email:dep_1",
+    startedAt: "2026-07-17T00:00:00.000Z",
+    finishedAt: "2026-07-17T00:00:01.000Z",
+    passed: false,
+    steps: [],
+    totals: {
+      steps: 2,
+      passed: 1,
+      unchecked: 0,
+      skipped: 0,
+      failed: 1,
+      ms: 40,
+      llmInputTokens: 0,
+      llmOutputTokens: 0,
+    },
+  };
+}
+
+describe("computeLedgerSummary — pure math over fixture rows", () => {
+  test("empty input yields all-zero summary with agentTurnCount passed through", () => {
+    const summary = computeLedgerSummary([], 5);
+    assert.equal(summary.tracesRecorded, 0);
+    assert.equal(summary.replayRunsTotal, 0);
+    assert.equal(summary.llmTurnsAvoided, 0);
+    assert.equal(summary.agentTurnCount, 5);
+    assert.equal(summary.lastActivityAt, null);
+  });
+
+  test("counts legacy kind='trace' rows separately from replay-run rows", () => {
+    const rows: LedgerTraceRow[] = [
+      {
+        id: "t1",
+        kind: "trace",
+        ok: true,
+        callCount: 2,
+        records: [],
+        createdAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+      {
+        id: "t2",
+        kind: "trace",
+        ok: false,
+        callCount: 1,
+        records: [],
+        createdAt: new Date("2026-07-17T00:01:00.000Z"),
+      },
+    ];
+    const summary = computeLedgerSummary(rows, 0);
+    assert.equal(summary.tracesRecorded, 2);
+    assert.equal(summary.replayRunsTotal, 0);
+    assert.equal(summary.llmTurnsAvoided, 0);
+  });
+
+  test("llmTurnsAvoided = count of ok=true replay-run rows, never an estimate", () => {
+    const rows: LedgerTraceRow[] = [
+      {
+        id: "r1",
+        kind: "replay-run",
+        ok: true,
+        callCount: 0,
+        records: passingRunRecord(),
+        createdAt: new Date("2026-07-17T00:02:00.000Z"),
+      },
+      {
+        id: "r2",
+        kind: "replay-run",
+        ok: true,
+        callCount: 0,
+        records: passingRunRecord({ passed: 4, unchecked: 0 }),
+        createdAt: new Date("2026-07-17T00:03:00.000Z"),
+      },
+      {
+        id: "r3",
+        kind: "replay-run",
+        ok: false,
+        callCount: 0,
+        records: failingRunRecord(),
+        createdAt: new Date("2026-07-17T00:04:00.000Z"),
+      },
+    ];
+    const summary = computeLedgerSummary(rows, 10);
+    assert.equal(summary.replayRunsTotal, 3);
+    assert.equal(summary.replayRunsOk, 2);
+    assert.equal(summary.replayRunsFailed, 1);
+    assert.equal(summary.llmTurnsAvoided, 2);
+    // Steps split — passed/unchecked NEVER merged into one figure.
+    assert.equal(summary.stepsPassed, 2 + 4 + 1);
+    assert.equal(summary.stepsUnchecked, 1 + 0 + 0);
+    assert.equal(summary.stepsFailed, 0 + 0 + 1);
+    assert.equal(summary.totalReplayMs, 120 + 120 + 40);
+    assert.equal(summary.agentTurnCount, 10);
+  });
+
+  test("lastActivityAt is the max createdAt across all rows regardless of kind", () => {
+    const rows: LedgerTraceRow[] = [
+      {
+        id: "t1",
+        kind: "trace",
+        ok: true,
+        callCount: 1,
+        records: [],
+        createdAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+      {
+        id: "r1",
+        kind: "replay-run",
+        ok: true,
+        callCount: 0,
+        records: passingRunRecord(),
+        createdAt: new Date("2026-07-18T00:00:00.000Z"),
+      },
+    ];
+    const summary = computeLedgerSummary(rows, 0);
+    assert.equal(summary.lastActivityAt?.toISOString(), "2026-07-18T00:00:00.000Z");
+  });
+
+  test("a replay-run row whose records blob isn't a RunRecord contributes 0 step totals (never throws)", () => {
+    const rows: LedgerTraceRow[] = [
+      {
+        id: "r1",
+        kind: "replay-run",
+        ok: true,
+        callCount: 0,
+        // Malformed on purpose — the reader must degrade honestly, not crash.
+        records: [] as unknown as ReelierRunRecord,
+        createdAt: new Date("2026-07-17T00:00:00.000Z"),
+      },
+    ];
+    const summary = computeLedgerSummary(rows, 0);
+    assert.equal(summary.replayRunsTotal, 1);
+    assert.equal(summary.replayRunsOk, 1);
+    assert.equal(summary.stepsPassed, 0);
+  });
+});
+
+describe("toLedgerRecentRun — pure shaping", () => {
+  test("kind='trace' row carries callCount, stepTotals null", () => {
+    const row: LedgerRecentRunSourceRow = {
+      id: "t1",
+      kind: "trace",
+      deploymentId: "dep_1",
+      deploymentName: "Acme HVAC",
+      ok: true,
+      callCount: 3,
+      records: [],
+      createdAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+    const run = toLedgerRecentRun(row);
+    assert.equal(run.callCount, 3);
+    assert.equal(run.stepTotals, null);
+    assert.equal(run.deploymentName, "Acme HVAC");
+  });
+
+  test("kind='replay-run' row carries stepTotals from records.totals", () => {
+    const row: LedgerRecentRunSourceRow = {
+      id: "r1",
+      kind: "replay-run",
+      deploymentId: "dep_1",
+      deploymentName: "Acme HVAC",
+      ok: true,
+      callCount: 0,
+      records: passingRunRecord(),
+      createdAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+    const run = toLedgerRecentRun(row);
+    assert.deepEqual(run.stepTotals, {
+      steps: 3,
+      passed: 2,
+      unchecked: 1,
+      skipped: 0,
+      failed: 0,
+      ms: 120,
+    });
+  });
+});
+
+describe("getLedgerSummary — org-scoped DI wrapper", () => {
+  test("calls both fetch fns with the caller's orgId", async () => {
+    const seenOrgIds: string[] = [];
+    const summary = await getLedgerSummary(ORG, {
+      fetchTraceRows: async (orgId) => {
+        seenOrgIds.push(orgId);
+        return [];
+      },
+      fetchAgentTurnCount: async (orgId) => {
+        seenOrgIds.push(orgId);
+        return 7;
+      },
+    });
+    assert.deepEqual(seenOrgIds, [ORG, ORG]);
+    assert.equal(summary.agentTurnCount, 7);
+  });
+});
+
+describe("getLedgerSkillRows — org-scoped DI wrapper", () => {
+  test("calls fetchSkillRows with the caller's orgId and passes rows through", async () => {
+    let seenOrgId: string | null = null;
+    const fakeRow = {
+      id: "s1",
+      deploymentId: "dep_1",
+      deploymentName: "Acme HVAC",
+      name: "email:dep_1",
+      status: "enabled" as const,
+      triggerFilter: null,
+      healCount: 0,
+      lastReplayAt: null,
+      sourceTraceId: "t1",
+      createdAt: new Date("2026-07-17T00:00:00.000Z"),
+    };
+    const rows = await getLedgerSkillRows(ORG, {
+      fetchSkillRows: async (orgId) => {
+        seenOrgId = orgId;
+        return [fakeRow];
+      },
+    });
+    assert.equal(seenOrgId, ORG);
+    assert.deepEqual(rows, [fakeRow]);
+  });
+});
+
+describe("getLedgerRecentRuns — org-scoped DI wrapper", () => {
+  test("calls fetchRecentRunRows with the caller's orgId and the default limit", async () => {
+    let seenArgs: [string, number] | null = null;
+    const runs = await getLedgerRecentRuns(ORG, {
+      fetchRecentRunRows: async (orgId, limit) => {
+        seenArgs = [orgId, limit];
+        return [];
+      },
+    });
+    assert.deepEqual(seenArgs, [ORG, LEDGER_RECENT_RUNS_LIMIT]);
+    assert.deepEqual(runs, []);
+  });
+
+  test("shapes fetched rows through toLedgerRecentRun", async () => {
+    const runs = await getLedgerRecentRuns(ORG, {
+      fetchRecentRunRows: async () => [
+        {
+          id: "r1",
+          kind: "replay-run",
+          deploymentId: "dep_1",
+          deploymentName: "Acme HVAC",
+          ok: true,
+          callCount: 0,
+          records: passingRunRecord(),
+          createdAt: new Date("2026-07-17T00:00:00.000Z"),
+        },
+      ],
+    });
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].stepTotals?.passed, 2);
+  });
+});


### PR DESCRIPTION
The first read surface over the replay evidence: 5 honest KPI cards (Replays w/ total replay time, LLM turns avoided = count of ok replay-runs, Agent turns for the side-by-side, Steps verified w/ unchecked/skipped/failed always separate, Traces recorded), compiled-skills table (status/filter/heals/source), recent-runs feed with per-step outcome chips. Every number is a count/sum of stored rows — no estimates, no dollar math (enforced in code comments + review). Org-scoped from session only; force-dynamic; nav entry under Agents (agency branch).

Review: APPROVE (org-scoping traced, honesty rules verified, legacy 0.1.x record degradation to ?? 0 covered incl. new fixture; sweep surfaced the agent-turns card + Source column). verify-build: PASS (219 tests, 2 known pre-existing failures, tsc 0-delta, journal unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)