### PR TITLE
persona-loop: build funnel claims "we read that site" for sites we never reached

### DIFF
--- a/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
+++ b/packages/crm/src/app/(dashboard)/clients/new/clients-new-form.tsx
@@ -35,6 +35,12 @@ const COPY = {
     invalid_url: "That URL doesn't look right. Check for typos and try again.",
     extraction_failed:
       "We couldn't read that site. Try a different URL — a homepage works best.",
+    // 2026-08-01 — site_unreachable honesty fix (persona-loop finding). The
+    // site was never actually fetched (network error, timeout, or a rate
+    // limit) — distinct from extraction_failed, where we read the page and
+    // found nothing usable. Server-sent `message` wins; this is the fallback.
+    site_unreachable:
+      "We couldn't reach that site — it may be down, blocking automated visits, or timed out. Try again in a bit.",
     // 2026-07-16 — credits_exhausted honesty fix. Out-of-credits is NOT an
     // unreadable site; the operator here may be on their own BYOK key, so
     // point at adding Anthropic credits. Server-sent `message` wins; this
@@ -314,13 +320,16 @@ export function ClientsNewForm({
         return;
       }
       if (data.code === 422) {
-        // credits_exhausted is a key-funding problem, not a site-reading one —
-        // show the server's honest message (fallback to the dedicated copy)
-        // instead of sending the operator hunting for a "better" URL.
+        // credits_exhausted and site_unreachable are NOT "we read the site
+        // and it lacked the basics" — show the server's honest message
+        // (fallback to the dedicated copy) instead of the extraction_failed
+        // copy, which would wrongly claim we read a site we never reached.
         setErrorBanner(
           data.reason === "credits_exhausted"
             ? data.message || COPY.errors.credits_exhausted
-            : COPY.errors.extraction_failed,
+            : data.reason === "site_unreachable"
+              ? data.message || COPY.errors.site_unreachable
+              : COPY.errors.extraction_failed,
         );
         return;
       }
@@ -402,13 +411,16 @@ export function ClientsNewForm({
         return;
       }
       if (data.code === 422) {
-        // credits_exhausted is a key-funding problem, not a site-reading one —
-        // show the server's honest message (fallback to the dedicated copy)
-        // instead of sending the operator hunting for a "better" URL.
+        // credits_exhausted and site_unreachable are NOT "we read the site
+        // and it lacked the basics" — show the server's honest message
+        // (fallback to the dedicated copy) instead of the extraction_failed
+        // copy, which would wrongly claim we read a site we never reached.
         setErrorBanner(
           data.reason === "credits_exhausted"
             ? data.message || COPY.errors.credits_exhausted
-            : COPY.errors.extraction_failed,
+            : data.reason === "site_unreachable"
+              ? data.message || COPY.errors.site_unreachable
+              : COPY.errors.extraction_failed,
         );
         return;
       }

--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,8 +236,15 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // "extraction_failed" means the page WAS read and simply lacked the
+    // facts we need (empty_content: <200 chars of real content) — that's
+    // a permanent condition for that URL. fetch_failed/timeout/rate_limited
+    // mean the page was NEVER read at all, so the honesty fix in
+    // run-create-from-url.ts ("We read that site but couldn't find...")
+    // would be a lie for those three. Give them their own reason so the
+    // caller can tell a visitor the truth: we couldn't reach their site.
     throw new WebFetchError(
-      "extraction_failed",
+      scrape.reason === "empty_content" ? "extraction_failed" : "site_unreachable",
       `Firecrawl fetch failed: ${scrape.reason}${
         scrape.detail ? `: ${scrape.detail}` : ""
       }`,

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -270,6 +270,14 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         // succeed until credits are added. Remaining reasons
         // (anthropic_unauthorized, internal_error) are untouched — those ARE
         // sometimes transient.
+        // 2026-08-01 — site_unreachable honesty fix. markdown-extractor.ts
+        // now splits the old catch-all extraction_failed bucket: a site
+        // that returned a fetch error, timed out, or hit a rate limit was
+        // NEVER actually read, so the "We read that site..." copy above was
+        // false for those cases (persona-loop finding). Unlike
+        // extraction_failed, this IS often transient (timeout, rate limit,
+        // a momentary block) — leave `message` unset here so the UI's
+        // default "Try again" affordance still applies.
         sse.error(
           422,
           reason === "extraction_failed"
@@ -280,7 +288,13 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
               }
             : reason === "credits_exhausted"
               ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
-              : { reason },
+              : reason === "site_unreachable"
+                ? {
+                    reason,
+                    message:
+                      "We couldn't reach that site — it may be down, blocking automated visits, or timed out. Try again in a bit, or describe your business instead.",
+                  }
+                : { reason },
         );
         sse.close();
         return;

--- a/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
@@ -40,6 +40,7 @@ import { parseExtraction } from "./extraction-parser";
 
 export type WebFetchErrorReason =
   | "extraction_failed"
+  | "site_unreachable"
   | "credits_exhausted"
   | "anthropic_unauthorized"
   | "internal_error";

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,10 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  test("Firecrawl throws -> WebFetchError(site_unreachable) with 'Firecrawl fetch failed' prefix", async () => {
+    // The site was never actually read (network error / bot block), so this
+    // must NOT be "extraction_failed" — that reason tells the visitor "we
+    // read your site but found nothing," which would be false here.
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,7 +126,7 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "site_unreachable" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
     );
   });


### PR DESCRIPTION
## Persona

Saturday persona: solo electrician, non-technical, on a phone, skeptical, bounces at the first confusing thing.

## Funnel step

The homepage hero form (`#hero-form`, "Build your first client workspace free →") routes to the public, unauthenticated "paste a URL, get a real workspace, no signup" build flow (`/try` → `GET /api/v1/web/build/stream`, confirmed live in prod — `SF_WEB_UNGATED_BUILD` is on). This is the very first real thing a visitor does after landing on seldonframe.com.

## Verbatim evidence

Hit the live anonymous build endpoint directly with a minimal-content URL:

```
$ curl -N 'https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fexample.com'
event: fetching
data: {"url":"https://example.com"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```

That's a real, live prod response, `200 OK` / `x-matched-path: /api/v1/web/build/stream`.

A solo electrician's website is exactly the kind of site this breaks on for real: a slow shared-hosting WordPress build that times out, a site currently down, or one behind Cloudflare bot protection that blocks the scraper — none of which were ever actually "read." Telling that visitor "we read your site" when we didn't is a trust-killer on the very first interaction, and it directly contradicts this repo's stated positioning (`CLAUDE.md` §1b): *"never-lies... grounded + enforced read-back."*

## Root cause

`packages/crm/src/lib/web-onboarding/firecrawl-scrape.ts` classifies scrape failures into four distinct reasons: `fetch_failed`, `timeout`, `rate_limited`, `empty_content`. But `markdown-extractor.ts`'s `if (!scrape.ok)` branch collapsed all four (via `WebFetchError("extraction_failed", ...)`) into the same bucket used for "we scraped the page and it genuinely had nothing on it." A 2026-07-14 "honesty fix" (`run-create-from-url.ts`) then hard-coded the message *"We read that site but couldn't find the basics..."* for every `extraction_failed`, on the assumption that reason only ever meant "read it, found nothing" — but three of its four underlying causes mean the opposite: the site was never read at all. An existing unit test (`markdown-extractor.spec.ts`, "Firecrawl throws...") encoded this exact bug: a Firecrawl `403`/network failure asserted `reason === "extraction_failed"`.

## The fix

- Added a new `WebFetchErrorReason` value, `site_unreachable`, for the three failure modes where the page was never fetched (`fetch_failed` / `timeout` / `rate_limited`). `empty_content` (page loaded, <200 chars of real content) keeps `extraction_failed` — that one is honestly "we read it, it had nothing."
- `run-create-from-url.ts` now sends honest, retry-friendly copy for `site_unreachable`: *"We couldn't reach that site — it may be down, blocking automated visits, or timed out. Try again in a bit, or describe your business instead."* (unlike the permanent no-facts-found case, this one is often transient, so the anonymous `/try` UI's default "Try again" affordance now correctly applies — no client-side change needed there, since it's already gated only on `reason === "extraction_failed"`).
- The authed `/clients/new` form (`clients-new-form.tsx`) had the *same* bug in its own error-banner branching (any 422 that wasn't `credits_exhausted` fell back to the same "We couldn't read that site" copy) — fixed identically there, since it consumes the same orchestrator and reason codes.
- Updated the one existing unit test that encoded the old (dishonest) behavior.

Scope: copy + error-classification only. No pricing, positioning claims, or security-sensitive code touched.

## Gate results (run from `packages/crm`)

- `node --import tsx --test tests/unit/web-onboarding/*.spec.ts` → **95/95 pass**
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` → same single pre-existing error on `main` (`app/api/copilot/turn/route.ts:315`, unrelated to this change, confirmed by diffing against a stash of `main`) — **no new errors**
- `bash scripts/check-use-server.sh src` → **pass**
- `node scripts/check-migrations-journaled.mjs` → **pass** (99 .sql files, 55 journaled, 44 known out-of-band, 0 orphans)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVrHHPSQ7fvjQRpHWSNQrS)_