### PR TITLE
Funnel observability: auth-secret hardening + PostHog funnel events + e2e smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,36 @@ jobs:
 
       - name: Event-registry drift-detector
         run: pnpm emit:event-registry:check
+
+      - name: Generator regression net
+        run: cd packages/crm && node --import tsx --test tests/regression/generator-prompts.spec.ts
+
+  e2e-smoke:
+    runs-on: ubuntu-latest
+    if: vars.E2E_BASE_URL != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10.18.1
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Funnel render-tier smoke
+        # RENDER tier only — never set E2E_FULL here, it creates data.
+        run: pnpm --filter @seldonframe/crm exec playwright test e2e/funnel-smoke.spec.ts
+        env:
+          E2E_BASE_URL: ${{ vars.E2E_BASE_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright chromium
-        run: npx playwright install --with-deps chromium
+        run: pnpm --filter @seldonframe/crm exec playwright install --with-deps chromium
 
       - name: Funnel render-tier smoke
         # RENDER tier only — never set E2E_FULL here, it creates data.

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -49,3 +49,14 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Install Playwright chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Post-deploy funnel smoke (RENDER tier, GET-only)
+        # This deploy step doesn't expose a URL output, so we default to
+        # the known demo host. Never sets E2E_FULL — GET-only, safe
+        # against production.
+        run: pnpm --filter @seldonframe/crm exec playwright test e2e/funnel-smoke.spec.ts
+        env:
+          E2E_BASE_URL: https://app.seldonframe.com

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -51,7 +51,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Install Playwright chromium
-        run: npx playwright install --with-deps chromium
+        run: pnpm --filter @seldonframe/crm exec playwright install --with-deps chromium
 
       - name: Post-deploy funnel smoke (RENDER tier, GET-only)
         # This deploy step doesn't expose a URL output, so we default to

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 # testing
 /coverage
 
+# playwright artifacts (any workspace)
+test-results/
+playwright-report/
+blob-report/
+
 # next.js
 /.next/
 **/.next/

--- a/docs/learnings/2026-08-06-funnel-distinct-id-spaces.md
+++ b/docs/learnings/2026-08-06-funnel-distinct-id-spaces.md
@@ -1,0 +1,21 @@
+# Funnel events that all work individually can still be unjoinable — distinct-id spaces are the funnel
+
+**Date:** 2026-08-06 · **Branch:** feat/funnel-observability · **Related:** packages/crm/src/lib/analytics/funnel.ts, tasks/todo.md (funnel observability task)
+
+## 1. The problem, in one line
+Three correctly-firing PostHog events (`workspace_created`, `signed_up`, `checkout_started`) produced a funnel that would read ~0% on the product's primary path, because the first was keyed to an orgId and the other two to a userId, and PostHog treats those as two unrelated persons.
+
+## 2. The approach
+1. Before instrumenting, list every event's distinct_id at its REAL call site — not the intended id, the one actually in scope. (Here: `createFullWorkspace` runs before any user exists on the anonymous build-first path, so only orgId is available; signup/checkout have userId.)
+2. If any two funnel stages key to different id spaces, the funnel is broken regardless of how correct each event is. Ask: where does the identity link happen in the DOMAIN? For build-anonymously-then-claim products, it is the moment ownership is assigned.
+3. Find every code site that assigns ownership (here: grep for Drizzle `.update(organizations).set({ ownerId: ... })` — six sites) and fire `posthog alias(distinctId: userId, alias: orgId)` at each, fire-and-forget, lazy-imported.
+4. Client-side is a THIRD id space (device anon-id): `posthog.identify(userId)` in the authenticated layout merges it.
+5. Verify joinability as its own review question ("can these events be assembled into the named funnel?") — unit tests on payload shape will never catch this; ours were all green while the funnel was dead.
+
+## 3. Judgment calls
+- **Deliberately NO alias on the agency operator-claim path** (link-workspace-to-operator.ts). One operator claims many client workspaces; PostHog person merges are irreversible, so aliasing there would permanently fold 50 client pseudo-persons into one operator. Wrong-side default: when in doubt, don't merge — you can add a missing alias later, you can never split a merged person. Client workspaces should become a PostHog *group* if org-level funnels are ever needed on that path.
+- Kept the alias on inline-org signup paths even though no org-keyed event precedes it there (one wasted `$create_alias` per signup) — uniformity at the claim sites beats a conditional that will rot.
+- Did NOT switch to PostHog group analytics for the main funnel: it's a paid add-on and person-level joins were achievable with alias.
+
+## 4. The reusable rule, one line
+Before wiring any multi-stage analytics funnel, write down each stage's distinct-id AT ITS CALL SITE and refuse to ship until they provably join — and never alias/merge persons on any path where one actor claims many entities.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "db:seed": "pnpm --filter @seldonframe/crm db:seed",
     "db:seed-demo": "pnpm --filter @seldonframe/crm db:seed-demo",
     "template:validate": "pnpm --filter @seldonframe/crm template:validate",
-    "tsx": "node scripts/run-tsx.js"
+    "tsx": "node scripts/run-tsx.js",
+    "e2e:smoke": "pnpm --filter @seldonframe/crm exec playwright test e2e/funnel-smoke.spec.ts"
   },
   "devDependencies": {
     "turbo": "^2.10.5"

--- a/packages/crm/auth.ts
+++ b/packages/crm/auth.ts
@@ -173,6 +173,12 @@ const adapter = {
           email: users.email,
           emailVerified: users.emailVerified,
           image: users.avatarUrl,
+          // 2026-08-06 funnel observability — orgId isn't part of NextAuth's
+          // AdapterUser shape, but events.createUser (lib/auth/config.ts)
+          // needs it to fire signed_up without a second DB query. Extra
+          // fields on the returned object are ignored by NextAuth itself,
+          // just carried through to the events.createUser callback.
+          orgId: users.orgId,
         });
 
       if (!created) {

--- a/packages/crm/auth.ts
+++ b/packages/crm/auth.ts
@@ -18,10 +18,18 @@ if (process.env.GOOGLE_CLIENT_SECRET) process.env.GOOGLE_CLIENT_SECRET = process
 // 2026-08-06 — auth secret hardening. Preview/Dev Vercel environments were
 // found to have NO auth secret configured at all (Production had
 // AUTH_SECRET, but "[auth][logger][error] Please define a secret" still
-// surfaced on / in prod, tracing back to secret being read once at module
-// load rather than at NextAuth() call time). resolveAuthSecret is pure and
-// exported so it's unit-testable without booting NextAuth; NextAuth() below
-// calls it at invocation time, not via a stale module-load constant.
+// surfaced on / in prod). resolveAuthSecret is pure and exported so it's
+// unit-testable without booting NextAuth. It is still evaluated once at
+// module load (NextAuth() itself runs at module load too, so there is no
+// "call time" re-evaluation happening here — that framing in an earlier
+// version of this comment was wrong), and env trimming already happened
+// above at lines 10-11 before this function ever sees the values. The two
+// real behavioral deltas this adds over reading `process.env.AUTH_SECRET`
+// directly are: (1) an explicit fallback to NEXTAUTH_SECRET — Auth.js v5
+// only auto-reads AUTH_SECRET, not the legacy v4 env var name — and (2) a
+// production-only visibility log (below) when neither resolves, so a
+// misconfigured prod env fails loudly instead of surfacing as a generic
+// auth-provider error downstream.
 export function resolveAuthSecret(env: Record<string, string | undefined>): string | undefined {
   const authSecret = env.AUTH_SECRET?.trim();
   if (authSecret) return authSecret;
@@ -195,6 +203,21 @@ const adapter = {
         if (code !== "42703") {
           throw error;
         }
+      }
+
+      // 2026-08-06 funnel observability — this org just gained an owner,
+      // so alias the pre-owner org-keyed distinct id (workspace_created)
+      // to the new user-keyed distinct id (signed_up) so PostHog can join
+      // the two halves of the funnel into one person. Lazy import: this
+      // file is reachable from proxy.ts (src/auth.ts -> ../auth), and a
+      // static import would pull posthog-node into that module graph.
+      try {
+        const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+        aliasOrgToUser(created.id, org.id);
+      } catch (error) {
+        console.warn(
+          `[auth][adapter] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
 
       return created;

--- a/packages/crm/auth.ts
+++ b/packages/crm/auth.ts
@@ -15,6 +15,23 @@ if (process.env.AUTH_URL) process.env.AUTH_URL = process.env.AUTH_URL.trim();
 if (process.env.GOOGLE_CLIENT_ID) process.env.GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID.trim();
 if (process.env.GOOGLE_CLIENT_SECRET) process.env.GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET.trim();
 
+// 2026-08-06 — auth secret hardening. Preview/Dev Vercel environments were
+// found to have NO auth secret configured at all (Production had
+// AUTH_SECRET, but "[auth][logger][error] Please define a secret" still
+// surfaced on / in prod, tracing back to secret being read once at module
+// load rather than at NextAuth() call time). resolveAuthSecret is pure and
+// exported so it's unit-testable without booting NextAuth; NextAuth() below
+// calls it at invocation time, not via a stale module-load constant.
+export function resolveAuthSecret(env: Record<string, string | undefined>): string | undefined {
+  const authSecret = env.AUTH_SECRET?.trim();
+  if (authSecret) return authSecret;
+
+  const nextAuthSecret = env.NEXTAUTH_SECRET?.trim();
+  if (nextAuthSecret) return nextAuthSecret;
+
+  return undefined;
+}
+
 function slugify(input: string) {
   return input
     .toLowerCase()
@@ -182,9 +199,20 @@ const adapter = {
   },
 };
 
+const resolvedAuthSecret = resolveAuthSecret(process.env);
+if (
+  !resolvedAuthSecret &&
+  (process.env.VERCEL_ENV === "production" || process.env.NODE_ENV === "production")
+) {
+  console.error(
+    "[auth] AUTH_SECRET/NEXTAUTH_SECRET missing or empty — sessions will fail",
+  );
+}
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   debug: true,
   trustHost: true,
+  secret: resolvedAuthSecret,
   // 2026-05-17 — explicit cookie config to fix the PKCE-cookie-missing-on-
   // callback bug we hit repeatedly on prod Google OAuth.
   //

--- a/packages/crm/drizzle/0078_organizations_is_internal.sql
+++ b/packages/crm/drizzle/0078_organizations_is_internal.sql
@@ -1,0 +1,21 @@
+-- packages/crm/drizzle/0078_organizations_is_internal.sql
+-- Funnel observability — organizations.is_internal (2026-08-06). Excludes
+-- founder/internal workspaces from growth metrics (signed_up /
+-- workspace_created / checkout_started rollups). Backfills founder-owned
+-- orgs to true via two idempotent UPDATEs keyed off the founder's email.
+--
+-- HAND-WRITTEN (house rule: never drizzle-kit generate in this repo).
+-- Additive only + idempotent (IF NOT EXISTS / re-runnable UPDATEs) so a
+-- re-run after an out-of-band apply is a no-op. Mirrors 0077's style.
+
+ALTER TABLE organizations ADD COLUMN IF NOT EXISTS is_internal boolean NOT NULL DEFAULT false;
+
+UPDATE organizations
+SET is_internal = true
+WHERE owner_id IN (SELECT id FROM users WHERE email = 'maximehoule100@gmail.com')
+  AND is_internal = false;
+
+UPDATE organizations
+SET is_internal = true
+WHERE parent_user_id IN (SELECT id FROM users WHERE email = 'maximehoule100@gmail.com')
+  AND is_internal = false;

--- a/packages/crm/drizzle/meta/_journal.json
+++ b/packages/crm/drizzle/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1784300000000,
       "tag": "0077_replay_gate_v2",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "7",
+      "when": 1786000000000,
+      "tag": "0078_organizations_is_internal",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/crm/e2e/README.md
+++ b/packages/crm/e2e/README.md
@@ -1,0 +1,39 @@
+# Funnel smoke (Playwright)
+
+`funnel-smoke.spec.ts` is a small, deliberately narrow end-to-end suite covering
+the signup/login/pricing funnel plus the AUTH_SECRET sentinel
+(`/api/auth/providers`).
+
+## Two tiers
+
+- **RENDER tier** — GET-only, no auth, no writes. Safe to run against
+  production. Runs by default.
+- **FLOW tier** — creates a real workspace via
+  `POST /api/v1/workspaces/create-full`. Gated behind `E2E_FULL=1` and
+  **must never run against production** — only point it at a disposable
+  environment.
+
+## Running locally
+
+```bash
+# once, to fetch the browser binary
+npx playwright install chromium
+
+# RENDER tier against local dev (next dev on :3000)
+pnpm --filter @seldonframe/crm exec playwright test
+
+# RENDER tier against a deployed URL
+E2E_BASE_URL=https://your-preview.vercel.app pnpm --filter @seldonframe/crm exec playwright test
+
+# FLOW tier — disposable environments ONLY
+E2E_FULL=1 E2E_BASE_URL=https://your-disposable-env pnpm --filter @seldonframe/crm exec playwright test
+```
+
+## CI gates
+
+- `.github/workflows/ci.yml` — `e2e-smoke` job runs the RENDER tier only,
+  and only when the `E2E_BASE_URL` repository variable is configured
+  (`vars.E2E_BASE_URL`). `E2E_FULL` is never set in CI.
+- `.github/workflows/deploy-demo.yml` — after a successful deploy, runs
+  the RENDER tier against the deployed URL (or
+  `https://app.seldonframe.com` as a fallback) as a post-deploy smoke.

--- a/packages/crm/e2e/README.md
+++ b/packages/crm/e2e/README.md
@@ -35,5 +35,8 @@ E2E_FULL=1 E2E_BASE_URL=https://your-disposable-env pnpm --filter @seldonframe/c
   and only when the `E2E_BASE_URL` repository variable is configured
   (`vars.E2E_BASE_URL`). `E2E_FULL` is never set in CI.
 - `.github/workflows/deploy-demo.yml` — after a successful deploy, runs
-  the RENDER tier against the deployed URL (or
-  `https://app.seldonframe.com` as a fallback) as a post-deploy smoke.
+  the RENDER tier as a post-deploy smoke. `E2E_BASE_URL` is hardcoded to
+  `https://app.seldonframe.com` in that workflow — the deploy step doesn't
+  expose the deployment's own URL as an output, so there is no "deployed
+  URL" being targeted here, and no fallback logic; it's just the fixed
+  demo host.

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -15,6 +15,27 @@ import { test, expect } from "@playwright/test";
 
 const BROKEN_PAGE_PATTERN = /Application error|missingsecret/i;
 
+// Hard production guard for the FLOW tier — this tier creates real data
+// (a workspace, a checkout attempt) and must NEVER run against production,
+// even if someone sets E2E_FULL=1 by mistake while E2E_BASE_URL still
+// points at the production host. This check happens regardless of
+// E2E_FULL so the guard can't be bypassed by the same env var that gates
+// the tier on.
+function isProductionHost(rawBaseUrl: string | undefined): boolean {
+  if (!rawBaseUrl) return false;
+  try {
+    const host = new URL(rawBaseUrl).hostname.toLowerCase();
+    return host === "seldonframe.com" || host.endsWith(".seldonframe.com");
+  } catch {
+    // An unparsable base URL isn't a production host we can identify —
+    // fail open on "unknown", not on "safe to mutate".
+    return false;
+  }
+}
+
+const FLOW_BASE_URL = process.env.E2E_BASE_URL;
+const FLOW_IS_PRODUCTION = isProductionHost(FLOW_BASE_URL);
+
 test.describe("render tier (GET-only, safe everywhere)", () => {
   test("GET / is healthy", async ({ page }) => {
     // Reality check (verified live 2026-08-06): src/proxy.ts treats
@@ -53,10 +74,13 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
   test("GET /signup renders the signup page", async ({ page }) => {
     const response = await page.goto("/signup");
     expect(response?.status()).toBe(200);
-    // Unique to /signup (login shares the same h1 but not this subline).
-    await expect(
-      page.getByText("Your website, booking, CRM, and AI receptionist", { exact: false })
-    ).toBeVisible();
+    // Durable structural sentinels, not marketing copy: the email input
+    // (shared shape with /login) plus the submit button text, which is
+    // unique to signup-form.tsx ("...email link" vs login's "...email").
+    // A marketing-copy sentinel here couples deploy-demo to unrelated
+    // landing-copy edits — see BLOCKING review 2026-08-06.
+    await expect(page.getByPlaceholder("you@company.com")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with email link" })).toBeVisible();
 
     const body = await page.content();
     expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
@@ -65,10 +89,9 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
   test("GET /login renders the login page", async ({ page }) => {
     const response = await page.goto("/login");
     expect(response?.status()).toBe(200);
-    // Unique to /login (signup shares the same h1 but not this subline).
-    await expect(
-      page.getByText("The operating system for your business.", { exact: false })
-    ).toBeVisible();
+    // Durable structural sentinels — see /signup test above for rationale.
+    await expect(page.getByPlaceholder("you@company.com")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with email" })).toBeVisible();
 
     const body = await page.content();
     expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
@@ -88,6 +111,9 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
 
 test.describe("flow tier (creates data — E2E_FULL=1 only, disposable envs only)", () => {
   test.skip(process.env.E2E_FULL !== "1", "set E2E_FULL=1 to run the data-creating flow tier");
+  // This guard must trigger even when E2E_FULL=1 — it is the last line of
+  // defense against accidentally mutating production, not a convenience.
+  test.skip(FLOW_IS_PRODUCTION, `refusing to run the data-creating flow tier against production host (${FLOW_BASE_URL})`);
 
   test("create-full workspace -> public workspace page -> checkout route is alive", async ({
     request,

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -16,18 +16,24 @@ import { test, expect } from "@playwright/test";
 const BROKEN_PAGE_PATTERN = /Application error|missingsecret/i;
 
 test.describe("render tier (GET-only, safe everywhere)", () => {
-  test("GET / renders the marketing landing page", async ({ page, request }) => {
+  test("GET / is healthy", async ({ page }) => {
+    // Reality check (verified live 2026-08-06): src/proxy.ts treats
+    // app.seldonframe.com / localhost / 127.0.0.1 / *.vercel.app as the
+    // "app host" and unconditionally redirects `/` there to /login
+    // (anonymous) or /dashboard (authenticated) BEFORE the marketing
+    // landing page ((public)/page.tsx) is ever reached — that page only
+    // renders at `/` on the marketing host (seldonframe.com /
+    // www.seldonframe.com), which E2E_BASE_URL does not target here.
+    // So on every environment this suite actually runs against, `/`
+    // resolving to a healthy /login is the correct sentinel, not
+    // landing-page nav copy.
     const response = await page.goto("/");
     expect(response?.status()).toBe(200);
-
-    // Stable structural sentinel from the fixed marketing nav
-    // (src/components/landing/marketing-nav.tsx) — not marketing copy,
-    // won't churn with headline/positioning rewrites.
-    await expect(page.getByLabel("SeldonFrame — home")).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe("/login");
+    await expect(page.getByRole("heading", { name: "Welcome to SeldonFrame" })).toBeVisible();
 
     const body = await page.content();
     expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
-    void request;
   });
 
   test("GET /api/auth/providers exposes at least one provider (AUTH_SECRET sentinel)", async ({

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -1,0 +1,124 @@
+// packages/crm/e2e/funnel-smoke.spec.ts
+//
+// Two-tier funnel smoke.
+//
+// RENDER tier — always runs, strictly GET-only, safe against ANY
+// environment including production. No mutation, no auth, no
+// destructive calls. This is what CI and the post-deploy gate run.
+//
+// FLOW tier — creates a real workspace via the public atomic-create
+// endpoint. Gated behind E2E_FULL=1 so it can never run by default
+// (in CI or locally) and never against production. Only point
+// E2E_BASE_URL at a disposable environment when running this tier.
+
+import { test, expect } from "@playwright/test";
+
+const BROKEN_PAGE_PATTERN = /Application error|missingsecret/i;
+
+test.describe("render tier (GET-only, safe everywhere)", () => {
+  test("GET / renders the marketing landing page", async ({ page, request }) => {
+    const response = await page.goto("/");
+    expect(response?.status()).toBe(200);
+
+    // Stable structural sentinel from the fixed marketing nav
+    // (src/components/landing/marketing-nav.tsx) — not marketing copy,
+    // won't churn with headline/positioning rewrites.
+    await expect(page.getByLabel("SeldonFrame — home")).toBeVisible();
+
+    const body = await page.content();
+    expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
+    void request;
+  });
+
+  test("GET /api/auth/providers exposes at least one provider (AUTH_SECRET sentinel)", async ({
+    request,
+  }) => {
+    // NextAuth's own providers endpoint 500s (or returns a non-JSON error
+    // page) when AUTH_SECRET is missing — this is the exact incident class
+    // this test guards against.
+    const response = await request.get("/api/auth/providers");
+    expect(response.status()).toBe(200);
+
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(typeof body).toBe("object");
+    expect(Object.keys(body).length).toBeGreaterThan(0);
+  });
+
+  test("GET /signup renders the signup page", async ({ page }) => {
+    const response = await page.goto("/signup");
+    expect(response?.status()).toBe(200);
+    // Unique to /signup (login shares the same h1 but not this subline).
+    await expect(
+      page.getByText("Your website, booking, CRM, and AI receptionist", { exact: false })
+    ).toBeVisible();
+
+    const body = await page.content();
+    expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
+  });
+
+  test("GET /login renders the login page", async ({ page }) => {
+    const response = await page.goto("/login");
+    expect(response?.status()).toBe(200);
+    // Unique to /login (signup shares the same h1 but not this subline).
+    await expect(
+      page.getByText("The operating system for your business.", { exact: false })
+    ).toBeVisible();
+
+    const body = await page.content();
+    expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
+  });
+
+  test("GET /pricing renders the pricing page", async ({ page }) => {
+    const response = await page.goto("/pricing");
+    expect(response?.status()).toBe(200);
+    // Present in both the flag-off (Accordion) and SF_TIER_LADDER-on
+    // (details/summary) renderings — see src/app/pricing/page.tsx.
+    await expect(page.getByText("Frequently asked", { exact: false }).first()).toBeVisible();
+
+    const body = await page.content();
+    expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
+  });
+});
+
+test.describe("flow tier (creates data — E2E_FULL=1 only, disposable envs only)", () => {
+  test.skip(process.env.E2E_FULL !== "1", "set E2E_FULL=1 to run the data-creating flow tier");
+
+  test("create-full workspace -> public workspace page -> checkout route is alive", async ({
+    request,
+  }) => {
+    // 1. POST /api/v1/workspaces/create-full — minimal valid payload.
+    const createResponse = await request.post("/api/v1/workspaces/create-full", {
+      data: {
+        business_name: `E2E Smoke Test Co ${Date.now()}`,
+        city: "Phoenix",
+        state: "AZ",
+        phone: "+16025551234",
+        services: ["HVAC repair"],
+        business_description: "Playwright funnel smoke test workspace.",
+      },
+    });
+    expect(createResponse.status()).toBe(200);
+
+    const created = (await createResponse.json()) as {
+      status: string;
+      workspace_id?: string;
+      slug?: string;
+    };
+    expect(created.status).toBe("ready");
+    expect(created.slug).toBeTruthy();
+
+    // 2. GET the public workspace page for the new slug.
+    const workspaceResponse = await request.get(`/w/${created.slug}`);
+    expect(workspaceResponse.status()).toBe(200);
+
+    // 3. POST /api/stripe/checkout unauthenticated — asserts the route is
+    // ALIVE (any deliberate 4xx/redirect is fine; a 5xx is not). We don't
+    // attempt an authenticated checkout or an agent LLM conversation here
+    // (needs live keys/session) — that's out of scope for this smoke.
+    const checkoutResponse = await request.post("/api/stripe/checkout", {
+      data: { tier: "builder" },
+    });
+    expect(checkoutResponse.status()).toBeLessThan(500);
+    expect(checkoutResponse.status()).toBeGreaterThanOrEqual(400);
+  });
+});

--- a/packages/crm/package.json
+++ b/packages/crm/package.json
@@ -82,6 +82,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/crm/playwright.config.ts
+++ b/packages/crm/playwright.config.ts
@@ -1,0 +1,25 @@
+// packages/crm/playwright.config.ts
+//
+// Funnel smoke coverage — a small, deliberately narrow Playwright suite
+// (see e2e/funnel-smoke.spec.ts). RENDER tier is GET-only and safe to
+// run against production; FLOW tier writes data and is gated behind
+// E2E_FULL=1 inside the spec itself, never by this config.
+
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  retries: 1,
+  reporter: "list",
+  use: {
+    baseURL: process.env.E2E_BASE_URL || "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/packages/crm/scripts/assert-schema-drift.mjs
+++ b/packages/crm/scripts/assert-schema-drift.mjs
@@ -71,6 +71,12 @@ export const CRITICAL_COLUMNS = [
     migration: "0022_organizations_timezone",
     why: "NOT NULL DEFAULT 'UTC'; read on scheduled-trigger next-fire computation.",
   },
+  {
+    table: "organizations",
+    column: "is_internal",
+    migration: "0078_organizations_is_internal",
+    why: "NOT NULL DEFAULT false; read on growth-metrics org exclusion and funnel event builders.",
+  },
 ];
 
 /**

--- a/packages/crm/scripts/assert-schema-drift.mjs
+++ b/packages/crm/scripts/assert-schema-drift.mjs
@@ -75,7 +75,7 @@ export const CRITICAL_COLUMNS = [
     table: "organizations",
     column: "is_internal",
     migration: "0078_organizations_is_internal",
-    why: "NOT NULL DEFAULT false; read on growth-metrics org exclusion and funnel event builders.",
+    why: "NOT NULL DEFAULT false; no reader yet (staged for growth-metrics exclusion) — guarded because Drizzle full-row selects on organizations 500 if the column is schema-declared but unapplied.",
   },
 ];
 

--- a/packages/crm/src/app/(dashboard)/layout.tsx
+++ b/packages/crm/src/app/(dashboard)/layout.tsx
@@ -16,6 +16,7 @@ import { AgencyKeyBanner } from "@/components/dashboard/agency-key-banner";
 import { DashboardTopbar } from "@/components/layout/dashboard-topbar";
 import { HelpButton } from "@/components/layout/help-button";
 import { SeldonChat } from "@/components/seldon-chat";
+import { IdentifyOnAuth } from "@/components/analytics/identify-on-auth";
 import { CommandBar } from "@/components/command-bar";
 import { isWinLadderOn, isSimpleHomeOn } from "@/lib/web-build/policy";
 import { isDraftApprovalsOn } from "@/lib/agent-drafts/policy";
@@ -281,6 +282,7 @@ export default async function DashboardLayout({
 
   return (
     <SoulProvider soul={soul} personality={personality}>
+      <IdentifyOnAuth userId={user?.id ?? null} email={user?.email ?? null} orgId={orgId} />
       <div className="min-h-screen w-full lg:p-3">
         <div className="flex min-h-screen w-full flex-col items-center justify-start bg-background/95 lg:rounded-2xl lg:border lg:border-border/80 lg:shadow-(--shadow-card)">
           <div className="animate-page-enter flex min-h-screen w-full flex-col md:flex-row">

--- a/packages/crm/src/app/(dashboard)/layout.tsx
+++ b/packages/crm/src/app/(dashboard)/layout.tsx
@@ -282,7 +282,12 @@ export default async function DashboardLayout({
 
   return (
     <SoulProvider soul={soul} personality={personality}>
-      <IdentifyOnAuth userId={user?.id ?? null} email={user?.email ?? null} orgId={orgId} />
+      <IdentifyOnAuth
+        userId={user?.id ?? null}
+        email={user?.email ?? null}
+        orgId={user?.orgId ?? null}
+        activeOrgId={isSwitchedOrg ? orgId : null}
+      />
       <div className="min-h-screen w-full lg:p-3">
         <div className="flex min-h-screen w-full flex-col items-center justify-start bg-background/95 lg:rounded-2xl lg:border lg:border-border/80 lg:shadow-(--shadow-card)">
           <div className="animate-page-enter flex min-h-screen w-full flex-col md:flex-row">

--- a/packages/crm/src/app/api/stripe/checkout/route.ts
+++ b/packages/crm/src/app/api/stripe/checkout/route.ts
@@ -26,6 +26,7 @@ import {
   resolveCheckoutTierGate,
 } from "@/lib/billing/checkout-items";
 import type { TierId } from "@/lib/billing/plans";
+import { buildCheckoutStartedEvent, captureFunnelEvent } from "@/lib/analytics/funnel";
 
 function normalizeReturnPath(value: unknown, fallback: string) {
   if (typeof value !== "string") {
@@ -301,6 +302,20 @@ export async function POST(req: NextRequest) {
       payment_method_types: ["card"],
     });
 
+    // 2026-08-06 funnel observability — checkout_started, tier path. Fired
+    // after sessions.create succeeds; never touches the Stripe call itself
+    // and never fails the route on a capture problem (captureFunnelEvent
+    // is fire-and-forget/catch-swallowing). No org row is loaded on this
+    // path, so is_internal is omitted rather than adding a DB query.
+    captureFunnelEvent(
+      buildCheckoutStartedEvent({
+        userId,
+        orgId,
+        workspaceId: targetWorkspaceId,
+        tier: targetTier,
+      }),
+    );
+
     return NextResponse.json({ url: checkoutSession.url, tier: targetTier });
   }
 
@@ -365,6 +380,19 @@ export async function POST(req: NextRequest) {
       },
     },
   });
+
+  // 2026-08-06 funnel observability — checkout_started, legacy priceId
+  // path. Same posture as the tier path above: fired after sessions.create
+  // succeeds, never fails the route on a capture problem, no DB query
+  // added for is_internal.
+  captureFunnelEvent(
+    buildCheckoutStartedEvent({
+      userId,
+      orgId,
+      workspaceId: targetWorkspaceId,
+      priceId: resolvedPriceId,
+    }),
+  );
 
   return NextResponse.json({ url: checkoutSession.url, tier: targetTier });
 }

--- a/packages/crm/src/app/api/v1/workspace/[id]/link-owner/route.ts
+++ b/packages/crm/src/app/api/v1/workspace/[id]/link-owner/route.ts
@@ -203,6 +203,20 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     );
   }
 
+  // 2026-08-06 funnel observability — this is the MCP/admin-token claim
+  // path. Alias the org-keyed distinct id to the new owner so PostHog can
+  // join workspace_created (orgId-keyed) to signed_up/checkout_started
+  // (userId-keyed). Lazy import keeps posthog-node out of module graphs
+  // that don't need it.
+  try {
+    const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+    aliasOrgToUser(userRow.id, updated.id);
+  } catch (error) {
+    console.warn(
+      `[link-owner] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
   // Best-effort membership upsert. Unique index on (org_id, user_id) prevents duplicates.
   await db
     .insert(orgMembers)

--- a/packages/crm/src/components/analytics/identify-on-auth.tsx
+++ b/packages/crm/src/components/analytics/identify-on-auth.tsx
@@ -5,9 +5,12 @@
 // (instrumentation-client.ts runs on every route) — this just calls
 // posthog.identify() once per (userId, email, orgId) tuple so the person
 // record carries org_id, matching the same posthog-js singleton
-// share-visit-beacon.tsx uses. posthog-js queues calls made before init
-// completes, so there's no need to gate on an internal __loaded flag —
-// just call identify directly and let the try/catch absorb anything
+// share-visit-beacon.tsx uses. Note: the posthog-js npm module build does
+// NOT queue pre-init identify calls (that's snippet-loader behaviour) — a
+// pre-init call logs an "uninitialized" warning and is dropped. That drop
+// is accepted: instrumentation-client.ts initializes before hydration in
+// any env with NEXT_PUBLIC_POSTHOG_KEY, and without the key there is
+// nothing to identify against anyway. The try/catch absorbs anything
 // unexpected. Guards on userId being present — synthetic sessions (admin
 // token, operator portal) have no real user id to identify.
 //
@@ -45,7 +48,10 @@ export function IdentifyOnAuth({
       posthog.identify(userId, {
         email: email ?? undefined,
         org_id: orgId ?? undefined,
-        active_org_id: activeOrgId ?? undefined,
+        // Explicit null (not undefined): undefined is stripped on
+        // serialization and would leave a STALE switched-workspace id on the
+        // person record after the user switches back to their home org.
+        active_org_id: activeOrgId ?? null,
       });
     } catch {
       // Never let an identify call throw into the dashboard render path.

--- a/packages/crm/src/components/analytics/identify-on-auth.tsx
+++ b/packages/crm/src/components/analytics/identify-on-auth.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// 2026-08-06 funnel observability — $identify for the authenticated
+// dashboard. posthog-js is already initialized globally
+// (instrumentation-client.ts runs on every route) — this just calls
+// posthog.identify() once per (userId, email, orgId) tuple so the person
+// record carries org_id, matching the same posthog-js singleton
+// share-visit-beacon.tsx uses. Guards on posthog being loaded (it no-ops
+// when NEXT_PUBLIC_POSTHOG_KEY is unset) and on userId being present —
+// synthetic sessions (admin token, operator portal) have no real user id
+// to identify.
+
+import { useEffect, useRef } from "react";
+import posthog from "posthog-js";
+
+export function IdentifyOnAuth({
+  userId,
+  email,
+  orgId,
+}: {
+  userId: string | null;
+  email: string | null;
+  orgId: string | null;
+}) {
+  const lastIdentified = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!userId) return;
+    if (!posthog.__loaded) return;
+
+    const key = `${userId}:${email ?? ""}:${orgId ?? ""}`;
+    if (lastIdentified.current === key) return;
+    lastIdentified.current = key;
+
+    posthog.identify(userId, {
+      email: email ?? undefined,
+      org_id: orgId ?? undefined,
+    });
+  }, [userId, email, orgId]);
+
+  return null;
+}

--- a/packages/crm/src/components/analytics/identify-on-auth.tsx
+++ b/packages/crm/src/components/analytics/identify-on-auth.tsx
@@ -5,10 +5,16 @@
 // (instrumentation-client.ts runs on every route) — this just calls
 // posthog.identify() once per (userId, email, orgId) tuple so the person
 // record carries org_id, matching the same posthog-js singleton
-// share-visit-beacon.tsx uses. Guards on posthog being loaded (it no-ops
-// when NEXT_PUBLIC_POSTHOG_KEY is unset) and on userId being present —
-// synthetic sessions (admin token, operator portal) have no real user id
-// to identify.
+// share-visit-beacon.tsx uses. posthog-js queues calls made before init
+// completes, so there's no need to gate on an internal __loaded flag —
+// just call identify directly and let the try/catch absorb anything
+// unexpected. Guards on userId being present — synthetic sessions (admin
+// token, operator portal) have no real user id to identify.
+//
+// org_id is the user's HOME org (user.orgId), not whatever workspace is
+// currently active — an agency user switching between client workspaces
+// must not rewrite their own person record's org_id every switch.
+// active_org_id carries the switched-to workspace separately, when known.
 
 import { useEffect, useRef } from "react";
 import posthog from "posthog-js";
@@ -17,26 +23,34 @@ export function IdentifyOnAuth({
   userId,
   email,
   orgId,
+  activeOrgId,
 }: {
   userId: string | null;
   email: string | null;
+  /** The user's home org — stable identity, not the active workspace. */
   orgId: string | null;
+  /** The currently active/switched-to workspace, if different and known. */
+  activeOrgId?: string | null;
 }) {
   const lastIdentified = useRef<string | null>(null);
 
   useEffect(() => {
     if (!userId) return;
-    if (!posthog.__loaded) return;
 
-    const key = `${userId}:${email ?? ""}:${orgId ?? ""}`;
+    const key = `${userId}:${email ?? ""}:${orgId ?? ""}:${activeOrgId ?? ""}`;
     if (lastIdentified.current === key) return;
     lastIdentified.current = key;
 
-    posthog.identify(userId, {
-      email: email ?? undefined,
-      org_id: orgId ?? undefined,
-    });
-  }, [userId, email, orgId]);
+    try {
+      posthog.identify(userId, {
+        email: email ?? undefined,
+        org_id: orgId ?? undefined,
+        active_org_id: activeOrgId ?? undefined,
+      });
+    } catch {
+      // Never let an identify call throw into the dashboard render path.
+    }
+  }, [userId, email, orgId, activeOrgId]);
 
   return null;
 }

--- a/packages/crm/src/db/schema/organizations.ts
+++ b/packages/crm/src/db/schema/organizations.ts
@@ -158,6 +158,12 @@ export const organizations = pgTable("organizations", {
   // never counts against the builder's limit / triggers a charge). NULL =
   // active (existing behavior). Set via cancelDeploymentAction.
   archivedAt: timestamp("archived_at", { withTimezone: true }),
+  // 2026-08-06 funnel observability — excludes founder/internal workspaces
+  // from growth metrics. Default false so all existing (and every new,
+  // non-founder) workspace is unaffected; backfilled to true for
+  // owner_id/parent_user_id rows resolving to the founder's account by the
+  // 0078 migration.
+  isInternal: boolean("is_internal").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/packages/crm/src/instrumentation-client.ts
+++ b/packages/crm/src/instrumentation-client.ts
@@ -1,7 +1,12 @@
 import posthog from "posthog-js";
 
 // PostHog Cloud US, project 497925. The key is the PUBLISHABLE client key —
-// public by design (ships in the bundle); revenue/PII stays server-side.
+// public by design (ships in the bundle); revenue stays server-side. Email
+// is a deliberate exception to "PII stays server-side": as of the
+// 2026-08-06 funnel-observability work, IdentifyOnAuth
+// (components/analytics/identify-on-auth.tsx) sets it as a person
+// property via posthog.identify() so the signed_up -> checkout_started
+// funnel is readable by email in the PostHog UI, not just by opaque id.
 // api_host points at our own /ingest reverse proxy (next.config rewrites →
 // us.i.posthog.com) so ad-blockers don't eat events; ui_host keeps deep links
 // into the PostHog app working.

--- a/packages/crm/src/lib/analytics/capture.ts
+++ b/packages/crm/src/lib/analytics/capture.ts
@@ -44,10 +44,15 @@ export function getPosthogClient(): PostHog | null {
   return client;
 }
 
+export type CaptureServerPropertyValue = string | number | boolean | null;
+
 export type CaptureServerEventInput = {
   event: string;
   distinctId: string;
-  properties?: Record<string, string | number | boolean | null>;
+  /** Flat values, plus PostHog's nested $set for person-property writes. */
+  properties?: Record<string, CaptureServerPropertyValue> & {
+    $set?: Record<string, CaptureServerPropertyValue>;
+  };
 };
 
 /**

--- a/packages/crm/src/lib/analytics/funnel.ts
+++ b/packages/crm/src/lib/analytics/funnel.ts
@@ -53,7 +53,12 @@ export type BuildSignedUpEventInput = {
  */
 export function buildSignedUpEvent(input: BuildSignedUpEventInput): FunnelEvent | null {
   const distinctId = resolveDistinctId(input.userId, input.orgId);
-  if (!distinctId || !input.orgId?.trim()) return null;
+  if (!distinctId || !input.orgId?.trim()) {
+    // Signup always has an org by the time events.createUser fires — a
+    // missing id here is genuinely malformed input, not a quiet path.
+    console.warn("[funnel] buildSignedUpEvent: missing user/org id — event dropped");
+    return null;
+  }
 
   const properties: FunnelEvent["properties"] = {
     org_id: input.orgId.trim(),
@@ -86,7 +91,12 @@ export type BuildWorkspaceCreatedEventInput = {
  */
 export function buildWorkspaceCreatedEvent(input: BuildWorkspaceCreatedEventInput): FunnelEvent | null {
   const distinctId = resolveDistinctId(input.userId, input.orgId);
-  if (!distinctId || !input.orgId?.trim()) return null;
+  if (!distinctId || !input.orgId?.trim()) {
+    // createFullWorkspace always has an orgId by capture time — a missing
+    // id here is genuinely malformed input, not a quiet path.
+    console.warn("[funnel] buildWorkspaceCreatedEvent: missing org id — event dropped");
+    return null;
+  }
 
   const properties: FunnelEvent["properties"] = {
     org_id: input.orgId.trim(),
@@ -148,9 +158,10 @@ export function buildCheckoutStartedEvent(input: BuildCheckoutStartedEventInput)
  * Thin fire-and-forget wrapper delegating to captureServerEvent. Accepts
  * the builder's null-on-missing-ids output directly so call sites never
  * need a separate guard. A null payload is expected on legitimate paths
- * (e.g. checkout with no org resolved yet) so this is a SILENT no-op —
- * builders themselves are the right place to warn on genuinely malformed
- * input, not this pass-through.
+ * (e.g. checkout with no org resolved yet) so this is a SILENT no-op.
+ * Where a null return IS malformed (signed_up / workspace_created, which
+ * always have an org by capture time), the builder itself warns;
+ * checkout_started's null is a legitimate quiet path and stays silent.
  */
 export function captureFunnelEvent(payload: FunnelEvent | null): void {
   if (!payload) return;

--- a/packages/crm/src/lib/analytics/funnel.ts
+++ b/packages/crm/src/lib/analytics/funnel.ts
@@ -13,12 +13,17 @@
 // straight through as a no-op, so call sites can always write
 // `captureFunnelEvent(buildXEvent({...}))` without an extra guard.
 
-import { captureServerEvent } from "@/lib/analytics/capture";
+import { captureServerEvent, getPosthogClient } from "@/lib/analytics/capture";
+
+export type FunnelPropertyValue = string | number | boolean | null;
 
 export type FunnelEvent = {
   event: string;
   distinctId: string;
-  properties: Record<string, unknown>;
+  /** Flat properties, plus PostHog's nested $set for person-property writes. */
+  properties: Record<string, FunnelPropertyValue> & {
+    $set?: Record<string, FunnelPropertyValue>;
+  };
 };
 
 function resolveDistinctId(userId: string | null | undefined, orgId: string | null | undefined): string | null {
@@ -50,7 +55,7 @@ export function buildSignedUpEvent(input: BuildSignedUpEventInput): FunnelEvent 
   const distinctId = resolveDistinctId(input.userId, input.orgId);
   if (!distinctId || !input.orgId?.trim()) return null;
 
-  const properties: Record<string, unknown> = {
+  const properties: FunnelEvent["properties"] = {
     org_id: input.orgId.trim(),
   };
 
@@ -83,7 +88,7 @@ export function buildWorkspaceCreatedEvent(input: BuildWorkspaceCreatedEventInpu
   const distinctId = resolveDistinctId(input.userId, input.orgId);
   if (!distinctId || !input.orgId?.trim()) return null;
 
-  const properties: Record<string, unknown> = {
+  const properties: FunnelEvent["properties"] = {
     org_id: input.orgId.trim(),
     source: input.source,
   };
@@ -118,10 +123,13 @@ export function buildCheckoutStartedEvent(input: BuildCheckoutStartedEventInput)
   const orgId = input.orgId?.trim();
   if (!userId || !orgId) return null;
 
-  const properties: Record<string, unknown> = {
+  const properties: FunnelEvent["properties"] = {
     org_id: orgId,
-    workspace_id: input.workspaceId ?? "",
   };
+
+  if (input.workspaceId) {
+    properties.workspace_id = input.workspaceId;
+  }
 
   if (input.tier) {
     properties.tier = input.tier;
@@ -139,25 +147,55 @@ export function buildCheckoutStartedEvent(input: BuildCheckoutStartedEventInput)
 /**
  * Thin fire-and-forget wrapper delegating to captureServerEvent. Accepts
  * the builder's null-on-missing-ids output directly so call sites never
- * need a separate guard — a null payload from a malformed builder input is
- * a silent no-op, logged so it's visible without ever affecting the
- * caller's request path.
+ * need a separate guard. A null payload is expected on legitimate paths
+ * (e.g. checkout with no org resolved yet) so this is a SILENT no-op —
+ * builders themselves are the right place to warn on genuinely malformed
+ * input, not this pass-through.
  */
 export function captureFunnelEvent(payload: FunnelEvent | null): void {
-  if (!payload) {
-    console.warn("[funnel] captureFunnelEvent skipped — builder returned null (missing required id)");
-    return;
-  }
+  if (!payload) return;
 
   try {
     captureServerEvent({
       event: payload.event,
       distinctId: payload.distinctId,
-      properties: payload.properties as Record<string, string | number | boolean | null>,
+      properties: payload.properties,
     });
   } catch (err) {
     console.warn(
       `[funnel] captureFunnelEvent threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+}
+
+/**
+ * Alias an anonymous org-keyed distinct id to the user who just claimed
+ * ownership of it. Every person-funnel event fired before a user exists
+ * (workspace_created) is keyed by orgId; every event fired after
+ * (signed_up, checkout_started) is keyed by userId. Without this alias
+ * PostHog sees two unrelated persons and the funnel never joins.
+ *
+ * Fire-and-forget, same posture as captureFunnelEvent: no-ops when either
+ * id is missing or when PostHog isn't configured, never throws into the
+ * caller's request path. Uses aliasImmediate (not the buffered alias())
+ * for the same serverless-safety reason captureServerEvent uses
+ * captureImmediate — see capture.ts.
+ */
+export function aliasOrgToUser(userId: string | null | undefined, orgId: string | null | undefined): void {
+  const trimmedUserId = userId?.trim();
+  const trimmedOrgId = orgId?.trim();
+  if (!trimmedUserId || !trimmedOrgId) return;
+
+  try {
+    const ph = getPosthogClient();
+    if (!ph) return;
+
+    void ph
+      .aliasImmediate({ distinctId: trimmedUserId, alias: trimmedOrgId })
+      .catch(() => {
+        // Swallow — an alias failure must be invisible to the caller.
+      });
+  } catch {
+    // Never let an alias-construction bug reach the caller's request path.
   }
 }

--- a/packages/crm/src/lib/analytics/funnel.ts
+++ b/packages/crm/src/lib/analytics/funnel.ts
@@ -1,0 +1,163 @@
+// 2026-08-06 — Funnel observability. Pure event builders for the
+// signed_up / workspace_created / checkout_started person-funnel, plus a
+// thin fire-and-forget capture wrapper. Distinct-id convention for these
+// NEW person-funnel events: distinctId = user id when a user is known,
+// else orgId; org_id is ALWAYS attached as a property. This is a
+// deliberate departure from the existing orgId-keyed events (e.g.
+// activation_step_completed in lib/activation/ladder-server.ts) — do not
+// change those.
+//
+// Builders return null (never a half-formed event) when a required id is
+// missing, so a caller can distinguish "nothing to send" from "send this"
+// without inspecting properties. captureFunnelEvent takes that null
+// straight through as a no-op, so call sites can always write
+// `captureFunnelEvent(buildXEvent({...}))` without an extra guard.
+
+import { captureServerEvent } from "@/lib/analytics/capture";
+
+export type FunnelEvent = {
+  event: string;
+  distinctId: string;
+  properties: Record<string, unknown>;
+};
+
+function resolveDistinctId(userId: string | null | undefined, orgId: string | null | undefined): string | null {
+  const trimmedUserId = userId?.trim();
+  if (trimmedUserId) return trimmedUserId;
+
+  const trimmedOrgId = orgId?.trim();
+  if (trimmedOrgId) return trimmedOrgId;
+
+  return null;
+}
+
+export type BuildSignedUpEventInput = {
+  userId?: string | null;
+  orgId?: string | null;
+  /** Auth provider, when cheaply available (e.g. "google"). Omitted, not
+   *  null, when unknown — keeps the property absent rather than noisy. */
+  method?: string | null;
+  email?: string | null;
+};
+
+/**
+ * signed_up — fired once from events.createUser (lib/auth/config.ts).
+ * Requires at least orgId to resolve a distinct id (userId preferred);
+ * returns null otherwise so the caller never fires a malformed event.
+ * email goes under $set so the PostHog person record gets it attached.
+ */
+export function buildSignedUpEvent(input: BuildSignedUpEventInput): FunnelEvent | null {
+  const distinctId = resolveDistinctId(input.userId, input.orgId);
+  if (!distinctId || !input.orgId?.trim()) return null;
+
+  const properties: Record<string, unknown> = {
+    org_id: input.orgId.trim(),
+  };
+
+  if (input.method) {
+    properties.method = input.method;
+  }
+
+  if (input.email) {
+    properties.$set = { email: input.email };
+  }
+
+  return { event: "signed_up", distinctId, properties };
+}
+
+export type BuildWorkspaceCreatedEventInput = {
+  userId?: string | null;
+  orgId?: string | null;
+  source: string;
+  isInternal?: boolean;
+};
+
+/**
+ * workspace_created — fired from lib/workspace/create-full.ts, the single
+ * choke point for every workspace creation path (API route,
+ * provisionClientWorkspace, MCP atomic create). Requires orgId; userId
+ * (owner/creator) is frequently absent at creation time (anonymous
+ * workspace creation), in which case distinct id falls back to orgId.
+ */
+export function buildWorkspaceCreatedEvent(input: BuildWorkspaceCreatedEventInput): FunnelEvent | null {
+  const distinctId = resolveDistinctId(input.userId, input.orgId);
+  if (!distinctId || !input.orgId?.trim()) return null;
+
+  const properties: Record<string, unknown> = {
+    org_id: input.orgId.trim(),
+    source: input.source,
+  };
+
+  if (input.isInternal !== undefined) {
+    properties.is_internal = input.isInternal;
+  }
+
+  return { event: "workspace_created", distinctId, properties };
+}
+
+export type BuildCheckoutStartedEventInput = {
+  userId?: string | null;
+  orgId?: string | null;
+  workspaceId?: string | null;
+  /** Tier path (new self-service checkout). */
+  tier?: string | null;
+  /** Legacy priceId path — mutually exclusive with tier in practice, but
+   *  the builder doesn't enforce that; callers pass whichever they have. */
+  priceId?: string | null;
+  isInternal?: boolean;
+};
+
+/**
+ * checkout_started — fired from app/api/stripe/checkout/route.ts on both
+ * the tier path and the legacy priceId path. distinct_id is always the
+ * authenticated userId (no anonymous checkout exists), so unlike the other
+ * two builders there is no orgId fallback — userId is required.
+ */
+export function buildCheckoutStartedEvent(input: BuildCheckoutStartedEventInput): FunnelEvent | null {
+  const userId = input.userId?.trim();
+  const orgId = input.orgId?.trim();
+  if (!userId || !orgId) return null;
+
+  const properties: Record<string, unknown> = {
+    org_id: orgId,
+    workspace_id: input.workspaceId ?? "",
+  };
+
+  if (input.tier) {
+    properties.tier = input.tier;
+  } else if (input.priceId) {
+    properties.price_id = input.priceId;
+  }
+
+  if (input.isInternal !== undefined) {
+    properties.is_internal = input.isInternal;
+  }
+
+  return { event: "checkout_started", distinctId: userId, properties };
+}
+
+/**
+ * Thin fire-and-forget wrapper delegating to captureServerEvent. Accepts
+ * the builder's null-on-missing-ids output directly so call sites never
+ * need a separate guard — a null payload from a malformed builder input is
+ * a silent no-op, logged so it's visible without ever affecting the
+ * caller's request path.
+ */
+export function captureFunnelEvent(payload: FunnelEvent | null): void {
+  if (!payload) {
+    console.warn("[funnel] captureFunnelEvent skipped — builder returned null (missing required id)");
+    return;
+  }
+
+  try {
+    captureServerEvent({
+      event: payload.event,
+      distinctId: payload.distinctId,
+      properties: payload.properties as Record<string, string | number | boolean | null>,
+    });
+  } catch (err) {
+    console.warn(
+      `[funnel] captureFunnelEvent threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/packages/crm/src/lib/auth/actions.ts
+++ b/packages/crm/src/lib/auth/actions.ts
@@ -143,6 +143,18 @@ export async function signupAction(_: AuthActionState, formData: FormData): Prom
           throw error;
         }
       }
+
+      // 2026-08-06 funnel observability — alias the org-keyed distinct id
+      // to the new user, same as every other ownerId-claim site. Lazy
+      // import keeps posthog-node out of module graphs that don't need it.
+      try {
+        const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+        aliasOrgToUser(owner.id, org.id);
+      } catch (error) {
+        console.warn(
+          `[auth][actions] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
 
     try {

--- a/packages/crm/src/lib/auth/config.ts
+++ b/packages/crm/src/lib/auth/config.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { accounts, organizations, users } from "@/db/schema";
 import { and, eq } from "drizzle-orm";
 import { sendNewSignupAlert } from "@/lib/notifications/ops-notifications";
+import { buildSignedUpEvent, captureFunnelEvent } from "@/lib/analytics/funnel";
 
 const BILLING_STATUSES = ["trialing", "active", "past_due", "canceled", "unpaid"] as const;
 const BILLING_PERIODS = ["monthly", "yearly"] as const;
@@ -411,6 +412,24 @@ export const authConfig = {
       } catch (err) {
         console.warn(
           `[auth][events.createUser] sendNewSignupAlert threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // 2026-08-06 funnel observability — signed_up person-funnel event.
+      // Never let a capture failure affect signup: captureFunnelEvent is
+      // itself fire-and-forget/catch-swallowing, but events.createUser's
+      // own signature has no provider/account context to cheaply derive
+      // `method`, so it's omitted here (builder treats it as optional).
+      // orgId comes from the adapter's createUser `returning` (auth.ts) —
+      // NextAuth passes the adapter's return value through as `user`.
+      try {
+        const orgId = typeof (user as { orgId?: unknown }).orgId === "string" ? (user as { orgId: string }).orgId : null;
+        const userId = typeof user.id === "string" ? user.id : null;
+        const email = typeof user.email === "string" ? user.email : null;
+        captureFunnelEvent(buildSignedUpEvent({ userId, orgId, email }));
+      } catch (err) {
+        console.warn(
+          `[auth][events.createUser] signed_up capture threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     },

--- a/packages/crm/src/lib/auth/config.ts
+++ b/packages/crm/src/lib/auth/config.ts
@@ -5,7 +5,10 @@ import { db } from "@/db";
 import { accounts, organizations, users } from "@/db/schema";
 import { and, eq } from "drizzle-orm";
 import { sendNewSignupAlert } from "@/lib/notifications/ops-notifications";
-import { buildSignedUpEvent, captureFunnelEvent } from "@/lib/analytics/funnel";
+// funnel.ts (posthog-node) is imported lazily below, not statically here —
+// config.ts sits in the proxy/middleware module graph (config -> auth ->
+// src/proxy.ts), and a static import would pull posthog-node into that
+// bundle for every request, not just the rare createUser event.
 
 const BILLING_STATUSES = ["trialing", "active", "past_due", "canceled", "unpaid"] as const;
 const BILLING_PERIODS = ["monthly", "yearly"] as const;
@@ -426,6 +429,7 @@ export const authConfig = {
         const orgId = typeof (user as { orgId?: unknown }).orgId === "string" ? (user as { orgId: string }).orgId : null;
         const userId = typeof user.id === "string" ? user.id : null;
         const email = typeof user.email === "string" ? user.email : null;
+        const { buildSignedUpEvent, captureFunnelEvent } = await import("@/lib/analytics/funnel");
         captureFunnelEvent(buildSignedUpEvent({ userId, orgId, email }));
       } catch (err) {
         console.warn(

--- a/packages/crm/src/lib/billing/orgs.ts
+++ b/packages/crm/src/lib/billing/orgs.ts
@@ -734,6 +734,18 @@ export async function createManagedOrganizationAction(formData: FormData) {
 
     if (owner?.id) {
       await db.update(organizations).set({ ownerId: owner.id, updatedAt: new Date() }).where(eq(organizations.id, org.id));
+
+      // 2026-08-06 funnel observability — alias the org-keyed distinct id
+      // to the new owner, same as every other ownerId-claim site. Lazy
+      // import keeps posthog-node out of module graphs that don't need it.
+      try {
+        const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+        aliasOrgToUser(owner.id, org.id);
+      } catch (error) {
+        console.warn(
+          `[billing/orgs] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
     }
   }
 
@@ -1181,6 +1193,21 @@ export async function claimAnonymousWorkspaceForEmail(
     .update(organizations)
     .set({ ownerId: createdUser.id, updatedAt: new Date() })
     .where(eq(organizations.id, workspaceId));
+
+  // 2026-08-06 funnel observability — this is the canonical anonymous-org
+  // claim path (admin-token workspace -> real account). Alias the
+  // org-keyed distinct id to the new user so PostHog can join
+  // workspace_created (orgId-keyed) to signed_up/checkout_started
+  // (userId-keyed). Lazy import keeps posthog-node out of module graphs
+  // that don't need it.
+  try {
+    const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+    aliasOrgToUser(createdUser.id, workspaceId);
+  } catch (error) {
+    console.warn(
+      `[billing/orgs] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 
   return { ok: true, userId: createdUser.id, userExisted: false };
 }

--- a/packages/crm/src/lib/workspace/create-full.ts
+++ b/packages/crm/src/lib/workspace/create-full.ts
@@ -33,6 +33,7 @@ import { resolvePersonalityForBusiness } from "@/lib/crm/personality-generator";
 import { classifyBusinessTypeFromSoul } from "@/lib/page-schema/classify-business";
 import { inferTimezone } from "@/lib/workspace/infer-timezone";
 import { trackEvent } from "@/lib/analytics/track";
+import { buildWorkspaceCreatedEvent, captureFunnelEvent } from "@/lib/analytics/funnel";
 import type { AestheticArchetypeId } from "@/lib/workspace/aesthetic-archetypes";
 import { buildBusinessHoursSoulPatch } from "@/lib/workspace/business-hours-soul";
 import { seedIntakeFieldsOnBookingTemplates } from "@/lib/workspace/seed-booking-intake-fields";
@@ -754,6 +755,19 @@ export async function createFullWorkspace(
       source: "mcp_atomic",
     },
     { orgId: createResult.orgId }
+  );
+
+  // 2026-08-06 funnel observability — workspace_created person-funnel
+  // event, right beside the existing internal workspace_created_full
+  // trackEvent above. This is the single choke point for ALL creation
+  // paths (API route, provisionClientWorkspace, MCP), so one capture here
+  // covers everything. No owner/creator user id is in scope at this call
+  // site (createAnonymousWorkspace sets ownerId: null at creation time),
+  // so distinct id falls back to orgId — see buildWorkspaceCreatedEvent.
+  // is_internal is likewise not in scope here (only createResult.orgId is
+  // available, no org row loaded) — omitted rather than adding a query.
+  captureFunnelEvent(
+    buildWorkspaceCreatedEvent({ orgId: createResult.orgId, source: "mcp_atomic" }),
   );
 
   return {

--- a/packages/crm/src/lib/workspace/link-workspace-to-operator.ts
+++ b/packages/crm/src/lib/workspace/link-workspace-to-operator.ts
@@ -98,18 +98,13 @@ export async function linkWorkspaceToOperator(
       return { ok: false, reason: "owned_by_other" };
     }
 
-    // 2026-08-06 funnel observability — alias the org-keyed distinct id to
-    // the new owner so PostHog can join workspace_created (orgId-keyed) to
-    // signed_up/checkout_started (userId-keyed). Lazy import keeps
-    // posthog-node out of module graphs that don't need it.
-    try {
-      const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
-      aliasOrgToUser(userId, workspaceId);
-    } catch (error) {
-      console.warn(
-        `[link-workspace-to-operator] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
+    // 2026-08-06 funnel observability — deliberately NO aliasOrgToUser here,
+    // unlike the other ownerId-claim sites. This is the agency/operator claim
+    // path: one operator claims many client workspaces, and a PostHog alias
+    // per claim would irreversibly merge every client workspace's org-keyed
+    // person into the operator's person record. Client workspaces should be
+    // modelled as a PostHog group if org-level funnels are ever needed on
+    // this path.
   }
 
   // Best-effort membership upsert. The unique (org_id, user_id) index

--- a/packages/crm/src/lib/workspace/link-workspace-to-operator.ts
+++ b/packages/crm/src/lib/workspace/link-workspace-to-operator.ts
@@ -97,6 +97,19 @@ export async function linkWorkspaceToOperator(
       // Lost the race to another claimer.
       return { ok: false, reason: "owned_by_other" };
     }
+
+    // 2026-08-06 funnel observability — alias the org-keyed distinct id to
+    // the new owner so PostHog can join workspace_created (orgId-keyed) to
+    // signed_up/checkout_started (userId-keyed). Lazy import keeps
+    // posthog-node out of module graphs that don't need it.
+    try {
+      const { aliasOrgToUser } = await import("@/lib/analytics/funnel");
+      aliasOrgToUser(userId, workspaceId);
+    } catch (error) {
+      console.warn(
+        `[link-workspace-to-operator] aliasOrgToUser threw (swallowed): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   // Best-effort membership upsert. The unique (org_id, user_id) index

--- a/packages/crm/tests/unit/analytics/funnel-events.spec.ts
+++ b/packages/crm/tests/unit/analytics/funnel-events.spec.ts
@@ -18,6 +18,7 @@ import {
   buildWorkspaceCreatedEvent,
   buildCheckoutStartedEvent,
   captureFunnelEvent,
+  aliasOrgToUser,
 } from "../../../src/lib/analytics/funnel";
 
 describe("buildSignedUpEvent", () => {
@@ -113,6 +114,11 @@ describe("buildCheckoutStartedEvent", () => {
     assert.equal(result, null);
   });
 
+  test("workspace_id omitted entirely when absent", () => {
+    const result = buildCheckoutStartedEvent({ userId: "user-1", orgId: "org-1", tier: "workspace" });
+    assert.equal("workspace_id" in (result?.properties ?? {}), false);
+  });
+
   test("price_id used instead of tier for the legacy path", () => {
     const result = buildCheckoutStartedEvent({
       userId: "user-1",
@@ -169,5 +175,46 @@ describe("captureFunnelEvent", () => {
   test("no-ops silently when given null (malformed input upstream)", () => {
     captureFunnelEvent(null);
     assert.equal(captured.length, 0);
+  });
+});
+
+describe("aliasOrgToUser", () => {
+  type AliasCall = { distinctId: string; alias: string };
+
+  let aliased: AliasCall[] = [];
+  const originalAliasImmediate = PostHog.prototype.aliasImmediate;
+
+  beforeEach(() => {
+    aliased = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (PostHog.prototype as any).aliasImmediate = async function (data: AliasCall) {
+      aliased.push(data);
+      return undefined;
+    };
+  });
+
+  afterEach(() => {
+    PostHog.prototype.aliasImmediate = originalAliasImmediate;
+  });
+
+  test("delegates to the posthog-node client with {distinctId: userId, alias: orgId}", () => {
+    aliasOrgToUser("user-1", "org-1");
+    assert.equal(aliased.length, 1);
+    assert.deepEqual(aliased[0], { distinctId: "user-1", alias: "org-1" });
+  });
+
+  test("no-ops when userId is missing", () => {
+    aliasOrgToUser(null, "org-1");
+    assert.equal(aliased.length, 0);
+  });
+
+  test("no-ops when orgId is missing", () => {
+    aliasOrgToUser("user-1", null);
+    assert.equal(aliased.length, 0);
+  });
+
+  test("no-ops when both are missing", () => {
+    aliasOrgToUser(undefined, undefined);
+    assert.equal(aliased.length, 0);
   });
 });

--- a/packages/crm/tests/unit/analytics/funnel-events.spec.ts
+++ b/packages/crm/tests/unit/analytics/funnel-events.spec.ts
@@ -1,0 +1,173 @@
+// PostHog person-funnel event builders — pure functions so payload shape,
+// the distinct-id fallback rule, and the null-on-missing-ids contract are
+// unit-testable without a network call. Mirrors llm-capture.spec.ts's
+// prototype-patch pattern for captureFunnelEvent (no DI seam in
+// captureServerEvent — see capture.ts).
+//
+// Run:
+//   node --import tsx --test tests/unit/analytics/funnel-events.spec.ts
+
+import { describe, test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key_funnel_events";
+
+import { PostHog } from "posthog-node";
+import {
+  buildSignedUpEvent,
+  buildWorkspaceCreatedEvent,
+  buildCheckoutStartedEvent,
+  captureFunnelEvent,
+} from "../../../src/lib/analytics/funnel";
+
+describe("buildSignedUpEvent", () => {
+  test("distinct_id = userId when userId present, org_id always attached", () => {
+    const result = buildSignedUpEvent({ userId: "user-1", orgId: "org-1", email: "a@b.com" });
+    assert.deepEqual(result, {
+      event: "signed_up",
+      distinctId: "user-1",
+      properties: {
+        org_id: "org-1",
+        $set: { email: "a@b.com" },
+      },
+    });
+  });
+
+  test("distinct_id falls back to orgId when userId is missing", () => {
+    const result = buildSignedUpEvent({ orgId: "org-1" });
+    assert.equal(result?.distinctId, "org-1");
+  });
+
+  test("returns null when both userId and orgId are missing", () => {
+    const result = buildSignedUpEvent({});
+    assert.equal(result, null);
+  });
+
+  test("method is included when provided, omitted when absent", () => {
+    const withMethod = buildSignedUpEvent({ userId: "user-1", orgId: "org-1", method: "google" });
+    assert.equal(withMethod?.properties.method, "google");
+
+    const withoutMethod = buildSignedUpEvent({ userId: "user-1", orgId: "org-1" });
+    assert.equal("method" in (withoutMethod?.properties ?? {}), false);
+  });
+
+  test("email is omitted from $set when not provided", () => {
+    const result = buildSignedUpEvent({ userId: "user-1", orgId: "org-1" });
+    assert.equal("$set" in (result?.properties ?? {}), false);
+  });
+});
+
+describe("buildWorkspaceCreatedEvent", () => {
+  test("distinct_id = userId when present, org_id always attached", () => {
+    const result = buildWorkspaceCreatedEvent({ userId: "user-1", orgId: "org-1", source: "mcp_atomic" });
+    assert.deepEqual(result, {
+      event: "workspace_created",
+      distinctId: "user-1",
+      properties: { org_id: "org-1", source: "mcp_atomic" },
+    });
+  });
+
+  test("distinct_id falls back to orgId when userId is missing", () => {
+    const result = buildWorkspaceCreatedEvent({ orgId: "org-1", source: "mcp_atomic" });
+    assert.equal(result?.distinctId, "org-1");
+  });
+
+  test("returns null when orgId is missing", () => {
+    const result = buildWorkspaceCreatedEvent({ userId: "user-1", source: "mcp_atomic" });
+    assert.equal(result, null);
+  });
+
+  test("is_internal passes through when provided", () => {
+    const result = buildWorkspaceCreatedEvent({ orgId: "org-1", source: "mcp_atomic", isInternal: true });
+    assert.equal(result?.properties.is_internal, true);
+  });
+
+  test("is_internal omitted when not provided", () => {
+    const result = buildWorkspaceCreatedEvent({ orgId: "org-1", source: "mcp_atomic" });
+    assert.equal("is_internal" in (result?.properties ?? {}), false);
+  });
+});
+
+describe("buildCheckoutStartedEvent", () => {
+  test("distinct_id = userId (required), org_id + workspace_id attached", () => {
+    const result = buildCheckoutStartedEvent({
+      userId: "user-1",
+      orgId: "org-1",
+      workspaceId: "ws-1",
+      tier: "workspace",
+    });
+    assert.deepEqual(result, {
+      event: "checkout_started",
+      distinctId: "user-1",
+      properties: { org_id: "org-1", workspace_id: "ws-1", tier: "workspace" },
+    });
+  });
+
+  test("returns null when userId is missing", () => {
+    const result = buildCheckoutStartedEvent({ orgId: "org-1", workspaceId: "ws-1", tier: "workspace" });
+    assert.equal(result, null);
+  });
+
+  test("returns null when orgId is missing", () => {
+    const result = buildCheckoutStartedEvent({ userId: "user-1", workspaceId: "ws-1", tier: "workspace" });
+    assert.equal(result, null);
+  });
+
+  test("price_id used instead of tier for the legacy path", () => {
+    const result = buildCheckoutStartedEvent({
+      userId: "user-1",
+      orgId: "org-1",
+      workspaceId: "ws-1",
+      priceId: "price_123",
+    });
+    assert.equal(result?.properties.price_id, "price_123");
+    assert.equal("tier" in (result?.properties ?? {}), false);
+  });
+
+  test("is_internal passes through when provided", () => {
+    const result = buildCheckoutStartedEvent({
+      userId: "user-1",
+      orgId: "org-1",
+      workspaceId: "ws-1",
+      tier: "workspace",
+      isInternal: true,
+    });
+    assert.equal(result?.properties.is_internal, true);
+  });
+});
+
+describe("captureFunnelEvent", () => {
+  type CapturedEvent = {
+    distinctId: string;
+    event: string;
+    properties?: Record<string, unknown>;
+  };
+
+  let captured: CapturedEvent[] = [];
+  const originalCaptureImmediate = PostHog.prototype.captureImmediate;
+
+  beforeEach(() => {
+    captured = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (PostHog.prototype as any).captureImmediate = async function (event: CapturedEvent) {
+      captured.push(event);
+      return undefined;
+    };
+  });
+
+  afterEach(() => {
+    PostHog.prototype.captureImmediate = originalCaptureImmediate;
+  });
+
+  test("delegates to captureServerEvent with the built payload", () => {
+    captureFunnelEvent(buildSignedUpEvent({ userId: "user-1", orgId: "org-1" }));
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0].event, "signed_up");
+    assert.equal(captured[0].distinctId, "user-1");
+  });
+
+  test("no-ops silently when given null (malformed input upstream)", () => {
+    captureFunnelEvent(null);
+    assert.equal(captured.length, 0);
+  });
+});

--- a/packages/crm/tests/unit/auth/resolve-auth-secret.spec.ts
+++ b/packages/crm/tests/unit/auth/resolve-auth-secret.spec.ts
@@ -1,0 +1,63 @@
+// Auth secret hardening — resolveAuthSecret is a pure function extracted
+// from auth.ts so the resolution order (AUTH_SECRET wins over
+// NEXTAUTH_SECRET, whitespace-only treated as missing, trims surrounding
+// whitespace, both absent -> undefined) is unit-testable without booting
+// NextAuth.
+//
+// Run:
+//   node --import tsx --test tests/unit/auth/resolve-auth-secret.spec.ts
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveAuthSecret } from "../../../auth";
+
+describe("resolveAuthSecret", () => {
+  test("AUTH_SECRET wins over NEXTAUTH_SECRET when both are set", () => {
+    const result = resolveAuthSecret({
+      AUTH_SECRET: "auth-secret-value",
+      NEXTAUTH_SECRET: "nextauth-secret-value",
+    });
+    assert.equal(result, "auth-secret-value");
+  });
+
+  test("falls back to NEXTAUTH_SECRET when AUTH_SECRET is absent", () => {
+    const result = resolveAuthSecret({
+      NEXTAUTH_SECRET: "nextauth-secret-value",
+    });
+    assert.equal(result, "nextauth-secret-value");
+  });
+
+  test("whitespace-only AUTH_SECRET is treated as missing, falls through", () => {
+    const result = resolveAuthSecret({
+      AUTH_SECRET: "   ",
+      NEXTAUTH_SECRET: "nextauth-secret-value",
+    });
+    assert.equal(result, "nextauth-secret-value");
+  });
+
+  test("whitespace-only NEXTAUTH_SECRET (and no AUTH_SECRET) resolves to undefined", () => {
+    const result = resolveAuthSecret({
+      NEXTAUTH_SECRET: "   ",
+    });
+    assert.equal(result, undefined);
+  });
+
+  test("trims surrounding whitespace from AUTH_SECRET", () => {
+    const result = resolveAuthSecret({
+      AUTH_SECRET: "  auth-secret-value  ",
+    });
+    assert.equal(result, "auth-secret-value");
+  });
+
+  test("trims surrounding whitespace from NEXTAUTH_SECRET fallback", () => {
+    const result = resolveAuthSecret({
+      NEXTAUTH_SECRET: "\tnextauth-secret-value\n",
+    });
+    assert.equal(result, "nextauth-secret-value");
+  });
+
+  test("both absent resolves to undefined", () => {
+    const result = resolveAuthSecret({});
+    assert.equal(result, undefined);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 0.27.3
       '@workflow/next':
         specifier: ^4.0.5
-        version: 4.0.5(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        version: 4.0.5(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -149,10 +149,10 @@ importers:
         version: 12.42.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next:
         specifier: 16.2.10
-        version: 16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
         specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        version: 5.0.0-beta.30(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -200,7 +200,7 @@ importers:
         version: 1.4.0
       workflow:
         specifier: ^4.2.4
-        version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+        version: 4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       ws:
         specifier: 8.21.1
         version: 8.21.1
@@ -211,6 +211,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -1892,6 +1895,11 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@posthog/core@1.43.1':
     resolution: {integrity: sha512-hGM8f5sp3we6Em/RQHXbmyYm554hUx9+9jhf92ZQgDS4/xW72KHyZiO9wcFye+qAx2cJAOhOCDIznmO1FV8IbA==}
@@ -4555,6 +4563,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5793,6 +5806,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
@@ -8464,6 +8487,10 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@posthog/core@1.43.1':
     dependencies:
       '@posthog/types': 1.397.0
@@ -9828,7 +9855,7 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@workflow/next@4.0.5(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
+  '@workflow/next@4.0.5(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))':
     dependencies:
       '@swc/core': 1.15.3
       '@workflow/builders': 4.0.5
@@ -9837,7 +9864,7 @@ snapshots:
       semver: 7.7.4
       watchpack: 2.5.1
     optionalDependencies:
-      next: 16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@swc/helpers'
@@ -11624,6 +11651,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -12412,10 +12442,10 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next-auth@5.0.0-beta.30(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.30(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
       '@auth/core': 0.41.0
-      next: 16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
   next-themes@0.4.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
@@ -12423,7 +12453,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.10
       '@swc/helpers': 0.5.15
@@ -12442,6 +12472,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.10
       '@next/swc-win32-arm64-msvc': 16.2.10
       '@next/swc-win32-x64-msvc': 16.2.10
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -12724,6 +12755,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@5.0.0: {}
 
@@ -14032,14 +14071,14 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
-  workflow@4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3):
+  workflow@4.2.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3):
     dependencies:
       '@workflow/astro': 4.0.4
       '@workflow/cli': 4.2.4
       '@workflow/core': 4.2.4
       '@workflow/errors': 4.1.1
       '@workflow/nest': 0.0.4(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@swc/cli@0.8.1(@swc/core@1.15.3)(chokidar@5.0.0))(@swc/core@1.15.3)
-      '@workflow/next': 4.0.5(next@16.2.10(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+      '@workflow/next': 4.0.5(next@16.2.10(@babel/core@7.29.0)(@playwright/test@1.62.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       '@workflow/nitro': 4.0.5
       '@workflow/nuxt': 4.0.5
       '@workflow/rollup': 4.0.4

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -7,6 +7,22 @@ with a checkable plan, gets ticked off as it ships, and ends with a review block
 
 ## In flight
 
+### Task — funnel observability: auth-secret fix + PostHog funnel events + e2e smoke (2026-08-06, worktree funnel-observability) — BUILT, awaiting merge
+
+Approved by Max after the funnel audit (visitor→paid = 234→10→12→2→0; zero external payers ever; funnel
+unmeasurable in PostHog). Branch feat/funnel-observability off origin/main @ 589220221, 10 commits.
+
+- [x] A. Auth secret: explicit `secret:` into NextAuth via pure `resolveAuthSecret()` (AUTH_SECRET ?? NEXTAUTH_SECRET — v5 only auto-reads the former) + prod fail-loud log + 7 specs
+- [x] B. PostHog funnel: `signed_up` (events.createUser) · `workspace_created` (createFullWorkspace choke point) · `checkout_started` (both Stripe checkout paths, observation-only) · `$identify` client component in (dashboard) layout (home org, active_org_id clears via explicit null) · `aliasOrgToUser` at 5 self-serve ownerId-claim sites (NOT the agency operator-claim path — irreversible person merges) · lazy imports keep posthog-node out of the proxy graph · organizations.is_internal + migration 0078 (journaled; founder backfill; **apply by hand**; staged — no reader yet)
+- [x] C. E2E + CI: @playwright/test + two-tier funnel-smoke (RENDER always/GET-only incl. /api/auth/providers AUTH_SECRET sentinel — live-passed 5/5 vs production; FLOW gated E2E_FULL=1 + hard prod-host guard) · ci.yml + generator regression net + e2e job gated on E2E_BASE_URL · deploy-demo post-deploy smoke · playwright install via workspace bin (not root npx)
+
+**Review (2026-08-06):** verify-build PASS — 106 tests; tsc/use-server/journal clean; regression grep empty.
+Opus round 1: 2 blocking (npx playwright drift; funnel not joinable across orgId/userId spaces) — both fixed.
+Round 2: ship, no blocking. Deferred/known: typecheck CI gate NOT added (pre-existing TS2353 in
+api/copilot/turn/route.ts on main — fix that first); is_internal wiring into jwt→session→identify is the
+next slice; AUTH_SECRET absent from Vercel Preview env (ops task, one command); wasted $create_alias on
+inline-org signup paths accepted for uniformity.
+
 ### Task — cursor.directory security-scan fixes: @seldonframe/mcp (2026-07-17, worktree vibrant-hamilton-3697cd)
 
 Scan flagged 4 findings; plugin hidden pending review. Ground truth established before coding:


### PR DESCRIPTION
Follow-up to the 2026-08-06 funnel audit (visitor→paid = 234→10→12→2→0, zero external payers ever, funnel unmeasurable in PostHog).

## What this ships
- **Auth secret hardening** — explicit `secret:` into NextAuth via pure `resolveAuthSecret()` (AUTH_SECRET ?? NEXTAUTH_SECRET — Auth.js v5 only auto-reads the former) + production fail-loud log. Context: prod logged `[auth] Please define a secret` on `/` while Preview had no secret at all (now added to Vercel Preview env out-of-band).
- **PostHog funnel instrumentation** — `signed_up` (events.createUser), `workspace_created` (createFullWorkspace choke point), `checkout_started` (both Stripe checkout paths, observation-only), client `$identify` in the (dashboard) layout, and `aliasOrgToUser` at the five self-serve ownerId-claim sites so org-keyed pre-signup events join user-keyed post-signup events. Deliberately NOT aliased on the agency operator-claim path (irreversible person merges). Lazy imports keep posthog-node out of the proxy graph.
- **organizations.is_internal** — migration 0078 (journaled, additive, idempotent, founder backfill; applied by hand per house rule). Staged: no reader yet; next slice wires it into jwt→session→identify.
- **E2E + CI** — @playwright/test two-tier funnel smoke: RENDER tier (GET-only; `/`, `/signup`, `/login`, `/pricing`, `/api/auth/providers` as the AUTH_SECRET sentinel — live-passed 5/5 against production) and FLOW tier (E2E_FULL=1 + hard production-host guard). ci.yml gains the generator regression net (17/17) and an e2e job gated on the `E2E_BASE_URL` repo variable; deploy-demo gains a post-deploy render smoke. Playwright installs via the workspace bin (root npx would drift to playwright@latest under pnpm non-hoisting).

## Gates
- verify-build: **PASS — 106 tests; tsc/use-server/journal clean; regression grep empty**
- Opus review round 1: 2 blocking (playwright install drift; funnel not joinable across distinct-id spaces) — both fixed. Round 2: **ship, zero blocking**.
- Typecheck CI gate deliberately NOT added: pre-existing TS2353 in `api/copilot/turn/route.ts` on main is red — follow-up PR fixes it and adds the gate.

Learnings note: `docs/learnings/2026-08-06-funnel-distinct-id-spaces.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)