### PR TITLE
fix(agents): implement executeTurn persist:false + typecheck CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Event-registry drift-detector
         run: pnpm emit:event-registry:check
 
+      - name: Typecheck (crm)
+        # Lands as a CI gate only now: fix/copilot-persist-ephemeral fixed
+        # the last standing tsc error in the package (TS2353 — route.ts's
+        # `persist: false` on executeTurn's input had no matching property).
+        # Keeping this out of `pnpm test:unit` above so a failure reports as
+        # its own clearly-named step.
+        run: pnpm --filter crm exec tsc --noEmit
+
       - name: Generator regression net
         run: cd packages/crm && node --import tsx --test tests/regression/generator-prompts.spec.ts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
         # the exact cause of the 0019 / 0055 production outages. No DB needed.
         run: pnpm db:check-journaled
 
+      - name: Typecheck (crm)
+        # Lands as a CI gate only now: fix/copilot-persist-ephemeral fixed
+        # the last standing tsc error in the package (TS2353 — route.ts's
+        # `persist: false` on executeTurn's input had no matching property).
+        # Kept out of `pnpm test:unit` below so a failure reports as its own
+        # clearly-named step. Runs BEFORE the unit-test suite (fail-fast: a
+        # ~40s typecheck shouldn't wait on a full test run to report).
+        run: pnpm --filter @seldonframe/crm exec tsc --noEmit
+
       - name: Unit tests
         run: pnpm test:unit
 
@@ -48,14 +57,6 @@ jobs:
 
       - name: Event-registry drift-detector
         run: pnpm emit:event-registry:check
-
-      - name: Typecheck (crm)
-        # Lands as a CI gate only now: fix/copilot-persist-ephemeral fixed
-        # the last standing tsc error in the package (TS2353 — route.ts's
-        # `persist: false` on executeTurn's input had no matching property).
-        # Keeping this out of `pnpm test:unit` above so a failure reports as
-        # its own clearly-named step.
-        run: pnpm --filter crm exec tsc --noEmit
 
       - name: Generator regression net
         run: cd packages/crm && node --import tsx --test tests/regression/generator-prompts.spec.ts

--- a/packages/crm/src/lib/agents/runtime.ts
+++ b/packages/crm/src/lib/agents/runtime.ts
@@ -125,13 +125,21 @@ export async function executeTurn(input: {
    *    - the user turn is NOT inserted into agentTurns
    *    - the assistant reply is NOT inserted into agentTurns (this includes
    *      the capped-usage holding-reply insert)
-   *    - agentConversations aggregate counters tied to turn count/timing
-   *      (lastTurnAt, tokensIn/tokensOut, llmCostCents, turnCount) are NOT
-   *      updated, since they exist to record that a turn happened
+   *    - ONLY lastTurnAt and turnCount are withheld on agentConversations —
+   *      they exist to record that a TURN happened, and a synthetic retry
+   *      turn must not move them
+   *    - token/cost aggregates (tokensIn, tokensOut, llmCostCents) on
+   *      agentConversations STILL accrue, because the LLM call behind a
+   *      persist:false turn is real and billed regardless of persist —
+   *      un-recording it would silently undercount org spend for every
+   *      reader that sums llmCostCents. agentConversations.tokensIn may by
+   *      design exceed sum(agentTurns.tokensIn): "tokens spent on this
+   *      conversation" vs. "tokens attributable to recorded turns"
    *    - the in-memory Anthropic messages array still includes the turn (see
    *      buildTurnMessages in ./turn-messages) so the model has full
    *      context, and tool EXECUTION side effects still run unchanged
-   *  Net effect: a persist:false turn writes ZERO agentTurns rows. */
+   *  Net effect: a persist:false turn writes ZERO agentTurns rows, but its
+   *  real token/cost spend is still counted. */
   persist?: boolean;
 }): Promise<ExecuteTurnResult> {
   const t0 = Date.now();
@@ -394,7 +402,7 @@ export async function executeTurn(input: {
       `[agent-runtime] usage_capped agentId=${agent.id} convId=${conv.id} orgId=${agent.orgId}`,
     );
 
-    if (nextTurnIndex === 0 && conv.status !== "test") {
+    if (persist && nextTurnIndex === 0 && conv.status !== "test") {
       await writeFirstTurnActivity(agent, orgRow.id, conv.id, input.userMessage);
     }
 
@@ -829,24 +837,40 @@ export async function executeTurn(input: {
       // static default — so cost/observability reflect real spend.
       model: lastModelUsed,
     });
-
-    // 9. Update conversation aggregates
-    await db
-      .update(agentConversations)
-      .set({
-        lastTurnAt: new Date(),
-        tokensIn: sql`${agentConversations.tokensIn} + ${totalTokensIn}`,
-        tokensOut: sql`${agentConversations.tokensOut} + ${totalTokensOut}`,
-        llmCostCents: sql`${agentConversations.llmCostCents} + ${costCents}`,
-        turnCount: sql`${agentConversations.turnCount} + 2`,
-      })
-      .where(eq(agentConversations.id, input.conversationId));
   }
+
+  // 9. Update conversation aggregates. Money and turn-existence are split:
+  // tokensIn/tokensOut/llmCostCents accrue UNCONDITIONALLY, because the LLM
+  // call that produced totalTokensIn/totalTokensOut/costCents was real and
+  // billed regardless of persist — a persist:false retry still makes a real
+  // Anthropic call (up to MAX_TURN_ITERATIONS with tools) and those tokens
+  // must never be un-recorded. sum(agentConversations.llmCostCents) is read
+  // as org spend by the usage-cap gate (src/lib/ai/client.ts), the usage-cap
+  // cron/lib (usage-cap.ts, cron/usage-caps/route.ts), the agency billing
+  // rollup (usage-rollup.ts), super-admin workspace stats, and the
+  // conversations dashboard cost column — none of those must silently lose
+  // tokens because a turn was ephemeral.
+  // lastTurnAt/turnCount stay gated on `persist`: they exist to record that a
+  // TURN happened (and turnCount is read as a user-visible "N turns" count
+  // and as an abandonment signal — turnCount <= 2 → "abandoned" in
+  // improve/source-conversations.ts), so a synthetic retry turn must not
+  // move them. Net effect: agentConversations.tokensIn/tokensOut may exceed
+  // sum(agentTurns.tokensIn/tokensOut) by design — "tokens spent on this
+  // conversation" vs. "tokens attributable to recorded turns".
+  await db
+    .update(agentConversations)
+    .set({
+      tokensIn: sql`${agentConversations.tokensIn} + ${totalTokensIn}`,
+      tokensOut: sql`${agentConversations.tokensOut} + ${totalTokensOut}`,
+      llmCostCents: sql`${agentConversations.llmCostCents} + ${costCents}`,
+      ...(persist
+        ? { lastTurnAt: new Date(), turnCount: sql`${agentConversations.turnCount} + 2` }
+        : {}),
+    })
+    .where(eq(agentConversations.id, input.conversationId));
   // persist:false — zero agentTurns rows written for this turn (neither the
-  // user turn above nor the assistant reply here), and agentConversations'
-  // turn-count/timing aggregate is left untouched, since it exists to record
-  // that a turn happened. `costCents` is computed either way (harmless, no
-  // side effect) but only applied to the aggregate when persisted.
+  // user turn above nor the assistant reply here). See the aggregate-update
+  // comment above for what still accrues vs. what stays untouched.
 
   // v1.27.9 — agents.tokensUsedToday increment removed (see budget note
   // above). Per-turn tokens still persist on agent_turns rows for
@@ -859,8 +883,11 @@ export async function executeTurn(input: {
 
   // 10. Activity bridge — first user turn → activity row on contact's
   // timeline. Subsequent turns are aggregated for the operator review
-  // surface (v1.26.1).
-  if (nextTurnIndex === 0 && conv.status !== "test") {
+  // surface (v1.26.1). Gated on `persist`: a persist:false turn writes no
+  // agentTurns row, so an activity row referencing it would dangle. Not
+  // reachable today (the retry always follows an already-persisted first
+  // turn), but cheap to close off.
+  if (persist && nextTurnIndex === 0 && conv.status !== "test") {
     await writeFirstTurnActivity(agent, orgRow.id, conv.id, input.userMessage);
   }
 

--- a/packages/crm/src/lib/agents/runtime.ts
+++ b/packages/crm/src/lib/agents/runtime.ts
@@ -60,6 +60,7 @@ import type { BookingPolicy } from "@/lib/agents/booking/booking-policy";
 import { bindingToCtxBooking } from "@/lib/agents/booking/binding-ctx";
 import { captureLlmGeneration } from "@/lib/analytics/llm-capture";
 import { VOICE_PROFILE_NOTE_PATH } from "@/lib/agents/voice-profile/ingest-sent-mail";
+import { buildTurnMessages, type TurnMessage } from "@/lib/agents/turn-messages";
 
 const MODEL = process.env.ANTHROPIC_AGENT_MODEL?.trim() || "claude-sonnet-4-5-20250929";
 const MAX_TURN_ITERATIONS = 6; // tool-call cap per single turn (catches loops)
@@ -116,8 +117,25 @@ export async function executeTurn(input: {
    *  prompt is composed from the agent's own blueprint/soul, byte-for-byte
    *  unchanged. */
   persona?: DeploymentPromptPersona;
+  /** Ephemeral-turn flag (Never-Lies L2b, 2026-07-06). Default true (normal,
+   *  persisted turn). Set to false for SYNTHETIC turns that must never
+   *  appear as prior USER context in a future turn's history — e.g. the
+   *  copilot route's vision-retry coaching instruction (route.ts). When
+   *  false:
+   *    - the user turn is NOT inserted into agentTurns
+   *    - the assistant reply is NOT inserted into agentTurns (this includes
+   *      the capped-usage holding-reply insert)
+   *    - agentConversations aggregate counters tied to turn count/timing
+   *      (lastTurnAt, tokensIn/tokensOut, llmCostCents, turnCount) are NOT
+   *      updated, since they exist to record that a turn happened
+   *    - the in-memory Anthropic messages array still includes the turn (see
+   *      buildTurnMessages in ./turn-messages) so the model has full
+   *      context, and tool EXECUTION side effects still run unchanged
+   *  Net effect: a persist:false turn writes ZERO agentTurns rows. */
+  persist?: boolean;
 }): Promise<ExecuteTurnResult> {
   const t0 = Date.now();
+  const persist = input.persist !== false;
 
   // 1. Load conversation + agent + org + soul
   const [conv] = await db
@@ -182,12 +200,17 @@ export async function executeTurn(input: {
     .limit(1);
   const nextTurnIndex = (lastTurn?.turnIndex ?? -1) + 1;
 
-  await db.insert(agentTurns).values({
-    conversationId: input.conversationId,
-    turnIndex: nextTurnIndex,
-    role: "user",
-    content: input.userMessage,
-  });
+  if (persist) {
+    await db.insert(agentTurns).values({
+      conversationId: input.conversationId,
+      turnIndex: nextTurnIndex,
+      role: "user",
+      content: input.userMessage,
+    });
+  }
+  // persist:false — skip the insert. The DB-derived `history` selected below
+  // will therefore NOT include this turn; buildTurnMessages appends it in
+  // memory instead (see below), so the model still sees it.
 
   // 4. Build messages array from conversation history
   const history = await db
@@ -202,20 +225,14 @@ export async function executeTurn(input: {
     .orderBy(asc(agentTurns.turnIndex));
 
   // Convert Seldon turn shape → Anthropic Messages API shape.
-  type AnthropicMessage = {
-    role: "user" | "assistant";
-    content:
-      | string
-      | Array<
-          | { type: "text"; text: string }
-          | { type: "tool_use"; id: string; name: string; input: unknown }
-          | { type: "tool_result"; tool_use_id: string; content: string; is_error?: boolean }
-        >;
-  };
-  const messages: AnthropicMessage[] = [];
+  // TurnMessage (imported) is the same shape as the old locally-defined
+  // AnthropicMessage — kept as an alias so the rest of this function reads
+  // unchanged.
+  type AnthropicMessage = TurnMessage;
+  const historyMessages: AnthropicMessage[] = [];
   for (const turn of history) {
     if (turn.role === "user") {
-      messages.push({ role: "user", content: turn.content ?? "" });
+      historyMessages.push({ role: "user", content: turn.content ?? "" });
     } else if (turn.role === "assistant") {
       const blocks: Array<
         | { type: "text"; text: string }
@@ -227,14 +244,14 @@ export async function executeTurn(input: {
           blocks.push({ type: "tool_use", id: tc.id, name: tc.name, input: tc.input });
         }
       }
-      messages.push({ role: "assistant", content: blocks });
+      historyMessages.push({ role: "assistant", content: blocks });
       // Tool results from previous turns ride as a user message. Capped at
       // rebuild time (token economy, 2026-07-16): the FULL output is persisted
       // on the turn row, but every later turn of the conversation re-sends
       // this history — an unbounded historical payload would tax every turn
       // that follows it, forever.
       if (turn.toolResults && turn.toolResults.length > 0) {
-        messages.push({
+        historyMessages.push({
           role: "user",
           content: turn.toolResults.map((tr) => ({
             type: "tool_result" as const,
@@ -248,6 +265,13 @@ export async function executeTurn(input: {
       }
     }
   }
+
+  // persist:true — the DB insert above already happened before this select,
+  // so `historyMessages` already ends with the current user turn; unchanged.
+  // persist:false — no such row exists, so the current user turn is missing
+  // from `historyMessages`; append it in memory so the model still sees it
+  // (pure, unit-tested in turn-messages.spec.ts).
+  const messages: AnthropicMessage[] = buildTurnMessages(historyMessages, input.userMessage, persist);
 
   // 5. System prompt + tools
   // blueprintOverride is set by the eval runner for fixture-injection scenarios
@@ -341,24 +365,30 @@ export async function executeTurn(input: {
     const holdingReply = await resolveCappedUsageReply(agent.orgId);
     const latencyMs = Date.now() - t0;
 
-    await db.insert(agentTurns).values({
-      conversationId: input.conversationId,
-      turnIndex: nextTurnIndex + 1,
-      role: "assistant",
-      content: holdingReply,
-      toolCalls: null,
-      toolResults: null,
-      validatorsPassed: [],
-      latencyMs,
-      tokensIn: 0,
-      tokensOut: 0,
-      model: "usage_capped",
-    });
+    if (persist) {
+      await db.insert(agentTurns).values({
+        conversationId: input.conversationId,
+        turnIndex: nextTurnIndex + 1,
+        role: "assistant",
+        content: holdingReply,
+        toolCalls: null,
+        toolResults: null,
+        validatorsPassed: [],
+        latencyMs,
+        tokensIn: 0,
+        tokensOut: 0,
+        model: "usage_capped",
+      });
 
-    await db
-      .update(agentConversations)
-      .set({ lastTurnAt: new Date(), turnCount: sql`${agentConversations.turnCount} + 2` })
-      .where(eq(agentConversations.id, input.conversationId));
+      await db
+        .update(agentConversations)
+        .set({ lastTurnAt: new Date(), turnCount: sql`${agentConversations.turnCount} + 2` })
+        .where(eq(agentConversations.id, input.conversationId));
+    }
+    // persist:false — no agentTurns row for the holding reply, and the
+    // conversation's turnCount/lastTurnAt (which record that a turn
+    // happened) stay untouched. The holding reply text is still returned to
+    // the caller below.
 
     console.warn(
       `[agent-runtime] usage_capped agentId=${agent.id} convId=${conv.id} orgId=${agent.orgId}`,
@@ -782,34 +812,41 @@ export async function executeTurn(input: {
   const latencyMs = Date.now() - t0;
   const costCents = computeCostCents(totalTokensIn, totalTokensOut);
 
-  await db.insert(agentTurns).values({
-    conversationId: input.conversationId,
-    turnIndex: nextTurnIndex + 1,
-    role: "assistant",
-    content: finalText,
-    toolCalls: allToolCalls.length > 0 ? allToolCalls : null,
-    toolResults: allToolResults.length > 0 ? allToolResults : null,
-    validatorsPassed: validatorResults,
-    latencyMs,
-    tokensIn: totalTokensIn,
-    tokensOut: totalTokensOut,
-    // Record the model ACTUALLY used for the final call this turn (adaptive
-    // selection may have escalated a hard turn to the premium model), not the
-    // static default — so cost/observability reflect real spend.
-    model: lastModelUsed,
-  });
+  if (persist) {
+    await db.insert(agentTurns).values({
+      conversationId: input.conversationId,
+      turnIndex: nextTurnIndex + 1,
+      role: "assistant",
+      content: finalText,
+      toolCalls: allToolCalls.length > 0 ? allToolCalls : null,
+      toolResults: allToolResults.length > 0 ? allToolResults : null,
+      validatorsPassed: validatorResults,
+      latencyMs,
+      tokensIn: totalTokensIn,
+      tokensOut: totalTokensOut,
+      // Record the model ACTUALLY used for the final call this turn (adaptive
+      // selection may have escalated a hard turn to the premium model), not the
+      // static default — so cost/observability reflect real spend.
+      model: lastModelUsed,
+    });
 
-  // 9. Update conversation aggregates
-  await db
-    .update(agentConversations)
-    .set({
-      lastTurnAt: new Date(),
-      tokensIn: sql`${agentConversations.tokensIn} + ${totalTokensIn}`,
-      tokensOut: sql`${agentConversations.tokensOut} + ${totalTokensOut}`,
-      llmCostCents: sql`${agentConversations.llmCostCents} + ${costCents}`,
-      turnCount: sql`${agentConversations.turnCount} + 2`,
-    })
-    .where(eq(agentConversations.id, input.conversationId));
+    // 9. Update conversation aggregates
+    await db
+      .update(agentConversations)
+      .set({
+        lastTurnAt: new Date(),
+        tokensIn: sql`${agentConversations.tokensIn} + ${totalTokensIn}`,
+        tokensOut: sql`${agentConversations.tokensOut} + ${totalTokensOut}`,
+        llmCostCents: sql`${agentConversations.llmCostCents} + ${costCents}`,
+        turnCount: sql`${agentConversations.turnCount} + 2`,
+      })
+      .where(eq(agentConversations.id, input.conversationId));
+  }
+  // persist:false — zero agentTurns rows written for this turn (neither the
+  // user turn above nor the assistant reply here), and agentConversations'
+  // turn-count/timing aggregate is left untouched, since it exists to record
+  // that a turn happened. `costCents` is computed either way (harmless, no
+  // side effect) but only applied to the aggregate when persisted.
 
   // v1.27.9 — agents.tokensUsedToday increment removed (see budget note
   // above). Per-turn tokens still persist on agent_turns rows for

--- a/packages/crm/src/lib/agents/turn-messages.ts
+++ b/packages/crm/src/lib/agents/turn-messages.ts
@@ -1,0 +1,59 @@
+// Ephemeral-turn message assembly (Never-Lies L2b follow-up, 2026-08-06).
+//
+// executeTurn (./runtime.ts, "use server") builds its Anthropic messages
+// array from DB history. For a persist:false turn (e.g. the copilot route's
+// synthetic vision-retry coaching instruction — route.ts) the user turn is
+// deliberately NEVER inserted into agentTurns, so the DB-derived history has
+// no row for it. The model still needs to see the turn, so it has to be
+// appended IN MEMORY instead.
+//
+// Pulled out of runtime.ts (a "use server" module — Turbopack rejects any
+// non-async export from one) so this decision is a plain, synchronous, unit-
+// testable pure function, mirroring how bindingToCtxBooking was extracted to
+// ./booking/binding-ctx for the same reason.
+
+export type TurnMessageContent =
+  | string
+  | Array<
+      | { type: "text"; text: string }
+      | { type: "tool_use"; id: string; name: string; input: unknown }
+      | { type: "tool_result"; tool_use_id: string; content: string; is_error?: boolean }
+    >;
+
+export type TurnMessage = {
+  role: "user" | "assistant";
+  content: TurnMessageContent;
+};
+
+/**
+ * Assemble the final in-memory messages array executeTurn sends to Anthropic.
+ *
+ * `history` is the DB-derived conversation converted to Anthropic message
+ * shape, in turn order. When `persist` is true, executeTurn has already
+ * inserted the current user turn into agentTurns BEFORE selecting history,
+ * so `history` already ends with it — this function returns it unchanged.
+ * When `persist` is false, no such row exists, so this function appends
+ * `{ role: "user", content: userMessage }` after the existing history.
+ *
+ * Guarded against duplication either way: if `history` already ends with a
+ * plain-string user message equal to `userMessage`, it is never appended
+ * twice.
+ */
+export function buildTurnMessages(
+  history: TurnMessage[],
+  userMessage: string,
+  persist: boolean,
+): TurnMessage[] {
+  const last = history[history.length - 1];
+  const historyAlreadyEndsWithThisMessage =
+    last !== undefined &&
+    last.role === "user" &&
+    typeof last.content === "string" &&
+    last.content === userMessage;
+
+  if (persist || historyAlreadyEndsWithThisMessage) {
+    return history;
+  }
+
+  return [...history, { role: "user", content: userMessage }];
+}

--- a/packages/crm/tests/unit/agents/turn-messages.spec.ts
+++ b/packages/crm/tests/unit/agents/turn-messages.spec.ts
@@ -1,0 +1,65 @@
+// Ephemeral-turn message assembly — unit properties for buildTurnMessages
+// (src/lib/agents/turn-messages.ts). Extracted from runtime.ts's executeTurn
+// so the persist:false decision (never-lies L2b: synthetic vision-retry
+// coaching text must never land in agentTurns) is testable without a DB.
+//
+// Properties under test:
+//   - persist:true → history returned unchanged (message already came from
+//     the DB insert-before-select ordering in executeTurn)
+//   - persist:false → userMessage appended in memory, at the end (ordering)
+//   - persist:false but history already ends with the identical user
+//     message → not duplicated
+//   - persist:true but history is empty (defensive) → returns empty, no
+//     append (never fabricates a turn the DB doesn't have)
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildTurnMessages, type TurnMessage } from "@/lib/agents/turn-messages";
+
+const asst = (text: string): TurnMessage => ({
+  role: "assistant",
+  content: [{ type: "text", text }],
+});
+const usr = (text: string): TurnMessage => ({ role: "user", content: text });
+
+describe("buildTurnMessages", () => {
+  test("persist:true returns history unchanged (message comes from DB)", () => {
+    const history: TurnMessage[] = [usr("hello"), asst("hi there"), usr("book me a slot")];
+    const out = buildTurnMessages(history, "book me a slot", true);
+    assert.deepEqual(out, history);
+  });
+
+  test("persist:false appends userMessage in memory when absent from history", () => {
+    const history: TurnMessage[] = [usr("hello"), asst("hi there")];
+    const out = buildTurnMessages(history, "retry: fix the tagline field", false);
+    assert.equal(out.length, 3);
+    assert.deepEqual(out[2], { role: "user", content: "retry: fix the tagline field" });
+  });
+
+  test("persist:false ordering — appended message is last, prior history untouched", () => {
+    const history: TurnMessage[] = [usr("a"), asst("b"), usr("c"), asst("d")];
+    const out = buildTurnMessages(history, "e", false);
+    assert.deepEqual(out.slice(0, 4), history);
+    assert.deepEqual(out[4], { role: "user", content: "e" });
+  });
+
+  test("persist:false does not duplicate when history already ends with the same user message", () => {
+    const history: TurnMessage[] = [usr("hello"), asst("hi"), usr("same text")];
+    const out = buildTurnMessages(history, "same text", false);
+    assert.equal(out.length, 3);
+    assert.deepEqual(out, history);
+  });
+
+  test("persist:true with empty history returns empty (never fabricates a row the DB doesn't have)", () => {
+    const out = buildTurnMessages([], "first message", true);
+    assert.deepEqual(out, []);
+  });
+
+  test("does not mutate the input history array", () => {
+    const history: TurnMessage[] = [usr("hello")];
+    const frozen = Object.freeze([...history]);
+    buildTurnMessages(frozen as TurnMessage[], "next", false);
+    assert.deepEqual(frozen, [usr("hello")]);
+  });
+});

--- a/packages/crm/tests/unit/agents/turn-messages.spec.ts
+++ b/packages/crm/tests/unit/agents/turn-messages.spec.ts
@@ -62,4 +62,41 @@ describe("buildTurnMessages", () => {
     buildTurnMessages(frozen as TurnMessage[], "next", false);
     assert.deepEqual(frozen, [usr("hello")]);
   });
+
+  // N1 — the ONE production persist:false shape. The copilot retry
+  // (runtime.ts:253-265) only fires after the original turn made
+  // edit_/update_/add_ tool calls, so the last DB-derived message in the
+  // real caller is a user message whose `content` is an ARRAY of
+  // tool_result blocks — never a plain string. The dup-guard's
+  // `typeof last.content === "string"` check must fall through for this
+  // shape (it does — a string check on array content is false), so the
+  // synthetic retry message still gets appended instead of being
+  // (wrongly) treated as a duplicate.
+  test("persist:false with history ending in a tool_result array (real copilot-retry shape) still appends", () => {
+    const history: TurnMessage[] = [
+      usr("hello"),
+      asst("hi there"),
+      {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tool_1", content: "field updated" },
+        ],
+      },
+    ];
+    const out = buildTurnMessages(history, "retry: fix the tagline field", false);
+    assert.equal(out.length, 4);
+    assert.deepEqual(out[3], { role: "user", content: "retry: fix the tagline field" });
+  });
+
+  // N2 — the property that actually matters for runtime.ts's mid-turn
+  // pushes (lines ~542/639): persist:true returns the CALLER'S ARRAY BY
+  // REFERENCE, not a copy. A future "defensive copy" refactor of
+  // buildTurnMessages would silently break those in-place appends without
+  // ever failing the frozen-array non-mutation test above (that test never
+  // asserts identity, only that history's own contents are unchanged).
+  test("persist:true returns the same array reference as the input (relied on for mid-turn pushes)", () => {
+    const history: TurnMessage[] = [usr("hello"), asst("hi there"), usr("book me a slot")];
+    const out = buildTurnMessages(history, "book me a slot", true);
+    assert.equal(out, history);
+  });
 });


### PR DESCRIPTION
Follow-up to #175. Fixes the pre-existing TS2353 that blocked a typecheck gate, and the silent behavioral bug underneath it.

## The bug
`api/copilot/turn/route.ts:315` passes `persist: false` to `executeTurn` with a comment promising the synthetic vision-retry coaching text is "never written to agentTurns". `executeTurn` had no such parameter — a type error, and at runtime a no-op: the synthetic text WAS persisted and leaked into later turns' history as prior USER context.

## What ships
- **`persist?: boolean`** (default true) on `executeTurn`. When false, all three `agentTurns` inserts (user turn, capped holding reply, assistant reply) are skipped — zero rows — while the model still sees the message via the new pure `buildTurnMessages` helper. Tool execution and vision re-grading are untouched; the retry's real side effects still happen.
- **`buildTurnMessages`** extracted to a non-`"use server"` module (`turn-messages.ts`), mirroring the existing `bindingToCtxBooking` precedent — `runtime.ts` is `"use server"` and Turbopack rejects non-async exports from it.
- **Typecheck CI gate** — `tsc --noEmit`, placed before unit tests for fail-fast.
- `writeFirstTurnActivity` gated on `persist` (closes a latent hole where an ephemeral first turn would write an activities row referencing a turn that doesn't exist).

## Review found a money hole — fixed
First round returned NO-SHIP. The `persist` guard had been widened past turn ROWS to turn COST, skipping the `agentConversations` token/cost aggregate. The retry makes up to 6 real billed Anthropic calls, and four readers take `sum(llmCostCents)` as org spend (`ai/client.ts` cap gate, `billing/usage-cap.ts`, the usage-caps cron, `billing/usage-rollup.ts` agency billing, plus super-admin + the conversations cost column). Because `persist:false` was previously an unknown property — a type error but a runtime no-op — those tokens were being aggregated before this branch; skipping them would have been a regression, not a pre-existing gap.

Now split by what each field means: **money always accrues** (`tokensIn`/`tokensOut`/`llmCostCents`), **turn-existence markers do not** (`lastTurnAt`/`turnCount` — consumed as a user-visible turn count and as the `turnCount <= 2 → abandoned` signal, which a synthetic turn must not move). `agentConversations.tokensIn` may now exceed `sum(agentTurns.tokensIn)` by design: "tokens spent on this conversation" vs "tokens attributable to recorded turns".

## Gates
- `tsc --noEmit` — zero errors (re-verified after rebase onto post-squash main)
- `turn-messages.spec.ts` — 8/8, including the one shape production actually hits (history ending in a `tool_result` array, not a plain string) and reference-identity on the `persist:true` path that `runtime.ts` relies on for mid-turn pushes
- executeTurn-adjacent specs — 65/65
- `check:use-server` — green

## Known, deliberately not in this PR
When a capped-usage org hits the vision-retry, the retry's holding reply replaces the first turn's successful answer — and with `persist:false`, without a DB record. The fix is one condition in `route.ts`, but it changes which reply an operator sees, so it's a product call, raised separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)