### PR TITLE
feat(replay): daily heartbeat cron - alert when an active email deployment goes silent >24h

### DIFF
--- a/packages/crm/src/app/api/cron/replay-heartbeat/route.ts
+++ b/packages/crm/src/app/api/cron/replay-heartbeat/route.ts
@@ -1,0 +1,134 @@
+// Inbound-chain dead-man's switch (roadmap #7, 2026-07-18) — the daily
+// heartbeat that would have caught the 2026-07-16 incident: the email-agent
+// chain died silently for two days (canceled deployments upstream) and
+// nobody noticed until traces were missing.
+//
+// PLATFORM-OPERATOR CRON: this route is NOT a per-org dashboard read. It
+// sweeps every org's ACTIVE email-surface deployments in one pass — there is
+// no request-supplied orgId to scope against (the usual "resolve org from
+// host, never from body" invariant doesn't apply here; this route has no
+// org-scoped body/host to resolve at all). Auth is CRON_SECRET only, same
+// fail-closed pattern as api/cron/usage-caps/route.ts.
+//
+// Read-only + one optional email send: this route never mutates deployment
+// or trace rows. All math lives in lib/deployments/replay/heartbeat.ts
+// (computeHeartbeat, unit-tested with DI fakes, no DB) — this route only
+// wires the real DB reads + the real email send via
+// lib/notifications/ops-notifications.ts::sendReplayHeartbeatAlert.
+//
+// Email is sent ONLY when at least one deployment is 'silent' (quiet when
+// healthy — no email on a clean sweep). Email failures are fail-soft
+// (sendReplayHeartbeatAlert never throws — see its header) so a Resend
+// outage never turns this cron red. Always returns JSON status for the cron
+// log regardless of whether an email was sent.
+//
+// Schedule: registered in vercel.json at "30 7 * * *" (daily 07:30 UTC) —
+// 30 minutes after the usage-caps sweep so the two platform-operator crons
+// don't collide.
+
+import { getHeartbeat, type HeartbeatDeploymentResult, type HeartbeatResult } from "@/lib/deployments/replay/heartbeat";
+import { sendReplayHeartbeatAlert } from "@/lib/notifications/ops-notifications";
+
+export const runtime = "nodejs";
+
+let warnedMissingSecret = false;
+
+// Exported so the route's auth gate is directly testable without importing
+// the whole route module's request-handling path.
+export function isAuthorized(request: Request) {
+  const configuredSecret = process.env.CRON_SECRET;
+
+  if (!configuredSecret) {
+    if (!warnedMissingSecret) {
+      console.warn(
+        "[replay-heartbeat] CRON_SECRET is unset — fail-closed, denying all requests. This route reads deployments/traces across every org and sends email; it must not run unauthenticated."
+      );
+      warnedMissingSecret = true;
+    }
+    return false;
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader === `Bearer ${configuredSecret}`) {
+    return true;
+  }
+
+  const cronHeader = request.headers.get("x-cron-secret");
+  return cronHeader === configuredSecret;
+}
+
+function toSilentRow(d: HeartbeatDeploymentResult) {
+  return {
+    deploymentId: d.deploymentId,
+    clientName: d.clientName,
+    orgName: d.orgName,
+    orgId: d.orgId,
+    // Guaranteed non-null for status === 'silent' — see heartbeat.ts's
+    // computeHeartbeat (only 'never' rows carry a null hoursSinceActivity).
+    hoursSinceActivity: d.hoursSinceActivity ?? 0,
+  };
+}
+
+export type RunHeartbeatCronDeps = {
+  getHeartbeat?: () => Promise<HeartbeatResult>;
+  sendReplayHeartbeatAlert?: typeof sendReplayHeartbeatAlert;
+};
+
+// DI-injectable core so "email sent only when silent exists" and "email
+// failure still returns 200" are unit-testable without mocking modules
+// (mirrors set-booking-policy.spec.ts's rationale: tsx's CJS interop makes
+// mock.module unreliable for @/ imports in this repo — inject instead).
+export async function runHeartbeatCron(deps: RunHeartbeatCronDeps = {}) {
+  const fetchHeartbeat = deps.getHeartbeat ?? getHeartbeat;
+  const sendAlert = deps.sendReplayHeartbeatAlert ?? sendReplayHeartbeatAlert;
+
+  const result = await fetchHeartbeat();
+  const silent = result.deployments.filter((d) => d.status === "silent");
+
+  if (silent.length > 0) {
+    try {
+      await sendAlert({ silentDeployments: silent.map(toSilentRow) });
+    } catch (err) {
+      // sendReplayHeartbeatAlert already fail-softs internally (never
+      // throws — see its header), but guard here too so a future change to
+      // that contract can never take this cron down.
+      console.warn(
+        JSON.stringify({
+          event: "replay_heartbeat_email_failed",
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  }
+
+  return {
+    generatedAt: result.generatedAt.toISOString(),
+    deploymentsChecked: result.deployments.length,
+    silentCount: result.silentCount,
+    neverCount: result.deployments.filter((d) => d.status === "never").length,
+    okCount: result.deployments.filter((d) => d.status === "ok").length,
+    lastReceiptAt: result.lastReceiptAt ? result.lastReceiptAt.toISOString() : null,
+    emailSent: silent.length > 0,
+    silentDeployments: silent.map((d) => ({
+      deploymentId: d.deploymentId,
+      clientName: d.clientName,
+      orgId: d.orgId,
+      orgName: d.orgName,
+      hoursSinceActivity: d.hoursSinceActivity,
+    })),
+  };
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return Response.json(await runHeartbeatCron());
+}
+
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return Response.json(await runHeartbeatCron());
+}

--- a/packages/crm/src/lib/deployments/replay/heartbeat.ts
+++ b/packages/crm/src/lib/deployments/replay/heartbeat.ts
@@ -1,0 +1,191 @@
+// Inbound-chain dead-man's switch (roadmap #7, 2026-07-18).
+//
+// WHY: on 2026-07-16 the email-agent chain died silently for 2 days
+// (deployments got canceled upstream; nobody noticed until traces were
+// missing). This module is the daily check that would have caught it —
+// for every ACTIVE email-surface deployment, has it produced ANY
+// agent_workflow_traces row (kind='trace' or 'replay-run' — "any kind" per
+// the roadmap item) in the last 24h?
+//
+// Status per deployment:
+//   'ok'     — activity (a trace/replay-run row) within the last 24h.
+//   'silent' — has activity historically, but none in the last 24h. This is
+//              the alertable state (the exact shape of the 2026-07-16 incident).
+//   'never'  — active deployment, zero rows EVER. Informational only — a
+//              brand-new deployment that hasn't received its first inbound
+//              email yet looks identical to a dead one on day 0, so this
+//              status is never treated as alertable (see computeHeartbeat).
+//
+// DI pattern mirrors ledger-queries.ts in this same directory: the pure
+// math (computeHeartbeat) takes already-loaded rows and a clock, no I/O; the
+// DB wrapper (getHeartbeat) does the real reads via injectable fetch fns
+// (each defaulting to a lazy `@/db` import, kept out of the top-level import
+// graph so this module stays test-friendly without a DB).
+//
+// PLATFORM-OPERATOR SCOPE: unlike every other read in ledger-queries.ts,
+// this module is NOT org-scoped by design — the caller (the cron route) is
+// a platform-operator job that sweeps every org, not a per-org dashboard
+// read. There is no request-supplied orgId anywhere in this file (L-04 is
+// about never trusting a client-supplied org id; a platform cron with no
+// request-scoped org has nothing to trust wrongly). See the cron route's
+// header for the same note next to its auth check.
+
+export type HeartbeatDeploymentStatus = "ok" | "silent" | "never";
+
+export type HeartbeatDeploymentRow = {
+  deploymentId: string;
+  clientName: string;
+  orgId: string;
+  orgName: string | null;
+  /** Latest agent_workflow_traces.created_at for this deployment, across
+   *  every kind. `null` = this deployment has never produced a row. */
+  lastActivityAt: Date | null;
+};
+
+export type HeartbeatDeploymentResult = HeartbeatDeploymentRow & {
+  status: HeartbeatDeploymentStatus;
+  /** Hours since lastActivityAt. `null` when lastActivityAt is null
+   *  (status === 'never'). */
+  hoursSinceActivity: number | null;
+};
+
+export type HeartbeatResult = {
+  deployments: HeartbeatDeploymentResult[];
+  /** Count of status === 'silent' rows — the ONLY status that should ever
+   *  trigger the alert email. 'never' rows are informational (see header). */
+  silentCount: number;
+  /** Global signal: the most recent agent_run_receipts.created_at across ALL
+   *  orgs. Included per the roadmap item ("Also global: last receipt age")
+   *  as a second, coarser sanity check independent of the per-deployment
+   *  trace table. `null` = no receipts have ever been written. */
+  lastReceiptAt: Date | null;
+  generatedAt: Date;
+};
+
+export const HEARTBEAT_SILENT_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** Pure: no I/O, no Date.now() — `now` is always passed in so tests are
+ *  deterministic and the 24h boundary is exercisable exactly. */
+export function computeHeartbeat(
+  rows: HeartbeatDeploymentRow[],
+  now: Date,
+  lastReceiptAt: Date | null,
+): HeartbeatResult {
+  const deployments: HeartbeatDeploymentResult[] = rows.map((row) => {
+    if (!row.lastActivityAt) {
+      return { ...row, status: "never", hoursSinceActivity: null };
+    }
+    const ageMs = now.getTime() - row.lastActivityAt.getTime();
+    const status: HeartbeatDeploymentStatus = ageMs <= HEARTBEAT_SILENT_THRESHOLD_MS ? "ok" : "silent";
+    return { ...row, status, hoursSinceActivity: ageMs / (60 * 60 * 1000) };
+  });
+
+  return {
+    deployments,
+    silentCount: deployments.filter((d) => d.status === "silent").length,
+    lastReceiptAt,
+    generatedAt: now,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DB wrapper
+// ---------------------------------------------------------------------------
+
+export type HeartbeatDeps = {
+  /** ACTIVE email-surface deployments, one row per deployment, with org
+   *  identity attached. No lastActivityAt — that's filled in separately
+   *  (see fetchLastActivityByDeployment) so this fetch stays a simple join. */
+  fetchActiveEmailDeployments?: () => Promise<
+    Omit<HeartbeatDeploymentRow, "lastActivityAt">[]
+  >;
+  /** Latest agent_workflow_traces.created_at per deployment id, for exactly
+   *  the deployment ids passed in. Missing ids in the returned map mean
+   *  "never had a row" (status 'never'), not zero rows fetched. */
+  fetchLastActivityByDeployment?: (deploymentIds: string[]) => Promise<Map<string, Date>>;
+  /** Global max(agent_run_receipts.created_at) across all orgs. */
+  fetchGlobalLastReceiptAt?: () => Promise<Date | null>;
+  now?: () => Date;
+};
+
+async function defaultFetchActiveEmailDeployments(): Promise<
+  Omit<HeartbeatDeploymentRow, "lastActivityAt">[]
+> {
+  const { db } = await import("@/db");
+  const { deployments } = await import("@/db/schema/deployments");
+  const { organizations } = await import("@/db/schema/organizations");
+  const { and, eq } = await import("drizzle-orm");
+  const rows = await db
+    .select({
+      deploymentId: deployments.id,
+      clientName: deployments.clientName,
+      orgId: deployments.builderOrgId,
+      orgName: organizations.name,
+    })
+    .from(deployments)
+    .leftJoin(organizations, eq(deployments.builderOrgId, organizations.id))
+    .where(and(eq(deployments.status, "active"), eq(deployments.surface, "email")));
+  return rows.map((r) => ({
+    deploymentId: r.deploymentId,
+    clientName: r.clientName,
+    orgId: r.orgId,
+    orgName: r.orgName ?? null,
+  }));
+}
+
+async function defaultFetchLastActivityByDeployment(deploymentIds: string[]): Promise<Map<string, Date>> {
+  const result = new Map<string, Date>();
+  if (deploymentIds.length === 0) return result;
+
+  const { db } = await import("@/db");
+  const { agentWorkflowTraces } = await import("@/db/schema/agent-workflow-traces");
+  const { inArray, sql } = await import("drizzle-orm");
+  const rows = await db
+    .select({
+      deploymentId: agentWorkflowTraces.deploymentId,
+      lastAt: sql<Date>`max(${agentWorkflowTraces.createdAt})`,
+    })
+    .from(agentWorkflowTraces)
+    .where(inArray(agentWorkflowTraces.deploymentId, deploymentIds))
+    .groupBy(agentWorkflowTraces.deploymentId);
+
+  for (const row of rows) {
+    if (row.deploymentId && row.lastAt) {
+      result.set(row.deploymentId, new Date(row.lastAt));
+    }
+  }
+  return result;
+}
+
+async function defaultFetchGlobalLastReceiptAt(): Promise<Date | null> {
+  const { db } = await import("@/db");
+  const { agentRunReceipts } = await import("@/db/schema/agent-run-receipts");
+  const { sql } = await import("drizzle-orm");
+  const [row] = await db
+    .select({ lastAt: sql<Date | null>`max(${agentRunReceipts.createdAt})` })
+    .from(agentRunReceipts);
+  return row?.lastAt ? new Date(row.lastAt) : null;
+}
+
+/** Platform-operator read — sweeps every org's active email deployments.
+ *  See the header note: intentionally NOT org-scoped, called only from the
+ *  authenticated cron route. */
+export async function getHeartbeat(deps: HeartbeatDeps = {}): Promise<HeartbeatResult> {
+  const fetchActiveEmailDeployments = deps.fetchActiveEmailDeployments ?? defaultFetchActiveEmailDeployments;
+  const fetchLastActivityByDeployment = deps.fetchLastActivityByDeployment ?? defaultFetchLastActivityByDeployment;
+  const fetchGlobalLastReceiptAt = deps.fetchGlobalLastReceiptAt ?? defaultFetchGlobalLastReceiptAt;
+  const now = deps.now ?? (() => new Date());
+
+  const deploymentsWithoutActivity = await fetchActiveEmailDeployments();
+  const [activityByDeployment, lastReceiptAt] = await Promise.all([
+    fetchLastActivityByDeployment(deploymentsWithoutActivity.map((d) => d.deploymentId)),
+    fetchGlobalLastReceiptAt(),
+  ]);
+
+  const rows: HeartbeatDeploymentRow[] = deploymentsWithoutActivity.map((d) => ({
+    ...d,
+    lastActivityAt: activityByDeployment.get(d.deploymentId) ?? null,
+  }));
+
+  return computeHeartbeat(rows, now(), lastReceiptAt);
+}

--- a/packages/crm/src/lib/notifications/ops-notifications.ts
+++ b/packages/crm/src/lib/notifications/ops-notifications.ts
@@ -175,7 +175,13 @@ function resolveApiKey(
  * itself stays observable from Vercel function logs.
  */
 async function dispatch(params: {
-  event: "new_signup" | "paid_conversion" | "new_lead" | "usage_cap_breach" | "retainer_payment_failed";
+  event:
+    | "new_signup"
+    | "paid_conversion"
+    | "new_lead"
+    | "usage_cap_breach"
+    | "retainer_payment_failed"
+    | "replay_heartbeat_silent";
   to: string;
   from: string;
   subject: string;
@@ -635,6 +641,120 @@ Stripe is automatically retrying the charge on the card on file. The client has 
   await dispatch({
     event: "retainer_payment_failed",
     to: params.toEmail,
+    from,
+    subject,
+    text,
+    html,
+    apiKey,
+    fetcher,
+  });
+}
+
+export type HeartbeatSilentDeploymentRow = {
+  deploymentId: string;
+  clientName: string;
+  orgName: string | null;
+  orgId: string;
+  /** Hours since the deployment's last agent_workflow_traces row. Always a
+   *  number here (a 'silent' row always has a prior lastActivityAt — see
+   *  heartbeat.ts's computeHeartbeat; 'never' rows are never passed to this
+   *  function). */
+  hoursSinceActivity: number;
+};
+
+export type ReplayHeartbeatAlertParams = {
+  /** Only 'silent' deployments — the caller (the cron route) filters before
+   *  calling; this function sends unconditionally when invoked. */
+  silentDeployments: HeartbeatSilentDeploymentRow[];
+};
+
+/**
+ * Send the "replay heartbeat" alert — the inbound-chain dead-man's switch
+ * (roadmap #7). Fires from the replay-heartbeat cron ONLY when at least one
+ * ACTIVE email-surface deployment has gone silent (no agent_workflow_traces
+ * row) for more than 24h — the exact shape of the 2026-07-16 incident where
+ * the email-agent chain died silently for two days before anyone noticed.
+ *
+ * Platform-level send (one global recipient, no per-workspace Resend
+ * lookup) — mirrors sendNewSignupAlert/sendNewLeadAlert. Never throws — the
+ * cron route must always return 200 for the cron log even if Resend is down.
+ */
+export async function sendReplayHeartbeatAlert(
+  params: ReplayHeartbeatAlertParams,
+  deps: OpsNotificationDeps = {},
+): Promise<void> {
+  const env = deps.env ?? process.env;
+  const fetcher = deps.fetcher ?? globalThis.fetch;
+  const apiKey = resolveApiKey(deps.apiKey, env);
+  const to = resolveOpsNotificationRecipient(env);
+  const from = resolveFromAddress(env);
+
+  const n = params.silentDeployments.length;
+  const subject = `Replay heartbeat: ${n} deployment(s) silent >24h`;
+
+  const textRows = params.silentDeployments
+    .map(
+      (d) =>
+        `- ${d.clientName} (deployment ${d.deploymentId}) — org ${d.orgName ?? d.orgId} — last activity ${d.hoursSinceActivity.toFixed(1)}h ago`,
+    )
+    .join("\n");
+
+  const text = `${n} active email deployment(s) have had no activity in over 24 hours.
+
+${textRows}
+
+This is the daily inbound-chain heartbeat check — it catches a deployment going silent (e.g. a canceled upstream connection) before it goes unnoticed for days.`;
+
+  const htmlRows = params.silentDeployments
+    .map((d) => {
+      const safeName = escapeHtml(d.clientName);
+      const safeOrg = escapeHtml(d.orgName ?? d.orgId);
+      const safeDeploymentId = escapeHtml(d.deploymentId);
+      const hours = d.hoursSinceActivity.toFixed(1);
+      return `<tr>
+        <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;">${safeName}</td>
+        <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;font-family:monospace;font-size:12px;">${safeDeploymentId}</td>
+        <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;">${safeOrg}</td>
+        <td style="padding:6px 8px;border-bottom:1px solid #e5e7eb;">${hours}h ago</td>
+      </tr>`;
+    })
+    .join("\n");
+
+  const html = `<!doctype html>
+<html lang="en">
+<body style="margin:0;padding:0;background:#f5f5f7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;color:#111;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f7;padding:24px 12px;">
+    <tr><td align="center">
+      <table role="presentation" width="640" cellpadding="0" cellspacing="0" style="max-width:640px;width:100%;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb;">
+        <tr><td style="background:#b91c1c;padding:20px 24px;color:#ffffff;">
+          <div style="font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:#fecaca;margin-bottom:6px;">Replay heartbeat</div>
+          <div style="font-size:20px;font-weight:600;line-height:1.25;">${n} deployment(s) silent &gt;24h</div>
+        </td></tr>
+        <tr><td style="padding:20px 24px;font-size:14px;line-height:1.6;color:#1a1a1f;">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;">
+            <thead>
+              <tr>
+                <th align="left" style="padding:6px 8px;border-bottom:2px solid #e5e7eb;color:#6b7280;font-size:12px;text-transform:uppercase;">Deployment</th>
+                <th align="left" style="padding:6px 8px;border-bottom:2px solid #e5e7eb;color:#6b7280;font-size:12px;text-transform:uppercase;">ID</th>
+                <th align="left" style="padding:6px 8px;border-bottom:2px solid #e5e7eb;color:#6b7280;font-size:12px;text-transform:uppercase;">Org</th>
+                <th align="left" style="padding:6px 8px;border-bottom:2px solid #e5e7eb;color:#6b7280;font-size:12px;text-transform:uppercase;">Last activity</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${htmlRows}
+            </tbody>
+          </table>
+          <p style="margin:16px 0 0 0;font-size:13px;color:#6b7280;">Daily inbound-chain heartbeat check — catches a canceled/broken email deployment before it goes unnoticed for days.</p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+
+  await dispatch({
+    event: "replay_heartbeat_silent",
+    to,
     from,
     subject,
     text,

--- a/packages/crm/tests/unit/cron/replay-heartbeat.spec.ts
+++ b/packages/crm/tests/unit/cron/replay-heartbeat.spec.ts
@@ -1,0 +1,188 @@
+// Inbound-chain dead-man's switch (roadmap #7) — unit tests for the
+// replay-heartbeat cron route.
+//
+// DI style rather than mock.module: runHeartbeatCron accepts injectable
+// getHeartbeat/sendReplayHeartbeatAlert fns (see set-booking-policy.spec.ts's
+// header — tsx's CJS interop makes module-mocking @/ imports unreliable in
+// this repo). isAuthorized is tested directly with a plain Request, exercising
+// the real CRON_SECRET check with no DB/network involved.
+//
+// Run:
+//   node --import tsx --test tests/unit/cron/replay-heartbeat.spec.ts
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { isAuthorized, runHeartbeatCron, GET } from "../../../src/app/api/cron/replay-heartbeat/route";
+import type { HeartbeatResult, HeartbeatDeploymentResult } from "../../../src/lib/deployments/replay/heartbeat";
+
+const NOW = new Date("2026-07-18T12:00:00.000Z");
+
+function heartbeatResult(deployments: HeartbeatDeploymentResult[]): HeartbeatResult {
+  return {
+    deployments,
+    silentCount: deployments.filter((d) => d.status === "silent").length,
+    lastReceiptAt: new Date("2026-07-18T11:00:00.000Z"),
+    generatedAt: NOW,
+  };
+}
+
+function okDeployment(overrides: Partial<HeartbeatDeploymentResult> = {}): HeartbeatDeploymentResult {
+  return {
+    deploymentId: "dep_ok",
+    clientName: "Healthy Co",
+    orgId: "org_ok",
+    orgName: "Org Ok",
+    lastActivityAt: new Date(NOW.getTime() - 1000),
+    status: "ok",
+    hoursSinceActivity: 0.0003,
+    ...overrides,
+  };
+}
+
+function silentDeployment(overrides: Partial<HeartbeatDeploymentResult> = {}): HeartbeatDeploymentResult {
+  return {
+    deploymentId: "dep_silent",
+    clientName: "Silent Co",
+    orgId: "org_silent",
+    orgName: "Org Silent",
+    lastActivityAt: new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000),
+    status: "silent",
+    hoursSinceActivity: 72,
+    ...overrides,
+  };
+}
+
+describe("isAuthorized — CRON_SECRET fail-closed auth", () => {
+  const originalSecret = process.env.CRON_SECRET;
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CRON_SECRET;
+    } else {
+      process.env.CRON_SECRET = originalSecret;
+    }
+  });
+
+  test("rejects when CRON_SECRET is unset (fail-closed)", () => {
+    delete process.env.CRON_SECRET;
+    const req = new Request("https://example.com/api/cron/replay-heartbeat");
+    assert.equal(isAuthorized(req), false);
+  });
+
+  test("rejects a request with no auth header when a secret IS configured", () => {
+    process.env.CRON_SECRET = "test-secret";
+    const req = new Request("https://example.com/api/cron/replay-heartbeat");
+    assert.equal(isAuthorized(req), false);
+  });
+
+  test("rejects a wrong bearer token", () => {
+    process.env.CRON_SECRET = "test-secret";
+    const req = new Request("https://example.com/api/cron/replay-heartbeat", {
+      headers: { authorization: "Bearer wrong-secret" },
+    });
+    assert.equal(isAuthorized(req), false);
+  });
+
+  test("accepts the correct bearer token", () => {
+    process.env.CRON_SECRET = "test-secret";
+    const req = new Request("https://example.com/api/cron/replay-heartbeat", {
+      headers: { authorization: "Bearer test-secret" },
+    });
+    assert.equal(isAuthorized(req), true);
+  });
+
+  test("accepts the correct x-cron-secret header", () => {
+    process.env.CRON_SECRET = "test-secret";
+    const req = new Request("https://example.com/api/cron/replay-heartbeat", {
+      headers: { "x-cron-secret": "test-secret" },
+    });
+    assert.equal(isAuthorized(req), true);
+  });
+
+  test("GET returns 401 and never touches getHeartbeat when unauthorized", async () => {
+    delete process.env.CRON_SECRET;
+    const req = new Request("https://example.com/api/cron/replay-heartbeat");
+    const res = await GET(req);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.error, "Unauthorized");
+  });
+});
+
+describe("runHeartbeatCron — email invoked only when silent exists", () => {
+  test("no silent deployments → email NOT sent, status 200 shape returned", async () => {
+    let sendCalled = false;
+    const result = await runHeartbeatCron({
+      getHeartbeat: async () => heartbeatResult([okDeployment()]),
+      sendReplayHeartbeatAlert: async () => {
+        sendCalled = true;
+      },
+    });
+    assert.equal(sendCalled, false);
+    assert.equal(result.emailSent, false);
+    assert.equal(result.silentCount, 0);
+    assert.equal(result.deploymentsChecked, 1);
+  });
+
+  test("at least one silent deployment → email sent exactly once with the silent rows", async () => {
+    let callCount = 0;
+    const receivedSilentCounts: number[] = [];
+    const result = await runHeartbeatCron({
+      getHeartbeat: async () => heartbeatResult([okDeployment(), silentDeployment()]),
+      sendReplayHeartbeatAlert: async (params) => {
+        callCount += 1;
+        receivedSilentCounts.push(params.silentDeployments.length);
+      },
+    });
+    assert.equal(callCount, 1);
+    assert.equal(result.emailSent, true);
+    assert.equal(result.silentCount, 1);
+    assert.deepEqual(receivedSilentCounts, [1]);
+    assert.deepEqual(result.silentDeployments.map((d: { deploymentId: string }) => d.deploymentId), ["dep_silent"]);
+  });
+
+  test("'never' status deployments are NOT treated as silent and never trigger an email", async () => {
+    const neverDeployment = okDeployment({
+      deploymentId: "dep_never",
+      status: "never",
+      lastActivityAt: null,
+      hoursSinceActivity: null,
+    });
+    let sendCalled = false;
+    const result = await runHeartbeatCron({
+      getHeartbeat: async () => heartbeatResult([neverDeployment]),
+      sendReplayHeartbeatAlert: async () => {
+        sendCalled = true;
+      },
+    });
+    assert.equal(sendCalled, false);
+    assert.equal(result.emailSent, false);
+    assert.equal(result.neverCount, 1);
+  });
+
+  test("email send failure is caught — runHeartbeatCron still resolves (route still returns 200)", async () => {
+    const result = await runHeartbeatCron({
+      getHeartbeat: async () => heartbeatResult([silentDeployment()]),
+      sendReplayHeartbeatAlert: async () => {
+        throw new Error("Resend is down");
+      },
+    });
+    // No throw propagated — the function resolved normally despite the
+    // injected send failing.
+    assert.equal(result.emailSent, true);
+    assert.equal(result.silentCount, 1);
+  });
+
+  test("always returns JSON-shaped status regardless of email outcome", async () => {
+    const result = await runHeartbeatCron({
+      getHeartbeat: async () => heartbeatResult([okDeployment(), silentDeployment()]),
+      sendReplayHeartbeatAlert: async () => {},
+    });
+    assert.equal(typeof result.generatedAt, "string");
+    assert.equal(result.deploymentsChecked, 2);
+    assert.equal(result.okCount, 1);
+    assert.equal(result.silentCount, 1);
+    assert.equal(result.lastReceiptAt, "2026-07-18T11:00:00.000Z");
+  });
+});

--- a/packages/crm/tests/unit/deployments/replay/heartbeat.spec.ts
+++ b/packages/crm/tests/unit/deployments/replay/heartbeat.spec.ts
@@ -1,0 +1,141 @@
+// Inbound-chain dead-man's switch (roadmap #7) — unit tests for
+// heartbeat.ts.
+//
+// Two layers, mirroring ledger-queries.spec.ts's style:
+//   1. Pure math (computeHeartbeat) tested directly against fixture rows and
+//      an explicit `now` — no DB, no DI, deterministic 24h boundary.
+//   2. The DI wrapper (getHeartbeat) tested at spy level: assert the
+//      injected fetch fns are called and their results are folded correctly.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeHeartbeat,
+  getHeartbeat,
+  HEARTBEAT_SILENT_THRESHOLD_MS,
+  type HeartbeatDeploymentRow,
+} from "@/lib/deployments/replay/heartbeat";
+
+const NOW = new Date("2026-07-18T12:00:00.000Z");
+
+function row(overrides: Partial<HeartbeatDeploymentRow> = {}): HeartbeatDeploymentRow {
+  return {
+    deploymentId: "dep_1",
+    clientName: "Metro Med Spa",
+    orgId: "org_1",
+    orgName: "Metro Med Spa Agency",
+    lastActivityAt: null,
+    ...overrides,
+  };
+}
+
+describe("computeHeartbeat — pure status matrix", () => {
+  test("never had activity → status 'never', hoursSinceActivity null, never counted as silent", () => {
+    const result = computeHeartbeat([row({ lastActivityAt: null })], NOW, null);
+    assert.equal(result.deployments[0].status, "never");
+    assert.equal(result.deployments[0].hoursSinceActivity, null);
+    assert.equal(result.silentCount, 0);
+  });
+
+  test("activity 1 minute ago → status 'ok'", () => {
+    const lastActivityAt = new Date(NOW.getTime() - 60 * 1000);
+    const result = computeHeartbeat([row({ lastActivityAt })], NOW, null);
+    assert.equal(result.deployments[0].status, "ok");
+    assert.equal(result.silentCount, 0);
+  });
+
+  test("activity exactly 24h ago (boundary, inclusive) → status 'ok'", () => {
+    const lastActivityAt = new Date(NOW.getTime() - HEARTBEAT_SILENT_THRESHOLD_MS);
+    const result = computeHeartbeat([row({ lastActivityAt })], NOW, null);
+    assert.equal(result.deployments[0].status, "ok");
+  });
+
+  test("activity 24h + 1ms ago → status 'silent'", () => {
+    const lastActivityAt = new Date(NOW.getTime() - HEARTBEAT_SILENT_THRESHOLD_MS - 1);
+    const result = computeHeartbeat([row({ lastActivityAt })], NOW, null);
+    assert.equal(result.deployments[0].status, "silent");
+    assert.equal(result.silentCount, 1);
+  });
+
+  test("activity 3 days ago → status 'silent' with hoursSinceActivity ~72", () => {
+    const lastActivityAt = new Date(NOW.getTime() - 3 * 24 * 60 * 60 * 1000);
+    const result = computeHeartbeat([row({ lastActivityAt })], NOW, null);
+    assert.equal(result.deployments[0].status, "silent");
+    assert.ok(Math.abs((result.deployments[0].hoursSinceActivity ?? 0) - 72) < 0.001);
+  });
+
+  test("mixed rows: silentCount only counts 'silent', never 'never' or 'ok'", () => {
+    const rows: HeartbeatDeploymentRow[] = [
+      row({ deploymentId: "ok_1", lastActivityAt: new Date(NOW.getTime() - 1000) }),
+      row({
+        deploymentId: "silent_1",
+        lastActivityAt: new Date(NOW.getTime() - 2 * HEARTBEAT_SILENT_THRESHOLD_MS),
+      }),
+      row({ deploymentId: "silent_2", lastActivityAt: new Date(NOW.getTime() - HEARTBEAT_SILENT_THRESHOLD_MS - 5000) }),
+      row({ deploymentId: "never_1", lastActivityAt: null }),
+    ];
+    const result = computeHeartbeat(rows, NOW, null);
+    assert.equal(result.silentCount, 2);
+    assert.equal(result.deployments.length, 4);
+  });
+
+  test("lastReceiptAt and generatedAt pass through unchanged", () => {
+    const lastReceiptAt = new Date("2026-07-18T10:00:00.000Z");
+    const result = computeHeartbeat([], NOW, lastReceiptAt);
+    assert.equal(result.lastReceiptAt, lastReceiptAt);
+    assert.equal(result.generatedAt, NOW);
+    assert.equal(result.deployments.length, 0);
+    assert.equal(result.silentCount, 0);
+  });
+
+  test("null lastReceiptAt (no receipts ever) passes through as null, never throws", () => {
+    const result = computeHeartbeat([], NOW, null);
+    assert.equal(result.lastReceiptAt, null);
+  });
+});
+
+describe("getHeartbeat — DI wrapper folds fetch results correctly", () => {
+  test("folds per-deployment activity map onto the deployment list; missing map entries become 'never'", async () => {
+    const deploymentsFetched: string[][] = [];
+    const result = await getHeartbeat({
+      fetchActiveEmailDeployments: async () => [
+        { deploymentId: "dep_active", clientName: "Active Co", orgId: "org_a", orgName: "Org A" },
+        { deploymentId: "dep_quiet", clientName: "Quiet Co", orgId: "org_b", orgName: "Org B" },
+      ],
+      fetchLastActivityByDeployment: async (ids) => {
+        deploymentsFetched.push(ids);
+        const map = new Map<string, Date>();
+        map.set("dep_active", new Date(NOW.getTime() - 1000));
+        // dep_quiet intentionally absent — never had a row.
+        return map;
+      },
+      fetchGlobalLastReceiptAt: async () => new Date("2026-07-18T11:00:00.000Z"),
+      now: () => NOW,
+    });
+
+    assert.deepEqual(deploymentsFetched[0].sort(), ["dep_active", "dep_quiet"]);
+    const active = result.deployments.find((d) => d.deploymentId === "dep_active");
+    const quiet = result.deployments.find((d) => d.deploymentId === "dep_quiet");
+    assert.equal(active?.status, "ok");
+    assert.equal(quiet?.status, "never");
+    assert.equal(result.lastReceiptAt?.toISOString(), "2026-07-18T11:00:00.000Z");
+  });
+
+  test("zero active email deployments → empty result, activity fetch called with empty array, never throws", async () => {
+    let calledWith: string[] | null = null;
+    const result = await getHeartbeat({
+      fetchActiveEmailDeployments: async () => [],
+      fetchLastActivityByDeployment: async (ids) => {
+        calledWith = ids;
+        return new Map();
+      },
+      fetchGlobalLastReceiptAt: async () => null,
+      now: () => NOW,
+    });
+    assert.deepEqual(calledWith, []);
+    assert.equal(result.deployments.length, 0);
+    assert.equal(result.silentCount, 0);
+    assert.equal(result.lastReceiptAt, null);
+  });
+});

--- a/packages/crm/vercel.json
+++ b/packages/crm/vercel.json
@@ -60,6 +60,10 @@
       "schedule": "0 7 * * *"
     },
     {
+      "path": "/api/cron/replay-heartbeat",
+      "schedule": "30 7 * * *"
+    },
+    {
       "path": "/api/cron/payment-dunning",
       "schedule": "0 8 * * *"
     },


### PR DESCRIPTION
The dead-man's switch encoding the 2026-07-16 lesson (chain died silently for 2 days). Daily 07:30 UTC cron: any ACTIVE email deployment with historical activity but none in 24h -> one summary email to ops via Resend. Fail-closed auth (CRON_SECRET, mirrors usage-caps), read-only, fail-soft email, quiet when healthy. Platform-operator cross-org read disclosed in headers.

Review: APPROVE (boundary math verified 24h-exact=ok, never-rows inform not alert, no secrets in email; the 4 'assertion failures' in gate-v2 execution specs were proven to be the dep-less-worktree artifact - runtime imports of @seldonframe/reelier throwing into the conservative catch - green with deps installed). verify-build: PASS (21 new tests, tsc 0-delta, journal unchanged, vercel.json exactly +1 cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)