### PR TITLE
persona-loop: don't claim a bot-blocked site was "read"

### DIFF
--- a/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
@@ -35,6 +35,13 @@ const COPY = {
     invalid_url: "That URL doesn't look right. Check for typos and try again.",
     extraction_failed:
       "We couldn't read that site. Try a different URL — a homepage works best.",
+    // 2026-07-25 — site_unreachable honesty fix. Distinct from
+    // extraction_failed: the page itself was never readable (bot-blocked,
+    // timed out, or came back empty) rather than read-but-missing-fields —
+    // most commonly a Facebook/Instagram page. Server always sends a
+    // `message` for this reason; this is only the fallback.
+    site_unreachable:
+      "We couldn't load that page. Try your business's own website instead of a social media page.",
     // 2026-07-16 — credits_exhausted honesty fix. Out-of-credits is NOT an
     // unreadable site; the operator here may be on their own BYOK key, so
     // point at adding Anthropic credits. Server-sent `message` wins; this
@@ -317,10 +324,16 @@ export function ClientsNewForm({
         // credits_exhausted is a key-funding problem, not a site-reading one —
         // show the server's honest message (fallback to the dedicated copy)
         // instead of sending the operator hunting for a "better" URL.
+        // site_unreachable (page never actually read — bot-blocked/timed
+        // out/empty) gets the same server-message-first treatment so the
+        // operator isn't told "couldn't find the basics" for a site we
+        // never read at all.
         setErrorBanner(
           data.reason === "credits_exhausted"
             ? data.message || COPY.errors.credits_exhausted
-            : COPY.errors.extraction_failed,
+            : data.reason === "site_unreachable"
+              ? data.message || COPY.errors.site_unreachable
+              : COPY.errors.extraction_failed,
         );
         return;
       }
@@ -405,10 +418,16 @@ export function ClientsNewForm({
         // credits_exhausted is a key-funding problem, not a site-reading one —
         // show the server's honest message (fallback to the dedicated copy)
         // instead of sending the operator hunting for a "better" URL.
+        // site_unreachable (page never actually read — bot-blocked/timed
+        // out/empty) gets the same server-message-first treatment so the
+        // operator isn't told "couldn't find the basics" for a site we
+        // never read at all.
         setErrorBanner(
           data.reason === "credits_exhausted"
             ? data.message || COPY.errors.credits_exhausted
-            : COPY.errors.extraction_failed,
+            : data.reason === "site_unreachable"
+              ? data.message || COPY.errors.site_unreachable
+              : COPY.errors.extraction_failed,
         );
         return;
       }

--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -155,7 +155,12 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       }
       es.close();
       setEventSource(null);
-      const isExtractionFailed = data.reason === "extraction_failed";
+      // site_unreachable (bot-blocked/timed out/empty — the page was never
+      // actually read) shares the same "no blind retry, offer alternatives"
+      // UI as extraction_failed (page was read, required fields missing):
+      // retrying the identical URL would just fail the same way again.
+      const isExtractionFailed =
+        data.reason === "extraction_failed" || data.reason === "site_unreachable";
       setRateLimited(data.code === "rate_limited");
       setExtractionFailed(isExtractionFailed);
       setCreditsExhausted(data.reason === "credits_exhausted");

--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,8 +236,15 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // The scrape itself never produced readable content (blocked, timed
+    // out, rate-limited, or came back empty) — distinct from
+    // "extraction_failed" below, which means we DID read the page and the
+    // LLM couldn't find the required fields in it. Conflating the two used
+    // to tell visitors "we read that site but couldn't find the basics"
+    // even when the site was never actually read (e.g. Facebook/Instagram
+    // pages routinely bot-block Firecrawl) — a false claim.
     throw new WebFetchError(
-      "extraction_failed",
+      "site_unreachable",
       `Firecrawl fetch failed: ${scrape.reason}${
         scrape.detail ? `: ${scrape.detail}` : ""
       }`,

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -259,17 +259,27 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
       } catch (err: unknown) {
         const reason = (err as { reason?: string }).reason ?? "extraction_failed";
         // 2026-07-14 — extraction-failed honesty fix. extraction_failed is a
-        // PERMANENT condition for that URL (no phone/name/location found
-        // anywhere on the site) — retrying can never succeed. Without a
-        // `message`, the UI falls back to "Something broke on our end. Give
-        // it another try." and shows a Try again button, which burns the
-        // visitor's rate limit on a build that will fail identically every
-        // time.
+        // PERMANENT condition for that URL (we DID read the page, but no
+        // phone/name/location was found anywhere on it) — retrying can
+        // never succeed. Without a `message`, the UI falls back to
+        // "Something broke on our end. Give it another try." and shows a
+        // Try again button, which burns the visitor's rate limit on a build
+        // that will fail identically every time.
         // 2026-07-16 — same honesty rule for credits_exhausted: the Anthropic
         // account funding the extraction is out of credits, so no retry can
         // succeed until credits are added. Remaining reasons
         // (anthropic_unauthorized, internal_error) are untouched — those ARE
         // sometimes transient.
+        // 2026-07-25 — site_unreachable honesty fix. The two reasons above
+        // both used to collapse into "extraction_failed" and its "We read
+        // that site but couldn't find the basics" message, which is a false
+        // claim when the page was never actually read (bot-blocked, timed
+        // out, rate-limited, or came back empty) — e.g. every Facebook or
+        // Instagram business page, which is often the ONLY web presence a
+        // solo tradesperson has. site_unreachable is retryable in spirit
+        // (a different, scrapeable URL might work), so it points the
+        // visitor at alternatives instead of implying their site is
+        // incomplete.
         sse.error(
           422,
           reason === "extraction_failed"
@@ -278,9 +288,15 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
                 message:
                   "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
               }
-            : reason === "credits_exhausted"
-              ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
-              : { reason },
+            : reason === "site_unreachable"
+              ? {
+                  reason,
+                  message:
+                    "We couldn't load that page — some sites (like Facebook and Instagram) block automated visits, or it took too long to respond. Try your business's own website, or describe your business instead.",
+                }
+              : reason === "credits_exhausted"
+                ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
+                : { reason },
         );
         sse.close();
         return;

--- a/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
@@ -40,6 +40,7 @@ import { parseExtraction } from "./extraction-parser";
 
 export type WebFetchErrorReason =
   | "extraction_failed"
+  | "site_unreachable"
   | "credits_exhausted"
   | "anthropic_unauthorized"
   | "internal_error";

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,10 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  test("Firecrawl throws -> WebFetchError(site_unreachable) with 'Firecrawl fetch failed' prefix", async () => {
+    // Scrape-layer failure (never got readable content) is a distinct
+    // reason from extraction_failed (content WAS read, fields missing) —
+    // see markdown-extractor.ts's 2026-07-25 honesty fix.
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,14 +126,16 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "site_unreachable" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
     );
   });
 
-  test("near-empty markdown (< 200 chars) -> WebFetchError(extraction_failed)", async () => {
+  test("near-empty markdown (< 200 chars) -> WebFetchError(site_unreachable)", async () => {
     // JS-only SPA shell / anti-bot challenge / blank doc — Firecrawl
-    // returns markdown but well below the MIN_MARKDOWN_CHARS floor.
+    // returns markdown but well below the MIN_MARKDOWN_CHARS floor. The
+    // page was never actually read, so this is site_unreachable, not
+    // extraction_failed (which implies we DID read it).
     const firecrawl = makeFakeFirecrawl(async () => ({
       markdown: "# Loading\n\nEnable JavaScript.",
       metadata: { sourceURL: "https://spa.example/", statusCode: 200 },
@@ -146,7 +151,7 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "site_unreachable" &&
         err.message.includes("empty_content"),
     );
   });

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -228,6 +228,18 @@ describe("runCreateFromUrl", () => {
     assert.match(text, /out of credits/i, "the message must say credits ran out, not a generic failure");
   });
 
+  // 2026-07-25 — site_unreachable honesty fix. Distinct from
+  // extraction_failed: the scrape never produced readable content (bot-
+  // blocked, timed out, rate-limited, or empty — e.g. a Facebook page),
+  // so the message must NOT claim the site was read.
+  test("site_unreachable 422 carries an honest message and does not claim the site was read", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("Firecrawl fetch failed: fetch_failed"); (e as any).reason = "site_unreachable"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://facebook.com/x" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"site_unreachable".*"message":"/);
+    assert.ok(!text.includes("We read that site"), "must not claim the site was read when it never loaded");
+  });
+
   test("a different reason (e.g. anthropic_unauthorized) carries no `message`", async () => {
     const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad key"); (e as any).reason = "anthropic_unauthorized"; (e as any).name = "WebFetchError"; throw e; } };
     const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });


### PR DESCRIPTION
## Summary

**Persona:** solo electrician (Saturday persona), non-technical, on their phone. Like a large share of solo tradespeople, they don't have a real business website — only a Facebook Business Page.

**Funnel step:** the ungated "paste your website URL" build flow (`/try`, and the equivalent signed-in `/clients/new` flow) — the primary CTA on the homepage hero, and the exact zero-friction path CLAUDE.md §1 calls for.

**First failure:** pasting a Facebook page URL (or any bot-blocked/thin-content page) produces the error *"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."* — but the site was never actually read. Firecrawl gets bot-blocked on facebook.com and returns no usable content; the copy nonetheless claims we read it and it was lacking. This is a direct violation of the "never-lies" positioning principle in CLAUDE.md §1b.

**Verbatim evidence** (live, `https://www.seldonframe.com`):
```
$ curl "https://www.seldonframe.com/api/v1/web/build/stream?url=https://www.facebook.com/mikeselectricalservicesnj"
event: fetching
data: {"url":"https://www.facebook.com/mikeselectricalservicesnj"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```
(HTTP 200 / SSE 422 payload)

**Root cause:** `firecrawl-scrape.ts` correctly classifies why a scrape didn't produce content (`fetch_failed`, `empty_content`, `timeout`, `rate_limited`). But `markdown-extractor.ts`'s `extractBusinessFactsFromUrl` collapsed all of those into the same generic `WebFetchError("extraction_failed", ...)` used for a *different* failure mode — content successfully scraped, but the LLM couldn't find required fields in it. `run-create-from-url.ts` then always showed the "We read that site..." copy for `extraction_failed`, which is only true for the second case.

**Fix:** scrape-layer failures (page never actually read) now throw a new `site_unreachable` reason instead of reusing `extraction_failed`, with an honest SSE message pointing at alternatives:

> "We couldn't load that page — some sites (like Facebook and Instagram) block automated visits, or it took too long to respond. Try your business's own website, or describe your business instead."

`extraction_failed` keeps its original meaning/message for the genuine "we read it, fields are missing" case. Both the anonymous `/try` flow and the signed-in `/clients/new` flow share the same `runCreateFromUrl` orchestrator, so one fix covers both. Minimal, additive change — no existing reason codes or messages altered for other failure modes (`credits_exhausted`, `anthropic_unauthorized`, `internal_error` untouched).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing / gate results

- `node --import tsx --test tests/unit/web-onboarding/markdown-extractor.spec.ts tests/unit/web-onboarding/route-create-from-url.spec.ts tests/unit/web-onboarding/try-client.spec.tsx tests/unit/web-onboarding/clients-new-form.spec.tsx` — **37/37 pass** (2 existing scrape-failure tests updated to assert `site_unreachable`; 1 new test added asserting the SSE payload never claims "We read that site" for this reason)
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 1 pre-existing error (`api/copilot/turn/route.ts:315`, unrelated `persist` property), confirmed present verbatim on `main` at the same base commit — **no new errors**
- `bash scripts/check-use-server.sh src` — pass
- `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)

## Notes for reviewers

- Deviation note carried over from `try-client.tsx`'s existing header comment: the "describe your business" tab isn't wired to a public anonymous route yet — out of scope here, unrelated to this fix.
- Did not touch pricing, positioning claims, or SSRF/auth guards, per the persona-loop hard rules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSQ2hH15tcqvdyQtWYgeZp)_