### PR TITLE
feat(replay): gate v2 — idempotent-send with claim ledger + asymmetric fallback (SF_REPLAY_GATE_V2, dark)

### DIFF
--- a/.superpowers/sdd/replay-gate-v2-report.md
+++ b/.superpowers/sdd/replay-gate-v2-report.md
@@ -1,0 +1,205 @@
+# Replay gate v2 — idempotent-send — build report
+
+## Files changed
+
+New:
+- `packages/crm/drizzle/0077_replay_gate_v2.sql`
+- `packages/crm/src/db/schema/replay-send-claims.ts`
+- `packages/crm/src/lib/deployments/replay/gate-v2.ts`
+- `packages/crm/src/lib/deployments/replay/send-claim.ts`
+- `packages/crm/tests/unit/deployments/replay/gate-v2.spec.ts`
+- `packages/crm/tests/unit/deployments/replay/replay-gate-v2-execution.spec.ts`
+- `packages/crm/tests/unit/deployments/replay/send-claim.spec.ts`
+
+Modified:
+- `packages/crm/drizzle/meta/_journal.json` (registers 0077)
+- `packages/crm/scripts/replay-ops.ts` (new `set-idempotency` command; `list-skills` shows idempotency)
+- `packages/crm/src/db/schema/agent-workflow-traces.ts` (`AgentWorkflowTraceKind` gains `'replay-run-failed-post-send'`)
+- `packages/crm/src/db/schema/index.ts` (barrel export for `replay-send-claims`)
+- `packages/crm/src/db/schema/replay-skills.ts` (`idempotency` jsonb column + `ReplaySkillIdempotency` type)
+- `packages/crm/src/lib/deployments/composio-event-dispatch-deps.ts` (`persistReplayRun` maps `failed-post-send` → the new trace kind)
+- `packages/crm/src/lib/deployments/replay/replay-before-llm.ts` (v2 branch: `attemptV2Replay`, `wrapToolWithSendClaim`, `trustedEffect` now exported, new `failed-post-send` result kind)
+- `packages/crm/src/lib/deployments/replay/replay-or-turn.ts` (handles `failed-post-send`: never calls `runTurn`)
+- `packages/crm/src/lib/web-build/policy.ts` (`isReplayGateV2On`)
+- `packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts` (failed-post-send tests)
+- `packages/crm/tests/unit/deployments/replay/replay-skills-schema.spec.ts` (idempotency column + migration 0077 section)
+- `packages/crm/tests/unit/web-build-policy.spec.ts` (flag test)
+
+## Idempotency-key storage decision (as requested by the brief)
+
+**Chosen: out-of-band, on `replay_skills.idempotency` (nullable jsonb `{stepN, keyVar}`)** — NOT inside `skill_md`.
+
+Why: verified directly against the installed `@seldonframe/reelier@0.2.0` dist
+(`node_modules/@seldonframe/reelier/dist/skill.js`, confirmed byte-identical to the
+0.2.1 source repo on this point) — `parseSkill`'s step-block grammar only recognizes
+`intent|action|assert|bind|effect` bullets; any other `- key:` line throws
+`SkillParseError("Unrecognized step field...")`. An `- idempotency-key: {{message_id}}`
+bullet as sketched in the spec would make the skill unparseable. Forking reelier (an
+external npm dependency shared by other consumers) was rejected. The out-of-band
+column mirrors the exact precedent `trigger_filter` set in migration 0076 for the same
+class of problem ("a linear skill needs scoping metadata reelier's grammar has no room
+for"). Validated by `gate-v2.ts`'s `validateIdempotencyConfig` (same shape/contract as
+`trigger-filter.ts`'s `validateTriggerFilter`) and set via the new
+`replay-ops.ts set-idempotency <skillId> --step <N> --key-var message_id` command,
+which reuses `passesGateV2` — the SAME function replay-time uses — so a config accepted
+by the CLI is guaranteed to pass at replay time too.
+
+## A safety gap found and closed during implementation (not in the original spec)
+
+Reelier's own `runSkill` refuses to execute ANY step whose **raw compiled** `effect:
+destructive` line is set unless the caller passes `allowDestructive: true` for the
+whole run — this check is independent of SF's tool-effects.ts allowlist. v1 always
+passes `allowDestructive: false`. v2 needs `true` so the one gate-validated destructive
+step can actually execute for real (found this by literally running the real reelier
+package against a v2 fixture — the "happy path" test initially came back
+`failed-post-send` with `"Refusing to execute destructive step without --yes"`).
+
+Setting `allowDestructive: true` for the whole run creates a real bypass: if some OTHER
+step's **raw** compiled effect also happens to say `destructive` (a compiler
+misclassification, or a hand-edited skill_md) — even if SF's own allowlist trusts that
+tool as `read`/`idempotent-write` — it would now execute for real WITHOUT ever going
+through the claim wrapper (only the ONE declared destructive step's tool is wrapped).
+
+Closed this in `gate-v2.ts`'s `passesGateV2`: v2 eligibility now ALSO requires that
+every step other than the declared destructive one has a raw `step.effect !==
+"destructive"` (not just an allowlist-trusted effect of read/idempotent-write). Any
+skill that fails this additional check refuses v2 eligibility and falls through to v1
+(safe — v1 never sets `allowDestructive: true`).
+
+## Execution design
+
+`attemptV2Replay` (module-private, `replay-before-llm.ts`) reuses the REAL
+`@seldonframe/reelier` `runSkill` unmodified — same tool registry, allowlist, template
+fill, and assert loop v1 uses — with exactly one delta: the declared destructive step's
+tool is wrapped by `wrapToolWithSendClaim`, which:
+1. Calls `claimSendStep` (INSERT `replay_send_claims`, outcome=`unknown`) before
+   executing anything.
+2. `already-claimed` (lost the unique-index race, or a redelivery) → does NOT execute
+   the real tool; returns a synthetic 200 observation so the run keeps going (post-send
+   steps still execute for real — redelivery convergence).
+3. `claim-error` (ambiguous — DB couldn't confirm) → throws, refusing to execute.
+   Fails closed.
+4. Claimed → executes the real tool. A `status >= 400` result is ALSO thrown (v2 never
+   trusts the compiled skill's own assert coverage for the one step with real-world
+   consequences), marking the claim `failed`; success marks it `sent`.
+
+`attemptL0Replay` then classifies any divergence by comparing the first `failed` step's
+number to the declared `destructiveStepN`: strictly before → `kind: "diverged"` (today's
+v1 fallback semantics, unchanged); at or after → `kind: "failed-post-send"` (spec §3's
+asymmetric policy — `replay-or-turn.ts` never calls `runTurn` for this kind, returning
+`{ok:false, errorMessage}` instead, which reuses the EXISTING receipt-writing plumbing
+for the "loud receipt note" the spec calls for — no new receipt code needed).
+
+`maxLevel` stays `0` unconditionally in both v1 and v2 paths (unchanged literal), so
+reelier's own escalation ladder is structurally unreachable — it never constructs an
+LLM client at `maxLevel: 0`, confirmed by reading `runner.ts`'s `attemptEscalation`.
+
+## Deviation from the brief's literal wording
+
+Brief asked for a "distinct marker field" alongside `kind='replay-run', ok=false`. I
+instead added a new value to the EXISTING `agent_workflow_traces.kind` column
+(`'replay-run-failed-post-send'`) rather than adding a new column. That column has no
+DB CHECK constraint (confirmed in migration 0075 — plain `text`), so this needed no
+migration, and `kind` is already the field that distinguishes trace shapes — this is
+the more consistent, lower-surface-area choice. Documented in
+`agent-workflow-traces.ts`'s updated JSDoc.
+
+The `replay_send_claims.outcome` enum includes `'skipped-claimed'` (per the brief's
+literal spec) even though no row is ever actually WRITTEN with that value — a losing
+claim attempt's INSERT never succeeds at all (that's the whole point of the unique
+index), so `'skipped-claimed'` describes a STEP-record label (used in `attemptL0Replay`'s
+`toolCalls` note and read via the `events.skippedClaimed` side-channel), not a value
+that appears in the claims table itself. Documented in the schema file's JSDoc.
+
+## Test results (verbatim tail)
+
+Replay + policy suite (209 tests, includes all new v2 tests):
+```
+✔ resolveWebBuildRateLimit: env override with strict fallback (12.9502ms)
+ℹ tests 209
+ℹ suites 56
+ℹ pass 209
+ℹ fail 0
+ℹ cancelled 0
+ℹ skipped 0
+ℹ todo 0
+ℹ duration_ms 1157.0081
+```
+
+`tsc --noEmit`: 1 error, pre-existing on the base branch
+(`src/app/api/copilot/turn/route.ts(315,9)`, unrelated `'persist'` property — confirmed
+present before any of my changes via `git stash` + rerun). Zero NEW errors introduced.
+
+`pnpm run check:use-server`: `✓ All 'use server' files export only async functions / types.`
+
+Broader `deployments/*.spec.ts` sweep (360 tests, sanity check that
+`composio-event-dispatch-deps.ts`'s edit didn't regress anything): 359 pass, 1
+pre-existing unrelated failure (`deploy-readiness.spec.ts` — a brand-copy string
+mismatch, "Seldon" vs "SF" wording drift, nothing to do with this change).
+
+Full-repo `scripts/run-unit-tests.js` hits the documented Windows `ENAMETOOLONG` (772
+spec files as argv — pre-existing platform limitation, memory:
+`crm-unit-test-harness`). Batched manually instead; batches touching DB integration
+tests hit expected `ECONNREFUSED` against a local Neon endpoint (pre-existing baseline,
+memory: `green-main-ci-fix-2026-07-10` — "remaining red = DB-bound Neon baseline").
+
+Migration/journal consistency: verified via
+`replay-skills-schema.spec.ts`'s new "migration 0077" describe block (checks the SQL
+file's ALTER/CREATE TABLE/UNIQUE INDEX statements match the Drizzle schema, and that
+the journal registers 0077 immediately after 0076) — all green in the 209-test run
+above.
+
+## Open risks / follow-ups
+
+1. **Not staging-drilled.** Spec §Rollout item 3 (10 consecutive live emails, assert
+   exactly one forward per messageId) is explicitly a LATER step gated on Max review of
+   a recompiled forwarder skill — out of scope for this build.
+2. **`ReelierObservation.status >= 400` as the sole send-failure signal.** This is a
+   deliberate choice (v2 never trusts assert coverage for the send step), but means a
+   tool that returns a non-JSON/non-HTTP-shaped "failure" without a `status` field
+   >= 400 would not be caught by this check — bounded by the fact that
+   `defaultBuildTools`' wrapper (unchanged, v1) already normalizes every tool result to
+   `{status, headers, body}`, so this only matters for a future custom tool bridge.
+3. **The `claim-error` (ambiguous DB failure) path fails closed by refusing to send**,
+   which is safe but means a transient DB blip during exactly the claim-insert moment
+   turns into a `failed-post-send` run needing manual attention rather than a silent
+   retry. Accepted as the conservative default per the spec's "never risk a double-send"
+   framing — not revisited here.
+4. Ops CLI's `set-idempotency` has no dedicated test file (mirrors the existing
+   `replay-ops.ts`, which also has none — script is exercised indirectly via
+   `passesGateV2`, which IS unit-tested). If this becomes a heavier-traffic surface,
+   worth a dedicated spec later.
+
+## Worktree
+
+`C:\Users\maxim\CascadeProjects\Seldon Frame\.claude\worktrees\agent-a2db413932da348e3`
+Branch: `feat/replay-gate-v2` (based on `origin/chore/replay-trace-unification`,
+commit `4eb74fcb2`). Not pushed, no PR opened, as instructed.
+
+## Diff stat
+
+```
+ packages/crm/drizzle/0077_replay_gate_v2.sql       |  41 ++
+ packages/crm/drizzle/meta/_journal.json            |   7 +
+ packages/crm/scripts/replay-ops.ts                 | 100 ++++-
+ .../crm/src/db/schema/agent-workflow-traces.ts     |  12 +-
+ packages/crm/src/db/schema/index.ts                |   2 +
+ packages/crm/src/db/schema/replay-send-claims.ts   |  71 ++++
+ packages/crm/src/db/schema/replay-skills.ts        |  20 +
+ .../deployments/composio-event-dispatch-deps.ts    |   6 +-
+ packages/crm/src/lib/deployments/replay/gate-v2.ts | 160 ++++++++
+ .../lib/deployments/replay/replay-before-llm.ts    | 341 +++++++++++++++-
+ .../src/lib/deployments/replay/replay-or-turn.ts   |  28 +-
+ .../crm/src/lib/deployments/replay/send-claim.ts   | 126 ++++++
+ packages/crm/src/lib/web-build/policy.ts           |  13 +
+ .../tests/unit/deployments/replay/gate-v2.spec.ts  | 150 +++++++
+ .../replay/replay-gate-v2-execution.spec.ts        | 445 +++++++++++++++++++++
+ .../unit/deployments/replay/replay-or-turn.spec.ts |  35 ++
+ .../replay/replay-skills-schema.spec.ts            |  66 +++
+ .../unit/deployments/replay/send-claim.spec.ts     | 115 ++++++
+ packages/crm/tests/unit/web-build-policy.spec.ts   |   9 +
+ 19 files changed, 1715 insertions(+), 32 deletions(-)
+```
+
+Commit: `3c74234d6` — "feat(replay): gate v2 — idempotent-send with claim ledger and
+asymmetric fallback (migration 0077, SF_REPLAY_GATE_V2)"

--- a/packages/crm/drizzle/0077_replay_gate_v2.sql
+++ b/packages/crm/drizzle/0077_replay_gate_v2.sql
@@ -1,0 +1,41 @@
+-- packages/crm/drizzle/0077_replay_gate_v2.sql
+-- Replay gate v2 — idempotent-send
+-- (docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md, approved by
+-- Max 2026-07-18). Adds:
+--   1. `replay_skills.idempotency` — nullable jsonb {stepN, keyVar}. Reelier's
+--      parseSkill (external npm dep, @seldonframe/reelier) rejects any
+--      unrecognized `- key:` step bullet (confirmed against the installed
+--      0.2.0 dist), so a v2 skill's idempotency-key declaration cannot live
+--      inside skill_md — it's stored out-of-band here instead, set via
+--      `pnpm tsx scripts/replay-ops.ts set-idempotency`. Mirrors
+--      trigger_filter's precedent (migration 0076) exactly.
+--   2. `replay_send_claims` — the double-send lock. One row per
+--      (skill, step, idempotency_key) claim attempt; the UNIQUE index below
+--      IS the lock — a concurrent second INSERT for the same key raises a
+--      23505 unique-violation, which
+--      lib/deployments/replay/send-claim.ts treats as "already sent, do not
+--      execute" (skip the step as skipped-claimed, continue).
+--
+-- HAND-WRITTEN (house rule: never drizzle-kit generate in this repo).
+-- Additive only + idempotent (IF NOT EXISTS) so a re-run after an
+-- out-of-band apply is a no-op. Mirrors 0076's style.
+
+ALTER TABLE "replay_skills"
+  ADD COLUMN IF NOT EXISTS "idempotency" jsonb;
+
+CREATE TABLE IF NOT EXISTS "replay_send_claims" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "org_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "skill_id" uuid NOT NULL REFERENCES "replay_skills"("id") ON DELETE CASCADE,
+  "step_n" integer NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "claimed_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "outcome" text NOT NULL DEFAULT 'unknown'
+);
+
+-- THE double-send lock: at most one claim row per (skill, step, key).
+CREATE UNIQUE INDEX IF NOT EXISTS "replay_send_claims_skill_step_key_idx"
+  ON "replay_send_claims" ("skill_id", "step_n", "idempotency_key");
+
+CREATE INDEX IF NOT EXISTS "replay_send_claims_org_idx"
+  ON "replay_send_claims" ("org_id");

--- a/packages/crm/drizzle/meta/_journal.json
+++ b/packages/crm/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1784200000000,
       "tag": "0076_replay_skills_trigger_filter",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1784300000000,
+      "tag": "0077_replay_gate_v2",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crm/scripts/replay-ops.ts
+++ b/packages/crm/scripts/replay-ops.ts
@@ -268,6 +268,7 @@ async function cmdListSkills(flags: Record<string, string>) {
       healCount: replaySkills.healCount,
       lastReplayAt: replaySkills.lastReplayAt,
       triggerFilter: replaySkills.triggerFilter,
+      idempotency: replaySkills.idempotency,
     })
     .from(replaySkills)
     .orderBy(desc(replaySkills.createdAt));
@@ -284,9 +285,97 @@ async function cmdListSkills(flags: Record<string, string>) {
   console.log(`${rows.length} skill(s):\n`);
   for (const row of rows) {
     console.log(
-      `${row.id}  deployment=${row.deploymentId}  name=${row.name ?? "-"}  status=${row.status}  heals=${row.healCount}  lastReplay=${row.lastReplayAt ? row.lastReplayAt.toISOString() : "-"}  filter=${row.triggerFilter ? truncate(row.triggerFilter, 200) : "-"}`,
+      `${row.id}  deployment=${row.deploymentId}  name=${row.name ?? "-"}  status=${row.status}  heals=${row.healCount}  lastReplay=${row.lastReplayAt ? row.lastReplayAt.toISOString() : "-"}  filter=${row.triggerFilter ? truncate(row.triggerFilter, 200) : "-"}  idempotency=${row.idempotency ? truncate(row.idempotency, 200) : "-"}`,
     );
   }
+}
+
+/**
+ * Set (or clear) a skill's Replay gate v2 idempotency config
+ * (replay_skills.idempotency, migration 0077). Validated with the SAME
+ * passesGateV2 function replay-before-llm.ts uses at replay time, checked
+ * BEFORE any DB write, so a config that's accepted here is guaranteed to
+ * pass there too — mirrors set-filter/enable's parseFilterFlag pattern
+ * exactly. Requires the skill's OWN destructive step number (--step) and
+ * the key var (--key-var, only "message_id" is ever accepted — sender/
+ * subject are attacker-influenceable and forbidden as key material).
+ */
+async function cmdSetIdempotency(skillId: string | undefined, flags: Record<string, string>) {
+  const usage =
+    "usage: set-idempotency <skillId> --step <N> --key-var message_id  |  set-idempotency <skillId> --clear";
+  if (!skillId) {
+    console.error(usage);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { db } = await import("@/db");
+  const { replaySkills } = await import("@/db/schema/replay-skills");
+  const { eq } = await import("drizzle-orm");
+
+  const [skill] = await db
+    .select({ id: replaySkills.id, deploymentId: replaySkills.deploymentId, skillMd: replaySkills.skillMd })
+    .from(replaySkills)
+    .where(eq(replaySkills.id, skillId))
+    .limit(1);
+  if (!skill) {
+    console.error(`skill not found: ${skillId}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (flags.clear) {
+    await db
+      .update(replaySkills)
+      .set({ idempotency: null, updatedAt: new Date() })
+      .where(eq(replaySkills.id, skillId));
+    console.log(`${skillId}: idempotency config cleared  (deployment ${skill.deploymentId})`);
+    return;
+  }
+
+  if (!flags.step || !flags["key-var"]) {
+    console.error(usage);
+    process.exitCode = 1;
+    return;
+  }
+
+  const stepN = Number.parseInt(flags.step, 10);
+  if (!Number.isFinite(stepN) || stepN < 1) {
+    console.error(`--step must be a positive integer, got: ${flags.step}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { parseSkill } = await import("@seldonframe/reelier/skill");
+  let parsed: import("@seldonframe/reelier/skill").ReelierSkill;
+  try {
+    parsed = parseSkill(skill.skillMd);
+  } catch (err) {
+    console.error(`skill_md failed to parse: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const { passesGateV2 } = await import("@/lib/deployments/replay/gate-v2");
+  const config = { stepN, keyVar: flags["key-var"] };
+  const gate = passesGateV2(parsed, config);
+  if (!gate.ok) {
+    console.error(`set-idempotency rejected: ${gate.reason}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  await db
+    .update(replaySkills)
+    .set({ idempotency: config, updatedAt: new Date() })
+    .where(eq(replaySkills.id, skillId));
+  console.log(
+    `${skillId}: idempotency -> step ${stepN} key ${config.keyVar}  (deployment ${skill.deploymentId})\n\n` +
+      `WARNING: once SF_REPLAY_GATE_V2=1 is set, gate v2 replay will EXECUTE this skill's destructive ` +
+      `step FOR REAL during L0 replay (claim-guarded against a double-send, but a real send nonetheless). ` +
+      `Review the compiled skill_md above before enabling this in production, and run the staging drill ` +
+      `(spec §Rollout item 3: 10 consecutive live events, assert exactly one send per key) before flipping the flag.`,
+  );
 }
 
 /** Parse + strictly validate a `--filter` CLI flag value with the SAME
@@ -454,16 +543,21 @@ async function main() {
     case "set-filter":
       await cmdSetFilter(positional[0], flags);
       break;
+    case "set-idempotency":
+      await cmdSetIdempotency(positional[0], flags);
+      break;
     default:
       console.error(
-        "usage: replay-ops.ts <list-traces|show-trace|compile|list-skills|enable|disable|set-filter> [args]\n\n" +
+        "usage: replay-ops.ts <list-traces|show-trace|compile|list-skills|enable|disable|set-filter|set-idempotency> [args]\n\n" +
           "  list-traces [--org <id>] [--deployment <id>] [--limit N]\n" +
           "  show-trace <traceId>\n" +
           "  compile <traceId>\n" +
           "  list-skills [--deployment <id>]\n" +
           "  enable <skillId> [--filter '<json>']\n" +
           "  disable <skillId>\n" +
-          "  set-filter <skillId> --filter '<json>'",
+          "  set-filter <skillId> --filter '<json>'\n" +
+          "  set-idempotency <skillId> --step <N> --key-var message_id  |  set-idempotency <skillId> --clear\n" +
+          "    (Replay gate v2 — also requires SF_REPLAY_GATE_V2=1 to activate at replay time)",
       );
       process.exitCode = command ? 1 : 0;
   }

--- a/packages/crm/src/db/schema/agent-workflow-traces.ts
+++ b/packages/crm/src/db/schema/agent-workflow-traces.ts
@@ -47,8 +47,16 @@ export type AgentWorkflowTraceTriggerKind = "email";
  *  RunRecord the replay attempt produced — see
  *  lib/deployments/replay/replay-before-llm.ts). Default 'trace' so every
  *  slice-1 row (and every insert that doesn't pass `kind`) keeps its
- *  existing meaning unchanged. */
-export type AgentWorkflowTraceKind = "trace" | "replay-run";
+ *  existing meaning unchanged.
+ *
+ *  Replay gate v2 (2026-07-18) adds `'replay-run-failed-post-send'` — the
+ *  DISTINCT marker the spec calls for on a divergence AT/AFTER a v2 skill's
+ *  destructive step (no agent fallback attempted; see replay-or-turn.ts).
+ *  Deliberately reuses this existing `kind` column rather than adding a new
+ *  one (no CHECK constraint ties it to a fixed enum — see migration 0075's
+ *  plain `text` column) — this IS already the field that distinguishes
+ *  trace shapes, and a new value here needs no migration. */
+export type AgentWorkflowTraceKind = "trace" | "replay-run" | "replay-run-failed-post-send";
 export type AgentWorkflowTraceRecords = TraceRecord[] | ReelierRunRecord;
 
 export const agentWorkflowTraces = pgTable(

--- a/packages/crm/src/db/schema/index.ts
+++ b/packages/crm/src/db/schema/index.ts
@@ -56,6 +56,8 @@ export * from "./agent-run-receipts";
 export * from "./agent-workflow-traces";
 // Deterministic replay — Reelier phase 2c slice 2 (compile + L0 replay).
 export * from "./replay-skills";
+// Replay gate v2 — idempotent-send claim ledger (migration 0077).
+export * from "./replay-send-claims";
 // May 1, 2026 — Measurement Layers 2 + 3.
 export * from "./seldonframe-events";
 export * from "./brain-outcomes";

--- a/packages/crm/src/db/schema/replay-send-claims.ts
+++ b/packages/crm/src/db/schema/replay-send-claims.ts
@@ -1,0 +1,71 @@
+// replay_send_claims — Replay gate v2, the double-send lock (migration
+// 0077). One row per (skill, step, idempotency_key) claim ATTEMPT — the
+// UNIQUE index on (skill_id, step_n, idempotency_key) below IS the lock: a
+// concurrent second INSERT for the same key raises a Postgres 23505
+// unique-violation, which lib/deployments/replay/send-claim.ts's
+// claimSendStep treats as "a prior attempt already reached this step for
+// this key — do not execute, treat as already-sent" (see
+// docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md §2).
+//
+// Lifecycle of one row: INSERT with outcome='unknown' (the claim itself,
+// BEFORE the destructive tool call runs) -> UPDATE to 'sent' (tool call
+// succeeded) or 'failed' (tool call threw — the claim stays either way,
+// so a retry never re-attempts an ambiguous send; see the spec's asymmetric
+// divergence policy). 'skipped-claimed' is a STEP-record label used at
+// replay time when an INSERT loses the unique race (see
+// AttemptL0ReplayResult's "failed-post-send"/"passed" kinds in
+// replay-before-llm.ts) — no row is ever WRITTEN with that outcome value
+// (the losing attempt's INSERT never succeeds), but it's included in the
+// column's type for forward-compat / ops annotation.
+//
+// Org-scoped: every read/write is scoped by org_id (L-04, security
+// invariant) — mirrors replay_skills.ts's contract. skill_id is NOT NULL +
+// ON DELETE CASCADE (a claim has no meaning detached from the skill it
+// gates), mirroring replay_skills.deployment_id's own cascade reasoning.
+import {
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+
+import { organizations } from "./organizations";
+import { replaySkills } from "./replay-skills";
+
+export type ReplaySendClaimOutcome = "sent" | "failed" | "unknown" | "skipped-claimed";
+
+export const replaySendClaims = pgTable(
+  "replay_send_claims",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    skillId: uuid("skill_id")
+      .notNull()
+      .references(() => replaySkills.id, { onDelete: "cascade" }),
+    /** The skill's declared destructive step number (replay_skills.idempotency.stepN). */
+    stepN: integer("step_n").notNull(),
+    /** The resolved key VALUE (never the var name) — for v2, always the
+     *  fired event's message_id (the only allowed key var; see
+     *  gate-v2.ts's ALLOWED_KEY_VARS). */
+    idempotencyKey: text("idempotency_key").notNull(),
+    claimedAt: timestamp("claimed_at", { withTimezone: true }).notNull().defaultNow(),
+    outcome: text("outcome").$type<ReplaySendClaimOutcome>().notNull().default("unknown"),
+  },
+  (table) => [
+    // THE double-send lock — see module header.
+    uniqueIndex("replay_send_claims_skill_step_key_idx").on(
+      table.skillId,
+      table.stepN,
+      table.idempotencyKey,
+    ),
+    index("replay_send_claims_org_idx").on(table.orgId),
+  ],
+);
+
+export type ReplaySendClaimRow = typeof replaySendClaims.$inferSelect;
+export type NewReplaySendClaimRow = typeof replaySendClaims.$inferInsert;

--- a/packages/crm/src/db/schema/replay-skills.ts
+++ b/packages/crm/src/db/schema/replay-skills.ts
@@ -34,6 +34,21 @@ import type { TriggerFilter } from "@/lib/deployments/replay/trigger-filter";
 
 export type ReplaySkillStatus = "draft" | "enabled" | "disabled";
 
+/** Replay gate v2 (migration 0077) — out-of-band idempotency-key config for
+ *  a skill's ONE destructive step. Lives here, NOT inside skill_md, because
+ *  reelier's parseSkill (external npm dep) rejects any step bullet it
+ *  doesn't recognize (`- idempotency-key: ...` would throw) — see
+ *  lib/deployments/replay/gate-v2.ts's module header for the full
+ *  rationale. `stepN` is the skill's own step number (1-based, matches
+ *  ReelierSkillStep.n); `keyVar` MUST be `"message_id"` — see
+ *  gate-v2.ts's ALLOWED_KEY_VARS (sender/subject are attacker-influenceable
+ *  and forbidden as key material by the spec). Set via
+ *  `pnpm tsx scripts/replay-ops.ts set-idempotency`, validated there with
+ *  the SAME passesGateV2 function replay-before-llm.ts uses at replay
+ *  time. NULL = not v2-eligible (gate v2 never activates for this skill,
+ *  regardless of SF_REPLAY_GATE_V2). */
+export type ReplaySkillIdempotency = { stepN: number; keyVar: string };
+
 export const replaySkills = pgTable(
   "replay_skills",
   {
@@ -76,6 +91,11 @@ export const replaySkills = pgTable(
      *  evaluateTriggerFilter re-validate every time, since this column has
      *  no CHECK constraint (a hand-edited row could be malformed). */
     triggerFilter: jsonb("trigger_filter").$type<TriggerFilter | null>(),
+    /** Replay gate v2 (migration 0077) — see ReplaySkillIdempotency above.
+     *  NULL = not v2-eligible. Never trusted as-is on read — gate-v2.ts's
+     *  validateIdempotencyConfig re-validates every time (this column has
+     *  no CHECK constraint; a hand-edited row could be malformed). */
+    idempotency: jsonb("idempotency").$type<ReplaySkillIdempotency | null>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/crm/src/lib/deployments/composio-event-dispatch-deps.ts
+++ b/packages/crm/src/lib/deployments/composio-event-dispatch-deps.ts
@@ -287,7 +287,11 @@ export function buildDispatchComposioEventDeps(): DispatchComposioEventDeps {
               ok: replay.kind === "passed",
               callCount: replay.record.steps.length,
               records: replay.record,
-              kind: "replay-run",
+              // Replay gate v2 — a distinct marker for "diverged AT/AFTER
+              // the destructive step, no agent fallback attempted" so ops
+              // (replay-ops.ts list-traces/show-trace) can tell it apart
+              // from a normal (pre-send) diverged replay at a glance.
+              kind: replay.kind === "failed-post-send" ? "replay-run-failed-post-send" : "replay-run",
               inputTokens: 0,
               outputTokens: 0,
             });

--- a/packages/crm/src/lib/deployments/replay/gate-v2.ts
+++ b/packages/crm/src/lib/deployments/replay/gate-v2.ts
@@ -1,0 +1,160 @@
+// Replay gate v2 — idempotent-send eligibility
+// (docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md §1, §4).
+//
+// WHY A SEPARATE GATE (not a loosened passesAllReadGate): v1's fail-open
+// fallback (a diverged replay falls back to a fresh agentic turn) is only
+// safe because v1 guarantees nothing side-effectful ran before the
+// fallback — see replay-before-llm.ts's module header. v2 allows exactly
+// ONE destructive step to run mid-replay, which means the SAME fallback
+// would risk a double-send once that step has executed. passesGateV2 is
+// therefore a STRICTER, opt-in check layered on top of v1's tool-effect
+// allowlist (tool-effects.ts) — it never replaces passesAllReadGate; a
+// skill that fails this gate (or whose org hasn't set SF_REPLAY_GATE_V2)
+// still gets evaluated against v1's gate exactly as before (see
+// replay-before-llm.ts's attemptL0Replay: v2 is tried FIRST only when a
+// skill carries idempotency config, and always falls through to the
+// unchanged v1 path otherwise).
+//
+// STORAGE CHOICE (documented for the orchestrator): an
+// `- idempotency-key: {{message_id}}` step bullet, as sketched in the
+// spec, CANNOT be added to skill_md — reelier's parseSkill (external npm
+// dep, @seldonframe/reelier, confirmed against the installed 0.2.0 dist:
+// node_modules/@seldonframe/reelier/dist/skill.js) throws
+// SkillParseError("Unrecognized step field...") on any `- key:` bullet
+// outside its fixed intent/action/assert/bind/effect grammar. Forking
+// reelier was rejected (external dependency, would fork every consumer's
+// parser). So the config lives OUT OF BAND on `replay_skills.idempotency`
+// (migration 0077, jsonb {stepN, keyVar}) — exactly the precedent
+// trigger_filter (migration 0076) already set for "a linear skill needs
+// scoping metadata reelier's grammar has no room for."
+import type { ReelierSkill } from "@seldonframe/reelier/skill";
+import type { ReplaySkillIdempotency } from "@/db/schema/replay-skills";
+import { trustedEffect } from "./replay-before-llm";
+
+/** The ONLY var a v2 idempotency key may be sourced from. message_id is
+ *  server-extracted (the Gmail id) and already the dispatch-level dedup
+ *  key — sender/subject are attacker-influenceable free text and are
+ *  forbidden as key material (spec §1, §4). */
+const ALLOWED_KEY_VARS = new Set<string>(["message_id"]);
+
+export type ValidateIdempotencyConfigResult =
+  | { ok: true; config: ReplaySkillIdempotency | null }
+  | { ok: false; error: string };
+
+/**
+ * Strictly validate a candidate `replay_skills.idempotency` value — either
+ * freshly-constructed CLI input, or the raw jsonb column value straight off
+ * a row (which may predate this validator, or have been hand-edited).
+ * `null`/`undefined` is valid (means "not v2-eligible"). Mirrors
+ * trigger-filter.ts's validateTriggerFilter shape/contract exactly.
+ */
+export function validateIdempotencyConfig(value: unknown): ValidateIdempotencyConfigResult {
+  if (value === null || value === undefined) return { ok: true, config: null };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "idempotency must be a JSON object or null" };
+  }
+
+  const obj = value as Record<string, unknown>;
+  const knownKeys = new Set(["stepN", "keyVar"]);
+  const unknownKeys = Object.keys(obj).filter((k) => !knownKeys.has(k));
+  if (unknownKeys.length > 0) {
+    return { ok: false, error: `unknown idempotency key(s): ${unknownKeys.join(", ")}` };
+  }
+
+  const { stepN, keyVar } = obj;
+  if (typeof stepN !== "number" || !Number.isInteger(stepN) || stepN < 1) {
+    return { ok: false, error: "idempotency.stepN must be a positive integer" };
+  }
+  if (typeof keyVar !== "string" || keyVar.trim().length === 0) {
+    return { ok: false, error: "idempotency.keyVar must be a non-empty string" };
+  }
+  if (!ALLOWED_KEY_VARS.has(keyVar)) {
+    return {
+      ok: false,
+      error: `idempotency.keyVar '${keyVar}' is not allowed — only ${[...ALLOWED_KEY_VARS].join(", ")} may be used as key material (sender/subject are attacker-influenceable and forbidden)`,
+    };
+  }
+
+  return { ok: true, config: { stepN, keyVar } };
+}
+
+export type GateV2Result =
+  | { ok: true; destructiveStepN: number }
+  | { ok: false; reason: string };
+
+/**
+ * v2 replay gate: every step is `read` or `idempotent-write` EXCEPT exactly
+ * ONE `destructive` step, and that step's number must match the skill's
+ * declared idempotency config (config.stepN) — i.e. the operator's
+ * idempotency-key declaration must point at the ACTUAL (allowlist-trusted)
+ * destructive step, never a step the operator merely believes is
+ * destructive. Unlike v1's passesAllReadGate, the destructive step need NOT
+ * be last — v2 explicitly allows post-send steps (spec §1, §3's "post-send
+ * writes are idempotent by class").
+ *
+ * "Non-read" here is the SAME allowlist-trusted effect
+ * (replay-before-llm.ts's trustedEffect) v1 uses — never skill_md's raw
+ * `effect:` line directly, for the identical search_and_purge reason
+ * tool-effects.ts documents.
+ */
+export function passesGateV2(skill: ReelierSkill, config: ReplaySkillIdempotency): GateV2Result {
+  if (skill.steps.length === 0) return { ok: false, reason: "skill has no steps" };
+
+  if (!ALLOWED_KEY_VARS.has(config.keyVar)) {
+    return {
+      ok: false,
+      reason: `idempotency keyVar '${config.keyVar}' is not allowed — only message_id may be used as key material`,
+    };
+  }
+
+  const destructiveSteps = skill.steps.filter((step) => trustedEffect(step) === "destructive");
+  if (destructiveSteps.length !== 1) {
+    return {
+      ok: false,
+      reason: `v2 requires EXACTLY one destructive step, found ${destructiveSteps.length}`,
+    };
+  }
+
+  const destructiveStep = destructiveSteps[0];
+  if (destructiveStep.n !== config.stepN) {
+    return {
+      ok: false,
+      reason: `declared idempotency stepN ${config.stepN} does not match the skill's actual destructive step (step ${destructiveStep.n})`,
+    };
+  }
+
+  const restOk = skill.steps.every(
+    (step) => step.n === destructiveStep.n || trustedEffect(step) !== "destructive",
+  );
+  if (!restOk) {
+    // Unreachable given the count check above, kept as a belt-and-suspenders
+    // guard against a future refactor silently loosening the count check.
+    return { ok: false, reason: "non-destructive steps must all be read or idempotent-write" };
+  }
+
+  // EXECUTION-LAYER guard, not just the gate: v2's runSkill call must pass
+  // `allowDestructive: true` (reelier's OWN runner refuses ANY step whose
+  // RAW compiled `effect: destructive` line is set, independent of SF's
+  // allowlist-trusted effect — see runner.ts's executeStep, `step.effect
+  // === "destructive" && !ctx.allowDestructive`). Flipping that flag for
+  // the whole run would let a DIFFERENT step — one SF's own allowlist
+  // trusts as read/idempotent-write but whose raw compiled `effect:` line
+  // still says "destructive" (a compiler misclassification or a
+  // hand-edited skill_md) — execute for real WITHOUT ever going through
+  // the claim wrapper, since only the ONE declared destructive step's tool
+  // is wrapped. Refuse v2 eligibility outright if any OTHER step's raw
+  // declared effect is "destructive", so allowDestructive:true can never
+  // free-pass an unclaimed step.
+  const rawEffectsOk = skill.steps.every(
+    (step) => step.n === destructiveStep.n || step.effect !== "destructive",
+  );
+  if (!rawEffectsOk) {
+    return {
+      ok: false,
+      reason:
+        "a step other than the declared destructive step carries a raw compiled effect:'destructive' line — v2 refuses (would bypass the claim wrapper once allowDestructive is set for the run)",
+    };
+  }
+
+  return { ok: true, destructiveStepN: destructiveStep.n };
+}

--- a/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-before-llm.ts
@@ -38,13 +38,24 @@
 // loosened (e.g. before mid-sequence writes are ever allowed).
 import type { AgentBlueprint } from "@/db/schema/agents";
 import type { ToolExecuteContext } from "@/lib/agents/tools";
+import type { ReplaySkillIdempotency } from "@/db/schema/replay-skills";
+import type { ReplaySendClaimOutcome } from "@/db/schema/replay-send-claims";
 import type {
+  ReelierObservation,
   ReelierRunRecord,
   ReelierTool,
+  ReelierToolRunCtx,
 } from "@seldonframe/reelier";
 import type { ReelierSkill, ReelierSkillStep } from "@seldonframe/reelier/skill";
 import { effectForTool } from "./tool-effects";
 import { evaluateTriggerFilter } from "./trigger-filter";
+import { passesGateV2, validateIdempotencyConfig } from "./gate-v2";
+import {
+  claimSendStep as defaultClaimSendStep,
+  markSendClaimOutcome as defaultMarkSendClaimOutcome,
+  type ClaimSendStepResult,
+} from "./send-claim";
+import { isReplayGateV2On } from "@/lib/web-build/policy";
 
 /** The fired event's trigger fields, threaded through to (a) fill a skill's
  *  `{{message_id}}`/`{{sender}}`/`{{subject}}` template vars and (b)
@@ -80,17 +91,36 @@ export type AttemptL0ReplayPassedResult = {
   toolCalls: Array<{ tool: string; ok: boolean; note?: string }>;
   replyText?: string;
 };
+/** Replay gate v2 ONLY (spec §3, "the asymmetric fallback") — a divergence
+ *  AT or AFTER the v2 skill's destructive step. NEVER produced by v1 (v1
+ *  never executes a non-final step, so it can never diverge "after" one).
+ *  The caller (replay-or-turn.ts) MUST NOT fall back to the agentic turn
+ *  for this kind — the destructive step may have already sent for real;
+ *  falling back would risk a real double-send. */
+export type AttemptL0ReplayFailedPostSendResult = {
+  kind: "failed-post-send";
+  skillId: string;
+  record: ReelierRunRecord;
+  failures: string[];
+  destructiveStepN: number;
+};
 export type AttemptL0ReplayResult =
   | AttemptL0ReplaySkippedResult
   | AttemptL0ReplayDivergedResult
-  | AttemptL0ReplayPassedResult;
+  | AttemptL0ReplayPassedResult
+  | AttemptL0ReplayFailedPostSendResult;
 
-// triggerFilter is optional on the row shape (rather than required) so
-// every existing fake constructing `{ id, skillMd }` (predating the
-// trigger-filter gate) keeps compiling unchanged — `undefined` is treated
-// identically to a stored `null` by evaluateTriggerFilter (no filter,
-// attempt every event).
-type EnabledSkillRow = { id: string; skillMd: string; triggerFilter?: unknown };
+// triggerFilter/idempotency are optional on the row shape (rather than
+// required) so every existing fake constructing `{ id, skillMd }`
+// (predating those gates) keeps compiling unchanged — `undefined` is
+// treated identically to a stored `null` by evaluateTriggerFilter /
+// validateIdempotencyConfig (no filter / not v2-eligible).
+type EnabledSkillRow = {
+  id: string;
+  skillMd: string;
+  triggerFilter?: unknown;
+  idempotency?: unknown;
+};
 
 /**
  * A step's TRUSTED effect for gate purposes. Consults tool-effects.ts's
@@ -107,7 +137,7 @@ type EnabledSkillRow = { id: string; skillMd: string; triggerFilter?: unknown };
  * single bounded final-step slot, exactly like a genuinely destructive
  * allowlisted tool.
  */
-function trustedEffect(step: ReelierSkillStep): ReelierSkill["steps"][number]["effect"] {
+export function trustedEffect(step: ReelierSkillStep): ReelierSkill["steps"][number]["effect"] {
   const known = effectForTool(step.actionTool);
   if (known !== undefined) return known;
   return "destructive";
@@ -136,6 +166,19 @@ export type AttemptL0ReplayDeps = {
     skill: ReelierSkill,
     options: import("@seldonframe/reelier").ReelierRunSkillOptions,
   ) => Promise<ReelierRunRecord>;
+  /** Replay gate v2 ONLY. Defaults to send-claim.ts's real DB-backed
+   *  claimSendStep/markSendClaimOutcome. Injected here (rather than only
+   *  as a nested SendClaimDeps) so a test can fully control claim behavior
+   *  — including simulating the unique-violation race — without touching
+   *  Postgres, mirroring how buildTools/parseSkill/runSkill are already
+   *  injected as whole functions. */
+  claimSendStep?: (input: {
+    orgId: string;
+    skillId: string;
+    stepN: number;
+    idempotencyKey: string;
+  }) => Promise<ClaimSendStepResult>;
+  markSendClaimOutcome?: (claimId: string, outcome: ReplaySendClaimOutcome) => Promise<void>;
 };
 
 async function defaultLoadEnabledSkill(
@@ -150,6 +193,7 @@ async function defaultLoadEnabledSkill(
       id: replaySkills.id,
       skillMd: replaySkills.skillMd,
       triggerFilter: replaySkills.triggerFilter,
+      idempotency: replaySkills.idempotency,
     })
     .from(replaySkills)
     .where(
@@ -254,6 +298,226 @@ function emptyFailedRecord(skillName: string, reason: string): ReelierRunRecord 
 }
 
 /**
+ * Wrap the ONE destructive tool with claim-before-send (spec §2). Every
+ * OTHER tool in the registry passes through unchanged — reads and
+ * idempotent-writes execute exactly as v1 already does, real reelier
+ * runSkill, unmodified. This is the entire delta v2 makes to execution:
+ * one tool's `run` gains a claim check.
+ *
+ * Claim outcomes:
+ *  - `already-claimed` (a prior attempt already reached this step for this
+ *    key) -> do NOT execute; return a synthetic success observation and
+ *    record `events.skippedClaimed = true` (never a StepOutcome reelier
+ *    itself knows about — read back by attemptV2Replay after runSkill
+ *    returns, purely for toolCalls labeling). The step still needs to
+ *    "pass" from reelier's point of view so post-send steps keep running
+ *    (redelivery convergence, spec §3).
+ *  - `claim-error` (ambiguous — DB couldn't confirm either way) -> THROW.
+ *    v2 never trusts the compiled skill's own assert coverage for the one
+ *    step with real-world consequences: an ambiguous claim must fail the
+ *    step outright, not silently pass through.
+ *  - claimed -> execute the real tool. A resulting `status >= 400` is ALSO
+ *    thrown (not just muted into the observation, unlike every other
+ *    tool's wrapper) for the same reason — the send step's own asserts are
+ *    never the sole failure signal.
+ */
+function wrapToolWithSendClaim(
+  tools: Record<string, ReelierTool>,
+  toolName: string,
+  claimInput: { orgId: string; skillId: string; stepN: number; idempotencyKey: string },
+  events: { skippedClaimed: boolean },
+  claimSendStepFn: (input: {
+    orgId: string;
+    skillId: string;
+    stepN: number;
+    idempotencyKey: string;
+  }) => Promise<ClaimSendStepResult>,
+  markSendClaimOutcomeFn: (claimId: string, outcome: ReplaySendClaimOutcome) => Promise<void>,
+): Record<string, ReelierTool> {
+  const original = tools[toolName];
+  if (!original) return tools; // unknown tool — runner will fail naturally ("Unknown tool")
+
+  const wrapped: ReelierTool = {
+    effect: original.effect,
+    async run(args: unknown, ctx: ReelierToolRunCtx): Promise<ReelierObservation> {
+      const claim = await claimSendStepFn(claimInput);
+      if (!claim.claimed) {
+        if (claim.reason === "already-claimed") {
+          events.skippedClaimed = true;
+          return {
+            status: 200,
+            headers: {},
+            body: JSON.stringify({ skipped: true, reason: "already-claimed" }),
+          };
+        }
+        throw new Error(
+          "send-claim could not be acquired (claim-error) — refusing to execute the destructive step",
+        );
+      }
+
+      let result: ReelierObservation;
+      try {
+        result = await original.run(args, ctx);
+      } catch (err) {
+        await markSendClaimOutcomeFn(claim.claimId, "failed");
+        throw err;
+      }
+
+      const sendFailed = typeof result?.status === "number" && result.status >= 400;
+      await markSendClaimOutcomeFn(claim.claimId, sendFailed ? "failed" : "sent");
+      if (sendFailed) {
+        throw new Error(
+          `destructive step tool returned status ${result.status} — treated as a send failure (v2 never trusts assert coverage for the send step)`,
+        );
+      }
+      return result;
+    },
+  };
+  return { ...tools, [toolName]: wrapped };
+}
+
+/**
+ * The v2 execution path (spec §2, §3) — reuses the SAME reelier runSkill
+ * v1 calls (real tool registry, real allowlist, real fillTemplate/assert
+ * loop), with only the destructive tool wrapped for the claim. Returns
+ * `null` when a runtime precondition isn't met (no message_id to key the
+ * claim on) — the caller treats that as "fall through to v1", safe because
+ * nothing has executed yet.
+ */
+async function attemptV2Replay(opts: {
+  input: AttemptL0ReplayInput;
+  skill: ReelierSkill;
+  skillRow: EnabledSkillRow;
+  trigger: AttemptL0ReplayTrigger;
+  vars: Record<string, string>;
+  destructiveStepN: number;
+  buildTools: (input: AttemptL0ReplayInput) => Promise<Record<string, ReelierTool>>;
+  runSkillFn: (
+    skill: ReelierSkill,
+    options: import("@seldonframe/reelier").ReelierRunSkillOptions,
+  ) => Promise<ReelierRunRecord>;
+  claimSendStepFn: (input: {
+    orgId: string;
+    skillId: string;
+    stepN: number;
+    idempotencyKey: string;
+  }) => Promise<ClaimSendStepResult>;
+  markSendClaimOutcomeFn: (claimId: string, outcome: ReplaySendClaimOutcome) => Promise<void>;
+}): Promise<AttemptL0ReplayResult | null> {
+  const { input, skill, skillRow, trigger, vars, destructiveStepN } = opts;
+
+  // The ONLY allowed key var is message_id (gate-v2.ts's ALLOWED_KEY_VARS)
+  // — if the fired event carries none, there is no key to claim on. Fall
+  // through to v1 rather than guessing; nothing has executed yet.
+  const keyValue = trigger.messageId;
+  if (!keyValue) return null;
+
+  const destructiveStep = skill.steps.find((s) => s.n === destructiveStepN);
+  if (!destructiveStep) return null; // defensive; passesGateV2 already guarantees this exists
+
+  let tools: Record<string, ReelierTool>;
+  try {
+    tools = await opts.buildTools(input);
+  } catch {
+    // Nothing executed yet — a normal precondition skip, full fallback safe.
+    return null;
+  }
+
+  const events = { skippedClaimed: false };
+  const wrappedTools = wrapToolWithSendClaim(
+    tools,
+    destructiveStep.actionTool,
+    { orgId: input.orgId, skillId: skillRow.id, stepN: destructiveStepN, idempotencyKey: keyValue },
+    events,
+    opts.claimSendStepFn,
+    opts.markSendClaimOutcomeFn,
+  );
+
+  let record: ReelierRunRecord;
+  try {
+    // maxLevel STAYS 0 — same hard invariant as v1 (module header). v2
+    // never raises it: escalation must never touch the destructive step's
+    // args (spec §4), and at maxLevel 0 reelier never constructs an LLM
+    // client at all, so that invariant holds structurally, not by
+    // convention.
+    //
+    // allowDestructive IS true here — unlike v1's hardcoded false. Reelier's
+    // OWN runner refuses ANY step whose raw compiled effect is
+    // 'destructive' unless this is set (independent of SF's allowlist);
+    // v2's whole purpose is letting the ONE gate-validated destructive step
+    // execute for real. This is safe ONLY because passesGateV2 (called by
+    // the caller before reaching here) already verified there is EXACTLY
+    // one such step AND that no other step's raw effect is 'destructive'
+    // either — see gate-v2.ts's "EXECUTION-LAYER guard" comment. Never used
+    // outside this v2 branch; v1's own runSkillFn call below is unchanged.
+    record = await opts.runSkillFn(skill, {
+      tools: wrappedTools,
+      allowDestructive: true,
+      maxLevel: 0,
+      dryRun: true,
+      vars,
+    });
+  } catch (err) {
+    // A raw runSkill throw (not a clean per-step divergence) is ambiguous
+    // about WHERE it happened — v2 treats any ambiguity here as
+    // conservatively as the claim-error path: never risk a fallback that
+    // could double-send. Unlike v1 (which always falls back on a throw),
+    // this is failed-post-send, no exceptions.
+    return {
+      kind: "failed-post-send",
+      skillId: skillRow.id,
+      record: emptyFailedRecord(skill.name, "runSkill threw (v2)"),
+      failures: [err instanceof Error ? err.message : String(err)],
+      destructiveStepN,
+    };
+  }
+
+  const toolCallsFor = (rec: ReelierRunRecord) =>
+    rec.steps.map((stepRecord, idx) => ({
+      tool: skill.steps[idx]?.actionTool ?? stepRecord.title,
+      ok: true,
+      note:
+        stepRecord.n === destructiveStepN && events.skippedClaimed
+          ? `replay-l0-v2: ${stepRecord.title} (skipped-claimed — already sent by a prior attempt)`
+          : `replay-l0-v2: ${stepRecord.title}`,
+    }));
+
+  if (record.passed) {
+    return {
+      kind: "passed",
+      skillId: skillRow.id,
+      record,
+      toolCalls: toolCallsFor(record),
+      replyText: undefined,
+    };
+  }
+
+  // Diverged — the asymmetric policy (spec §3): find where.
+  const failedStep = record.steps.find((s) => s.outcome === "failed");
+  const failedStepN = failedStep?.n ?? Number.MAX_SAFE_INTEGER;
+
+  if (failedStepN < destructiveStepN) {
+    // Strictly BEFORE the destructive step — nothing side-effecting ran.
+    // Same fallback semantics as v1's diverged kind.
+    return {
+      kind: "diverged",
+      skillId: skillRow.id,
+      record,
+      failures: record.steps.flatMap((s) => s.failures),
+    };
+  }
+
+  // AT or AFTER the destructive step — no agent fallback, ever.
+  return {
+    kind: "failed-post-send",
+    skillId: skillRow.id,
+    record,
+    failures: record.steps.flatMap((s) => s.failures),
+    destructiveStepN,
+  };
+}
+
+/**
  * Try to satisfy this deployment's turn via a deterministic L0 skill replay.
  * FAIL-OPEN BY CONTRACT: never throws — any unexpected error anywhere in
  * this path degrades to `{kind:"skipped", reason}` so the caller always
@@ -304,6 +568,54 @@ export async function attemptL0Replay(
       };
     }
 
+    // Trigger vars (gap 1) — the ONLY vars a skill's {{...}} templates get
+    // filled from. message_id mirrors the same value already used
+    // upstream as the dedupe/claim trigger_key; "" (never undefined) when
+    // a field is absent so reelier's fillTemplate always finds the key
+    // (an EMPTY resolved value, not a missing one) — an unresolved
+    // {{var}} outside this fixed set still throws inside fillTemplate,
+    // which the runner turns into a step failure → diverge (unchanged).
+    // Moved above the v1 gate (was previously constructed just before
+    // runSkillFn) so BOTH the v2 branch below and v1's own runSkillFn call
+    // can share it — pure, no side effects, so this reordering changes
+    // nothing about v1's own behavior.
+    const vars: Record<string, string> = {
+      message_id: trigger.messageId ?? "",
+      sender: trigger.sender,
+      subject: trigger.subject,
+    };
+
+    // Replay gate v2 (spec) — tried FIRST, only when the flag is on AND the
+    // skill carries a validated idempotency config. Any other case (flag
+    // off, no config, a malformed config, or a config that doesn't satisfy
+    // passesGateV2) falls straight through to the UNCHANGED v1 path below —
+    // byte-identical v1 behavior, per the spec's own test matrix.
+    const idempotencyValidated = validateIdempotencyConfig(skillRow.idempotency);
+    const v2FlagOn = isReplayGateV2On({ SF_REPLAY_GATE_V2: process.env.SF_REPLAY_GATE_V2 });
+    const idempotencyConfig = idempotencyValidated.ok ? idempotencyValidated.config : null;
+    if (v2FlagOn && idempotencyConfig) {
+      const gateV2 = passesGateV2(skill, idempotencyConfig);
+      if (gateV2.ok) {
+        const v2Result = await attemptV2Replay({
+          input,
+          skill,
+          skillRow,
+          trigger,
+          vars,
+          destructiveStepN: gateV2.destructiveStepN,
+          buildTools,
+          runSkillFn,
+          claimSendStepFn: deps?.claimSendStep ?? defaultClaimSendStep,
+          markSendClaimOutcomeFn: deps?.markSendClaimOutcome ?? defaultMarkSendClaimOutcome,
+        });
+        if (v2Result) return v2Result;
+        // v2Result === null means "fell through" (e.g. no message_id at
+        // runtime to key the claim on) — treated as a precondition skip,
+        // exactly like v1's own precondition skips, safe because nothing
+        // executed yet.
+      }
+    }
+
     if (!passesAllReadGate(skill)) {
       return {
         kind: "skipped",
@@ -321,19 +633,6 @@ export async function attemptL0Replay(
         reason: `tool bridge failed: ${err instanceof Error ? err.message : String(err)}`,
       };
     }
-
-    // Trigger vars (gap 1) — the ONLY vars a skill's {{...}} templates get
-    // filled from. message_id mirrors the same value already used
-    // upstream as the dedupe/claim trigger_key; "" (never undefined) when
-    // a field is absent so reelier's fillTemplate always finds the key
-    // (an EMPTY resolved value, not a missing one) — an unresolved
-    // {{var}} outside this fixed set still throws inside fillTemplate,
-    // which the runner turns into a step failure → diverge (unchanged).
-    const vars: Record<string, string> = {
-      message_id: trigger.messageId ?? "",
-      sender: trigger.sender,
-      subject: trigger.subject,
-    };
 
     let record: ReelierRunRecord;
     try {

--- a/packages/crm/src/lib/deployments/replay/replay-or-turn.ts
+++ b/packages/crm/src/lib/deployments/replay/replay-or-turn.ts
@@ -50,7 +50,8 @@ export async function replayOrTurn(
     return deps.runTurn();
   }
 
-  // pass OR diverge — both are a real, recorded replay attempt.
+  // pass OR diverge OR failed-post-send — all three are a real, recorded
+  // replay attempt.
   try {
     await deps.persistReplayRun(replay);
   } catch (err) {
@@ -72,9 +73,26 @@ export async function replayOrTurn(
     return { ok: true, toolCalls: replay.toolCalls, replyText: replay.replyText };
   }
 
-  // diverged — fall back to the normal agentic turn. The fallback's own
-  // result (ok/toolCalls/replyText/errorMessage) is the user-visible
-  // result; the failed replay attempt is invisible to the end user beyond
-  // its own persisted 'replay-run' row.
+  // Replay gate v2 ONLY (spec §3, the asymmetric fallback) — a divergence
+  // AT or AFTER the destructive step. deps.runTurn() is NEVER called here:
+  // the destructive step may have already sent for real, so a fresh
+  // agentic turn risks a genuine double-send. The run ends here,
+  // unsuccessfully, with a loud errorMessage — the SAME plumbing every
+  // other run-failure already uses to surface an error receipt
+  // (composio-event-dispatch.ts's writeReceipt reads this errorMessage),
+  // so no new receipt code is needed for the "loud receipt note" the spec
+  // calls for.
+  if (replay.kind === "failed-post-send") {
+    return {
+      ok: false,
+      errorMessage: `replay diverged AFTER its destructive step (skill ${replay.skillId}, step ${replay.destructiveStepN}) — no agent fallback attempted (would risk a real double-send); failures: ${replay.failures.join("; ") || "unknown"}`,
+    };
+  }
+
+  // diverged (v1, or v2 strictly BEFORE the destructive step) — fall back
+  // to the normal agentic turn. The fallback's own result
+  // (ok/toolCalls/replyText/errorMessage) is the user-visible result; the
+  // failed replay attempt is invisible to the end user beyond its own
+  // persisted 'replay-run' row.
   return deps.runTurn();
 }

--- a/packages/crm/src/lib/deployments/replay/send-claim.ts
+++ b/packages/crm/src/lib/deployments/replay/send-claim.ts
@@ -1,0 +1,126 @@
+// Replay gate v2 — the send-claim ledger (spec §2, migration 0077's
+// replay_send_claims). Mirrors deployments/store.ts's claimComposioPushRun
+// idiom: ONE atomic write is the lock, a Postgres unique-violation (23505)
+// on that write means "someone else already claimed this" — fails CLOSED
+// (never executes, never throws into the caller as an ambiguous state).
+//
+// Lifecycle: claimSendStep (INSERT, outcome='unknown') BEFORE the
+// destructive tool call runs -> markSendClaimOutcome('sent'|'failed') AFTER
+// it resolves. The claim row is NEVER deleted or retried automatically —
+// a failed claim intentionally blocks a later automatic retry from
+// re-attempting an ambiguous send (spec §2: "a failed send may or may not
+// have delivered ... the claim stays, preventing automatic retry").
+import type {
+  NewReplaySendClaimRow,
+  ReplaySendClaimOutcome,
+} from "@/db/schema/replay-send-claims";
+
+export type ClaimSendStepInput = {
+  orgId: string;
+  skillId: string;
+  stepN: number;
+  /** The resolved key VALUE (e.g. the fired event's message_id) — never
+   *  the var name. */
+  idempotencyKey: string;
+};
+
+export type ClaimSendStepResult =
+  | { claimed: true; claimId: string }
+  | { claimed: false; reason: "already-claimed" | "claim-error" };
+
+/** Injectable I/O — defaults to real DB calls (kept out of the top-level
+ *  import graph so this module stays test-friendly, mirroring every other
+ *  replay module's Deps pattern). */
+export type SendClaimDeps = {
+  insert?: (row: NewReplaySendClaimRow) => Promise<{ id: string }>;
+  updateOutcome?: (claimId: string, outcome: ReplaySendClaimOutcome) => Promise<void>;
+};
+
+async function defaultInsert(row: NewReplaySendClaimRow): Promise<{ id: string }> {
+  const { db } = await import("@/db");
+  const { replaySendClaims } = await import("@/db/schema/replay-send-claims");
+  const [inserted] = await db
+    .insert(replaySendClaims)
+    .values(row)
+    .returning({ id: replaySendClaims.id });
+  return inserted;
+}
+
+async function defaultUpdateOutcome(
+  claimId: string,
+  outcome: ReplaySendClaimOutcome,
+): Promise<void> {
+  const { db } = await import("@/db");
+  const { replaySendClaims } = await import("@/db/schema/replay-send-claims");
+  const { eq } = await import("drizzle-orm");
+  await db.update(replaySendClaims).set({ outcome }).where(eq(replaySendClaims.id, claimId));
+}
+
+/** True iff `err` is a Postgres unique-constraint violation (code 23505).
+ *  Same check as deployments/store.ts's claimComposioPushRun error path /
+ *  scripts/replay-ops.ts's isUniqueViolation — reimplemented locally
+ *  (each of those modules' own contract is about a different domain), a
+ *  one-line dependency-free check. */
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  return (err as { code?: string }).code === "23505";
+}
+
+/**
+ * Attempt to claim the send-once slot for one (skill, step, key). FAILS
+ * CLOSED on any ambiguity:
+ *  - unique-violation (someone already claimed this key) -> `claimed:false,
+ *    reason:"already-claimed"` — the caller must NOT execute the send;
+ *    treat it as already-sent and continue past this step.
+ *  - any OTHER insert failure (DB error, connectivity) -> `claimed:false,
+ *    reason:"claim-error"` — the caller must ALSO not execute (we cannot
+ *    tell whether a prior attempt succeeded), but this is a real failure
+ *    (not "already sent") and should propagate as a step failure so the
+ *    run is honestly recorded as failed-post-send rather than silently
+ *    treated as a successful skip. Never throws.
+ */
+export async function claimSendStep(
+  input: ClaimSendStepInput,
+  deps?: SendClaimDeps,
+): Promise<ClaimSendStepResult> {
+  const insert = deps?.insert ?? defaultInsert;
+  try {
+    const row = await insert({
+      orgId: input.orgId,
+      skillId: input.skillId,
+      stepN: input.stepN,
+      idempotencyKey: input.idempotencyKey,
+      outcome: "unknown",
+    });
+    return { claimed: true, claimId: row.id };
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      return { claimed: false, reason: "already-claimed" };
+    }
+    console.warn(
+      "[deployments/replay/send-claim] claim insert failed (treated as claim-error, fails closed):",
+      err instanceof Error ? err.message : String(err),
+    );
+    return { claimed: false, reason: "claim-error" };
+  }
+}
+
+/** Record the outcome of an executed send. FAIL-SOFT — a bookkeeping write
+ *  must never mask the underlying tool result the caller already has (the
+ *  claim row exists either way; a failed write here just means it stays
+ *  'unknown' until someone investigates, never silently 'sent'). */
+export async function markSendClaimOutcome(
+  claimId: string,
+  outcome: ReplaySendClaimOutcome,
+  deps?: SendClaimDeps,
+): Promise<void> {
+  try {
+    const updateOutcome = deps?.updateOutcome ?? defaultUpdateOutcome;
+    await updateOutcome(claimId, outcome);
+  } catch (err) {
+    console.warn(
+      "[deployments/replay/send-claim] markSendClaimOutcome failed (fail-soft):",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}

--- a/packages/crm/src/lib/web-build/policy.ts
+++ b/packages/crm/src/lib/web-build/policy.ts
@@ -87,3 +87,16 @@ export function isDeterministicReplayOn(env: {
 }): boolean {
   return env.SF_DETERMINISTIC_REPLAY?.trim() === "1";
 }
+
+/** Replay gate v2 — idempotent-send (2026-07-18,
+ *  docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md). Separate flag
+ *  from SF_DETERMINISTIC_REPLAY by design (spec §1): turning this on alone
+ *  does nothing — a skill must ALSO carry a valid idempotency config
+ *  (replay_skills.idempotency, set via `replay-ops.ts set-idempotency`)
+ *  before lib/deployments/replay/replay-before-llm.ts's v2 branch ever
+ *  activates for it. Same strict-"1" contract as every other flag here:
+ *  dark by default. When off (or a skill has no idempotency config), replay
+ *  behavior is BYTE-IDENTICAL to v1 — see gate-v2.ts's module header. */
+export function isReplayGateV2On(env: { SF_REPLAY_GATE_V2?: string | undefined }): boolean {
+  return env.SF_REPLAY_GATE_V2?.trim() === "1";
+}

--- a/packages/crm/tests/unit/deployments/replay/gate-v2.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/gate-v2.spec.ts
@@ -147,4 +147,42 @@ describe("passesGateV2 — eligibility", () => {
     const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
     assert.deepEqual(result, { ok: true, destructiveStepN: 1 });
   });
+
+  // Reviewer P2 (security-critical, pre-merge): rawEffectsOk is the guard
+  // that stops allowDestructive:true (set for the whole v2 run) from giving
+  // a free pass to a step SF's allowlist trusts as 'read' but whose raw
+  // COMPILED skill_md line still says 'destructive' — reelier's own runner
+  // gates purely on that raw line, not on tool-effects.ts. Without this
+  // guard such a step would execute for real without ever going through
+  // the claim wrapper (only the declared destructive step's tool is
+  // wrapped). See gate-v2.ts's "EXECUTION-LAYER guard" comment.
+  test("a non-declared step with an allowlist-READ tool but raw effect:'destructive' is refused (the anti-bypass guard)", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "destructive", actionTool: "take_message" }),
+        // GMAIL_FETCH_EMAILS is allowlisted 'read' (tool-effects.ts), so
+        // trustedEffect() would happily count this as read/idempotent-write
+        // and NOT as the skill's second destructive step — but its raw
+        // compiled effect line disagrees, which is exactly what
+        // rawEffectsOk exists to catch.
+        makeStep({ n: 2, effect: "destructive", actionTool: "composio__GMAIL_FETCH_EMAILS" }),
+      ],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.equal(result.ok, false);
+    if (!result.ok) {
+      assert.match(result.reason, /raw compiled effect/);
+    }
+  });
+
+  test("INVERSE CONTROL: the same skill with that step's raw effect 'read' (matching its allowlist trust) is eligible", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "destructive", actionTool: "take_message" }),
+        makeStep({ n: 2, effect: "read", actionTool: "composio__GMAIL_FETCH_EMAILS" }),
+      ],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.deepEqual(result, { ok: true, destructiveStepN: 1 });
+  });
 });

--- a/packages/crm/tests/unit/deployments/replay/gate-v2.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/gate-v2.spec.ts
@@ -1,0 +1,150 @@
+// Replay gate v2 — passesGateV2 / validateIdempotencyConfig unit tests
+// (docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md §1, §4).
+// Mirrors replay-before-llm.spec.ts's fixture style (makeStep) so the two
+// gates stay directly comparable.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { passesGateV2, validateIdempotencyConfig } from "@/lib/deployments/replay/gate-v2";
+import type { ReelierSkill } from "@seldonframe/reelier/skill";
+
+function makeStep(overrides: Partial<ReelierSkill["steps"][number]> = {}): ReelierSkill["steps"][number] {
+  return {
+    n: 1,
+    title: "step",
+    intent: "do a thing",
+    actionTool: "look_up_availability",
+    actionArgs: {},
+    asserts: [],
+    binds: [],
+    effect: "read",
+    line: 1,
+    ...overrides,
+  };
+}
+
+describe("validateIdempotencyConfig", () => {
+  test("null/undefined is valid — not v2-eligible", () => {
+    assert.deepEqual(validateIdempotencyConfig(null), { ok: true, config: null });
+    assert.deepEqual(validateIdempotencyConfig(undefined), { ok: true, config: null });
+  });
+
+  test("a well-formed {stepN, keyVar: message_id} config is accepted", () => {
+    const result = validateIdempotencyConfig({ stepN: 2, keyVar: "message_id" });
+    assert.deepEqual(result, { ok: true, config: { stepN: 2, keyVar: "message_id" } });
+  });
+
+  test("keyVar 'sender' is rejected — sender is attacker-influenceable, forbidden as key material", () => {
+    const result = validateIdempotencyConfig({ stepN: 2, keyVar: "sender" });
+    assert.equal(result.ok, false);
+  });
+
+  test("keyVar 'subject' is rejected — same reason as sender", () => {
+    const result = validateIdempotencyConfig({ stepN: 2, keyVar: "subject" });
+    assert.equal(result.ok, false);
+  });
+
+  test("a non-integer or zero/negative stepN is rejected", () => {
+    assert.equal(validateIdempotencyConfig({ stepN: 0, keyVar: "message_id" }).ok, false);
+    assert.equal(validateIdempotencyConfig({ stepN: 1.5, keyVar: "message_id" }).ok, false);
+    assert.equal(validateIdempotencyConfig({ stepN: "2", keyVar: "message_id" }).ok, false);
+  });
+
+  test("an unknown key is rejected", () => {
+    const result = validateIdempotencyConfig({ stepN: 2, keyVar: "message_id", extra: "x" });
+    assert.equal(result.ok, false);
+  });
+
+  test("a non-object value is rejected", () => {
+    assert.equal(validateIdempotencyConfig("nope").ok, false);
+    assert.equal(validateIdempotencyConfig(42).ok, false);
+    assert.equal(validateIdempotencyConfig([1, 2]).ok, false);
+  });
+});
+
+describe("passesGateV2 — eligibility", () => {
+  test("read steps + exactly one destructive step (not necessarily last) passes, matching declared stepN", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "read", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "destructive", actionTool: "book_appointment" }),
+        makeStep({ n: 3, effect: "idempotent-write", actionTool: "escalate_to_human" }),
+      ],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 2, keyVar: "message_id" });
+    assert.deepEqual(result, { ok: true, destructiveStepN: 2 });
+  });
+
+  test("two destructive steps refused — v2 requires EXACTLY one", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "destructive", actionTool: "book_appointment" }),
+        makeStep({ n: 2, effect: "destructive", actionTool: "take_message" }),
+      ],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.equal(result.ok, false);
+  });
+
+  test("zero destructive steps refused — v2 requires EXACTLY one (a pure-read skill has nothing to key)", () => {
+    const skill = {
+      steps: [makeStep({ n: 1, effect: "read", actionTool: "look_up_availability" })],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.equal(result.ok, false);
+  });
+
+  test("declared stepN not matching the skill's actual destructive step is refused", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "read", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "destructive", actionTool: "book_appointment" }),
+      ],
+    } as ReelierSkill;
+    // Operator declared step 1 as the destructive one, but it's actually step 2.
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.equal(result.ok, false);
+  });
+
+  test("keyVar 'sender'/'subject' is refused even with an otherwise-valid single destructive step", () => {
+    const skill = {
+      steps: [makeStep({ n: 1, effect: "destructive", actionTool: "book_appointment" })],
+    } as ReelierSkill;
+    assert.equal(passesGateV2(skill, { stepN: 1, keyVar: "sender" }).ok, false);
+    assert.equal(passesGateV2(skill, { stepN: 1, keyVar: "subject" }).ok, false);
+  });
+
+  test("an UNKNOWN tool (not in tool-effects.ts allowlist) is treated as destructive — same v1 search_and_purge protection", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "read", actionTool: "look_up_availability" }),
+        makeStep({ n: 2, effect: "read", actionTool: "search_and_purge" }),
+      ],
+    } as ReelierSkill;
+    // search_and_purge is unknown -> trustedEffect -> "destructive", so this
+    // IS a valid single-destructive-step skill from the gate's point of view.
+    const result = passesGateV2(skill, { stepN: 2, keyVar: "message_id" });
+    assert.deepEqual(result, { ok: true, destructiveStepN: 2 });
+  });
+
+  test("an empty skill never passes", () => {
+    const result = passesGateV2({ steps: [] } as unknown as ReelierSkill, {
+      stepN: 1,
+      keyVar: "message_id",
+    });
+    assert.equal(result.ok, false);
+  });
+
+  test("post-send steps are allowed — v2's whole point vs v1 (destructive step need not be last)", () => {
+    const skill = {
+      steps: [
+        makeStep({ n: 1, effect: "destructive", actionTool: "take_message" }),
+        makeStep({ n: 2, effect: "idempotent-write", actionTool: "escalate_to_human" }),
+        makeStep({ n: 3, effect: "read", actionTool: "look_up_availability" }),
+      ],
+    } as ReelierSkill;
+    const result = passesGateV2(skill, { stepN: 1, keyVar: "message_id" });
+    assert.deepEqual(result, { ok: true, destructiveStepN: 1 });
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/replay-gate-v2-execution.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-gate-v2-execution.spec.ts
@@ -1,0 +1,445 @@
+// Replay gate v2 — attemptL0Replay's v2 execution branch
+// (docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md §2, §3).
+// Deliberately does NOT override `runSkill` in deps — unlike
+// replay-before-llm.spec.ts's v1 tests (which fake runSkill entirely to
+// isolate gate logic), these tests let the REAL @seldonframe/reelier
+// runSkill execute against a FAKE tool registry, because the property
+// under test IS the integration between the claim wrapper
+// (wrapToolWithSendClaim, module-private) and reelier's real per-step
+// loop — faking runSkill too would test nothing but our own mock.
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { attemptL0Replay, type AttemptL0ReplayDeps } from "@/lib/deployments/replay/replay-before-llm";
+import type { ReelierSkill } from "@seldonframe/reelier/skill";
+import type { ReelierObservation, ReelierTool, ReelierToolRunCtx } from "@seldonframe/reelier";
+
+const ORG = "org_1";
+const DEPLOYMENT = "dep_1";
+const SKILL_ID = "skill_1";
+const MESSAGE_ID = "msg_123";
+
+function baseInput() {
+  return {
+    orgId: ORG,
+    deploymentId: DEPLOYMENT,
+    orgSlug: "acme",
+    timezone: "UTC",
+    blueprint: { capabilities: [] } as never,
+    trigger: { messageId: MESSAGE_ID, sender: "a@b.com", subject: "hi" },
+  };
+}
+
+function makeStep(overrides: Partial<ReelierSkill["steps"][number]> = {}): ReelierSkill["steps"][number] {
+  return {
+    n: 1,
+    title: "step",
+    intent: "do a thing",
+    actionTool: "look_up_availability",
+    actionArgs: {},
+    asserts: ["status == 200"],
+    binds: [],
+    effect: "read",
+    line: 1,
+    ...overrides,
+  };
+}
+
+/** A v2-eligible 3-step skill: read -> destructive (step 2) -> idempotent-write. */
+function v2Skill(): ReelierSkill {
+  return {
+    name: "v2-forwarder",
+    description: "d",
+    steps: [
+      makeStep({ n: 1, title: "lookup", actionTool: "look_up_availability", effect: "read" }),
+      makeStep({ n: 2, title: "send", actionTool: "take_message", effect: "destructive" }),
+      makeStep({ n: 3, title: "escalate", actionTool: "escalate_to_human", effect: "idempotent-write" }),
+    ],
+    preamble: "",
+    trailing: "",
+  };
+}
+
+/** A v1-ELIGIBLE skill too (single destructive step, LAST) — used to prove
+ *  "v2 refuses -> falls through to v1, byte-identical" without needing a
+ *  golden-file diff: same skill, only the v2 preconditions vary. */
+function v1AndV2EligibleSkill(): ReelierSkill {
+  return {
+    name: "v1-or-v2",
+    description: "d",
+    steps: [
+      makeStep({ n: 1, title: "lookup", actionTool: "look_up_availability", effect: "read" }),
+      makeStep({ n: 2, title: "send", actionTool: "take_message", effect: "destructive" }),
+    ],
+    preamble: "",
+    trailing: "",
+  };
+}
+
+function fakeTool(run: (args: unknown, ctx: ReelierToolRunCtx) => Promise<ReelierObservation>): ReelierTool {
+  return { effect: "destructive", run };
+}
+
+const OK: ReelierObservation = { status: 200, headers: {}, body: "{}" };
+const FAIL: ReelierObservation = { status: 500, headers: {}, body: JSON.stringify({ error: "boom" }) };
+
+let savedFlag: string | undefined;
+beforeEach(() => {
+  savedFlag = process.env.SF_REPLAY_GATE_V2;
+});
+afterEach(() => {
+  if (savedFlag === undefined) delete process.env.SF_REPLAY_GATE_V2;
+  else process.env.SF_REPLAY_GATE_V2 = savedFlag;
+});
+
+describe("attemptL0Replay — v2 happy path", () => {
+  test("claim goes unknown->sent, and the POST-send step still executes for real", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    let lookupCalls = 0;
+    let sendCalls = 0;
+    let escalateCalls = 0;
+    const claimCalls: Array<{ orgId: string; skillId: string; stepN: number; idempotencyKey: string }> = [];
+    const markCalls: Array<{ claimId: string; outcome: string }> = [];
+
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => v2Skill(),
+      buildTools: async () => ({
+        look_up_availability: fakeTool(async () => {
+          lookupCalls++;
+          return OK;
+        }),
+        take_message: fakeTool(async () => {
+          sendCalls++;
+          return OK;
+        }),
+        escalate_to_human: fakeTool(async () => {
+          escalateCalls++;
+          return OK;
+        }),
+      }),
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "claim_1" };
+      },
+      markSendClaimOutcome: async (claimId, outcome) => {
+        markCalls.push({ claimId, outcome });
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "passed");
+    assert.equal(lookupCalls, 1);
+    assert.equal(sendCalls, 1, "the real send tool must run exactly once on a fresh claim");
+    assert.equal(escalateCalls, 1, "a post-send step must still execute for real");
+    assert.deepEqual(claimCalls, [
+      { orgId: ORG, skillId: SKILL_ID, stepN: 2, idempotencyKey: MESSAGE_ID },
+    ]);
+    assert.deepEqual(markCalls, [{ claimId: "claim_1", outcome: "sent" }]);
+
+    if (result.kind === "passed") {
+      const sendCall = result.toolCalls.find((c) => c.tool === "take_message");
+      assert.ok(sendCall);
+      assert.ok(!sendCall!.note?.includes("skipped-claimed"));
+    }
+  });
+});
+
+describe("attemptL0Replay — pre-send divergence still falls back", () => {
+  test("a read-step failure BEFORE the destructive step -> kind:'diverged' (never failed-post-send), send never attempted", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    let sendCalls = 0;
+    const claimCalls: unknown[] = [];
+
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => v2Skill(),
+      buildTools: async () => ({
+        look_up_availability: fakeTool(async () => FAIL), // step 1 fails its assert
+        take_message: fakeTool(async () => {
+          sendCalls++;
+          return OK;
+        }),
+        escalate_to_human: fakeTool(async () => OK),
+      }),
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "claim_1" };
+      },
+      markSendClaimOutcome: async () => {},
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "diverged");
+    assert.equal(sendCalls, 0, "the destructive step must never even be attempted");
+    assert.equal(claimCalls.length, 0, "no claim is ever taken before the destructive step runs");
+  });
+});
+
+describe("attemptL0Replay — send tool error", () => {
+  test("a failing send -> failed-post-send, claim outcome=failed, post-send steps never run", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    let escalateCalls = 0;
+    const markCalls: Array<{ claimId: string; outcome: string }> = [];
+
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => v2Skill(),
+      buildTools: async () => ({
+        look_up_availability: fakeTool(async () => OK),
+        take_message: fakeTool(async () => FAIL), // the send itself fails
+        escalate_to_human: fakeTool(async () => {
+          escalateCalls++;
+          return OK;
+        }),
+      }),
+      claimSendStep: async () => ({ claimed: true, claimId: "claim_1" }),
+      markSendClaimOutcome: async (claimId, outcome) => {
+        markCalls.push({ claimId, outcome });
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "failed-post-send");
+    if (result.kind === "failed-post-send") {
+      assert.equal(result.destructiveStepN, 2);
+    }
+    assert.deepEqual(markCalls, [{ claimId: "claim_1", outcome: "failed" }]);
+    assert.equal(escalateCalls, 0, "steps after a diverged destructive step are skipped by reelier itself");
+  });
+});
+
+describe("attemptL0Replay — claim-error fails closed", () => {
+  test("an ambiguous claim (claim-error) refuses to execute the send at all", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    let sendCalls = 0;
+
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => v2Skill(),
+      buildTools: async () => ({
+        look_up_availability: fakeTool(async () => OK),
+        take_message: fakeTool(async () => {
+          sendCalls++;
+          return OK;
+        }),
+        escalate_to_human: fakeTool(async () => OK),
+      }),
+      claimSendStep: async () => ({ claimed: false, reason: "claim-error" }),
+      markSendClaimOutcome: async () => {},
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "failed-post-send");
+    assert.equal(sendCalls, 0, "an ambiguous claim must never execute the real send tool");
+  });
+});
+
+describe("attemptL0Replay — redelivery convergence", () => {
+  test("already-claimed (redelivery) -> the send is skipped-claimed, but post-send steps still run for real", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    let sendCalls = 0;
+    let escalateCalls = 0;
+
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => v2Skill(),
+      buildTools: async () => ({
+        look_up_availability: fakeTool(async () => OK),
+        take_message: fakeTool(async () => {
+          sendCalls++;
+          return OK;
+        }),
+        escalate_to_human: fakeTool(async () => {
+          escalateCalls++;
+          return OK;
+        }),
+      }),
+      claimSendStep: async () => ({ claimed: false, reason: "already-claimed" }),
+      markSendClaimOutcome: async () => {},
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "passed");
+    assert.equal(sendCalls, 0, "the real send tool must NEVER run on a redelivery");
+    assert.equal(escalateCalls, 1, "post-send steps must still run — redelivery convergence");
+
+    if (result.kind === "passed") {
+      const sendCall = result.toolCalls.find((c) => c.tool === "take_message");
+      assert.ok(sendCall?.note?.includes("skipped-claimed"));
+    }
+  });
+});
+
+describe("attemptL0Replay — v2 gate refuses -> falls through to v1, byte-identical", () => {
+  test("SF_REPLAY_GATE_V2 off -> v1 path runs unchanged, the claim ledger is never touched", async () => {
+    delete process.env.SF_REPLAY_GATE_V2;
+
+    const claimCalls: unknown[] = [];
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" }, // config present but flag is off
+      }),
+      parseSkill: async () => v1AndV2EligibleSkill(),
+      buildTools: async () => ({}),
+      runSkill: async () => ({
+        skill: "v1-or-v2",
+        startedAt: "2026-07-18T00:00:00.000Z",
+        finishedAt: "2026-07-18T00:00:01.000Z",
+        passed: true,
+        steps: [
+          { n: 1, title: "lookup", level: 0, outcome: "passed", ms: 1, failures: [] },
+          { n: 2, title: "send", level: 0, outcome: "passed", ms: 1, failures: [] },
+        ],
+        totals: { steps: 2, passed: 2, unchecked: 0, skipped: 0, failed: 0, ms: 2, llmInputTokens: 0, llmOutputTokens: 0 },
+      }),
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "should-never-happen" };
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "passed");
+    assert.equal(claimCalls.length, 0, "the claim ledger must never engage when the flag is off");
+    if (result.kind === "passed") {
+      assert.ok(result.toolCalls.every((c) => c.note?.startsWith("replay-l0:")), "v1's own toolCalls note format, not v2's");
+    }
+  });
+
+  test("keyVar 'sender' (forbidden key material) -> config invalid -> v1 path runs unchanged", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    const claimCalls: unknown[] = [];
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "sender" },
+      }),
+      parseSkill: async () => v1AndV2EligibleSkill(),
+      buildTools: async () => ({}),
+      runSkill: async () => ({
+        skill: "v1-or-v2",
+        startedAt: "2026-07-18T00:00:00.000Z",
+        finishedAt: "2026-07-18T00:00:01.000Z",
+        passed: true,
+        steps: [{ n: 1, title: "lookup", level: 0, outcome: "passed", ms: 1, failures: [] }, { n: 2, title: "send", level: 0, outcome: "passed", ms: 1, failures: [] }],
+        totals: { steps: 2, passed: 2, unchecked: 0, skipped: 0, failed: 0, ms: 2, llmInputTokens: 0, llmOutputTokens: 0 },
+      }),
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "should-never-happen" };
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "passed");
+    assert.equal(claimCalls.length, 0);
+  });
+
+  test("missing idempotency config -> v1 path runs unchanged", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    const claimCalls: unknown[] = [];
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({ id: SKILL_ID, skillMd: "irrelevant" }), // no idempotency field at all
+      parseSkill: async () => v1AndV2EligibleSkill(),
+      buildTools: async () => ({}),
+      runSkill: async () => ({
+        skill: "v1-or-v2",
+        startedAt: "2026-07-18T00:00:00.000Z",
+        finishedAt: "2026-07-18T00:00:01.000Z",
+        passed: true,
+        steps: [{ n: 1, title: "lookup", level: 0, outcome: "passed", ms: 1, failures: [] }, { n: 2, title: "send", level: 0, outcome: "passed", ms: 1, failures: [] }],
+        totals: { steps: 2, passed: 2, unchecked: 0, skipped: 0, failed: 0, ms: 2, llmInputTokens: 0, llmOutputTokens: 0 },
+      }),
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "should-never-happen" };
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+    assert.equal(result.kind, "passed");
+    assert.equal(claimCalls.length, 0);
+  });
+
+  test("two destructive steps -> passesGateV2 refuses -> falls through to v1's OWN refusal, identical reason text", async () => {
+    process.env.SF_REPLAY_GATE_V2 = "1";
+
+    const twoDestructive: ReelierSkill = {
+      name: "two-destructive",
+      description: "d",
+      steps: [
+        makeStep({ n: 1, title: "lookup", actionTool: "look_up_availability", effect: "read" }),
+        makeStep({ n: 2, title: "send1", actionTool: "take_message", effect: "destructive" }),
+        makeStep({ n: 3, title: "send2", actionTool: "book_appointment", effect: "destructive" }),
+      ],
+      preamble: "",
+      trailing: "",
+    };
+
+    const claimCalls: unknown[] = [];
+    let runSkillCalled = false;
+    const deps: AttemptL0ReplayDeps = {
+      loadEnabledSkill: async () => ({
+        id: SKILL_ID,
+        skillMd: "irrelevant",
+        idempotency: { stepN: 2, keyVar: "message_id" },
+      }),
+      parseSkill: async () => twoDestructive,
+      runSkill: async () => {
+        runSkillCalled = true;
+        throw new Error("should never be called — v1's own all-read gate must refuse first");
+      },
+      claimSendStep: async (input) => {
+        claimCalls.push(input);
+        return { claimed: true, claimId: "should-never-happen" };
+      },
+    };
+
+    const result = await attemptL0Replay(baseInput(), deps);
+
+    assert.equal(result.kind, "skipped");
+    if (result.kind === "skipped") {
+      assert.match(result.reason, /all-read gate refused/);
+    }
+    assert.equal(claimCalls.length, 0);
+    assert.equal(runSkillCalled, false);
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-or-turn.spec.ts
@@ -144,3 +144,38 @@ describe("replayOrTurn — skipped falls back WITHOUT persisting a run record", 
     assert.equal(result.replyText, "turn ran");
   });
 });
+
+describe("replayOrTurn — replay gate v2's asymmetric fallback (failed-post-send)", () => {
+  test("runTurn is NEVER called on a post-send divergence — the whole point of the asymmetric policy", async () => {
+    const { deps, runTurnCalled } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "failed-post-send",
+        skillId: "skill_1",
+        record: divergeRecord(),
+        failures: ["destructive step tool returned status 500"],
+        destructiveStepN: 2,
+      }),
+    });
+    const result = await replayOrTurn(deps, INPUT);
+    assert.equal(runTurnCalled.count, 0, "a fresh agentic turn would risk a real double-send");
+    assert.equal(result.ok, false);
+    assert.ok(result.errorMessage?.includes("skill_1"));
+    assert.ok(result.errorMessage?.includes("step 2"));
+  });
+
+  test("a post-send divergence still persists the run record (for ops visibility) but never marks the skill replayed", async () => {
+    const { deps, persisted, markedSkillIds } = baseDeps({
+      attemptL0Replay: async () => ({
+        kind: "failed-post-send",
+        skillId: "skill_1",
+        record: divergeRecord(),
+        failures: ["boom"],
+        destructiveStepN: 2,
+      }),
+    });
+    await replayOrTurn(deps, INPUT);
+    assert.equal(persisted.length, 1);
+    assert.equal(persisted[0].kind, "failed-post-send");
+    assert.equal(markedSkillIds.length, 0);
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/replay-skills-schema.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/replay-skills-schema.spec.ts
@@ -34,6 +34,7 @@ describe("replay_skills — table shape", () => {
     assert.ok("healCount" in replaySkills);
     assert.ok("lastReplayAt" in replaySkills);
     assert.ok("triggerFilter" in replaySkills);
+    assert.ok("idempotency" in replaySkills);
     assert.ok("createdAt" in replaySkills);
     assert.ok("updatedAt" in replaySkills);
   });
@@ -55,6 +56,7 @@ describe("replay_skills — table shape", () => {
       healCount: 0,
       lastReplayAt: null,
       triggerFilter: null,
+      idempotency: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
@@ -80,10 +82,30 @@ describe("replay_skills — table shape", () => {
       healCount: 0,
       lastReplayAt: null,
       triggerFilter: { senderEndsWith: "@seldonframe.com" },
+      idempotency: null,
       createdAt: new Date(),
       updatedAt: new Date(),
     };
     assert.deepEqual(row.triggerFilter, { senderEndsWith: "@seldonframe.com" });
+  });
+
+  test("idempotency round-trips a real config object (migration 0077)", () => {
+    const row: ReplaySkillRow = {
+      id: "00000000-0000-4000-8000-000000000001",
+      orgId: "00000000-0000-4000-8000-000000000002",
+      deploymentId: "00000000-0000-4000-8000-000000000003",
+      name: "email:dep_1",
+      skillMd: "---\nname: x\n---\n",
+      status: "enabled",
+      sourceTraceId: null,
+      healCount: 0,
+      lastReplayAt: null,
+      triggerFilter: null,
+      idempotency: { stepN: 3, keyVar: "message_id" },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    assert.deepEqual(row.idempotency, { stepN: 3, keyVar: "message_id" });
   });
 
   test("barrel re-export wires replay_skills into the db schema bundle", async () => {
@@ -163,5 +185,49 @@ describe("migration 0076 — trigger_filter column matches the Drizzle schema", 
     assert.ok(idx75 >= 0, "0075 must be registered");
     assert.ok(idx76 >= 0, "0076 must be registered");
     assert.equal(idx76, idx75 + 1, "0076 must immediately follow 0075");
+  });
+});
+
+describe("migration 0077 — replay gate v2 (idempotency column + send-claims table)", () => {
+  const migrationSql = readFileSync(
+    path.join(__dirname, "../../../../drizzle/0077_replay_gate_v2.sql"),
+    "utf8",
+  );
+
+  test("adds replay_skills.idempotency as a nullable jsonb column", () => {
+    assert.match(migrationSql, /ALTER TABLE "replay_skills"/);
+    assert.match(migrationSql, /ADD COLUMN IF NOT EXISTS "idempotency" jsonb;/);
+    assert.doesNotMatch(migrationSql, /"idempotency" jsonb NOT NULL/);
+  });
+
+  test("creates replay_send_claims with skill_id NOT NULL + ON DELETE CASCADE", () => {
+    assert.match(migrationSql, /CREATE TABLE IF NOT EXISTS "replay_send_claims"/);
+    assert.match(
+      migrationSql,
+      /"skill_id" uuid NOT NULL REFERENCES "replay_skills"\("id"\) ON DELETE CASCADE/,
+    );
+  });
+
+  test("creates the UNIQUE index on (skill_id, step_n, idempotency_key) — the double-send lock", () => {
+    assert.match(
+      migrationSql,
+      /CREATE UNIQUE INDEX IF NOT EXISTS "replay_send_claims_skill_step_key_idx"\s*\n\s*ON "replay_send_claims" \("skill_id", "step_n", "idempotency_key"\)/,
+    );
+  });
+
+  test("outcome defaults to 'unknown' at the SQL level", () => {
+    assert.match(migrationSql, /"outcome" text NOT NULL DEFAULT 'unknown'/);
+  });
+
+  test("journal registers 0077 after 0076", () => {
+    const journal = JSON.parse(
+      readFileSync(path.join(__dirname, "../../../../drizzle/meta/_journal.json"), "utf8"),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    const tags = journal.entries.map((e) => e.tag);
+    const idx76 = tags.indexOf("0076_replay_skills_trigger_filter");
+    const idx77 = tags.indexOf("0077_replay_gate_v2");
+    assert.ok(idx76 >= 0, "0076 must be registered");
+    assert.ok(idx77 >= 0, "0077 must be registered");
+    assert.equal(idx77, idx76 + 1, "0077 must immediately follow 0076");
   });
 });

--- a/packages/crm/tests/unit/deployments/replay/send-claim.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/send-claim.spec.ts
@@ -1,0 +1,115 @@
+// Replay gate v2 — send-claim.ts unit tests (spec §2, migration 0077's
+// replay_send_claims). The claim RACE itself is a real Postgres unique-
+// constraint behavior (no DB in this unit-test harness — see
+// tests/unit/deployments/replay/replay-before-llm.spec.ts's own DI
+// pattern) — simulated here with a fake `insert` that throws a 23505 on
+// its second call for the same key, exactly as a concurrent second INSERT
+// against the real UNIQUE index would.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { claimSendStep, markSendClaimOutcome } from "@/lib/deployments/replay/send-claim";
+
+const INPUT = { orgId: "org_1", skillId: "skill_1", stepN: 2, idempotencyKey: "msg_abc" };
+
+function uniqueViolation(): Error & { code: string } {
+  const err = new Error(
+    'duplicate key value violates unique constraint "replay_send_claims_skill_step_key_idx"',
+  ) as Error & { code: string };
+  err.code = "23505";
+  return err;
+}
+
+describe("claimSendStep — the double-send lock", () => {
+  test("claim race: two concurrent attempts for the SAME key -> exactly ONE claimed:true", async () => {
+    let calls = 0;
+    const insert = async (row: { orgId: string; skillId: string; stepN: number; idempotencyKey: string }) => {
+      calls++;
+      assert.equal(row.idempotencyKey, "msg_abc");
+      if (calls === 1) return { id: "claim_1" };
+      // The SECOND concurrent INSERT for the same (skill_id, step_n, key)
+      // loses the real unique index race.
+      throw uniqueViolation();
+    };
+
+    const [first, second] = await Promise.all([
+      claimSendStep(INPUT, { insert }),
+      claimSendStep(INPUT, { insert }),
+    ]);
+
+    const claimedResults = [first, second].filter((r) => r.claimed);
+    const notClaimedResults = [first, second].filter((r) => !r.claimed);
+    assert.equal(claimedResults.length, 1, "exactly one attempt must win the claim");
+    assert.equal(notClaimedResults.length, 1);
+    assert.equal(
+      notClaimedResults[0].claimed === false ? notClaimedResults[0].reason : undefined,
+      "already-claimed",
+    );
+  });
+
+  test("a fresh key claims successfully — outcome starts 'unknown'", async () => {
+    let capturedRow: unknown;
+    const insert = async (row: unknown) => {
+      capturedRow = row;
+      return { id: "claim_42" };
+    };
+    const result = await claimSendStep(INPUT, { insert });
+    assert.deepEqual(result, { claimed: true, claimId: "claim_42" });
+    assert.deepEqual(capturedRow, {
+      orgId: "org_1",
+      skillId: "skill_1",
+      stepN: 2,
+      idempotencyKey: "msg_abc",
+      outcome: "unknown",
+    });
+  });
+
+  test("redelivery: the SAME key on a later, separate attempt is refused (already-claimed), never re-executed", async () => {
+    const insert = async () => {
+      throw uniqueViolation();
+    };
+    const result = await claimSendStep(INPUT, { insert });
+    assert.deepEqual(result, { claimed: false, reason: "already-claimed" });
+  });
+
+  test("a non-unique-violation insert failure FAILS CLOSED (claim-error, never silently treated as claimed)", async () => {
+    const insert = async () => {
+      throw new Error("connection reset");
+    };
+    const result = await claimSendStep(INPUT, { insert });
+    assert.deepEqual(result, { claimed: false, reason: "claim-error" });
+  });
+
+  test("never throws into the caller — even a non-Error throw is swallowed into claim-error", async () => {
+    const insert = async () => {
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw "not an Error instance";
+    };
+    await assert.doesNotReject(() => claimSendStep(INPUT, { insert }));
+    const result = await claimSendStep(INPUT, { insert });
+    assert.equal(result.claimed, false);
+  });
+});
+
+describe("markSendClaimOutcome — fail-soft bookkeeping", () => {
+  test("updates the claim row's outcome via the injected updater", async () => {
+    const updates: Array<{ claimId: string; outcome: string }> = [];
+    await markSendClaimOutcome("claim_1", "sent", {
+      updateOutcome: async (claimId, outcome) => {
+        updates.push({ claimId, outcome });
+      },
+    });
+    assert.deepEqual(updates, [{ claimId: "claim_1", outcome: "sent" }]);
+  });
+
+  test("a throwing updater never rejects (fail-soft)", async () => {
+    await assert.doesNotReject(() =>
+      markSendClaimOutcome("claim_1", "failed", {
+        updateOutcome: async () => {
+          throw new Error("db down");
+        },
+      }),
+    );
+  });
+});

--- a/packages/crm/tests/unit/web-build-policy.spec.ts
+++ b/packages/crm/tests/unit/web-build-policy.spec.ts
@@ -4,6 +4,7 @@ import {
   isWebUngatedBuildOn,
   isAutopayConsoleOn,
   isDeterministicReplayOn,
+  isReplayGateV2On,
   shouldIndexWorkspace,
   WEB_BUILD_RATE_LIMIT,
   WEB_BUILD_RATE_WINDOW_MS,
@@ -36,6 +37,14 @@ test("flag: SF_DETERMINISTIC_REPLAY — on only for exact '1' (trimmed); everyth
   assert.equal(isDeterministicReplayOn({ SF_DETERMINISTIC_REPLAY: "true" }), false);
   assert.equal(isDeterministicReplayOn({ SF_DETERMINISTIC_REPLAY: "0" }), false);
   assert.equal(isDeterministicReplayOn({}), false);
+});
+
+test("flag: SF_REPLAY_GATE_V2 — on only for exact '1' (trimmed); everything else keeps v2 dark (default off)", () => {
+  assert.equal(isReplayGateV2On({ SF_REPLAY_GATE_V2: "1" }), true);
+  assert.equal(isReplayGateV2On({ SF_REPLAY_GATE_V2: " 1 " }), true);
+  assert.equal(isReplayGateV2On({ SF_REPLAY_GATE_V2: "true" }), false);
+  assert.equal(isReplayGateV2On({ SF_REPLAY_GATE_V2: "0" }), false);
+  assert.equal(isReplayGateV2On({}), false);
 });
 
 test("shouldIndexWorkspace: noindex ONLY for unclaimed anonymous web builds (Task 8)", () => {


### PR DESCRIPTION
Implements the Max-approved spec (docs/superpowers/plans/2026-07-18-replay-gate-v2-spec.md): replay_send_claims (migration 0077, UNIQUE(skill,step,key) = the double-send lock, claim-before-send, DB-error refuses send), asymmetric fallback (pre-send divergence -> agent turn as v1; at/after send -> failed-post-send, NEVER the agent), key material locked to message_id at CLI + runtime, idempotency config out-of-band in replay_skills.idempotency jsonb (reelier's parser rejects unknown step fields — documented choice), ops CLI set-idempotency, and a self-found hardening: with allowDestructive necessarily true for v2 runs, any non-declared step carrying raw effect destructive makes the skill INELIGIBLE (guard test-locked). Dark behind SF_REPLAY_GATE_V2; flag-off proven byte-identical to v1.

Adversarial review: APPROVE — double-send impossibility held under constructed races (23505 as the sync point), post-send divergence never reaches runTurn (spy-proven), allowlist (not skill text) identifies the destructive step. verify-build: PASS on all code checks (202 replay tests, tsc 0-delta, journal idx 54); live smoke deferred to post-merge deploy per deploy-prod skill (no route changes; the runner's NOT-DEPLOYED line reflects an unmerged branch, noted for transparency).

After merge: deploy -> staging drill per spec §Rollout (10 live emails, exactly one forward per messageId) -> Max reviews recompiled forwarder skill -> enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)