### PR TITLE
persona-loop: /try's extraction_failed CTA silently sent visitors to signup

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -350,6 +350,16 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                   // sign up to describe the business instead (the anonymous
                   // paste/describe path isn't public — see the file-header
                   // deviation note).
+                  //
+                  // 2026-07-31 — signup-honesty fix (persona-loop finding).
+                  // This page's own hero copy promises "no signup required" /
+                  // "nothing to sign up for yet". The old label here — "Describe
+                  // your business instead" — pointed at the same /signup href as
+                  // the rate-limited branch above but, unlike that branch, never
+                  // said "sign up", so it read as a second free path when it
+                  // wasn't one. Businesses with no scrapable website (e.g. a
+                  // Facebook-only page, which reliably 422s here) hit this exact
+                  // state. Match the rate-limited branch's honesty pattern.
                   <div className="mt-3 flex flex-wrap items-center gap-3">
                     <button
                       type="button"
@@ -362,7 +372,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                       href="/signup"
                       className="inline-flex items-center gap-1.5 rounded-[11px] bg-[#1F2B24] px-4 py-2 text-[13.5px] font-[600] text-[#FFFDFA]"
                     >
-                      Describe your business instead
+                      Sign up to describe your business instead
                     </a>
                   </div>
                 ) : creditsExhausted ? (

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -87,6 +87,32 @@ describe("TryClient — SSE error honesty", () => {
     );
   });
 
+  test("extraction_failed CTA honestly discloses signup (persona-loop 2026-07-31)", async () => {
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("https://www.facebook.com/somedentaloffice");
+    });
+
+    await act(async () => {
+      FakeEventSource.last!.fire("error", {
+        code: 422,
+        reason: "extraction_failed",
+        message:
+          "We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead.",
+      });
+    });
+
+    assert.ok(
+      screen.queryAllByText("Sign up to describe your business instead").length > 0,
+      "the /signup CTA must say 'sign up' — this page promises 'no signup required' up top, so the fallback link must not imply it's a second free path",
+    );
+    assert.equal(
+      screen.queryAllByText("Describe your business instead").length,
+      0,
+      "the old undisclosed-signup label must be gone",
+    );
+  });
+
   test("internal_error still shows the generic copy WITH a 'Try again' button", async () => {
     render(<TryClient initialUrl="" />);
     await act(async () => {


### PR DESCRIPTION
## Persona-loop finding — Friday persona: dentist office manager

**Persona:** Non-technical, impatient, skeptical, on a phone. Her dental practice doesn't have a real marketing website — like a lot of small practices, it's mostly a Facebook Page.

**Funnel step:** `www.seldonframe.com` → hero "Paste a URL" → `/try` (the anonymous, no-signup build flow) → paste her practice's Facebook page URL → extraction fails → the error card's fallback CTA.

## Verbatim evidence

`/try`'s own hero copy, right above the input, promises:
> "Watch it build — **no signup required**"
> "We build a real hosted website, CRM, and a working AI chatbot in a few minutes — free to try, **nothing to sign up for yet**."

Hitting the public build API directly with a Facebook-page URL (a very common "my business has no real website" case, and exactly the scenario the extraction pipeline can't parse a name/location/phone out of):

```
GET https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fwww.facebook.com%2Fsomedentaloffice
HTTP 200 (SSE)

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```

The page then renders two buttons for this state (`packages/crm/src/app/(public)/try/try-client.tsx:353-367`, pre-fix):
```tsx
<button onClick={reset}>Try a different URL</button>
<a href="/signup">Describe your business instead</a>
```

That second button goes straight to `/signup` — but its label never says "sign up," right after a screen that just told her signup wasn't required. Compare the sibling `rate_limited` branch a few lines up in the *same file*, which already gets this right:
```tsx
<a href="/signup">Sign up to keep building</a>
```

## Root cause

`try-client.tsx`'s `extractionFailed` branch was written before the `rateLimited` branch's honesty pattern was established (see the file's own `2026-07-14 — extraction-failed honesty fix` and `2026-07-16 — credits_exhausted honesty fix` comments — this is a continuation of that same lineage, just a spot the earlier passes missed). The label just never got updated to disclose the destination.

## Fix

Smallest honest fix: relabel the CTA to match the already-accepted pattern next to it.

```diff
- Describe your business instead
+ Sign up to describe your business instead
```

Plus a doc comment explaining why, and a new regression test (`extraction_failed CTA honestly discloses signup`) pinning the honest copy and asserting the old undisclosed label is gone.

No pricing, positioning, or security-sensitive code touched — this is a copy-honesty fix inside an existing, already-established pattern in the same component.

## Gate results (run from `packages/crm`)

- ✅ Targeted unit tests: `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx tests/unit/try-page-gate.spec.ts` — 4/4 pass (including the new test)
- ✅ `node_modules/.bin/tsc -p tsconfig.json --noEmit` — identical single pre-existing error vs `main` (`api/copilot/turn/route.ts` `persist` prop, unrelated to this change); zero new errors
- ✅ `bash scripts/check-use-server.sh src` — pass
- ✅ `node scripts/check-migrations-journaled.mjs` — pass (99 files, 55 journaled, 44 known out-of-band, 0 orphans)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GJVCj3ezdwJsfWmEkRzqur)_