### PR TITLE
fix(billing): unblock the MCP workspace path — the second copy of the #182 bug

### DIFF
--- a/packages/crm/src/lib/billing/limits.ts
+++ b/packages/crm/src/lib/billing/limits.ts
@@ -57,7 +57,14 @@ const defaultDeps: WorkspaceLimitDeps = {
  *  plans.ts again. `getPlan` has no "inactive" entry (it isn't a
  *  sellable/grandfathered plan), hence the explicit branch. -1 =
  *  unlimited. */
-function maxFullWorkspacesForTier(tier: BillingTier): number {
+// 2026-08-07 — exported so lib/billing/orgs.ts can derive its DISPLAY
+// cap (getWorkspaceLimitStatus's `maxOrgs`) from the exact same catalog
+// read the enforcement gate below uses, instead of a second hardcoded
+// table that drifted from the 2026-07-08 pricing ladder (it still only
+// recognized the old "agency"/"workspace" tier ids and silently
+// allotted every current sellable tier — builder, managed,
+// agency_starter, agency_growth, agency_scale — a display cap of 1).
+export function maxFullWorkspacesForTier(tier: BillingTier): number {
   if (tier === "inactive") return 1;
   return getPlan(tier)?.limits.maxOrgs ?? 0;
 }

--- a/packages/crm/src/lib/billing/orgs.ts
+++ b/packages/crm/src/lib/billing/orgs.ts
@@ -10,10 +10,11 @@ import { auth } from "@/auth";
 import { db } from "@/db";
 import { contacts, orgMembers, organizations, partnerAgencies, users } from "@/db/schema";
 import { getOrgFeatures, normalizeTierId } from "@/lib/billing/features";
-import { enforceWorkspaceLimit } from "@/lib/billing/limits";
+import { enforceWorkspaceLimit, maxFullWorkspacesForTier } from "@/lib/billing/limits";
 import { assertWritable } from "@/lib/demo/server";
 import { getPlan } from "@/lib/billing/plans";
 import { getOrgSubscription } from "@/lib/billing/subscription";
+import { getOwnedWorkspaceCount } from "@/lib/web-onboarding/owned-workspace-count";
 import { installSoul, type FrameworkConfig } from "@/lib/soul/install";
 import { seedInitialBlocks } from "@/lib/soul-compiler/blocks";
 import type { SoulV4 } from "@/lib/soul-compiler/schema";
@@ -206,17 +207,6 @@ async function getBillingUserForAdminTokenOrg(orgId: string) {
 const WORKSPACE_UPGRADE_REQUIRED_MESSAGE =
   "You've used your free workspace. Each additional workspace requires a paid tier (Growth $29/mo for up to 3 workspaces, or Scale $99/mo for unlimited).";
 
-async function getOwnedWorkspaceCount(userId: string) {
-  const [result] = await db
-    .select({ count: sql<number>`count(*)` })
-    .from(organizations)
-    // Front-office bridge: archived client workspaces are excluded so they never
-    // count against the builder's workspace limit / trigger a charge.
-    .where(and(eq(organizations.ownerId, userId), isNull(organizations.archivedAt)));
-
-  return Number(result?.count ?? 0);
-}
-
 /**
  * April 30, 2026 — pricing migration. The old "per-workspace add-on
  * quantity" model (legacy WORKSPACE_ADDON_MONTHLY_PRICE_ID) is gone.
@@ -237,11 +227,21 @@ function loadWorkspaceTierStatus(
   const stripeSubscriptionId = orgSubscription?.stripeSubscriptionId ?? null;
   const active = tier !== "inactive";
 
-  // Full-workspace allowance per tier. Agency = sentinel `999`
-  // (effectively unlimited for UI/display; the real gate uses
-  // `enforceWorkspaceLimit`); Workspace = 1; Builder = 0 (landing pages
-  // only).
-  const tierAllowance = tier === "agency" ? 999 : tier === "workspace" ? 1 : 0;
+  // 2026-08-07 — this used to be a hardcoded `agency`/`workspace`-only
+  // table left over from before the 2026-07-08 pricing ladder. It never
+  // learned the 5 new sellable tier ids (builder / managed /
+  // agency_starter / agency_growth / agency_scale), so every one of
+  // them silently fell into the `: 0` branch and displayed a 1-workspace
+  // cap here — even though `enforceWorkspaceLimit` (the actual gate)
+  // already read builder/agency_* as unlimited from the catalog. Now
+  // derived from the SAME `maxFullWorkspacesForTier` the gate uses, so
+  // this display value can't drift from enforcement again. Unlimited
+  // (-1) renders as the sentinel total 999 (quantity = 999 -
+  // FREE_WORKSPACE_ALLOWANCE) so the "X / Y" UI keeps working without a
+  // special case — the real gate is still `enforceWorkspaceLimit`.
+  const cap = maxFullWorkspacesForTier(tier);
+  const tierAllowance =
+    cap === -1 ? 999 - FREE_WORKSPACE_ALLOWANCE : Math.max(0, cap - FREE_WORKSPACE_ALLOWANCE);
 
   return {
     stripeSubscriptionId,
@@ -252,8 +252,39 @@ function loadWorkspaceTierStatus(
   };
 }
 
-async function ensureWorkspaceCreationBillingForUser(user: Awaited<ReturnType<typeof getBillingUserById>>, existingWorkspaces: number) {
-  const decision = await enforceWorkspaceLimit({
+// 2026-08-07 — deps seam (mirrors the enforceWorkspaceLimit DI pattern
+// in lib/billing/limits.ts, and the repo-wide preference for DI over
+// mock.module — see tests/unit/auth/magic-link-redirect.spec.ts) so
+// this composition — count-then-gate — is unit-testable with no DB.
+// This is the exact gate the MCP path (POST /api/v1/workspace/create,
+// via createWorkspaceFromSoulAction / createWorkspaceFromSetupAction)
+// runs through.
+export type EnsureWorkspaceCreationBillingDeps = {
+  getOwnedWorkspaceCount: (userId: string, excludeOrgId?: string | null) => Promise<number>;
+  enforceWorkspaceLimit: typeof enforceWorkspaceLimit;
+};
+
+const defaultEnsureWorkspaceCreationBillingDeps: EnsureWorkspaceCreationBillingDeps = {
+  getOwnedWorkspaceCount,
+  enforceWorkspaceLimit,
+};
+
+/**
+ * Count-then-gate for workspace creation. `excludeOrgId` (the caller's
+ * own primary org, `user.orgId`) is threaded into the shared counter so
+ * the operator's own primary org is never counted against their
+ * tenant-workspace cap — this was the P0 bug: the old private counter
+ * here counted `organizations.ownerId === userId`, which INCLUDES the
+ * primary org every signup path stamps at account creation, so a
+ * brand-new user's count was already 1 before they ever created a
+ * workspace, and `1 < 1` (cap 1, first-workspace-free) was false.
+ */
+export async function ensureWorkspaceCreationBillingForUser(
+  user: Awaited<ReturnType<typeof getBillingUserById>>,
+  deps: EnsureWorkspaceCreationBillingDeps = defaultEnsureWorkspaceCreationBillingDeps,
+) {
+  const existingWorkspaces = await deps.getOwnedWorkspaceCount(user.id, user.orgId ?? null);
+  const decision = await deps.enforceWorkspaceLimit({
     userId: user.id,
     primaryOrgId: user.orgId ?? null,
     ownedWorkspaceCount: existingWorkspaces,
@@ -371,7 +402,7 @@ export async function getWorkspaceLimitStatus() {
   const plan = getPlan(user.planId ?? "");
   const orgSubscription = await getOrgSubscription(user.orgId);
   const orgFeatures = getOrgFeatures(orgSubscription.tier ?? "free");
-  const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id);
+  const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id, user.orgId ?? null);
   const tierStatus = loadWorkspaceTierStatus(orgSubscription);
   // Tier-based cap: free=1, growth=3, scale=unlimited (rendered as
   // 999 here so the UI's "X / Y" display still works without a
@@ -394,7 +425,7 @@ export async function getWorkspaceLimitStatusForUser(userId: string) {
   const plan = getPlan(user.planId ?? "");
   const orgSubscription = await getOrgSubscription(user.orgId);
   const orgFeatures = getOrgFeatures(orgSubscription.tier ?? "free");
-  const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id);
+  const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id, user.orgId ?? null);
   const tierStatus = loadWorkspaceTierStatus(orgSubscription);
   // Tier-based cap: free=1, growth=3, scale=unlimited (rendered as
   // 999 here so the UI's "X / Y" display still works without a
@@ -904,8 +935,7 @@ export async function createWorkspaceFromSoulAction(input: CreateWorkspaceFromSo
   // Anonymous workspaces are free-tier with bearer-token admin access;
   // they don't count toward any user's workspace quota.
   if (user) {
-    const existingWorkspaces = await getOwnedWorkspaceCount(user.id);
-    await ensureWorkspaceCreationBillingForUser(user, existingWorkspaces);
+    await ensureWorkspaceCreationBillingForUser(user);
   }
 
   const baseSlug = slugify(businessName) || `workspace-${randomUUID().slice(0, 8)}`;
@@ -1041,8 +1071,7 @@ export async function createWorkspaceFromSetupAction(input: CreateWorkspaceFromS
     throw new Error("Framework is required");
   }
 
-  const existingWorkspaces = await getOwnedWorkspaceCount(user.id);
-  await ensureWorkspaceCreationBillingForUser(user, existingWorkspaces);
+  await ensureWorkspaceCreationBillingForUser(user);
 
   const baseSlug = slugify(businessName) || `workspace-${randomUUID().slice(0, 8)}`;
   let slug = baseSlug;

--- a/packages/crm/tests/unit/billing/mcp-workspace-creation-gate.spec.ts
+++ b/packages/crm/tests/unit/billing/mcp-workspace-creation-gate.spec.ts
@@ -1,0 +1,155 @@
+// packages/crm/tests/unit/billing/mcp-workspace-creation-gate.spec.ts
+//
+// 2026-08-07 — P0 follow-up to #182 (0d773bcab). #182 fixed the WEB path
+// (/clients/new) by (a) making maxFullWorkspacesForTier return 1 for
+// `inactive` instead of 0, and (b) adding excludeOrgId to the shared
+// owned-workspace-count helper so the operator's own primary org never
+// counts against their cap. The SAME bug was still live on a second,
+// PRIVATE counter in lib/billing/orgs.ts (`getOwnedWorkspaceCount`, now
+// deleted) that counted `organizations.ownerId === userId` — a predicate
+// that INCLUDES the operator's own primary org, because both signup
+// paths (OAuth/magic-link in packages/crm/auth.ts, email+password in
+// src/lib/auth/actions.ts) stamp `organizations.ownerId = user.id` on
+// it. So a brand-new user's count was already 1 before they ever created
+// a workspace, and the MCP path — POST /api/v1/workspace/create, via
+// ensureWorkspaceCreationBillingForUser — denied every first build.
+//
+// This spec drives `ensureWorkspaceCreationBillingForUser` (now exported
+// with an injectable deps seam, mirroring the repo's DI-over-mock.module
+// convention — see tests/unit/auth/magic-link-redirect.spec.ts) with NO
+// real DB, asserting the exact composition: count (excluding the
+// caller's primary org) → gate.
+//
+// Run:
+//   node --import tsx --test tests/unit/billing/mcp-workspace-creation-gate.spec.ts
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ensureWorkspaceCreationBillingForUser,
+  type EnsureWorkspaceCreationBillingDeps,
+} from "@/lib/billing/orgs";
+import { enforceWorkspaceLimit } from "@/lib/billing/limits";
+import { countOwnedWorkspacesFromRows } from "@/lib/web-onboarding/owned-workspace-count";
+
+type BillingUser = Parameters<typeof ensureWorkspaceCreationBillingForUser>[0];
+
+function billingUser(overrides: Partial<BillingUser> = {}): BillingUser {
+  return {
+    id: "user-1",
+    orgId: "org-primary",
+    planId: null,
+    stripeSubscriptionId: null,
+    subscriptionStatus: null,
+    name: "Test User",
+    email: "test@example.com",
+    ...overrides,
+  } as BillingUser;
+}
+
+/** Real enforceWorkspaceLimit, fake tier resolver — no DB, matches the
+ *  pattern already used in tests/unit/billing-workspace-limit.spec.ts. */
+function withTier(tier: "inactive" | "builder" | "managed" | "workspace" | "agency") {
+  return (params: Parameters<typeof enforceWorkspaceLimit>[0]) =>
+    enforceWorkspaceLimit(params, { resolveTier: async () => tier });
+}
+
+/** Simulates the shared getOwnedWorkspaceCount's row-then-exclude
+ *  semantics via the real, already-tested pure helper, so this spec
+ *  exercises the actual exclusion logic rather than re-describing it. */
+function ownedCountFromRows(rows: Array<{ orgId: string }>) {
+  return async (_userId: string, excludeOrgId?: string | null) =>
+    countOwnedWorkspacesFromRows(rows, excludeOrgId);
+}
+
+describe("ensureWorkspaceCreationBillingForUser — the MCP-path regression", () => {
+  test("REGRESSION: a brand-new user (own primary org only, tier inactive) is ALLOWED their first workspace", async () => {
+    const user = billingUser({ orgId: "org-primary" });
+    // Signup stamped organizations.ownerId on the primary org; the SHARED
+    // counter's row set reflects that shape (org_members owner row for
+    // the primary org — or none at all, per both signup paths today).
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      getOwnedWorkspaceCount: ownedCountFromRows([{ orgId: "org-primary" }]),
+      enforceWorkspaceLimit: withTier("inactive"),
+    };
+
+    await assert.doesNotReject(
+      () => ensureWorkspaceCreationBillingForUser(user, deps),
+      "the operator's own primary org must never count against their first-workspace-free cap",
+    );
+  });
+
+  test("their SECOND workspace via the MCP path is still denied", async () => {
+    const user = billingUser({ orgId: "org-primary" });
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      // Primary org + one real tenant workspace already owned.
+      getOwnedWorkspaceCount: ownedCountFromRows([
+        { orgId: "org-primary" },
+        { orgId: "org-tenant-1" },
+      ]),
+      enforceWorkspaceLimit: withTier("inactive"),
+    };
+
+    await assert.rejects(
+      () => ensureWorkspaceCreationBillingForUser(user, deps),
+      /Each additional workspace requires a paid tier/,
+    );
+  });
+
+  test("a paying tier (builder, unlimited per the catalog) is unaffected — allows many", async () => {
+    const user = billingUser({ orgId: "org-primary" });
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      getOwnedWorkspaceCount: ownedCountFromRows([
+        { orgId: "org-primary" },
+        ...Array.from({ length: 20 }, (_, i) => ({ orgId: `org-tenant-${i}` })),
+      ]),
+      enforceWorkspaceLimit: withTier("builder"),
+    };
+
+    await assert.doesNotReject(() => ensureWorkspaceCreationBillingForUser(user, deps));
+  });
+
+  test("a paying tier (managed, cap 1 per the catalog) still blocks the second workspace", async () => {
+    const user = billingUser({ orgId: "org-primary" });
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      getOwnedWorkspaceCount: ownedCountFromRows([
+        { orgId: "org-primary" },
+        { orgId: "org-tenant-1" },
+      ]),
+      enforceWorkspaceLimit: withTier("managed"),
+    };
+
+    await assert.rejects(() => ensureWorkspaceCreationBillingForUser(user, deps));
+  });
+
+  test("the operator's own primary org never counts, on the password-signup shape (excludeOrgId passed through)", async () => {
+    const user = billingUser({ orgId: "org-primary-pw" });
+    let capturedExcludeOrgId: string | null | undefined;
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      getOwnedWorkspaceCount: async (_userId, excludeOrgId) => {
+        capturedExcludeOrgId = excludeOrgId;
+        return countOwnedWorkspacesFromRows([{ orgId: "org-primary-pw" }], excludeOrgId);
+      },
+      enforceWorkspaceLimit: withTier("inactive"),
+    };
+
+    await assert.doesNotReject(() => ensureWorkspaceCreationBillingForUser(user, deps));
+    assert.equal(capturedExcludeOrgId, "org-primary-pw", "must pass user.orgId as excludeOrgId");
+  });
+
+  test("the operator's own primary org never counts, on the OAuth/magic-link shape (excludeOrgId passed through)", async () => {
+    const user = billingUser({ orgId: "org-primary-oauth" });
+    let capturedExcludeOrgId: string | null | undefined;
+    const deps: EnsureWorkspaceCreationBillingDeps = {
+      getOwnedWorkspaceCount: async (_userId, excludeOrgId) => {
+        capturedExcludeOrgId = excludeOrgId;
+        return countOwnedWorkspacesFromRows([{ orgId: "org-primary-oauth" }], excludeOrgId);
+      },
+      enforceWorkspaceLimit: withTier("inactive"),
+    };
+
+    await assert.doesNotReject(() => ensureWorkspaceCreationBillingForUser(user, deps));
+    assert.equal(capturedExcludeOrgId, "org-primary-oauth", "must pass user.orgId as excludeOrgId");
+  });
+});


### PR DESCRIPTION
Follow-up to #182. That PR unblocked the web `/clients/new` path; this one unblocks the MCP path, which is the product's documented headline onboarding flow.

## The bug
`src/lib/billing/orgs.ts:209-218` held a **private duplicate** of `getOwnedWorkspaceCount`, counting `organizations.ownerId === userId`. That predicate includes the operator's OWN primary org, because signup stamps `organizations.ownerId = user.id` on it (OAuth/magic-link `auth.ts:199`; email+password `actions.ts:138`).

So a brand-new user counted **1** before creating anything. With #182's corrected cap of 1 for `inactive`, `1 < 1` is false → **still denied**, with `WORKSPACE_UPGRADE_REQUIRED_MESSAGE`.

It feeds `ensureWorkspaceCreationBillingForUser` → `createWorkspaceFromSoulAction` / `createWorkspaceFromSetupAction` → `POST /api/v1/workspace/create`. CLAUDE.md §1 describes that path as the zero-friction first-run experience: *"Install MCP → type natural language → instantly get a real hosted workspace."*

## Fix
- **Deleted the duplicate counter.** `ensureWorkspaceCreationBillingForUser` now uses the shared, already-corrected `getOwnedWorkspaceCount` (`web-onboarding/owned-workspace-count.ts`) with `excludeOrgId = user.orgId`. Investigated whether the two counters had genuinely different semantics (seat-quantity vs tenant workspaces) and concluded they do not — `link-workspace-to-operator.ts`'s own header comment plus every workspace-creation insert path treat the shared `org_members`-based counter as authoritative. One source of truth beats two copies that agree today.
- **Replaced the second hardcoded tier table** at `orgs.ts:244` (`tier === 'agency' ? 999 : tier === 'workspace' ? 1 : 0`) with the catalog-derived `maxFullWorkspacesForTier`, now exported from `limits.ts`. This is display-only, and it had been silently showing a 1-workspace cap for every currently sellable tier (`builder`, `managed`, `agency_starter`, `agency_growth`, `agency_scale`) since it predated the 2026-07-08 pricing ladder.
- Added an injectable deps seam to `ensureWorkspaceCreationBillingForUser` (mirroring `enforceWorkspaceLimit`'s existing DI pattern) so the count-then-gate composition is unit-testable without a DB. Flagged as a deviation from the literal brief; rationale in the branch report.

Per-tier before/after caps are tabulated in `.superpowers/sdd/mcp-workspace-gate-report.md`. No paying tier's enforcement changes.

## Gates
`tsc --noEmit` zero errors · `check:use-server` green · new spec 6/6 · combined billing/onboarding specs **24/24** (independently re-run).

## Still outstanding after this
A **third** hardcoded cap table survives at `stripe/webhook/route.ts:245/447/588`, persisting `subscription.maxWorkspaces: 0` for managed/agency. That is the next PR (caps consolidation), which collapses everything onto `plans.ts` as the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)