### PR TITLE
feat(analytics): instrument the activation moment — agent_conversation_started + workspace_activated

### DIFF
--- a/packages/crm/src/app/api/v1/public/agent/[slug]/turn/route.ts
+++ b/packages/crm/src/app/api/v1/public/agent/[slug]/turn/route.ts
@@ -201,6 +201,23 @@ export async function POST(
       );
     }
     conversationId = created.id;
+
+    // 2026-08-07 — activation-moment analytics. Only for real ("active")
+    // conversations — the operator test sandbox routes through this same
+    // endpoint with status="test" (decidePublicConversationStatus above),
+    // and that traffic must never count as activation. Fire-and-forget:
+    // never awaited, internally swallows every error.
+    if (conversationStatus === "active") {
+      const { recordAgentConversationStarted } = await import(
+        "@/lib/analytics/record-agent-activation"
+      );
+      void recordAgentConversationStarted({
+        orgId: agentRow.orgId,
+        agentId: agentRow.id,
+        conversationId,
+        channel: "web",
+      });
+    }
   }
 
   // SSE branch ───────────────────────────────────────────────────────────

--- a/packages/crm/src/lib/agents/channels/run-channel-turn.ts
+++ b/packages/crm/src/lib/agents/channels/run-channel-turn.ts
@@ -368,6 +368,19 @@ async function defaultGetOrCreateConversation(
     .returning({ id: agentConversations.id });
 
   if (!created) throw new Error("agent_conversations insert returned no row");
+
+  // 2026-08-07 — activation-moment analytics. Fire-and-forget: never awaited,
+  // internally swallows every error, never delays or fails this insert.
+  const { recordAgentConversationStarted } = await import(
+    "@/lib/analytics/record-agent-activation"
+  );
+  void recordAgentConversationStarted({
+    orgId: args.orgId,
+    agentId: args.agentId,
+    conversationId: created.id,
+    channel: args.channel,
+  });
+
   return created.id;
 }
 

--- a/packages/crm/src/lib/agents/copilot/ensure-agent.ts
+++ b/packages/crm/src/lib/agents/copilot/ensure-agent.ts
@@ -137,6 +137,21 @@ async function defaultCreateConversation(input: {
       "ensureWorkspaceCopilotAgent: conversation insert returned no row",
     );
   }
+
+  // 2026-08-07 — activation-moment analytics. Fire-and-forget: never
+  // awaited, internally swallows every error, never delays this insert.
+  void (async () => {
+    const { recordAgentConversationStarted } = await import(
+      "@/lib/analytics/record-agent-activation"
+    );
+    await recordAgentConversationStarted({
+      orgId: input.orgId,
+      agentId: input.agentId,
+      conversationId: created.id,
+      channel: "copilot",
+    });
+  })();
+
   return created;
 }
 

--- a/packages/crm/src/lib/agents/voice/transcript.ts
+++ b/packages/crm/src/lib/agents/voice/transcript.ts
@@ -103,6 +103,25 @@ export async function startVoiceConversation(args: {
         to_number: args.toNumber ?? null,
       },
     });
+
+    // 2026-08-07 — activation-moment analytics. Fire-and-forget: never
+    // awaited, internally swallows every error, never delays this insert.
+    // recordAgentConversationStarted does its own DB reads (independent of
+    // insertConversation's injected dep), so unit tests that inject a fake
+    // insertConversation still exercise this — it fails closed (caught,
+    // logged, no-op) against the real @/db import with no test database.
+    void (async () => {
+      const { recordAgentConversationStarted } = await import(
+        "@/lib/analytics/record-agent-activation"
+      );
+      await recordAgentConversationStarted({
+        orgId: args.orgId,
+        agentId: args.agentId,
+        conversationId: id,
+        channel: "voice",
+      });
+    })();
+
     return id;
   } catch (error) {
     logEvent("voice_call_transcript_persist_error", { error, step: "start" });

--- a/packages/crm/src/lib/analytics/agent-activation.ts
+++ b/packages/crm/src/lib/analytics/agent-activation.ts
@@ -1,0 +1,133 @@
+// 2026-08-07 — Activation-moment PostHog events. A funnel audit found:
+// 234 visitors → 10 signups → 12 workspaces → 2 workspaces that EVER held an
+// agent conversation → 0 paid, ever. Agents auto-provision on workspace
+// creation, yet almost nobody reaches a first conversation — that gap
+// (workspace exists, agent never talks) was invisible in analytics. PR #175
+// instrumented the funnel's two ends (signed_up, workspace_created,
+// checkout_started); this module instruments the middle.
+//
+// Pure event builders ONLY — no DB, no PostHog client, no "use server". The
+// DB-touching orchestration (counting prior conversations, firing these
+// through captureFunnelEvent) lives in record-agent-activation.ts, which is
+// the imperative shell every conversation-creation call site invokes.
+//
+// Distinct-id convention: same as workspace_created (funnel.ts) — orgId is
+// the ONLY id available at conversation-start time for anonymous end-
+// customer channels (sms/email/web/voice), so distinctId = orgId always.
+// There is no userId fallback here (unlike buildSignedUpEvent) because the
+// person talking to the agent is essentially never the SF operator/user.
+//
+// Builders return null (never a half-formed event) when a required id is
+// missing, mirroring funnel.ts's contract — callers always write
+// `captureFunnelEvent(buildXEvent({...}))` without an extra guard.
+
+import type { FunnelEvent } from "@/lib/analytics/funnel";
+
+export type BuildAgentConversationStartedEventInput = {
+  orgId: string;
+  agentId: string;
+  conversationId: string;
+  /** "web" | "sms" | "email" | "voice" | "copilot" — whatever the call site's
+   *  channel concept is named; kept as a plain string so a new channel never
+   *  needs a type change here. */
+  channel: string;
+  /** True when this conversation resolved through a deployment's client-org
+   *  bridge (a deployed client agent); false for a workspace/operator's own
+   *  agent. Omitted (not false) when the call site has no cheap signal to
+   *  determine it, so "unknown" stays distinguishable from "known false" in
+   *  PostHog. */
+  isDeployedClientAgent?: boolean;
+  isFirstConversationForWorkspace: boolean;
+};
+
+/**
+ * agent_conversation_started — fired once per new agentConversations row
+ * (never on turns within an existing conversation). Every real inbound path
+ * that starts a conversation calls this via record-agent-activation.ts:
+ * run-channel-turn.ts (sms/email), the public agent turn route (web),
+ * voice/transcript.ts (voice), copilot/ensure-agent.ts (copilot).
+ */
+export function buildAgentConversationStartedEvent(
+  input: BuildAgentConversationStartedEventInput,
+): FunnelEvent | null {
+  const orgId = input.orgId?.trim();
+  const agentId = input.agentId?.trim();
+  const conversationId = input.conversationId?.trim();
+  const channel = input.channel?.trim();
+
+  if (!orgId || !agentId || !conversationId || !channel) {
+    // A brand-new agentConversations row always has all four by insert time —
+    // a missing one here is malformed input, not a quiet path.
+    console.warn(
+      "[activation] buildAgentConversationStartedEvent: missing org/agent/conversation id or channel — event dropped",
+    );
+    return null;
+  }
+
+  const properties: FunnelEvent["properties"] = {
+    org_id: orgId,
+    agent_id: agentId,
+    conversation_id: conversationId,
+    channel,
+    is_first_conversation_for_workspace: input.isFirstConversationForWorkspace,
+  };
+
+  if (input.isDeployedClientAgent !== undefined) {
+    properties.is_deployed_client_agent = input.isDeployedClientAgent;
+  }
+
+  return { event: "agent_conversation_started", distinctId: orgId, properties };
+}
+
+export type BuildWorkspaceActivatedEventInput = {
+  orgId: string;
+  agentId: string;
+  conversationId: string;
+  channel: string;
+};
+
+/**
+ * workspace_activated — the actual activation metric. Fired ONCE per
+ * workspace: the first time any conversation starts in it, ever. Idempotency
+ * is decided by shouldFireWorkspaceActivated below (a prior-conversation
+ * count, computed by the imperative shell) — this builder just shapes the
+ * payload once the caller has already decided to fire.
+ */
+export function buildWorkspaceActivatedEvent(
+  input: BuildWorkspaceActivatedEventInput,
+): FunnelEvent | null {
+  const orgId = input.orgId?.trim();
+  const agentId = input.agentId?.trim();
+  const conversationId = input.conversationId?.trim();
+  const channel = input.channel?.trim();
+
+  if (!orgId || !agentId || !conversationId || !channel) {
+    console.warn(
+      "[activation] buildWorkspaceActivatedEvent: missing org/agent/conversation id or channel — event dropped",
+    );
+    return null;
+  }
+
+  return {
+    event: "workspace_activated",
+    distinctId: orgId,
+    properties: {
+      org_id: orgId,
+      agent_id: agentId,
+      conversation_id: conversationId,
+      channel,
+    },
+  };
+}
+
+/**
+ * The pure idempotency decision for workspace_activated: fire iff the
+ * conversation just inserted is the ONLY conversation this org has ever had
+ * (i.e. a prior-count of 0, where "prior" means the count taken AFTER the
+ * new row was inserted — see record-agent-activation.ts). A non-finite count
+ * (a failed/garbled DB read) defaults to "do not fire" — under-firing a
+ * marketing event is a safe failure, double-firing it is not idempotent.
+ */
+export function shouldFireWorkspaceActivated(conversationCountForOrg: number): boolean {
+  return Number.isFinite(conversationCountForOrg) && conversationCountForOrg === 0;
+}

--- a/packages/crm/src/lib/analytics/record-agent-activation.ts
+++ b/packages/crm/src/lib/analytics/record-agent-activation.ts
@@ -1,0 +1,129 @@
+// 2026-08-07 — Imperative shell for the activation-moment events (see
+// agent-activation.ts for the pure builders + the "why"). This is the ONE
+// place every real conversation-creation call site calls into: it does the
+// DB reads the pure builders need (prior-conversation count for the
+// idempotent workspace_activated fire, and a best-effort deployment lookup
+// for is_deployed_client_agent), then fires both events through
+// captureFunnelEvent — the same fire-and-forget/catch-swallowing delivery
+// funnel.ts's signed_up/workspace_created/checkout_started use.
+//
+// Call sites (every real inbound path that inserts an agentConversations
+// row): run-channel-turn.ts (sms/email), the public agent turn route (web),
+// voice/transcript.ts (voice), copilot/ensure-agent.ts (copilot). Each
+// calls this ONCE, right after a successful insert — never on a reused
+// existing conversation.
+//
+// NOT called: eval-runner/run-deployed-agent-evals (eval traffic, not real
+// conversations), the /agents replay-test endpoint (status="test"), and the
+// marketplace MCP turn route (runs a DB-free stateless turn — no
+// agentConversations row exists to key an activation event off of).
+//
+// OPTIMISTIC-PATH GUARD: this function must never fail a conversation. Every
+// DB read and every capture call is wrapped so a PostHog or Postgres hiccup
+// here is invisible to the caller — logged, never thrown.
+
+import {
+  buildAgentConversationStartedEvent,
+  buildWorkspaceActivatedEvent,
+  shouldFireWorkspaceActivated,
+} from "@/lib/analytics/agent-activation";
+import { captureFunnelEvent } from "@/lib/analytics/funnel";
+
+export type RecordAgentConversationStartedInput = {
+  orgId: string;
+  agentId: string;
+  conversationId: string;
+  /** "web" | "sms" | "email" | "voice" | "copilot". */
+  channel: string;
+};
+
+/**
+ * Count every agentConversations row for this org (including the one just
+ * inserted) and check whether the org is a deployment's client org. Both
+ * reads are best-effort: a thrown error yields `null` counts /
+ * `isDeployedClientAgent: undefined` rather than propagating, so a DB
+ * hiccup degrades to "skip workspace_activated this time, omit the
+ * deployment flag" instead of breaking the conversation that triggered it.
+ */
+async function loadActivationContext(
+  orgId: string,
+): Promise<{ conversationCountForOrg: number | null; isDeployedClientAgent: boolean | undefined }> {
+  let conversationCountForOrg: number | null = null;
+  let isDeployedClientAgent: boolean | undefined;
+
+  try {
+    const { db } = await import("@/db");
+    const { agentConversations, deployments } = await import("@/db/schema");
+    const { eq, sql } = await import("drizzle-orm");
+
+    const [countRow] = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(agentConversations)
+      .where(eq(agentConversations.orgId, orgId));
+    conversationCountForOrg = countRow?.count ?? null;
+
+    const [deploymentRow] = await db
+      .select({ id: deployments.id })
+      .from(deployments)
+      .where(eq(deployments.clientOrgId, orgId))
+      .limit(1);
+    isDeployedClientAgent = Boolean(deploymentRow);
+  } catch (err) {
+    console.warn(
+      `[activation] loadActivationContext threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return { conversationCountForOrg, isDeployedClientAgent };
+}
+
+/**
+ * Fire agent_conversation_started (always) and workspace_activated (only on
+ * the org's very first conversation ever). Fire-and-forget: never throws,
+ * never awaited by callers beyond "started" (callers may still `await` it
+ * to keep request-scoped serverless functions alive long enough to flush,
+ * matching the captureImmediate posture elsewhere).
+ */
+export async function recordAgentConversationStarted(
+  input: RecordAgentConversationStartedInput,
+): Promise<void> {
+  try {
+    const { conversationCountForOrg, isDeployedClientAgent } = await loadActivationContext(
+      input.orgId,
+    );
+
+    // conversationCountForOrg counts the row already inserted, so "1" means
+    // this IS the first conversation — translate to the 0-based "prior
+    // count" shouldFireWorkspaceActivated expects. A null read (DB hiccup)
+    // becomes NaN, which shouldFireWorkspaceActivated treats as "don't fire".
+    const priorCount =
+      conversationCountForOrg === null ? Number.NaN : conversationCountForOrg - 1;
+    const isFirst = shouldFireWorkspaceActivated(priorCount);
+
+    captureFunnelEvent(
+      buildAgentConversationStartedEvent({
+        orgId: input.orgId,
+        agentId: input.agentId,
+        conversationId: input.conversationId,
+        channel: input.channel,
+        isDeployedClientAgent,
+        isFirstConversationForWorkspace: isFirst,
+      }),
+    );
+
+    if (isFirst) {
+      captureFunnelEvent(
+        buildWorkspaceActivatedEvent({
+          orgId: input.orgId,
+          agentId: input.agentId,
+          conversationId: input.conversationId,
+          channel: input.channel,
+        }),
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[activation] recordAgentConversationStarted threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/packages/crm/tests/unit/analytics/agent-activation.spec.ts
+++ b/packages/crm/tests/unit/analytics/agent-activation.spec.ts
@@ -1,0 +1,157 @@
+// agent_conversation_started / workspace_activated — the activation-moment
+// PostHog events. Pure event builders + the pure "should this fire" decision
+// for workspace_activated's idempotency, so the decidable logic is
+// unit-testable without a DB. Mirrors funnel-events.spec.ts's pattern.
+//
+// Run:
+//   node --import tsx --test tests/unit/analytics/agent-activation.spec.ts
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildAgentConversationStartedEvent,
+  buildWorkspaceActivatedEvent,
+  shouldFireWorkspaceActivated,
+} from "../../../src/lib/analytics/agent-activation";
+
+describe("buildAgentConversationStartedEvent", () => {
+  test("builds the full event with distinct_id = org_id", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "sms",
+      isDeployedClientAgent: true,
+      isFirstConversationForWorkspace: true,
+    });
+    assert.deepEqual(result, {
+      event: "agent_conversation_started",
+      distinctId: "org-1",
+      properties: {
+        org_id: "org-1",
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+        channel: "sms",
+        is_deployed_client_agent: true,
+        is_first_conversation_for_workspace: true,
+      },
+    });
+  });
+
+  test("returns null and warns when orgId is missing", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "sms",
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal(result, null);
+  });
+
+  test("returns null when agentId is missing", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "",
+      conversationId: "conv-1",
+      channel: "sms",
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal(result, null);
+  });
+
+  test("returns null when conversationId is missing", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "",
+      channel: "sms",
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal(result, null);
+  });
+
+  test("returns null when channel is missing", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "",
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal(result, null);
+  });
+
+  test("is_deployed_client_agent omitted when unknown (undefined)", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "web",
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal("is_deployed_client_agent" in (result?.properties ?? {}), false);
+  });
+
+  test("is_deployed_client_agent false is included (not treated as absent)", () => {
+    const result = buildAgentConversationStartedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "web",
+      isDeployedClientAgent: false,
+      isFirstConversationForWorkspace: false,
+    });
+    assert.equal(result?.properties.is_deployed_client_agent, false);
+  });
+});
+
+describe("buildWorkspaceActivatedEvent", () => {
+  test("builds the event, distinct_id = org_id", () => {
+    const result = buildWorkspaceActivatedEvent({
+      orgId: "org-1",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "email",
+    });
+    assert.deepEqual(result, {
+      event: "workspace_activated",
+      distinctId: "org-1",
+      properties: {
+        org_id: "org-1",
+        agent_id: "agent-1",
+        conversation_id: "conv-1",
+        channel: "email",
+      },
+    });
+  });
+
+  test("returns null when orgId is missing", () => {
+    const result = buildWorkspaceActivatedEvent({
+      orgId: "",
+      agentId: "agent-1",
+      conversationId: "conv-1",
+      channel: "email",
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe("shouldFireWorkspaceActivated", () => {
+  test("fires when this is the first conversation ever recorded for the org", () => {
+    assert.equal(shouldFireWorkspaceActivated(0), true);
+  });
+
+  test("does not fire on the second conversation", () => {
+    assert.equal(shouldFireWorkspaceActivated(1), false);
+  });
+
+  test("does not fire on later conversations", () => {
+    assert.equal(shouldFireWorkspaceActivated(42), false);
+  });
+
+  test("treats a non-finite count as 'do not fire' (safe default)", () => {
+    assert.equal(shouldFireWorkspaceActivated(Number.NaN), false);
+  });
+});


### PR DESCRIPTION
Third slice of funnel observability, after #175 (funnel ends) and #177 (persist/typecheck).

## Why
The audit measured 234 visitors → 10 signups → 12 workspaces → **2 workspaces that ever held a conversation** → 0 paid. #175 instrumented both ENDS of the funnel; the drop is in the middle, and it was invisible. This makes the activation moment a chart.

## What
- `agent_conversation_started` — org/workspace, agent, conversation, channel/surface, deployed-client vs operator agent, `is_first_conversation_for_workspace`.
- `workspace_activated` — fires once per workspace, the first time any conversation starts. Idempotency decided by a pure `shouldFireWorkspaceActivated` (prior-conversation count), unit-tested.
- Pure builders + idempotency decision in `src/lib/analytics/agent-activation.ts` (no DB, testable); imperative shell in `record-agent-activation.ts`.

## Wiring — 4 sites, because no single choke point exists
Unlike `workspace_created` (which had `createFullWorkspace`), conversation rows are inserted from several paths: `run-channel-turn.ts` (sms/email), the public agent turn route (web, gated to `status==="active"` so the operator test sandbox never counts), `voice/transcript.ts`, `copilot/ensure-agent.ts`.

**Known blind spot, stated rather than hidden:** the marketplace MCP turn route runs `runStatelessAgentTurn` and never touches `agentConversations` — there is no row to key an activation event off, so MCP-delivered activation is NOT counted. Eval runners and the replay-test endpoint are deliberately excluded.

## Deviation from brief, flagged not improvised
The existing `funnel.ts` helper does NOT exclude internal orgs at emit time — `is_internal` is tagged as a property and filtered downstream in PostHog. There was nothing to mirror, so no emit-time exclusion was added. Same convention as #175.

## Gates
`tsc --noEmit` clean · `check:use-server` green · new specs 13/13 · every pre-existing spec for each touched file re-run (49 + 28) with zero new failures.

Open risks are documented in the branch report: unindexed `deployments.clientOrgId` lookup, a rare concurrent-first-insert race on the idempotency check, and whether copilot turns should count toward activation at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)