### PR TITLE
persona-loop: /try tells visitors "we read that site" even when the scrape never succeeded

### DIFF
--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,8 +236,16 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // scrape.reason here is fetch_failed / timeout / rate_limited /
+    // empty_content — the page was never actually read, so this is NOT the
+    // same condition as "we read the site but it has no phone/name/location"
+    // (extraction_failed below). Often transient (a slow site, an anti-bot
+    // challenge, Firecrawl's own rate limit) — keep it a distinct reason so
+    // the UI doesn't tell the visitor "we read that site" when we didn't,
+    // and doesn't permanently block retrying a URL that may work seconds
+    // later.
     throw new WebFetchError(
-      "extraction_failed",
+      "site_unreachable",
       `Firecrawl fetch failed: ${scrape.reason}${
         scrape.detail ? `: ${scrape.detail}` : ""
       }`,

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -259,17 +259,25 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
       } catch (err: unknown) {
         const reason = (err as { reason?: string }).reason ?? "extraction_failed";
         // 2026-07-14 — extraction-failed honesty fix. extraction_failed is a
-        // PERMANENT condition for that URL (no phone/name/location found
-        // anywhere on the site) — retrying can never succeed. Without a
-        // `message`, the UI falls back to "Something broke on our end. Give
-        // it another try." and shows a Try again button, which burns the
-        // visitor's rate limit on a build that will fail identically every
-        // time.
+        // PERMANENT condition for that URL (we DID read the site — the LLM
+        // extractor just found no phone/name/location on it, even after the
+        // contact-page fallback retry) — retrying can never succeed. Without
+        // a `message`, the UI falls back to "Something broke on our end.
+        // Give it another try." and shows a Try again button, which burns
+        // the visitor's rate limit on a build that will fail identically
+        // every time.
         // 2026-07-16 — same honesty rule for credits_exhausted: the Anthropic
         // account funding the extraction is out of credits, so no retry can
-        // succeed until credits are added. Remaining reasons
-        // (anthropic_unauthorized, internal_error) are untouched — those ARE
-        // sometimes transient.
+        // succeed until credits are added.
+        // 2026-07-30 — persona-loop finding: site_unreachable is the OPPOSITE
+        // case — the scrape itself never succeeded (timeout, anti-bot block,
+        // Firecrawl's own rate limit, empty/JS-shell page), so we never read
+        // the site at all. That's often transient and has nothing to do with
+        // the site's content, so unlike extraction_failed it gets an honest,
+        // RETRYABLE message instead of "We read that site...". Remaining
+        // reasons (anthropic_unauthorized, internal_error) are untouched —
+        // those ARE sometimes transient too and already fall through to the
+        // default retryable path.
         sse.error(
           422,
           reason === "extraction_failed"
@@ -278,9 +286,15 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
                 message:
                   "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
               }
-            : reason === "credits_exhausted"
-              ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
-              : { reason },
+            : reason === "site_unreachable"
+              ? {
+                  reason,
+                  message:
+                    "We couldn't load that site just now — it may be temporarily down, blocking automated visits, or slow to respond. Try again in a moment.",
+                }
+              : reason === "credits_exhausted"
+                ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
+                : { reason },
         );
         sse.close();
         return;

--- a/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
@@ -40,6 +40,7 @@ import { parseExtraction } from "./extraction-parser";
 
 export type WebFetchErrorReason =
   | "extraction_failed"
+  | "site_unreachable"
   | "credits_exhausted"
   | "anthropic_unauthorized"
   | "internal_error";

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,11 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  test("Firecrawl throws -> WebFetchError(site_unreachable) with 'Firecrawl fetch failed' prefix", async () => {
+    // 2026-07-30 — persona-loop fix: a scrape-layer failure (the page was
+    // never actually read) is a distinct, often-transient reason from
+    // extraction_failed (the page WAS read but lacked required fields) — see
+    // markdown-extractor.ts's extractBusinessFactsFromUrl.
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,14 +127,16 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "site_unreachable" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
     );
   });
 
-  test("near-empty markdown (< 200 chars) -> WebFetchError(extraction_failed)", async () => {
+  test("near-empty markdown (< 200 chars) -> WebFetchError(site_unreachable)", async () => {
     // JS-only SPA shell / anti-bot challenge / blank doc — Firecrawl
-    // returns markdown but well below the MIN_MARKDOWN_CHARS floor.
+    // returns markdown but well below the MIN_MARKDOWN_CHARS floor. The
+    // page was never really read, so this is site_unreachable, not
+    // extraction_failed (see the 2026-07-30 note above).
     const firecrawl = makeFakeFirecrawl(async () => ({
       markdown: "# Loading\n\nEnable JavaScript.",
       metadata: { sourceURL: "https://spa.example/", statusCode: 200 },
@@ -146,7 +152,7 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "site_unreachable" &&
         err.message.includes("empty_content"),
     );
   });

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -228,6 +228,20 @@ describe("runCreateFromUrl", () => {
     assert.match(text, /out of credits/i, "the message must say credits ran out, not a generic failure");
   });
 
+  // 2026-07-30 — persona-loop fix. site_unreachable means the scrape never
+  // succeeded (timeout / anti-bot block / Firecrawl rate limit / empty
+  // page) — the SITE was never read, unlike extraction_failed where it was
+  // read but lacked required fields. Often transient, so unlike
+  // extraction_failed the message must NOT claim "we read that site" and
+  // must not be paired with UI copy that blocks retry.
+  test("site_unreachable 422 carries an honest, retry-friendly `message`", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("Firecrawl fetch failed: timeout"); (e as any).reason = "site_unreachable"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"site_unreachable".*"message":"/);
+    assert.ok(!text.includes("We read that site"), "must not claim the site was read when the scrape never succeeded");
+  });
+
   test("a different reason (e.g. anthropic_unauthorized) carries no `message`", async () => {
     const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("bad key"); (e as any).reason = "anthropic_unauthorized"; (e as any).name = "WebFetchError"; throw e; } };
     const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });


### PR DESCRIPTION
## Summary

Nightly persona-loop run (persona: landscaper, Thu). Walked the live `/try` "paste your URL" instant-build funnel on www.seldonframe.com and found the homepage's own copy — "no guest mode, no claim step, instantly get a real hosted workspace" — breaks the moment a scrape doesn't go perfectly, which is common: Facebook-only business pages, slow sites, or Firecrawl's own rate limit.

**Persona:** landscaper business owner, skeptical, on a phone, first time trying the "paste your website" flow.

**Funnel step:** homepage hero form → `/try?url=...` → `GET /api/v1/web/build/stream` (the ungated instant-build path; confirmed live in prod, `SF_WEB_UNGATED_BUILD` is on).

**Verbatim evidence:**
```
$ curl -sS -i --max-time 60 "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fwww.facebook.com%2Fpeoplemedia"
HTTP/2 200
event: fetching
data: {"url":"https://www.facebook.com/peoplemedia"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```
Many local trades (landscapers, plumbers, HVAC) only have a Facebook Page, not a real website — this is a very common first input, not an edge case.

**Root cause:** `firecrawl-scrape.ts` already classifies scrape failures correctly (`fetch_failed`, `timeout`, `rate_limited`, `empty_content` — e.g. an anti-bot/login-walled page like Facebook, or Firecrawl's own rate limit, which has nothing to do with the target site at all). But `markdown-extractor.ts`'s `extractBusinessFactsFromUrl` collapsed *every one of these* into the same `WebFetchError("extraction_failed", …)` used for "we successfully read the site but the LLM found no phone/name/location on it." `run-create-from-url.ts` then emitted the literally false "We read that site but couldn't find the basics…" for cases where the site was never read at all, and `try-client.tsx` treats `extraction_failed` as **permanent**, hiding the "Try again" button — so a visitor whose site just timed out, or who hit our own Firecrawl rate limit, is told the same false, non-retryable story as someone whose site genuinely has no business info, and is pushed toward signing up instead of retrying a URL that likely would have worked.

**Fix:** added a distinct `WebFetchError` reason, `site_unreachable`, for scrape-layer failures (`markdown-extractor.ts`). `run-create-from-url.ts` now maps it to an honest, retry-friendly message ("We couldn't load that site just now — it may be temporarily down, blocking automated visits, or slow to respond. Try again in a moment.") instead of claiming the site was read. Because this reason isn't `extraction_failed`, the existing UI logic in `try-client.tsx` already falls through to its default retryable branch (shows "Try again") — no UI changes needed. The genuinely-permanent `extraction_failed` case (site read fine, no business facts found even after the contact-page fallback) is untouched.

Minimal, scoped to the three files in the failure path plus their targeted tests — no copy/positioning changes, no touch to pricing, auth, or SSRF guard code (`assertPublicHttpUrl` is unchanged).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] Targeted unit tests (`node --import tsx --test` on the touched specs) — 45/45 pass, including 2 updated tests (scrape failure now asserts `site_unreachable`) and 1 new test (`site_unreachable 422 carries an honest, retry-friendly message`)
- [x] `tsc -p tsconfig.json --noEmit` — 0 new errors vs `main` (byte-identical diff against the pre-existing baseline error set, all unrelated to this change)
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass
- [ ] Manually verified the change in the browser — not done; this is a server-side SSE error-payload fix with no UI markup change (existing UI branch logic already handles the new reason correctly)

## Notes for reviewers

- No env/schema changes.
- `packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx` (the authed operator flow) also receives `site_unreachable` now, but its fallback copy ("We couldn't read that site...") was already honest and generic — left untouched as out of scope.

---
Filed by the nightly persona-loop routine per `CLAUDE.md` — one finding, one fix, one PR. Not merged; awaiting human review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LDoSKtgPYT4BfVwycNhtG1)_