### PR TITLE
test: repair 8 stale spec expectations (post-rebrand drift + one line-anchored matcher)

### DIFF
--- a/packages/crm/tests/unit/deployments/deploy-readiness.spec.ts
+++ b/packages/crm/tests/unit/deployments/deploy-readiness.spec.ts
@@ -90,7 +90,7 @@ describe("computeDeployReadiness — Tier-0-available telephony", () => {
     assert.ok(telephonyReq, "telephony should be in missing");
     assert.equal(
       telephonyReq!.label,
-      "Top up your wallet for an instant SF number, or connect your own Twilio.",
+      "Top up your wallet for an instant Seldon number, or connect your own Twilio.",
     );
   });
 

--- a/packages/crm/tests/unit/extract-instructions-route.spec.ts
+++ b/packages/crm/tests/unit/extract-instructions-route.spec.ts
@@ -40,7 +40,10 @@ test("returns 200 with playbook shape when ?url present", async () => {
   assert.equal(body.status, "instructions");
   assert.equal(body.url_echo, targetUrl);
   assert.equal(typeof body.instructions, "string");
-  assert.equal(body.next_tool, "create_workspace_v2");
+  // Retargeted 2026-07-02 (8a1eaee44): the from-url playbook now points at the
+  // atomic create_full_workspace path (the R1 multi-page site engine), not the
+  // block-iterated v2 flow.
+  assert.equal(body.next_tool, "create_full_workspace");
 
   // Sanity: instructions actually mention WebFetch + the URL was substituted
   assert.match(body.instructions, /WebFetch/);
@@ -51,7 +54,7 @@ test("returns 200 with playbook shape when ?url present", async () => {
   );
 
   // Required fields contract — these must stay exact; downstream
-  // create_workspace_v2 enforces them.
+  // create_full_workspace enforces them.
   for (const field of [
     "business_name",
     "city",
@@ -90,7 +93,23 @@ test("required_fields_schema includes both required and optional fields", async 
       properties: Record<string, unknown>;
     };
   };
-  // 6 required + 11 optional = 17 properties total
-  assert.equal(Object.keys(body.required_fields_schema.properties).length, 17);
+  // 6 required + 14 optional = 20 properties total.
+  // Was 17 until e4f886d0e (2026-05-22, "Phase U") added exactly three
+  // OPTIONAL enrichment fields — photos / faq / services_detailed. The
+  // required[] list was not touched, so the 6 below still holds.
+  assert.equal(Object.keys(body.required_fields_schema.properties).length, 20);
   assert.equal(body.required_fields_schema.required.length, 6);
+
+  // Name the Phase U fields explicitly so the next drift reports which key
+  // moved instead of surfacing as an opaque integer mismatch.
+  for (const field of ["photos", "faq", "services_detailed"]) {
+    assert.ok(
+      field in body.required_fields_schema.properties,
+      `required_fields_schema.properties is missing the Phase U field ${field}`
+    );
+    assert.ok(
+      !body.required_fields_schema.required.includes(field),
+      `Phase U field ${field} is optional and must not appear in required[]`
+    );
+  }
 });

--- a/packages/crm/tests/unit/integrations/anthropic-key-field.spec.tsx
+++ b/packages/crm/tests/unit/integrations/anthropic-key-field.spec.tsx
@@ -95,7 +95,7 @@ describe("<EncryptionNotice>", () => {
   test("renders the canonical AES-256-GCM sentence", () => {
     const html = renderToString(<EncryptionNotice />);
     assert.match(html, /Keys are encrypted with AES-256-GCM/);
-    assert.match(html, /SF cannot read your raw keys/);
+    assert.match(html, /Seldon cannot read your raw keys/);
     assert.match(html, /decrypted in memory at agent-turn time/);
   });
 

--- a/packages/crm/tests/unit/landing/brand-mark.spec.tsx
+++ b/packages/crm/tests/unit/landing/brand-mark.spec.tsx
@@ -7,7 +7,7 @@ import { BrandMark } from "../../../src/components/landing/brand-mark";
 describe("<BrandMark>", () => {
   test("renders the canonical brand asset, not an inline approximation", () => {
     const html = renderToString(React.createElement(BrandMark));
-    assert.match(html, /\/brand\/seldonframe-icon\.svg/);
+    assert.match(html, /\/brand\/seldon-mark\.svg/);
     assert.match(html, /SeldonFrame/);
   });
   test("withPathChip renders the /record chip (CSS-gated to record mode)", () => {

--- a/packages/crm/tests/unit/layout/nav-config.spec.ts
+++ b/packages/crm/tests/unit/layout/nav-config.spec.ts
@@ -218,13 +218,13 @@ describe("buildNavGroups — hiddenBlocks filtering", () => {
 // ---------------------------------------------------------------------
 
 describe("buildNavGroups — super-admin", () => {
-  test("adds the SF Admin entry (/super-admin) for super-admins", () => {
+  test("adds the Seldon Admin entry (/super-admin) for super-admins", () => {
     const groups = buildNavGroups(baseInput({ isSuperAdmin: true }));
     assert.equal(countHref(groups, "/super-admin"), 1);
-    assert.equal(findItem(groups, "/super-admin")?.label, "SF Admin");
+    assert.equal(findItem(groups, "/super-admin")?.label, "Seldon Admin");
   });
 
-  test("omits SF Admin for non-super-admins", () => {
+  test("omits Seldon Admin for non-super-admins", () => {
     const groups = buildNavGroups(baseInput({ isSuperAdmin: false }));
     assert.equal(hasHref(groups, "/super-admin"), false);
   });
@@ -316,7 +316,7 @@ describe("buildNavGroups — inside-client-workspace session", () => {
     assert.equal(hasHref(groups, "/docs"), false);
   });
 
-  test("adds SF Admin for super-admins inside a client workspace", () => {
+  test("adds Seldon Admin for super-admins inside a client workspace", () => {
     const groups = buildNavGroups(baseInput({ sessionType: "inside-client-workspace", isSuperAdmin: true }));
     assert.equal(hasHref(groups, "/super-admin"), true);
   });

--- a/packages/crm/tests/unit/onboarding/shell.spec.tsx
+++ b/packages/crm/tests/unit/onboarding/shell.spec.tsx
@@ -129,19 +129,29 @@ describe("<OnboardingShell> — a11y + chrome", () => {
     assert.match(html, /SeldonFrame — home/);
   });
 
-  test("brand mark uses the teal-500 accent (#14b8a6)", () => {
+  test("brand mark uses the emerald-600 accent (#059669)", () => {
     // Visual contract: the progress bar fill AND the logo's accent
-    // strokes both use #14b8a6. The shell renders both inline (logo as
+    // strokes both use #059669. The shell renders both inline (logo as
     // SVG strokes, bar via Tailwind arbitrary class), so this test
     // exists to catch a future palette swap that updates one but not
     // the other.
+    //
+    // 2026-08-07 — Retargeted from the old teal #14b8a6 to emerald
+    // #059669. The swap was deliberate and complete: b2b13cf64 (#65,
+    // 2026-07-13) "feat(brand): emerald green — replace muted teal
+    // across all pages + dashboard" retired #14b8a6 across 123 files.
+    // BOTH halves this test guards moved together, so it caught no
+    // partial swap — it was simply left behind (this spec was last
+    // touched at f76c534b1, which predates the brand commit). The
+    // shipped surfaces agree: public/logo{,-full,-small}.svg and
+    // src/lib/auth/config.ts all use #059669.
     const html = renderToString(
       <OnboardingShell step={2} total={3} title="Test" />,
     );
-    // The progress bar fill uses a Tailwind bg-[#14b8a6] class
-    assert.match(html, /bg-\[#14b8a6\]/);
+    // The progress bar fill uses a Tailwind bg-[#059669] class
+    assert.match(html, /bg-\[#059669\]/);
     // The logo SVG strokes use the literal hex
-    assert.match(html, /stroke="#14b8a6"/);
+    assert.match(html, /stroke="#059669"/);
   });
 
   test("showLogo={false} omits the brand mark + homepage link", () => {

--- a/packages/crm/tests/unit/page-schema-adapter.spec.ts
+++ b/packages/crm/tests/unit/page-schema-adapter.spec.ts
@@ -51,7 +51,11 @@ describe("blueprintFromSchema — workspace conversion", () => {
       "The open-source Business OS platform"
     );
     assert.equal(blueprint.workspace.theme.mode, "light"); // clean = light
-    assert.equal(blueprint.workspace.theme.accent, "#14b8a6"); // default
+    // Emerald brand default — `tokensForPersonality`'s `defaultAccent`
+    // param (src/lib/page-schema/design-tokens.ts). Teal #14b8a6 was
+    // retired repo-wide by b2b13cf64 (2026-07-13, #65); that commit
+    // touched no test files, which is why this assertion went stale.
+    assert.equal(blueprint.workspace.theme.accent, "#059669"); // default
   });
 
   test("SaaS workspace gets empty contact.phone (no phone CTA in nav)", () => {

--- a/packages/crm/tests/unit/workflow-event-log/category-portal.spec.ts
+++ b/packages/crm/tests/unit/workflow-event-log/category-portal.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, test } from "node:test";
 
-import { assertOrgIdExpr } from "./emit-site-extractor";
+import { assertEmitOrgId, assertOrgIdExpr } from "./emit-site-extractor";
 
 describe("SLICE 1-a — portal/actions.ts (2 sites)", () => {
   test("line 79 portal.message_sent — session.orgId", () => {
@@ -14,11 +14,36 @@ describe("SLICE 1-a — portal/actions.ts (2 sites)", () => {
   });
 });
 
+// 2026-08-07 — switched these two sites from line-anchored (assertOrgIdExpr)
+// to event-name-anchored (assertEmitOrgId). The product did NOT change: at
+// 34a6a430c (the commit that added this spec) auth.ts:165 was
+// `{ orgId: org.id }` and auth.ts:261 was `{ orgId: session.orgId }` — the same
+// two expressions live today at auth.ts:310 and auth.ts:413. Only the line
+// numbers moved, because the file grew above both sites (Measurement-Layer
+// trackEvent blocks, and f0518dcd2 "one-click /demo URL" which added a THIRD
+// portal.login emit). assertOrgIdExpr resolves "the FIRST emitSeldonEvent at or
+// after line N", so line 261 started resolving to the access-code site and the
+// refresh-flow assertion failed with got="org.id". The line-165 case was still
+// green, but only by accident — it too would have silently asserted the wrong
+// call on the next insertion, so it is migrated in the same edit.
+// Expected values are unchanged; site identity is strengthened from a line pin
+// to event + enclosing function.
+// NOTE: the third site (establishPortalDemoSession, auth.ts:478) is not
+// asserted here — enclosingFunctionName() currently reports null for it, so it
+// cannot be selected by inFunction. Fixing that helper is out of scope.
 describe("SLICE 1-a — portal/auth.ts (2 sites)", () => {
-  test("line 165 portal.login (access-code flow) — org.id", () => {
-    assertOrgIdExpr("src/lib/portal/auth.ts", 165, "org.id");
+  test("portal.login (access-code flow) — org.id", () => {
+    assertEmitOrgId(
+      "src/lib/portal/auth.ts",
+      { event: "portal.login", inFunction: "verifyPortalAccessCodeAction" },
+      "org.id",
+    );
   });
-  test("line 261 portal.login (refresh flow) — session.orgId", () => {
-    assertOrgIdExpr("src/lib/portal/auth.ts", 261, "session.orgId");
+  test("portal.login (refresh flow) — session.orgId", () => {
+    assertEmitOrgId(
+      "src/lib/portal/auth.ts",
+      { event: "portal.login", inFunction: "establishPortalMagicSession" },
+      "session.orgId",
+    );
   });
 });


### PR DESCRIPTION
Part of making CI mean something again. `unit-tests` has been red on `main` since 2026-07-18 — ~70 failures, every run — so no PR could be distinguished from noise.

This PR fixes only the failures where **the test was wrong and the product was right**. It does not touch the ~30 failures that are catching a real product bug (see below).

## What changed — 8 spec files, tests only, zero product files
Mostly post-rebrand drift (SF → Seldon, teal `#14b8a6` → emerald `#059669`, `seldonframe-icon.svg` → `seldon-mark.svg`). Each expectation was re-pointed at the value the product actually ships, verified against product source:
- `deployments/deploy-readiness.spec.ts` — telephony copy
- `integrations/anthropic-key-field.spec.tsx` — "Seldon cannot read your raw keys" (both render branches)
- `landing/brand-mark.spec.tsx` — shipped `seldon-mark.svg`
- `layout/nav-config.spec.ts` — "Seldon Admin"
- `onboarding/shell.spec.tsx`, `page-schema-adapter.spec.ts` — emerald accent (`git grep 14b8a6` over src + public now returns zero files)
- `extract-instructions-route.spec.ts` — tool name + field-count drift, replaced with membership + optionality assertions naming the actual fields
- `workflow-event-log/category-portal.spec.ts` — **strengthened**: swapped a line-anchored matcher (`assertOrgIdExpr(file, 261, ...)` = "first emit at or after line N") for an event+enclosing-function selector. The old matcher silently re-targeted when code was inserted above it — it was itself a dead guardrail, and one of its two cases was passing only by accident.

## Discipline applied
Each fix was produced by an agent that first had to classify the failure as STALE_TEST / REAL_BUG / ENV, then an independent adversarial pass re-derived all 8 diffs from git objects and re-ran them. No assertion was deleted; no matcher was loosened; every exact-equality stayed exact and every exact-hex/exact-path regex stayed exact — only the expected VALUE moved. Two specs are now strictly stronger than before.

## Verification
All 8 specs together on current main: **tests 103, pass 103, fail 0**.

## Explicitly NOT in this PR
~30 of the remaining failures across 7 workflow spec files trace to ONE real product bug: `advanceRun` calls `loadRunContext` unguarded, so a run whose context failed to build is stranded in `status='running'` forever with no failure record. Those tests are correct and were deliberately left untouched — fix in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)