### PR TITLE
persona-loop: hero loading overlay says "workspace" for a redirect that never builds one

### DIFF
--- a/packages/crm/src/components/landing/hero-submit-target.ts
+++ b/packages/crm/src/components/landing/hero-submit-target.ts
@@ -29,3 +29,21 @@ export function heroSubmitTarget(
   if (tab === "url") params.set("url", value);
   return `/signup?${params.toString()}`;
 }
+
+// Persona-loop finding (2026-07-26): the hero's transitional loading overlay
+// said "Spinning up your workspace…" for EVERY submission, but per
+// heroSubmitTarget above the biz tab (and the url tab with the flag off)
+// never spins up a workspace at all — they redirect straight to a Google-
+// OAuth signup wall with no build, no preview. A visitor who described their
+// business (the natural choice for someone with no real website — a common
+// case for a solo small-business owner) watched a fake "building" animation
+// that lied about what was about to happen. This mirrors heroSubmitTarget's
+// own branch so the two can never drift out of sync.
+export function heroSubmitLoadingMessage(
+  tab: HeroTabKind,
+  ungatedBuildEnabled: boolean,
+): string {
+  return ungatedBuildEnabled && tab === "url"
+    ? "Spinning up your workspace…"
+    : "Taking you to sign up…";
+}

--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -35,7 +35,7 @@ import { useRouter } from "next/navigation";
 import { ArrowRight, FileText, Globe } from "lucide-react";
 
 import { MarketingDemoMarquee } from "@/components/landing/marketing-demo-marquee";
-import { heroSubmitTarget } from "@/components/landing/hero-submit-target";
+import { heroSubmitLoadingMessage, heroSubmitTarget } from "@/components/landing/hero-submit-target";
 import { BorderBeam } from "@/components/ui/border-beam";
 import { Highlighter } from "@/components/ui/highlighter";
 import { AnimatedShinyText } from "@/components/ui/magic/animated-shiny-text";
@@ -464,7 +464,7 @@ export function MarketingHero({
         >
           <div className="size-7 animate-spin rounded-full border-2 border-[#1F2B24]/20 border-t-[#1F2B24]" aria-hidden />
           <div className="font-sans text-xs uppercase tracking-[0.12em] text-[#6E665A]">
-            Spinning up your workspace…
+            {heroSubmitLoadingMessage(tab, ungatedBuildEnabled)}
           </div>
         </div>
       ) : null}

--- a/packages/crm/tests/unit/marketing-hero-target.spec.ts
+++ b/packages/crm/tests/unit/marketing-hero-target.spec.ts
@@ -8,7 +8,10 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { heroSubmitTarget } from "../../src/components/landing/hero-submit-target";
+import {
+  heroSubmitLoadingMessage,
+  heroSubmitTarget,
+} from "../../src/components/landing/hero-submit-target";
 
 test("flag off → byte-identical current behavior", () => {
   assert.equal(
@@ -24,4 +27,23 @@ test("flag on → /try carries the url; biz tab routes to signup (description bu
     "/try?url=https%3A%2F%2Facme.com",
   );
   assert.equal(heroSubmitTarget("biz", "Family plumbing in Reno", true), "/signup?intent=build");
+});
+
+// Persona-loop finding (2026-07-26): the loading-overlay copy must never
+// claim a workspace is spinning up when heroSubmitTarget is actually about
+// to redirect to the signup wall — every non-"/try" destination is a
+// signup redirect, so the message has to say so.
+test("loading message matches heroSubmitTarget's destination for every tab/flag combination", () => {
+  for (const tab of ["url", "biz"] as const) {
+    for (const ungatedBuildEnabled of [true, false]) {
+      const destination = heroSubmitTarget(tab, "https://acme.com", ungatedBuildEnabled);
+      const message = heroSubmitLoadingMessage(tab, ungatedBuildEnabled);
+      if (destination.startsWith("/try")) {
+        assert.equal(message, "Spinning up your workspace…");
+      } else {
+        assert.equal(destination.startsWith("/signup"), true);
+        assert.equal(message, "Taking you to sign up…");
+      }
+    }
+  }
 });


### PR DESCRIPTION
## Summary

**Persona:** solo hair-salon owner (Sunday rotation), non-technical, on a phone, skeptical.

**Funnel step:** homepage hero (`www.seldonframe.com/#hero-form`) → "Describe the business" tab → "Build workspace".

**First failure:** the hero has two visually-equal tabs, "Paste a URL" and "Describe the business", both living under the same "Build it free →" CTA. Submitting either shows a full-screen overlay reading **"Spinning up your workspace…"**. But per `heroSubmitTarget` (`packages/crm/src/components/landing/hero-submit-target.ts`), only the URL tab (with `SF_WEB_UNGATED_BUILD=1`, confirmed live in prod — `/try?url=...` returns 200) actually builds anything. The biz tab *always* routes to `/signup?intent=build`, which 307-redirects to `app.seldonframe.com/signup?intent=build` — a bare Google-OAuth wall, confirmed live via curl (no preview, no build, just "Continue with Google").

So a salon owner who doesn't have a real website — very common — naturally picks "Describe the business", types a description, watches the "Spinning up your workspace…" animation for 380ms, and lands on a login screen. Nothing was built. The copy promised a build the app never attempted.

**Verbatim evidence:**
- Live homepage HTML (`curl https://www.seldonframe.com/`) shows the hero form with both tabs under `id="hero-form"`, CTA text "Build workspace".
- `curl -i https://www.seldonframe.com/try?url=https://example.com` → `200`, confirming `SF_WEB_UNGATED_BUILD=1` in prod (the URL tab really does build for free).
- `curl -i https://www.seldonframe.com/signup?intent=build` → `307` → `https://app.seldonframe.com/signup?intent=build` → `200`, body contains only `"Continue with Google"` — no build, no context carried over from the biz-tab description.
- Source: `packages/crm/src/components/landing/hero-submit-target.ts`'s own doc comment already flags this asymmetry ("The biz tab must NOT go to /try... It routes to /signup?intent=build") — the routing split is intentional and documented; the overlay copy simply never caught up to it.

**Root cause:** `marketing-hero.tsx`'s loading overlay rendered a hardcoded `"Spinning up your workspace…"` string regardless of which tab/destination `submit()` was about to route to.

**Fix (smallest honest one):** added `heroSubmitLoadingMessage(tab, ungatedBuildEnabled)` next to the existing `heroSubmitTarget` pure helper — it mirrors the exact same `tab === "url" && ungatedBuildEnabled` branch, so the two can never drift apart again. The overlay now shows "Spinning up your workspace…" only when a workspace is actually about to be built (`/try`), and "Taking you to sign up…" for every path that redirects to `/signup`. No routing, gating, or positioning logic changed — copy-only, scoped to the one component + its shared helper.

## Type of change

- [x] Bug fix

## Testing

- [x] `node --import tsx --test tests/unit/marketing-hero-target.spec.ts` — 3/3 pass (added a new test asserting the loading message matches `heroSubmitTarget`'s destination for all tab × flag combinations)
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — one pre-existing error (`src/app/api/copilot/turn/route.ts(315,9)`), byte-identical on `main` before this change (diffed directly) — no new errors introduced
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)
- [ ] Manually verified the change in the browser (headless Chromium in this sandbox can't reach the live host through the egress proxy — verified via curl + source read instead; see evidence above)

## Notes for reviewers

Scope intentionally stopped at the overlay copy. The bigger question — whether the biz tab *should* get its own ungated `/try`-style build path — is a product/positioning call (a new anonymous public route), which CLAUDE.md's persona-loop guardrails reserve for a human decision, not an automated PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_016A9evXRzpmLaMUhN2fdNgx)_