### PR TITLE
persona-loop: /try traps non-URL input in a lying "Try again" loop

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -99,6 +99,19 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
   // anthropic-error-map.ts) — a "Try again" button would be a lie. The
   // server's `message` explains it; we just suppress the retry affordance.
   const [creditsExhausted, setCreditsExhausted] = useState(false);
+  // 2026-08-06 — invalid_url honesty fix (persona-loop finding). A visitor
+  // who types something that isn't a URL (their business name, a phone
+  // number, free text) into the URL-only /try box gets route.ts's
+  // `invalid_url` error deterministically for that exact input — the
+  // client-side parse will fail identically on every retry. Before this
+  // fix invalid_url fell through to the generic "Try again" branch, which
+  // calls startBuild(url) directly with the SAME unmodified value and no
+  // way to edit it (the input box only remounts via reset()/phase="idle").
+  // That's an infinite dead-end loop for exactly the non-technical visitor
+  // this box is supposed to serve — and every "Try again" click re-hits
+  // the SSE route, which spends one of the 3 free builds/24h on the same
+  // guaranteed failure (route.ts's rate gate runs before URL validation).
+  const [invalidUrl, setInvalidUrl] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const autoSubmittedRef = useRef(false);
 
@@ -159,6 +172,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       setRateLimited(data.code === "rate_limited");
       setExtractionFailed(isExtractionFailed);
       setCreditsExhausted(data.reason === "credits_exhausted");
+      setInvalidUrl(data.code === "invalid_url");
       setError(
         data.message ??
           (isExtractionFailed
@@ -190,6 +204,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
     setRateLimited(false);
     setExtractionFailed(false);
     setCreditsExhausted(false);
+    setInvalidUrl(false);
     setBuildInput(null);
   }
 
@@ -365,6 +380,18 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                       Describe your business instead
                     </a>
                   </div>
+                ) : invalidUrl ? (
+                  // invalid_url is deterministic for this exact input — a
+                  // blind "Try again" would resubmit the same unparseable
+                  // value and fail identically while burning the visitor's
+                  // rate limit. reset() re-shows the editable input instead.
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="mt-3 rounded-[11px] border border-[rgba(34,29,23,.16)] bg-[#FFFDFA] px-4 py-2 text-[13.5px] font-[500] text-[#221D17]"
+                  >
+                    Edit your URL
+                  </button>
                 ) : creditsExhausted ? (
                   // credits_exhausted is non-retryable until credits are
                   // added upstream — no "Try again" (it would fail

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -87,6 +87,39 @@ describe("TryClient — SSE error honesty", () => {
     );
   });
 
+  test("invalid_url error shows an 'Edit your URL' button, NOT a blind 'Try again'", async () => {
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("Mikes Landscaping Stockton CA");
+    });
+
+    const message = "That URL can't be reached — double-check it and try again.";
+    await act(async () => {
+      FakeEventSource.last!.fire("error", { code: "invalid_url", message });
+    });
+
+    assert.ok(screen.queryAllByText(message).length > 0, "server message must be shown");
+    assert.equal(
+      screen.queryAllByText("Try again").length,
+      0,
+      "invalid_url is deterministic for this input — no blind Try again button",
+    );
+    assert.ok(
+      screen.queryAllByText("Edit your URL").length > 0,
+      "must offer a way back to the editable input instead of re-submitting the same bad value",
+    );
+
+    // Clicking through must actually restore the editable input (reset()),
+    // not just remove the button.
+    await act(async () => {
+      fireEvent.click(screen.getByText("Edit your URL"));
+    });
+    assert.ok(
+      screen.queryAllByLabelText("Your website URL").length > 0,
+      "the input box must be editable again after invalid_url",
+    );
+  });
+
   test("internal_error still shows the generic copy WITH a 'Try again' button", async () => {
     render(<TryClient initialUrl="" />);
     await act(async () => {


### PR DESCRIPTION
## Summary

**Persona:** Thursday → landscaper (non-technical, impatient, on a phone, no in-house web dev).

**Funnel step:** the public, ungated "paste a URL, watch it build" flow at `/try` (reached from the homepage's "Build it free" → `#hero-form` → URL tab, `SF_WEB_UNGATED_BUILD` is on in production — confirmed live).

**First failure found:** the "Paste a URL" box only accepts a URL, but nothing stops a non-technical visitor from typing their business name instead (very plausible for this persona — many solo landscapers don't have a real website). Doing so traps them in a **dead-end retry loop with a message that lies about what's wrong**, and each loop iteration burns one of their 3 free builds/24h.

### Verbatim evidence

Live `curl` against the production SSE route with a non-URL string (simulating a visitor typing their business name into the URL box):

```
$ curl -sS -N "https://www.seldonframe.com/api/v1/web/build/stream?url=Mikes%20Landscaping%20Stockton%20CA"
event: error
data: {"code":"invalid_url","message":"That URL can't be reached — double-check it and try again."}
```

The message frames this as a *reachability* problem ("can't be reached... try again"), but the real problem is the input was never a URL — `route.ts` prepends `https://` to any schemeless paste before validating it, so `"Mikes Landscaping Stockton CA"` becomes `https://Mikes Landscaping Stockton CA` and fails `assertPublicHttpUrl` **deterministically**. Retrying the exact same input will fail identically every time — there is no transient condition here.

Reading `packages/crm/src/app/(public)/try/try-client.tsx`, `invalid_url` wasn't given its own branch — it fell through to the generic error UI, whose only affordance is a **"Try again" button wired to `startBuild(url)` with the same unmodified value**, and no way to edit the input (the URL box only remounts via `reset()` → `phase="idle"`, which the generic branch never calls). So a visitor who mistypes gets stuck clicking "Try again" against a guaranteed failure until they either give up or burn through their rate limit — worth noting `route.ts`'s per-IP rate gate (3 builds/24h) runs **before** URL validation, so each hopeless retry still counts against it.

This is the same failure class the code already fixed twice before for `extraction_failed` (2026-07-14) and `credits_exhausted` (2026-07-16) — both explicitly call out "a 'Try again' button would be a lie" for deterministic per-input failures. `invalid_url` was simply missed when that pattern was established.

### Root cause

`try-client.tsx`'s SSE `error` handler tracked `rateLimited` / `extractionFailed` / `creditsExhausted` but had no state for `data.code === "invalid_url"`, so it fell into the catch-all branch designed for genuinely transient errors (e.g. `internal_error`).

### Fix

Smallest change that follows the file's own established pattern:
- Add an `invalidUrl` state, set from `data.code === "invalid_url"` in the SSE error handler (and cleared in `reset()`, matching the other three flags).
- Add a render branch: when `invalidUrl`, show an **"Edit your URL"** button wired to `reset()` (re-shows the editable input) instead of the generic "Try again" (which resubmits the identical unparseable value).

No copy/positioning changes, no touch to the SSRF guard, rate limiter, or route logic — purely the client's handling of an error code it already receives.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] Targeted unit test added (`invalid_url error shows an 'Edit your URL' button, NOT a blind 'Try again'`) in `packages/crm/tests/unit/web-onboarding/try-client.spec.tsx`, mirroring the existing `credits_exhausted`/`internal_error` honesty tests — verifies the message renders, no "Try again" appears, and the input box is reachable again after clicking through.
- [x] `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx` — 3/3 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — diffed against `main`: zero new error lines (one pre-existing, unrelated error in `src/app/api/copilot/turn/route.ts` present on both)
- [x] `bash scripts/check-use-server.sh src` — clean
- [x] `node scripts/check-migrations-journaled.mjs` — clean (no migrations touched)
- [ ] Manually verified the change in the browser (if UI) — not run; verified via targeted RTL test + live `curl` against the production SSE route instead (see evidence above)

## Notes for reviewers

Scoped to one file's client-side error handling (`try-client.tsx`) plus its test. Does not touch `route.ts`, the SSRF guard, the rate limiter, or any positioning/pricing copy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PpwbmAy34yS9KpjStFE4sr)_