### PR TITLE
persona-loop: free-build rate limit burns on invalid URLs

### DIFF
--- a/packages/crm/src/app/api/v1/web/build/stream/route.ts
+++ b/packages/crm/src/app/api/v1/web/build/stream/route.ts
@@ -69,22 +69,37 @@ export const runtime = "nodejs";
 
 export type WebBuildGateResult =
   | { kind: "not_found" }
+  | { kind: "invalid_url" }
   | { kind: "rate_limited" }
   | { kind: "ok" };
 
 /**
  * Pure gate helper — flag check first (unconditional 404 when the surface
- * is off, regardless of rate), THEN the rate check. Exported so the unit
- * test can pin all three outcomes without touching the DB/Redis-backed
- * checkRateLimit or a real request.
+ * is off, regardless of rate or URL), THEN URL validation, THEN the rate
+ * check. Exported so the unit test can pin all outcomes without touching
+ * the DB/Redis-backed checkRateLimit, DNS, or a real request.
+ *
+ * 2026-07-29 persona-loop fix: `validateUrl` moved ahead of `rateCheck`.
+ * Previously the per-IP daily build counter (3/24h, the "build it free — no
+ * signup" allowance) was consumed BEFORE the pasted URL was known to be
+ * fetchable at all, so a typo'd domain or an SSRF-blocked host silently
+ * burned one of the visitor's 3 free attempts for zero delivered value.
+ * `validateUrl` must not have side effects visible to the caller when it
+ * returns false other than reporting invalid — it should not touch the
+ * rate-limit counter.
  */
 export async function resolveWebBuildGate(
   env: { SF_WEB_UNGATED_BUILD?: string | undefined },
   ip: string,
+  validateUrl: () => Promise<boolean>,
   rateCheck: () => Promise<boolean>,
 ): Promise<WebBuildGateResult> {
   if (!isWebUngatedBuildOn(env)) {
     return { kind: "not_found" };
+  }
+  const urlOk = await validateUrl();
+  if (!urlOk) {
+    return { kind: "invalid_url" };
   }
   const allowed = await rateCheck();
   if (!allowed) {
@@ -195,28 +210,6 @@ export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url).searchParams.get("url");
   const ip = getClientIp(request);
 
-  const gate = await resolveWebBuildGate({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD }, ip, () =>
-    checkRateLimit(
-      `web-build:${ip}`,
-      resolveWebBuildRateLimit({ SF_WEB_BUILD_RATE_LIMIT: process.env.SF_WEB_BUILD_RATE_LIMIT }),
-      WEB_BUILD_RATE_WINDOW_MS,
-    ),
-  );
-
-  if (gate.kind === "not_found") {
-    return new Response(null, { status: 404 });
-  }
-
-  if (gate.kind === "rate_limited") {
-    const sse = createSseStream();
-    sse.emit("error", {
-      code: "rate_limited",
-      message: "You've built a few workspaces today — sign up to keep building.",
-    });
-    sse.close();
-    return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
-  }
-
   // SSRF hardening on the now-public path (final review 2026-07-04): resolve +
   // vet the pasted URL before any pipeline work. The actual scrape runs on
   // Firecrawl's hosted infra, so this is defense-in-depth, not a live hole.
@@ -228,22 +221,57 @@ export async function GET(request: Request): Promise<Response> {
   // rejects it (generic "Something broke" for any schemeless direct paste on
   // /try — the hero always passed full https URLs, masking it). The build must
   // receive the SAME normalized URL we vetted.
+  //
+  // Run inside resolveWebBuildGate's validateUrl step, BEFORE the rate-limit
+  // check below — a typo'd/unreachable URL must not consume one of the
+  // visitor's 3 free daily builds (2026-07-29 persona-loop fix; see that
+  // function's doc comment).
   let buildUrl = url;
-  if (url) {
-    const trimmed = url.trim();
-    const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-    try {
-      await assertPublicHttpUrl(candidate);
-    } catch {
-      const sse = createSseStream();
-      sse.emit("error", {
-        code: "invalid_url",
-        message: "That URL can't be reached — double-check it and try again.",
-      });
-      sse.close();
-      return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
-    }
-    buildUrl = candidate;
+  const gate = await resolveWebBuildGate(
+    { SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD },
+    ip,
+    async () => {
+      if (!url) return true;
+      const trimmed = url.trim();
+      const candidate = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+      try {
+        await assertPublicHttpUrl(candidate);
+      } catch {
+        return false;
+      }
+      buildUrl = candidate;
+      return true;
+    },
+    () =>
+      checkRateLimit(
+        `web-build:${ip}`,
+        resolveWebBuildRateLimit({ SF_WEB_BUILD_RATE_LIMIT: process.env.SF_WEB_BUILD_RATE_LIMIT }),
+        WEB_BUILD_RATE_WINDOW_MS,
+      ),
+  );
+
+  if (gate.kind === "not_found") {
+    return new Response(null, { status: 404 });
+  }
+
+  if (gate.kind === "invalid_url") {
+    const sse = createSseStream();
+    sse.emit("error", {
+      code: "invalid_url",
+      message: "That URL can't be reached — double-check it and try again.",
+    });
+    sse.close();
+    return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
+  }
+
+  if (gate.kind === "rate_limited") {
+    const sse = createSseStream();
+    sse.emit("error", {
+      code: "rate_limited",
+      message: "You've built a few workspaces today — sign up to keep building.",
+    });
+    sse.close();
+    return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
   }
 
   return runAnonymousBuild(buildUrl);

--- a/packages/crm/tests/unit/web-build-stream-route.spec.ts
+++ b/packages/crm/tests/unit/web-build-stream-route.spec.ts
@@ -2,17 +2,51 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { resolveWebBuildGate } from "@/app/api/v1/web/build/stream/route";
 
-test("flag off → not_found regardless of rate", async () => {
-  const out = await resolveWebBuildGate({}, "1.2.3.4", async () => true);
+test("flag off → not_found regardless of rate or url", async () => {
+  const out = await resolveWebBuildGate(
+    {},
+    "1.2.3.4",
+    async () => false,
+    async () => true,
+  );
   assert.deepEqual(out, { kind: "not_found" });
 });
 
-test("flag on + under limit → ok", async () => {
-  const out = await resolveWebBuildGate({ SF_WEB_UNGATED_BUILD: "1" }, "1.2.3.4", async () => true);
+test("flag on + valid url + under limit → ok", async () => {
+  const out = await resolveWebBuildGate(
+    { SF_WEB_UNGATED_BUILD: "1" },
+    "1.2.3.4",
+    async () => true,
+    async () => true,
+  );
   assert.deepEqual(out, { kind: "ok" });
 });
 
-test("flag on + over limit → rate_limited", async () => {
-  const out = await resolveWebBuildGate({ SF_WEB_UNGATED_BUILD: "1" }, "1.2.3.4", async () => false);
+test("flag on + invalid url → invalid_url without ever consuming the rate limit", async () => {
+  let rateCheckCalled = false;
+  const out = await resolveWebBuildGate(
+    { SF_WEB_UNGATED_BUILD: "1" },
+    "1.2.3.4",
+    async () => false,
+    async () => {
+      rateCheckCalled = true;
+      return true;
+    },
+  );
+  assert.deepEqual(out, { kind: "invalid_url" });
+  assert.equal(
+    rateCheckCalled,
+    false,
+    "a typo'd/unreachable URL must not burn one of the visitor's free daily builds",
+  );
+});
+
+test("flag on + valid url + over limit → rate_limited", async () => {
+  const out = await resolveWebBuildGate(
+    { SF_WEB_UNGATED_BUILD: "1" },
+    "1.2.3.4",
+    async () => true,
+    async () => false,
+  );
   assert.deepEqual(out, { kind: "rate_limited" });
 });


### PR DESCRIPTION
## Summary

Nightly persona-loop finding — Wednesday persona: **med-spa owner**, non-technical, impatient, on a phone.

**Funnel step:** the homepage hero → `/try` (`ungatedBuildEnabled` is `true` in production — confirmed via `curl https://www.seldonframe.com/`, which serves `"ungatedBuildEnabled":true` in the RSC payload). This is the flagship "paste a URL, build it free, no signup" wedge the whole zero-friction pitch in `CLAUDE.md` §1 rests on.

**First failure found:** the per-IP daily "3 free builds" allowance is consumed by attempts that deliver **zero value** — a typo'd domain, or a business whose only web presence is something the SSRF/extraction pipeline can't use (e.g. a bare Facebook page).

### Verbatim evidence

Hit the live anonymous SSE build route directly:

```
$ curl -sS -N "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fwww.facebook.com%2Fpersonalooptestmedspa"
event: fetching
data: {"url":"https://www.facebook.com/personalooptestmedspa"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}

$ curl -sS -N "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fwww.personalooptest-medspa-typo-nonexistent-domain-xyz123.con"
event: error
data: {"code":"invalid_url","message":"That URL can't be reached — double-check it and try again."}
```

Real med-spas very commonly have Instagram/Facebook-only presence, and a phone-typing owner will regularly typo a domain. Both of the above are realistic first inputs for this persona — and both are honest, well-copy'd error states (props to whoever wrote the `extraction_failed` non-retry UX on 2026-07-14). The bug isn't the copy — it's what happens to the visitor's quota underneath it.

### Root cause

`packages/crm/src/app/api/v1/web/build/stream/route.ts`'s `GET` handler called `resolveWebBuildGate(env, ip, rateCheck)`, which checks the feature flag and then **unconditionally calls `rateCheck()`** (the 3-per-24h Redis/in-memory counter) — *before* the pasted URL is even validated as a safe, fetchable target (`assertPublicHttpUrl` / SSRF guard ran afterward). So:

- A fat-fingered domain (DNS failure → `invalid_url`)
- A host rejected by the SSRF guard
- Any other pre-flight rejection

...all burn one of the visitor's 3 free daily attempts with zero backend work done and zero site built. For a business whose real-world web presence doesn't scrape cleanly (very common for med-spas / solo service businesses), this can mean the "build it free, no signup" promise from the homepage silently degrades to "you get 1-2 real tries before we tell you to sign up," with no visible warning anywhere in the copy.

### Fix

Reordered `resolveWebBuildGate` to run URL validation **before** the rate-limit check (new `invalid_url` gate outcome), and moved the route's existing SSRF/normalize block into that validation step. No change to the SSRF guard itself, no change to what counts as a valid URL, no change to the `extraction_failed` behavior (that happens after real LLM cost is incurred server-side, so it's still fine to count against quota — this PR only stops charging the quota for inputs that never got that far).

- `packages/crm/src/app/api/v1/web/build/stream/route.ts` — `resolveWebBuildGate` gains a `validateUrl` step ahead of `rateCheck`; `GET` handler reordered accordingly.
- `packages/crm/tests/unit/web-build-stream-route.spec.ts` — updated for the new signature, plus a new case asserting the rate-limit callback is never invoked when the URL is invalid.

## Type of change

- [x] Bug fix

## Testing

- [x] `node --import tsx --test tests/unit/web-build-stream-route.spec.ts` — 4/4 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — no new errors vs `main` (one pre-existing unrelated error in `copilot/turn/route.ts` on both)
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)

## Notes for reviewers

Scoped to the ordering of one route's gate checks — no security-sensitive logic (SSRF guard internals, auth, org-scoping) or pricing/positioning copy touched, per the persona-loop hard rules.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WU63NsCfDyaXj3YYTQTuTs)_