### PR TITLE
persona-loop: honest retry for scrape-level build failures on /try

### DIFF
--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,8 +236,18 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // 2026-08-05 — persona-loop honesty fix. "timeout"/"rate_limited"/
+    // "fetch_failed" all mean we never actually read the page (Firecrawl
+    // couldn't reach it, or hit its own rate limit) — an infra hiccup, not a
+    // verdict on the business's site. Collapsing them into extraction_failed
+    // made /try's honesty-fix copy ("We read that site but couldn't find the
+    // basics we need...") lie to the visitor and denied them a retry on a
+    // plainly transient failure (both /try's and clients-new-form's UIs treat
+    // extraction_failed as permanent/no-retry). Only "empty_content" (page
+    // loaded, near-nothing came back) is close enough to "couldn't find the
+    // basics" to keep that reason.
     throw new WebFetchError(
-      "extraction_failed",
+      scrape.reason === "empty_content" ? "extraction_failed" : "internal_error",
       `Firecrawl fetch failed: ${scrape.reason}${
         scrape.detail ? `: ${scrape.detail}` : ""
       }`,

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,13 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  // 2026-08-05 — persona-loop honesty fix. A raw Firecrawl throw (network
+  // error, anti-bot block, DNS failure) means we never read the page at all
+  // — that's an infra hiccup, not "we read your site and it's missing a
+  // phone number." It must map to internal_error (retryable, honest "give it
+  // another go" copy in both /try and clients-new-form), NOT extraction_failed
+  // (which both UIs treat as permanent with no retry affordance).
+  test("Firecrawl throws (fetch_failed) -> WebFetchError(internal_error) with 'Firecrawl fetch failed' prefix", async () => {
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,8 +129,32 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "internal_error" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
+    );
+  });
+
+  // A Firecrawl timeout is the clearest case: the visitor's site may be
+  // perfectly fine and simply slow to respond once. Retrying is often all
+  // that's needed, so this must never fall into the no-retry extraction_failed
+  // bucket.
+  test("Firecrawl times out -> WebFetchError(internal_error), not extraction_failed", async () => {
+    const firecrawl = makeFakeFirecrawl(async () => {
+      throw new Error("Request timed out after 45000ms");
+    });
+    const { client } = makeFakeAnthropic({ content: [{ type: "text", text: "{}" }] });
+    await assert.rejects(
+      () =>
+        extractBusinessFactsFromUrl({
+          url: "https://acme.com/slow",
+          byokKey: "sk-ant-test",
+          firecrawlClient: firecrawl,
+          anthropicClient: client,
+        }),
+      (err: unknown) =>
+        err instanceof WebFetchError &&
+        err.reason === "internal_error" &&
+        err.message.includes("Firecrawl fetch failed: timeout"),
     );
   });
 


### PR DESCRIPTION
## Summary

**Persona:** Wednesday → med-spa owner, non-technical, on a phone, skeptical.

**Funnel step:** `/try` — the anonymous "paste a URL, watch your business build itself" flow (`GET /api/v1/web/build/stream`), the real self-serve on-ramp for a solo small-business owner (the homepage hero is deliberately agency-voiced per `marketing-hero.tsx`'s 2026-07-15 repositioning note — SMB self-serve lives on `/try` + SEO pages, so that's out of scope here).

**First failure (verbatim evidence):** Live production, both requests returned the identical SSE payload:

```
GET https://www.seldonframe.com/api/v1/web/build/stream?url=https://example.com
event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```
Same exact message for `https://www.facebook.com/BotoxBarMedSpa` (the "site is just a Facebook page" case the persona-loop brief calls out — very common for med spas). No retry button is offered for either — the `/try` UI (`try-client.tsx`) treats `reason: "extraction_failed"` as a **permanent** condition.

**Root cause:** `markdown-extractor.ts` collapsed **every** Firecrawl scrape failure — `fetch_failed`, `timeout`, `rate_limited`, *and* `empty_content` (4 distinct reasons defined in `firecrawl-scrape.ts`) — into the same `WebFetchError("extraction_failed", ...)`. But `timeout`/`rate_limited`/`fetch_failed` mean **we never actually read the page** (network hiccup, Firecrawl's own rate limit, anti-bot block) — not "we read your site and it's missing a phone number." Telling a visitor "we read that site but couldn't find the basics" when we never read it, and then denying them a retry, is exactly the dishonest-success-reporting pattern CLAUDE.md §3.1 calls out (a claim not backed by the observable end-state) — and it directly undoes the intent of the existing 2026-07-14 "extraction-failed honesty fix" in the same file, which was about not lying regarding retryability.

For a med-spa owner whose real online presence is a slow-loading Squarespace site or a Facebook page, this is a trust-killing dead end on the very first thing they try.

## Fix

`markdown-extractor.ts`: only map Firecrawl's `empty_content` reason (page loaded, near-nothing came back — the closest real match for "we read it, there wasn't much there") to `extraction_failed`. `timeout`, `rate_limited`, and `fetch_failed` now map to `internal_error`, which both `/try` and `clients-new-form.tsx` already render as an honest, retryable "something broke on our end — give it another go" — no new UI code needed, that path already existed and was just being bypassed.

Scope kept deliberately narrow: `empty_content` is left unchanged (a defensible judgment call either way; not touched to keep blast radius minimal).

## Type of change

- [x] Bug fix

## Testing

- [x] `node --import tsx --test tests/unit/web-onboarding/*.spec.ts tests/unit/web-build/*.spec.ts` — 96/96 pass (updated the one existing test that encoded the old behavior, added a `timeout` case)
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — no new errors vs `main` (one pre-existing unrelated error in `copilot/turn/route.ts` on both)
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass
- [x] Reproduced live against production (`www.seldonframe.com`) before and reasoned through the fix against the actual source of the observed messages

## Notes for reviewers

No schema/env changes. The `empty_content` vs the other three reasons is a judgment call — happy to fold it in too if you'd rather, but I kept it out to stay minimal since it's the one case where "we read it, there wasn't much there" is arguably still an honest description.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XCinLefQqhcjFXUzqgBVz3)_