### PR TITLE
persona-loop: extraction_failed error routes anonymous /try visitors into a signup wall

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -162,7 +162,10 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       setError(
         data.message ??
           (isExtractionFailed
-            ? "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."
+            ? // This client is the anonymous /try surface only — "describe your
+              // business instead" would send the visitor into the /signup wall
+              // (see run-create-from-url.ts's 2026-07-28 persona-loop honesty fix).
+              "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different page for the business — their Google Business or Facebook listing often has what a bare site is missing."
             : "Something broke on our end. Give it another try."),
       );
       setPhase("error");

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -270,13 +270,29 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         // succeed until credits are added. Remaining reasons
         // (anthropic_unauthorized, internal_error) are untouched — those ARE
         // sometimes transient.
+        //
+        // 2026-07-28 — persona-loop honesty fix. "or describe your business
+        // instead" is only a truthful next step for an AUTHENTICATED caller
+        // (clients-new-form.tsx's biz tab really does build immediately, no
+        // signup). On the anonymous /try surface (includeClaimGrant: true),
+        // the marketing hero's "Describe the business" tab routes to
+        // /signup?intent=build — see hero-submit-target.ts and try-client.tsx's
+        // own top-of-file deviation note ("Wiring a description mode here
+        // would require a second public anonymous route this task doesn't
+        // create"). Telling a visitor whose site failed extraction to
+        // "describe your business instead" sends them straight into a
+        // sign-up wall the moment they take the error message's own advice —
+        // exactly the kind of broken promise the honesty fixes above exist to
+        // prevent. Point anonymous visitors at another URL for the SAME
+        // business instead of a suggestion that secretly gates them.
         sse.error(
           422,
           reason === "extraction_failed"
             ? {
                 reason,
-                message:
-                  "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
+                message: input.includeClaimGrant
+                  ? "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different page for the business — their Google Business or Facebook listing often has what a bare site is missing."
+                  : "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
               }
             : reason === "credits_exhausted"
               ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -228,6 +228,31 @@ describe("runCreateFromUrl", () => {
     assert.match(text, /out of credits/i, "the message must say credits ran out, not a generic failure");
   });
 
+  // 2026-07-28 — persona-loop honesty fix. The anonymous /try surface sets
+  // includeClaimGrant: true. Its marketing hero offers a "Describe the
+  // business" tab, but that tab actually routes to /signup?intent=build (see
+  // hero-submit-target.ts) — there is no anonymous description-build route.
+  // So telling an anonymous visitor to "describe your business instead"
+  // sends them straight into a signup wall the moment they follow the
+  // error's own advice. The authenticated path (includeClaimGrant unset)
+  // keeps the original suggestion because its biz tab really does build
+  // immediately, no signup (clients-new-form.tsx's startBizInfoStream).
+  test("extraction_failed message does not suggest signup-gated 'describe your business' on the anonymous claim-grant path", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad output"); (e as any).reason = "extraction_failed"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: null, includeClaimGrant: true });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"extraction_failed"/);
+    assert.ok(!text.includes("describe your business instead"), "anonymous visitors must not be pointed at the signup-gated biz tab");
+    assert.match(text, /Google Business or Facebook listing/, "anonymous message should suggest another URL for the same business instead");
+  });
+
+  test("extraction_failed message still suggests 'describe your business' for the authenticated in-app path", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad output"); (e as any).reason = "extraction_failed"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /describe your business instead/, "authenticated visitors CAN switch to the biz tab in-app, no signup needed");
+  });
+
   test("a different reason (e.g. anthropic_unauthorized) carries no `message`", async () => {
     const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad key"); (e as any).reason = "anthropic_unauthorized"; (e as any).name = "WebFetchError"; throw e; } };
     const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });


### PR DESCRIPTION
## Summary

**Persona:** Tuesday persona-loop run — non-technical HVAC business owner, on a phone, no real website.

**Funnel step:** homepage hero (`/`) → "Paste a URL" tab → `extraction_failed` error → follows the error's own suggestion ("describe your business instead") → homepage "Describe the business" tab → `/signup`.

**First failure:** the anonymous, ungated `/try` build flow (`SF_WEB_UNGATED_BUILD=1`, confirmed live) tells a visitor whose site extraction failed to "describe your business instead" — but that tab always routes to `/signup?intent=build`, forcing full Google/email account creation before any workspace exists. This breaks the "instantly get a real hosted workspace, no signup, no claim step" promise the same error message is trying to honor, for exactly the visitor it's trying to help (a small business with a bare/no-phone-number site — the persona for this run).

**Verbatim evidence (live, 2026-07-28):**
```
$ curl -sS -N "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fexample.com"
event: fetching
data: {"url":"https://example.com"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```
```
$ curl -sS -D - -o /dev/null "https://www.seldonframe.com/signup?intent=build&url=https%3A%2F%2Fexample.com"
location: https://app.seldonframe.com/signup?intent=build&url=https%3A%2F%2Fexample.com
```
That signup page renders a real Google-OAuth / email wall (`redirectTo=/clients/new?url=...&intent=build`) — the build only happens *after* auth.

**Root cause:** `packages/crm/src/lib/web-onboarding/run-create-from-url.ts`'s `extraction_failed` message is shared between two callers: the authenticated in-app flow (`clients-new-form.tsx`, where switching to the biz tab really does build immediately, no signup — see `startBizInfoStream`) and the anonymous `/try` route (`api/v1/web/build/stream/route.ts`, `includeClaimGrant: true`), whose marketing-hero "Describe the business" tab has never been wired to an anonymous build route (`hero-submit-target.ts` always sends `biz` to `/signup`; `try-client.tsx` already documents this as a known deviation). The message never accounted for that difference, so it gave anonymous visitors advice that silently gates them.

**Fix:** branch the `extraction_failed` message on `input.includeClaimGrant` (the same flag that already distinguishes the two callers everywhere else in this file). Anonymous visitors now get a suggestion that stays inside the ungated surface (try another URL for the same business — Google Business / Facebook listing) instead of one that dead-ends in signup. Authenticated callers keep the original, still-truthful copy. Also updated `try-client.tsx`'s client-side fallback copy (used only if the server ever omits `message`) to match, since that component only ever serves the anonymous surface.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

Closes #

## Testing

- [x] Targeted unit tests: `node --import tsx --test tests/unit/web-onboarding/route-create-from-url.spec.ts tests/unit/web-onboarding/try-client.spec.tsx tests/unit/try-page-gate.spec.ts tests/unit/web-build-policy.spec.ts` — all pass (19 + 15 = 34 tests, including 2 new tests pinning the anonymous-vs-authenticated message split)
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 1 pre-existing error in `src/app/api/copilot/turn/route.ts` (confirmed present on `main` via `git stash`); no new errors from this change
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no schema touched)
- [ ] Manually verified in the browser — not applicable (SSE error-copy change only; verified via live `curl` against the production SSE endpoint, see evidence above)

## Screenshots / GIFs

N/A — server-emitted SSE error copy, no visual change.

## Notes for reviewers

- Small, single-concern change: two message strings + one differentiating condition, no new API surface, no schema change.
- Does not attempt to build the anonymous description-based build route — that's real feature work (already flagged as a deviation in `try-client.tsx`'s file header) and out of scope for this fix.
- Does not touch pricing, positioning copy, or SSRF/security-sensitive code, per persona-loop hard rules.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1pdxJvqShdxnkndtwR8y6)_