### PR TITLE
fix(billing): restore the first-free-workspace promise — unblock every new signup

### DIFF
--- a/packages/crm/src/components/billing/upgrade-modal.tsx
+++ b/packages/crm/src/components/billing/upgrade-modal.tsx
@@ -140,13 +140,38 @@ type UpgradeTarget = LegacyUpgradeTarget | LadderUpgradeTarget;
 // User-facing strings — value-forward, no exclamation marks, no emoji.
 const SHARED_COPY = {
   title: "Add another client workspace",
-  // Card-capture branch headline (legacy "free"/inactive callers). Less
-  // jargony than the tier-comparison wording: matches the limits.ts ask.
-  freeTitle: "Add a card to unlock more workspaces",
+  // Legacy "free"/inactive-tier at-cap branch. Was "Add a card to
+  // unlock more workspaces" — retitled 2026-08-07 alongside the
+  // freeDestination fix below: saving a card never raises the inactive
+  // tier's workspace cap, only choosing a plan does, so the headline
+  // now matches the actual unblocking action.
+  freeTitle: "Choose a plan to add more workspaces",
+  // 2026-08-07: `limit === 0` used to render the nonsense "You've used
+  // 0/0 workspaces" — a stale display path from before the first-
+  // workspace-free fix (limits.ts's `inactive` cap is 1 now, never 0),
+  // and still reachable defensively if a caller passes a stale/legacy
+  // limit. Drop the used/limit clause entirely in that case rather than
+  // print a fraction that can never make sense.
   freeSubtitleTemplate: (used: number, limit: number) =>
-    `You've used ${used}/${limit} workspace${limit === 1 ? "" : "s"}. Save a card to keep building — we won't charge it until you upgrade.`,
-  freeCta: "Save a card and continue",
-  freeDestination: "/signup/billing?next=/clients/new",
+    limit === 0
+      ? `Your first workspace is free. Choose a plan to add more.`
+      : `You've used ${used}/${limit} workspace${limit === 1 ? "" : "s"}. Choose a plan to add more.`,
+  // 2026-08-07 — was "/signup/billing?next=/clients/new". That page's
+  // ENTIRE job is card capture, and a returning user who already has
+  // stripe_payment_method_id set skips straight through via
+  // `redirect(next)`. On the inactive tier, saving a card never raises
+  // the workspace cap (only an actual paid subscription does — see
+  // limits.ts), so `next` (this same gated page) 402s again, the modal
+  // reopens, and the visitor is bounced right back here: an infinite
+  // loop with no way out (production victim: a user with a card on
+  // file and no plan, stuck exactly here). This modal only ever renders
+  // when the operator is already AT their cap (file header: "Surfaced
+  // from /clients, /clients/new's 402 path"), so the meaningful next
+  // step is always "pick a plan," never "save a card" — send them to
+  // the real billing/upgrade surface instead, which does not bounce
+  // back into this dialog.
+  freeCta: "Choose a plan",
+  freeDestination: "/settings/billing",
   subtitleTemplate: (used: number, limit: number) =>
     `You're using ${used} of ${limit} workspace${limit === 1 ? "" : "s"} on your current plan`,
   footer:

--- a/packages/crm/src/lib/billing/limits.ts
+++ b/packages/crm/src/lib/billing/limits.ts
@@ -8,11 +8,17 @@
 // the agent dispatcher) keep compiling and never block.
 //
 // enforceWorkspaceLimit is the live gate:
-//   inactive (no plan) = 0 full workspaces
-//   builder            = 0 full workspaces (landing pages capped at 10
-//                        separately via lib/tier/limits.ts)
-//   workspace          = 1
-//   agency             = unlimited (billed per-seat past 10)
+//   inactive (no plan)    = 1 full workspace — "first workspace is free
+//                           forever" (CLAUDE.md §1). This was a live
+//                           P0: the constant below returned 0 for
+//                           `inactive`, so `0 < 0` was false and EVERY
+//                           brand-new user's first build was denied with
+//                           a 402 before any work happened — while the
+//                           deny message itself said "Your first
+//                           workspace is free." Fixed 2026-08-07.
+//   builder / everything else = read straight from the plans catalog
+//                           (plans.ts), which is the single source of
+//                           truth `maxSubAccountsForTier` already uses.
 //
 // The tier resolver is injectable via `deps` so the gate is
 // unit-testable without a DB (mirrors hasFeature's DI pattern).
@@ -43,13 +49,17 @@ const defaultDeps: WorkspaceLimitDeps = {
   resolveTier: async (orgId) => normalizeTierId(await resolveTierForWorkspace(orgId)),
 };
 
-/** Full-workspace allowance per tier. builder + inactive get 0 (builder
- *  sells landing pages, not workspaces); workspace = 1; agency = -1
- *  (unlimited, overage billed per-seat past the included count). */
+/** Full-workspace allowance per tier. `inactive` (no plan) gets the
+ *  magic first-run allowance of 1 — the first workspace is free forever
+ *  (CLAUDE.md §1) — every other tier reads its cap straight off the
+ *  plans catalog (`getPlan(tier).limits.maxOrgs`), mirroring
+ *  `maxSubAccountsForTier` below so this file never drifts from
+ *  plans.ts again. `getPlan` has no "inactive" entry (it isn't a
+ *  sellable/grandfathered plan), hence the explicit branch. -1 =
+ *  unlimited. */
 function maxFullWorkspacesForTier(tier: BillingTier): number {
-  if (tier === "agency") return -1;
-  if (tier === "workspace") return 1;
-  return 0; // builder, inactive
+  if (tier === "inactive") return 1;
+  return getPlan(tier)?.limits.maxOrgs ?? 0;
 }
 
 /**
@@ -95,12 +105,17 @@ export async function enforceWorkspaceLimit(
   // Over (or at) the cap. 2026-06-22 magic first-run: the first workspace is
   // free on us, so the over-cap copy leads with that and points at the BYOK
   // + plan upgrade as the path to more — not a scolding "you're capped".
+  //
+  // 2026-08-07: dropped the dead `tier === "builder"` branch here — since
+  // builder's cap now comes straight from the catalog (-1, unlimited), it
+  // can never reach this deny path, and the branch's copy ("Builder
+  // includes landing pages only") had drifted false anyway (builder has
+  // sold full front-office workspaces since the 2026-07-08 pricing ladder;
+  // see plans.ts).
   const message =
     tier === "workspace"
       ? `Your first workspace is free. Add your Anthropic key and upgrade to spin up more client workspaces.`
-      : tier === "builder"
-        ? `Builder includes landing pages only. Upgrade to Workspace to create a full business workspace (CRM, booking, chatbot).`
-        : `Your first workspace is free. Choose a plan to add more.`;
+      : `Your first workspace is free. Choose a plan to add more.`;
 
   return {
     allowed: false,

--- a/packages/crm/src/lib/billing/limits.ts
+++ b/packages/crm/src/lib/billing/limits.ts
@@ -80,10 +80,14 @@ export async function enforceAgentRunLimit(orgId: string): Promise<LimitDecision
 }
 
 /**
- * Workspace-creation cap. builder/inactive = 0 full workspaces,
- * workspace = 1, agency = unlimited. The acting org's tier is resolved
- * from its primary org (walking the agency chain for managed
- * workspaces).
+ * Workspace-creation cap. `inactive` (no plan) gets the magic
+ * first-workspace-free allowance of 1 (CLAUDE.md §1); every other tier
+ * (builder, workspace, agency, and the new sellable ladder) reads its
+ * cap straight from the plans catalog (`getPlan(tier).limits.maxOrgs`)
+ * — see `maxFullWorkspacesForTier` above. -1 there means unlimited.
+ * Future cap changes belong in plans.ts, not here. The acting org's
+ * tier is resolved from its primary org (walking the agency chain for
+ * managed workspaces).
  */
 export async function enforceWorkspaceLimit(
   params: {

--- a/packages/crm/src/lib/web-onboarding/owned-workspace-count.ts
+++ b/packages/crm/src/lib/web-onboarding/owned-workspace-count.ts
@@ -6,23 +6,47 @@
 // reinventing the tier-limit logic.
 //
 // The "owner" relationship in this codebase is via orgMembers.role === "owner".
-
-import { and, eq, isNull } from "drizzle-orm";
+//
+// 2026-08-07 — excludeOrgId param. This count must mean "workspaces the
+// user owns as TENANTS" (the thing enforceWorkspaceLimit caps), never
+// the operator's own primary/agency org — that org is where they run
+// their business, not a counted workspace. Neither signup path
+// (auth/actions.ts password signup, auth.ts OAuth/magic-link adapter)
+// currently inserts an org_members row for the primary org itself (both
+// only stamp organizations.ownerId), so today this predicate already
+// returns 0 for a brand-new user on both paths — verified against
+// production: all 10 users created 2026-07-23..08-07 have zero
+// owner-role org_members rows. The exclusion is defense-in-depth so a
+// future write path that DOES add an org_members row for the primary
+// org (e.g. for dashboard-listing consistency) can never silently
+// re-introduce the "second workspace" off-by-one against the operator's
+// own org.
+import { and, eq, isNull, ne } from "drizzle-orm";
 import { db } from "@/db";
 import { orgMembers, organizations } from "@/db/schema";
 
-/** Pure helper extracted for testability — dedupes by orgId (defensive). */
+/** Pure helper extracted for testability — dedupes by orgId (defensive),
+ *  and drops `excludeOrgId` (the caller's own primary/agency org) so it
+ *  never counts against their tenant-workspace cap. */
 export function countOwnedWorkspacesFromRows(
   rows: Array<{ orgId: string }>,
+  excludeOrgId?: string | null,
 ): number {
-  return new Set(rows.map((r) => r.orgId)).size;
+  const ids = new Set(rows.map((r) => r.orgId));
+  if (excludeOrgId) ids.delete(excludeOrgId);
+  return ids.size;
 }
 
 /**
- * Count orgs where this user is the owner. Returns 0 if the user has no
- * owner-role memberships.
+ * Count orgs where this user is the owner, excluding their own
+ * primary/agency org (`excludeOrgId` — pass the caller's
+ * `sessionUser.primaryOrgId`). Returns 0 if the user has no
+ * owner-role memberships outside that org.
  */
-export async function getOwnedWorkspaceCount(userId: string): Promise<number> {
+export async function getOwnedWorkspaceCount(
+  userId: string,
+  excludeOrgId?: string | null,
+): Promise<number> {
   const rows = await db
     .select({ orgId: orgMembers.orgId })
     .from(orgMembers)
@@ -35,8 +59,9 @@ export async function getOwnedWorkspaceCount(userId: string): Promise<number> {
         eq(orgMembers.userId, userId),
         eq(orgMembers.role, "owner"),
         isNull(organizations.archivedAt),
+        excludeOrgId ? ne(orgMembers.orgId, excludeOrgId) : undefined,
       ),
     );
 
-  return countOwnedWorkspacesFromRows(rows);
+  return countOwnedWorkspacesFromRows(rows, excludeOrgId);
 }

--- a/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-paste.ts
@@ -20,7 +20,9 @@ import { applyLandingTemplateForWorkspace } from "@/lib/landing/apply-landing-te
 
 export type RunPasteDeps = {
   enforceWorkspaceLimit: (args: { primaryOrgId: string | null; ownedWorkspaceCount: number }) => Promise<LimitDecision>;
-  getOwnedWorkspaceCount: (userId: string) => Promise<number>;
+  /** excludeOrgId: the caller's own primary/agency org — never counted
+   *  against their tenant-workspace cap. See owned-workspace-count.ts. */
+  getOwnedWorkspaceCount: (userId: string, excludeOrgId?: string | null) => Promise<number>;
   /** 2026-06-18 — MANAGED AI (BYOK gate removed). See run-create-from-url
    *  RunDeps.resolveExtractionKey for the contract. */
   resolveExtractionKey: (orgId: string | null) => Promise<{ key: string } | null>;
@@ -76,7 +78,10 @@ export async function runCreateFromPaste(input: RunPasteInput): Promise<RunPaste
       const pastedText = rawText.trim();
 
       // 3. Workspace limit
-      const ownedCount = await input.deps.getOwnedWorkspaceCount(input.sessionUser.id);
+      const ownedCount = await input.deps.getOwnedWorkspaceCount(
+        input.sessionUser.id,
+        input.sessionUser.primaryOrgId,
+      );
       const decision = await input.deps.enforceWorkspaceLimit({
         primaryOrgId: input.sessionUser.primaryOrgId,
         ownedWorkspaceCount: ownedCount,

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -56,7 +56,9 @@ import { logEvent } from "@/lib/observability/log";
 
 export type RunDeps = {
   enforceWorkspaceLimit: (args: { primaryOrgId: string | null; ownedWorkspaceCount: number }) => Promise<LimitDecision>;
-  getOwnedWorkspaceCount: (userId: string) => Promise<number>;
+  /** excludeOrgId: the caller's own primary/agency org — never counted
+   *  against their tenant-workspace cap. See owned-workspace-count.ts. */
+  getOwnedWorkspaceCount: (userId: string, excludeOrgId?: string | null) => Promise<number>;
   /**
    * 2026-06-18 — MANAGED AI (BYOK gate removed). Resolves the Anthropic
    * key used for URL extraction: the operator's own BYOK key if they've
@@ -216,7 +218,10 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
       //    own per-IP rate limit (resolveWebBuildGate) is the guardrail
       //    for that path instead, so this whole step is skipped.
       if (input.sessionUser) {
-        const ownedCount = await input.deps.getOwnedWorkspaceCount(input.sessionUser.id);
+        const ownedCount = await input.deps.getOwnedWorkspaceCount(
+          input.sessionUser.id,
+          input.sessionUser.primaryOrgId,
+        );
         const decision = await input.deps.enforceWorkspaceLimit({
           primaryOrgId: input.sessionUser.primaryOrgId,
           ownedWorkspaceCount: ownedCount,

--- a/packages/crm/tests/unit/billing-workspace-limit.spec.ts
+++ b/packages/crm/tests/unit/billing-workspace-limit.spec.ts
@@ -1,36 +1,87 @@
 // Phase 1 — enforceWorkspaceLimit per tier.
 //
-// builder = 0 full workspaces (landing pages capped separately at 10),
-// workspace = 1, agency = unlimited (billed per-seat past 10). The tier
-// resolver is injected via `deps` so the gate is unit-testable without a
-// DB (mirrors the hasFeature dependency-injection pattern).
+// 2026-08-07 — REWRITTEN for the first-workspace-free P0 fix. Production
+// data: every authenticated first-workspace build 402'd for 16 days
+// straight (zero successes) because `inactive` (every brand-new user's
+// starting tier) capped at 0 full workspaces while the deny message
+// itself promised "Your first workspace is free." `inactive` now gets
+// the promised 1 free workspace; every other tier reads its cap straight
+// off the plans catalog (plans.ts) instead of a second, drifted
+// hardcoded table — `builder` in particular used to hardcode 0 here
+// while the catalog + TIER_FEATURES both already said -1 (unlimited).
+// The tier resolver is injected via `deps` so the gate is
+// unit-testable without a DB (mirrors the hasFeature DI pattern).
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
 
 import { enforceWorkspaceLimit } from "@/lib/billing/limits";
+import { getPlan } from "@/lib/billing/plans";
 import type { BillingTier } from "@/lib/billing/features";
 
 function withTier(tier: BillingTier) {
   return { resolveTier: async (_orgId: string | null | undefined) => tier };
 }
 
-describe("enforceWorkspaceLimit — builder (0 full workspaces)", () => {
-  test("blocks the very first full workspace on builder", async () => {
+describe("enforceWorkspaceLimit — inactive (the P0 regression)", () => {
+  test("REGRESSION: a brand-new user (tier inactive, 0 owned) is allowed their first workspace", async () => {
     const decision = await enforceWorkspaceLimit(
       { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: 0 },
-      withTier("builder"),
+      withTier("inactive"),
+    );
+    assert.equal(decision.allowed, true, "the first workspace must be free — this is the bug that denied every signup for 16 days");
+    if (decision.allowed) assert.equal(decision.tier, "inactive");
+  });
+
+  test("blocks the SECOND workspace on inactive, with the upgrade message", async () => {
+    const decision = await enforceWorkspaceLimit(
+      { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: 1 },
+      withTier("inactive"),
     );
     assert.equal(decision.allowed, false);
     if (!decision.allowed) {
       assert.equal(decision.reason, "workspace_limit_reached");
-      assert.equal(decision.limit, 0);
-      assert.equal(decision.tier, "builder");
+      assert.equal(decision.limit, 1);
+      assert.match(decision.message, /first workspace is free/i);
+      assert.match(decision.message, /choose a plan/i);
+    }
+  });
+
+  test("missing primaryOrgId is treated as inactive — still allows the first workspace", async () => {
+    const decision = await enforceWorkspaceLimit(
+      { userId: "u1", primaryOrgId: null, ownedWorkspaceCount: 0 },
+      withTier("inactive"),
+    );
+    assert.equal(decision.allowed, true);
+  });
+
+  test("missing primaryOrgId + 1 already owned is still denied", async () => {
+    const decision = await enforceWorkspaceLimit(
+      { userId: "u1", primaryOrgId: null, ownedWorkspaceCount: 1 },
+      withTier("inactive"),
+    );
+    assert.equal(decision.allowed, false);
+  });
+});
+
+describe("enforceWorkspaceLimit — builder (unlimited own workspaces per the catalog)", () => {
+  test("catalog sanity: plans.ts says builder.limits.maxOrgs is -1 (unlimited)", () => {
+    assert.equal(getPlan("builder")?.limits.maxOrgs, -1);
+  });
+
+  test("allows workspaces well past what the old hardcoded 0-cap would have blocked", async () => {
+    for (const count of [0, 1, 10, 50]) {
+      const decision = await enforceWorkspaceLimit(
+        { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: count },
+        withTier("builder"),
+      );
+      assert.equal(decision.allowed, true, `builder must allow ${count} (catalog: unlimited)`);
+      if (decision.allowed) assert.equal(decision.tier, "builder");
     }
   });
 });
 
-describe("enforceWorkspaceLimit — workspace (1)", () => {
+describe("enforceWorkspaceLimit — workspace (1, per the catalog)", () => {
   test("allows the first workspace", async () => {
     const decision = await enforceWorkspaceLimit(
       { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: 0 },
@@ -53,37 +104,32 @@ describe("enforceWorkspaceLimit — workspace (1)", () => {
   });
 });
 
-describe("enforceWorkspaceLimit — agency (unlimited)", () => {
-  test("allows workspaces well past the included 10", async () => {
-    for (const count of [0, 1, 10, 25, 100]) {
-      const decision = await enforceWorkspaceLimit(
-        { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: count },
-        withTier("agency"),
-      );
-      assert.equal(decision.allowed, true, `agency must allow ${count}`);
-      if (decision.allowed) assert.equal(decision.tier, "agency");
-    }
+describe("enforceWorkspaceLimit — managed (1, per the catalog)", () => {
+  test("catalog sanity: plans.ts says managed.limits.maxOrgs is 1", () => {
+    assert.equal(getPlan("managed")?.limits.maxOrgs, 1);
+  });
+
+  test("blocks the second workspace on managed", async () => {
+    const decision = await enforceWorkspaceLimit(
+      { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: 1 },
+      withTier("managed"),
+    );
+    assert.equal(decision.allowed, false);
+    if (!decision.allowed) assert.equal(decision.limit, 1);
   });
 });
 
-describe("enforceWorkspaceLimit — inactive / no plan", () => {
-  test("blocks workspace creation with no active plan", async () => {
-    const decision = await enforceWorkspaceLimit(
-      { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: 0 },
-      withTier("inactive"),
-    );
-    assert.equal(decision.allowed, false);
-    if (!decision.allowed) {
-      assert.equal(decision.reason, "workspace_limit_reached");
-      assert.equal(decision.limit, 0);
+describe("enforceWorkspaceLimit — agency / agency_starter / agency_growth / agency_scale (unlimited)", () => {
+  test("allows workspaces well past the included 10", async () => {
+    for (const tier of ["agency", "agency_starter", "agency_growth", "agency_scale"] as const) {
+      for (const count of [0, 1, 10, 25, 100]) {
+        const decision = await enforceWorkspaceLimit(
+          { userId: "u1", primaryOrgId: "org-1", ownedWorkspaceCount: count },
+          withTier(tier),
+        );
+        assert.equal(decision.allowed, true, `${tier} must allow ${count}`);
+        if (decision.allowed) assert.equal(decision.tier, tier);
+      }
     }
-  });
-
-  test("missing primaryOrgId is treated as no plan (blocked)", async () => {
-    const decision = await enforceWorkspaceLimit(
-      { userId: "u1", primaryOrgId: null, ownedWorkspaceCount: 0 },
-      withTier("inactive"),
-    );
-    assert.equal(decision.allowed, false);
   });
 });

--- a/packages/crm/tests/unit/web-onboarding/owned-workspace-count.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/owned-workspace-count.spec.ts
@@ -27,4 +27,42 @@ describe("countOwnedWorkspacesFromRows", () => {
     const rows = [{ orgId: "a" }, { orgId: "a" }, { orgId: "b" }];
     assert.equal(countOwnedWorkspacesFromRows(rows), 2);
   });
+
+  // 2026-08-07 — F2: the count must mean "workspaces owned as TENANTS",
+  // never the operator's own primary/agency org. excludeOrgId is the
+  // caller's sessionUser.primaryOrgId on BOTH signup shapes (password
+  // signup via auth/actions.ts, OAuth/magic-link via auth.ts) — neither
+  // path currently writes an org_members row for the user's own primary
+  // org (both only stamp organizations.ownerId), so this is verified
+  // defense-in-depth: if a future write path ever adds one, the operator's
+  // own org must still never count against their workspace cap.
+  describe("excludeOrgId — the operator's own primary/agency org never counts", () => {
+    test("a user whose only 'owned' row is their own primary org counts as 0 (password-signup shape)", () => {
+      const primaryOrgId = "org-primary";
+      const rows = [{ orgId: primaryOrgId }];
+      assert.equal(countOwnedWorkspacesFromRows(rows, primaryOrgId), 0);
+    });
+
+    test("a user whose only 'owned' row is their own primary org counts as 0 (OAuth/magic-link shape)", () => {
+      // Same predicate, same exclusion — the shape of the row set is
+      // identical regardless of which signup path created the org; only
+      // the caller-supplied excludeOrgId (sessionUser.primaryOrgId)
+      // differs per request, not per signup path.
+      const primaryOrgId = "org-primary-oauth";
+      const rows = [{ orgId: primaryOrgId }];
+      assert.equal(countOwnedWorkspacesFromRows(rows, primaryOrgId), 0);
+    });
+
+    test("a real tenant workspace still counts once the primary org is excluded", () => {
+      const primaryOrgId = "org-primary";
+      const rows = [{ orgId: primaryOrgId }, { orgId: "org-tenant-1" }];
+      assert.equal(countOwnedWorkspacesFromRows(rows, primaryOrgId), 1);
+    });
+
+    test("no excludeOrgId provided — behaves exactly as before (no exclusion)", () => {
+      const rows = [{ orgId: "a" }, { orgId: "b" }];
+      assert.equal(countOwnedWorkspacesFromRows(rows, null), 2);
+      assert.equal(countOwnedWorkspacesFromRows(rows, undefined), 2);
+    });
+  });
 });

--- a/packages/crm/tests/unit/web-onboarding/upgrade-modal.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/upgrade-modal.spec.tsx
@@ -58,16 +58,40 @@ function setTierLadderEnv(value: "1" | undefined) {
 describe("UpgradeModal — free tier (add-a-card branch, flag-independent)", () => {
   beforeEach(() => setTierLadderEnv(undefined));
 
-  test("renders the add-a-card title and subtitle", () => {
+  test("renders the choose-a-plan title and subtitle", () => {
+    // 2026-08-07: retitled from "Add a card to unlock more workspaces" —
+    // saving a card never raises the inactive tier's cap, only choosing
+    // a plan does (see upgrade-modal.tsx's freeTitle/freeDestination
+    // comments for the infinite-loop bug this fixed).
     render(<UpgradeModal open={true} onOpenChange={() => {}} tier="free" used={1} limit={1} />);
     assert.ok(
-      screen.queryAllByText(/add a card to unlock more workspaces/i).length > 0,
-      "Add-a-card title missing",
+      screen.queryAllByText(/choose a plan to add more workspaces/i).length > 0,
+      "Choose-a-plan title missing",
     );
     assert.ok(
       screen.queryAllByText(/you've used 1\/1 workspace/i).length > 0,
       "used-N/N subtitle missing",
     );
+  });
+
+  test("never renders '0/0' in the subtitle when limit is 0 (stale/legacy caller)", () => {
+    render(<UpgradeModal open={true} onOpenChange={() => {}} tier="inactive" used={0} limit={0} />);
+    assert.equal(screen.queryAllByText(/0\/0/).length, 0, "must never render 0/0");
+    assert.ok(
+      screen.queryAllByText(/your first workspace is free/i).length > 0,
+      "limit-0 fallback copy missing",
+    );
+  });
+
+  test("routes the free/inactive CTA to /settings/billing, not the card-capture page", () => {
+    // Regression test for the infinite billing loop: /signup/billing's
+    // early-return for a user who already has a card on file just
+    // bounces to `next`, which re-402s on the inactive tier (saving a
+    // card never raises the cap) — an unbreakable loop. The at-cap
+    // modal must send visitors to the real upgrade surface instead.
+    render(<UpgradeModal open={true} onOpenChange={() => {}} tier="inactive" used={1} limit={1} />);
+    const cta = screen.getByRole("button", { name: /choose a plan/i });
+    assert.ok(cta, "Choose-a-plan CTA missing");
   });
 
   test("does NOT render any tier cards on free", () => {

--- a/packages/crm/tests/unit/web-onboarding/upgrade-modal.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/upgrade-modal.spec.tsx
@@ -89,9 +89,66 @@ describe("UpgradeModal — free tier (add-a-card branch, flag-independent)", () 
     // bounces to `next`, which re-402s on the inactive tier (saving a
     // card never raises the cap) — an unbreakable loop. The at-cap
     // modal must send visitors to the real upgrade surface instead.
-    render(<UpgradeModal open={true} onOpenChange={() => {}} tier="inactive" used={1} limit={1} />);
-    const cta = screen.getByRole("button", { name: /choose a plan/i });
-    assert.ok(cta, "Choose-a-plan CTA missing");
+    //
+    // This must actually observe the navigation target, not just that
+    // the button renders — a button-existence check passes unchanged
+    // even if the CTA's handler is reverted to send visitors back into
+    // /signup/billing. The component navigates via a hard
+    // `window.location.href = ...` assignment (not a link/href), so the
+    // only observable signal is that assignment.
+    //
+    // `window.location` itself can't be stubbed directly: per the HTML
+    // spec it's an "unforgeable" own property (configurable: false),
+    // and jsdom enforces that, so `Object.defineProperty(window,
+    // "location", ...)` throws "Cannot redefine property: location".
+    // Real navigation is also a no-op in jsdom ("Not implemented:
+    // navigation to another Document") and never updates
+    // `location.href`, so reading it back afterward wouldn't work
+    // either. Instead, swap the global `window` binding itself (which
+    // IS configurable — see tests/setup-dom.ts) for a Proxy that
+    // forwards everything to the real jsdom window except `location`,
+    // where it hands back a stub object that records the assignment.
+    // The component's bare `window` reference resolves against
+    // globalThis at call time, so it picks up the proxy.
+    const realWindow = window;
+    let assignedHref: string | undefined;
+    const locationStub = {
+      get href() {
+        return assignedHref ?? "";
+      },
+      set href(value: string) {
+        assignedHref = value;
+      },
+    };
+    const proxyWindow = new Proxy(realWindow, {
+      get(target, prop, _receiver) {
+        if (prop === "location") return locationStub;
+        return Reflect.get(target, prop, target);
+      },
+    });
+    Object.defineProperty(globalThis, "window", {
+      value: proxyWindow,
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+    try {
+      render(<UpgradeModal open={true} onOpenChange={() => {}} tier="inactive" used={1} limit={1} />);
+      const cta = screen.getByRole("button", { name: /choose a plan/i });
+      fireEvent.click(cta);
+      assert.equal(
+        assignedHref,
+        "/settings/billing",
+        "Choose-a-plan CTA must navigate to /settings/billing, not /signup/billing",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "window", {
+        value: realWindow,
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+    }
   });
 
   test("does NOT render any tier cards on free", () => {


### PR DESCRIPTION
**P0.** Every authenticated first-workspace build has been rejected with a 402 for 16 days. Zero succeeded. This restores the behaviour the product has always promised.

## The bug
`maxFullWorkspacesForTier` (limits.ts) returned **0** for `inactive` — and every new user is `inactive` (`organizations.plan` defaults `"free"`; `features.ts:231` maps free/unknown → inactive). The gate is `ownedWorkspaceCount < cap`, so `0 < 0` → **denied**, before any work happens (`run-create-from-url.ts:213-235`, step 3). The ~1.2s 402 is the billing modal users saw.

The contradiction lived in the same file: line 52 granted zero while line 98 rendered *"Your first workspace is free. Choose a plan to add more."* CLAUDE.md §1: "First workspace is free forever."

**Measured impact** (PostHog autocapture + HogQL, 2026-07-23..08-07): 28 "Build workspace" clicks by 9 distinct external users → **0** `/dashboard` views, **0** workspace pages, 0 successes. Plus a closed `/clients/new ⇄ /signup/billing` cycle, and 23 clicks on a "Skip and set one up by hand" link that could never navigate (`proxy.ts:655` bounces anyone without `soul_completed_at`, which is only stamped *after* a successful build).

**It also denied paying customers.** The old hardcoded table returned 0 for `builder`, `managed`, and all three agency tiers — tiers whose own catalog entries advertise unlimited or 1 workspace.

## The fix
- **F1** `limits.ts` — `inactive` → 1; every other tier now DERIVES from the plans catalog (`getPlan(tier).limits.maxOrgs`) instead of a second, drifted table. Fixes builder 0→-1, managed 0→1, agency_* 0→-1. Mirrors what `maxSubAccountsForTier` already did.
- **F2** `owned-workspace-count.ts` (+ the two `run-create-from-*` call sites) — `excludeOrgId` so the operator's own primary org can never count against their tenant cap.
- **F3** `upgrade-modal.tsx` — "You've used 0/0 workspaces." copy.
- **F4** `upgrade-modal.tsx` — at-cap CTA no longer points at `/signup/billing`, which immediately redirected back to `/clients/new` (an infinite loop for anyone with a saved card; `john@kespa.io` is a live victim, card on file + `plan_id` NULL).

## Review — 4 independent lenses, adjudicated SHIP-WITH-FIXES; both fixes applied
- **Unlock:** traced both signup paths → `tier=inactive, cap=1, owned=0` → allowed. `markOperatorOnboarded` then stamps `soul_completed_at` + `welcomeShown` + `plan_id`, clearing all three proxy gates in one write. JWT re-reads on every request, so no stale-cookie window.
- **Revenue:** no hole. `plan_id='free'` still normalizes to `inactive`, so the cap stays 1 and build #2 is correctly denied — `link-workspace-to-operator.ts:113` inserts the owner row that makes the cap bind.
- **Reachability:** the suspected relocated trap was **refuted with production data** — 6 users are at-cap; 0 have `soul_completed_at` NULL, 0 have `plan_id` NULL. `/settings/billing` is reachable for the only population that sees the CTA.
- **Tests:** flagged the F4 test as vacuous. **Fixed in b20afe5f0** — it now stubs navigation and pins the destination; reverting `freeDestination` makes it fail (verified), restoring makes it pass.

## Gates (re-verified after rebase onto b6820cead)
`tsc --noEmit` clean · `check:use-server` green · 28/28 on the three touched specs · all 8 `BillingTier` values now have gate coverage, up from 4.

## Known, NOT in this PR — follow-ups
1. **The same bug is still live on a second gate.** `orgs.ts:209-218` has a duplicate private `getOwnedWorkspaceCount` counting `organizations.ownerId === userId`, which *includes* the operator's own primary org → a new user counts 1, cap 1, `1 < 1` false. It feeds `POST /api/v1/workspace/create` — the MCP path, i.e. the documented zero-friction first-run flow. Not a regression (cap was 0 before), but this PR does not unlock MCP.
2. A **third** hardcoded cap table survives at `stripe/webhook/route.ts:245/447/588`, persisting `maxWorkspaces: 0` for managed/agency.
3. `dashboard/page.tsx:347` calls the now-two-arg counter without `excludeOrgId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)