### PR TITLE
fix(billing): derive the persisted workspace cap from the catalog — the last copies of the retired table

### DIFF
--- a/packages/crm/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/crm/src/app/(dashboard)/dashboard/page.tsx
@@ -344,7 +344,17 @@ export default async function DashboardPage({
     | null = null;
   if (!isOperatorSession && user?.id) {
     try {
-      const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id);
+      // 2026-08-07 — pass excludeOrgId (#182's second argument), matching
+      // run-create-from-url / run-create-from-paste and lib/billing/orgs.ts.
+      // The identifier is the operator's PRIMARY org (`user.orgId`), NOT the
+      // cookie-backed ACTIVE `orgId` above: when an operator has switched
+      // into a client workspace, that active org IS a counted tenant
+      // workspace and excluding it would under-count. Both forms return the
+      // same number today (no signup path writes an org_members owner row
+      // for the primary org), so this is defense-in-depth — without it this
+      // badge and the gate that blocks the build would silently disagree the
+      // moment one does.
+      const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id, user.orgId ?? null);
       const decision = await enforceWorkspaceLimit({
         userId: user.id,
         primaryOrgId: orgId,

--- a/packages/crm/src/app/(dashboard)/dashboard/page.tsx
+++ b/packages/crm/src/app/(dashboard)/dashboard/page.tsx
@@ -344,9 +344,8 @@ export default async function DashboardPage({
     | null = null;
   if (!isOperatorSession && user?.id) {
     try {
-      // 2026-08-07 — pass excludeOrgId (#182's second argument), matching
-      // run-create-from-url / run-create-from-paste and lib/billing/orgs.ts.
-      // The identifier is the operator's PRIMARY org (`user.orgId`), NOT the
+      // 2026-08-07 — pass excludeOrgId (#182's second argument). The
+      // identifier is the operator's PRIMARY org (`user.orgId`), NOT the
       // cookie-backed ACTIVE `orgId` above: when an operator has switched
       // into a client workspace, that active org IS a counted tenant
       // workspace and excluding it would under-count. Both forms return the
@@ -354,6 +353,16 @@ export default async function DashboardPage({
       // for the primary org), so this is defense-in-depth — without it this
       // badge and the gate that blocks the build would silently disagree the
       // moment one does.
+      //
+      // NOT full parity with the other call sites, deliberately noted: every
+      // other site pairs excludeOrgId with the SAME org on the gate
+      // (orgs.ts:286-289, run-create-from-*.ts) whereas this one excludes the
+      // primary org but gates on the ACTIVE `orgId` below. That pairing is
+      // pre-existing and untouched here; the consequence is that an operator
+      // switched into a client workspace sees a badge whose TIER resolves
+      // from the client workspace while the COUNT excludes their own primary
+      // org. Worth reconciling in its own change — do not read this call as
+      // certifying parity.
       const ownedWorkspaceCount = await getOwnedWorkspaceCount(user.id, user.orgId ?? null);
       const decision = await enforceWorkspaceLimit({
         userId: user.id,

--- a/packages/crm/src/app/api/stripe/webhook/route.ts
+++ b/packages/crm/src/app/api/stripe/webhook/route.ts
@@ -20,6 +20,7 @@ import { getOrgSubscription, updateOrgSubscription } from "@/lib/billing/subscri
 import { applyBrandingForTier, reRenderAllSurfacesForOrg } from "@/lib/blueprint/rerender-org";
 import { trackEvent } from "@/lib/analytics/track";
 import { getPlan } from "@/lib/billing/plans";
+import { maxFullWorkspacesForTier } from "@/lib/billing/limits";
 import { sendPaidConversionAlert } from "@/lib/notifications/ops-notifications";
 
 function getStripeClient() {
@@ -242,7 +243,15 @@ export async function POST(req: NextRequest) {
       // Workspace cap from the resolved tier (-1 = unlimited stored as
       // a sentinel; the create-workspace gate uses `getMaxOrgs()` to
       // turn it into POSITIVE_INFINITY).
-      const maxWorkspaces = tier === "agency" ? -1 : tier === "workspace" ? 1 : 0;
+      //
+      // 2026-08-07 — this used to be a hardcoded `agency`/`workspace`-only
+      // ternary, the third and last copy of the table #182/#183 killed in
+      // lib/billing/limits.ts and lib/billing/orgs.ts. It never learned the
+      // 2026-07-08 pricing ladder, so builder / managed / agency_starter /
+      // agency_growth / agency_scale all fell into its `: 0` branch and
+      // persisted a cap of 0 while the real gate read them off the catalog.
+      // Now derived from the same `maxFullWorkspacesForTier` the gate uses.
+      const maxWorkspaces = maxFullWorkspacesForTier(tier);
       const currentPeriodEnd = (subscription as Stripe.Subscription & { current_period_end?: number }).current_period_end;
       const selfServiceEnabled = tier !== "inactive";
       // OpenClaw / layer2 metadata flags ride along on the base price
@@ -444,7 +453,8 @@ export async function POST(req: NextRequest) {
 
       const tier = resolveTierFromSubscription(subscription);
       const priceId = pickBasePriceId(subscription, tier) ?? subscription.items.data[0]?.price?.id ?? null;
-      const maxWorkspaces = tier === "agency" ? -1 : tier === "workspace" ? 1 : 0;
+      // Catalog-derived — see checkout.session.completed above.
+      const maxWorkspaces = maxFullWorkspacesForTier(tier);
       const currentPeriodEnd = (subscription as Stripe.Subscription & { current_period_end?: number }).current_period_end;
       const selfServiceEnabled = tier !== "inactive";
       let openClawEnabled = false;
@@ -508,7 +518,11 @@ export async function POST(req: NextRequest) {
 
       await updateOrgSubscription(orgId, {
         tier: "inactive",
-        maxWorkspaces: 0,
+        // 2026-08-07 — was a literal 0, the `: 0` branch of the same
+        // retired table. Derived here too so `inactive` can't mean 0 on
+        // this path and 1 (the first-workspace-free allowance the gate
+        // actually grants) on the three tier-resolving paths above.
+        maxWorkspaces: maxFullWorkspacesForTier("inactive"),
         status: "canceled",
         stripeSubscriptionId: null,
         selfServiceEnabled: false,
@@ -575,8 +589,11 @@ export async function POST(req: NextRequest) {
       const previousSubscription = await getOrgSubscription(orgId);
 
       let stripePriceId: string | null = null;
-      let maxWorkspaces = 0;
       let tier: BillingTier = "inactive";
+      // Seeded from the same catalog helper as the assignment below, so the
+      // no-subscription fallback agrees with what tier "inactive" means
+      // everywhere else in this file.
+      let maxWorkspaces = maxFullWorkspacesForTier("inactive");
       let selfServiceEnabled = false;
       let openClawEnabled = false;
       let layer2Enabled = false;
@@ -585,7 +602,8 @@ export async function POST(req: NextRequest) {
         const subscription = await stripe.subscriptions.retrieve(subscriptionId);
         tier = resolveTierFromSubscription(subscription);
         stripePriceId = pickBasePriceId(subscription, tier) ?? subscription.items.data[0]?.price?.id ?? null;
-        maxWorkspaces = tier === "agency" ? -1 : tier === "workspace" ? 1 : 0;
+        // Catalog-derived — see checkout.session.completed above.
+        maxWorkspaces = maxFullWorkspacesForTier(tier);
         selfServiceEnabled = tier !== "inactive";
 
         if (stripePriceId) {

--- a/packages/crm/tests/unit/billing/webhook-max-workspaces.spec.ts
+++ b/packages/crm/tests/unit/billing/webhook-max-workspaces.spec.ts
@@ -1,0 +1,182 @@
+// packages/crm/tests/unit/billing/webhook-max-workspaces.spec.ts
+//
+// 2026-08-07 — the LAST copy of the retired workspace-cap table.
+//
+// #182 (0d773bcab) killed the hardcoded table in lib/billing/limits.ts by
+// deriving from the plans catalog (`getPlan(tier).limits.maxOrgs`); #183
+// (e293f2f3c) killed the second copy in lib/billing/orgs.ts. A THIRD copy
+// survived in the Stripe webhook, written three times verbatim:
+//
+//     const maxWorkspaces = tier === "agency" ? -1 : tier === "workspace" ? 1 : 0;
+//
+// It never learned the 2026-07-08 pricing ladder, so every currently
+// sellable tier — builder / managed / agency_starter / agency_growth /
+// agency_scale — fell into the `: 0` branch and persisted a cap of 0 into
+// `organizations.subscription.maxWorkspaces`, while the real gate
+// (enforceWorkspaceLimit → maxFullWorkspacesForTier) read builder and the
+// agency_* ladder as UNLIMITED from the catalog.
+//
+// This spec pins the invariant that closes the class: the persisted value
+// is the catalog value, for every tier, and the -1 unlimited sentinel
+// survives the round trip into JSONB and back out to its consumer.
+//
+// Run:
+//   node --import tsx --test tests/unit/billing/webhook-max-workspaces.spec.ts
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { maxFullWorkspacesForTier } from "@/lib/billing/limits";
+import { getPlan } from "@/lib/billing/plans";
+import { getMaxOrgs } from "@/lib/billing/entitlements";
+import { TIER_FEATURES, type BillingTier } from "@/lib/billing/features";
+
+const WEBHOOK_SRC = readFileSync(
+  fileURLToPath(new URL("../../../src/app/api/stripe/webhook/route.ts", import.meta.url)),
+  "utf8",
+);
+
+/** What the retired table persisted, per tier — the BEFORE column. Kept
+ *  literal (not re-derived) so this table can never silently agree with a
+ *  regression that reintroduces it. */
+const RETIRED_TABLE: Record<BillingTier, number> = {
+  inactive: 0,
+  builder: 0,
+  managed: 0,
+  agency_starter: 0,
+  agency_growth: 0,
+  agency_scale: 0,
+  workspace: 1,
+  agency: -1,
+};
+
+/** What the catalog says the cap actually is — the AFTER column.
+ *  `inactive` is not a sellable plan (no catalog entry); its 1 is the
+ *  "first workspace is free forever" allowance the gate grants. */
+const CATALOG_CAP: Record<BillingTier, number> = {
+  inactive: 1,
+  builder: -1,
+  managed: 1,
+  agency_starter: -1,
+  agency_growth: -1,
+  agency_scale: -1,
+  workspace: 1,
+  agency: -1,
+};
+
+const ALL_TIERS = Object.keys(TIER_FEATURES) as BillingTier[];
+
+describe("webhook workspace cap — the catalog is the only source", () => {
+  test("every tier in TIER_FEATURES is covered by this spec's before/after table", () => {
+    assert.deepEqual(
+      [...ALL_TIERS].sort(),
+      (Object.keys(CATALOG_CAP) as BillingTier[]).sort(),
+      "a new tier was added without deciding what maxWorkspaces it persists",
+    );
+  });
+
+  for (const tier of ALL_TIERS) {
+    test(`${tier}: persists the catalog cap ${CATALOG_CAP[tier]} (the retired table said ${RETIRED_TABLE[tier]})`, () => {
+      assert.equal(maxFullWorkspacesForTier(tier), CATALOG_CAP[tier]);
+    });
+  }
+
+  test("every sellable tier's cap is read straight off plans.ts, not restated", () => {
+    for (const tier of ALL_TIERS) {
+      const plan = getPlan(tier);
+      if (!plan) {
+        // Only `inactive` has no catalog entry.
+        assert.equal(tier, "inactive");
+        continue;
+      }
+      assert.equal(
+        maxFullWorkspacesForTier(tier),
+        plan.limits.maxOrgs,
+        `${tier} must equal getPlan("${tier}").limits.maxOrgs`,
+      );
+    }
+  });
+
+  test("the 2026-07-08 ladder tiers are no longer capped at 0 (the actual bug)", () => {
+    for (const tier of ["builder", "agency_starter", "agency_growth", "agency_scale"] as const) {
+      assert.equal(RETIRED_TABLE[tier], 0, "precondition: the retired table capped this tier at 0");
+      assert.equal(maxFullWorkspacesForTier(tier), -1, `${tier} is unlimited per the catalog`);
+    }
+    // managed is a real cap of 1, not unlimited — the retired table got it
+    // wrong in the other direction (0).
+    assert.equal(RETIRED_TABLE.managed, 0);
+    assert.equal(maxFullWorkspacesForTier("managed"), 1);
+  });
+
+  test("no PAYING tier that the retired table got right is changed by the fix", () => {
+    // The two tiers the retired table happened to know about must persist
+    // exactly what they persisted before — this fix is not allowed to move
+    // a grandfathered subscriber's cap.
+    assert.equal(maxFullWorkspacesForTier("workspace"), RETIRED_TABLE.workspace);
+    assert.equal(maxFullWorkspacesForTier("agency"), RETIRED_TABLE.agency);
+  });
+});
+
+describe("the unlimited sentinel round-trips", () => {
+  test("unlimited is the integer -1, never Infinity (JSONB must survive JSON.stringify)", () => {
+    const cap = maxFullWorkspacesForTier("builder");
+    assert.equal(cap, -1);
+    assert.ok(Number.isInteger(cap), "the persisted cap must be a finite integer");
+    // Number.POSITIVE_INFINITY serializes to null — persisting it would
+    // erase the cap entirely on the way into organizations.subscription.
+    assert.equal(JSON.stringify({ maxWorkspaces: cap }), '{"maxWorkspaces":-1}');
+    assert.equal(
+      JSON.parse(JSON.stringify({ maxWorkspaces: cap })).maxWorkspaces,
+      -1,
+      "the sentinel must survive a JSONB round trip unchanged",
+    );
+    assert.equal(JSON.stringify({ x: Number.POSITIVE_INFINITY }), '{"x":null}');
+  });
+
+  test("-1 is read back as unlimited by its consumer (entitlements.getMaxOrgs)", () => {
+    for (const tier of ["builder", "agency", "agency_starter", "agency_growth", "agency_scale"] as const) {
+      assert.equal(maxFullWorkspacesForTier(tier), -1);
+      assert.equal(getMaxOrgs(getPlan(tier) ?? null), Number.POSITIVE_INFINITY, tier);
+    }
+  });
+
+  test("a finite cap is read back verbatim, not turned into a sentinel", () => {
+    for (const tier of ["managed", "workspace"] as const) {
+      assert.equal(maxFullWorkspacesForTier(tier), 1);
+      assert.equal(getMaxOrgs(getPlan(tier) ?? null), 1, tier);
+    }
+  });
+});
+
+describe("stripe webhook route — the retired table is gone", () => {
+  test("no copy of the `tier === \"agency\" ? -1 : tier === \"workspace\" ? 1 : 0` table survives", () => {
+    assert.ok(
+      !/tier === "agency" \? -1/.test(WEBHOOK_SRC),
+      "the hardcoded workspace-cap table is back in src/app/api/stripe/webhook/route.ts",
+    );
+  });
+
+  test("every maxWorkspaces value written by the route is derived from maxFullWorkspacesForTier", () => {
+    assert.ok(
+      /from "@\/lib\/billing\/limits"/.test(WEBHOOK_SRC),
+      "the route must import the catalog-derived cap helper",
+    );
+    // Every assignment of the local `maxWorkspaces` (and the inactive
+    // literal in the cancel branch) must call the helper. Count the
+    // assignment sites and require each one to be a helper call.
+    const assignments = WEBHOOK_SRC.match(/maxWorkspaces(?::| =|\s*=)\s*[^,\n]+/g) ?? [];
+    const valueSites = assignments.filter(
+      (line) => !/maxWorkspaces,/.test(line) && !/previousMaxWorkspaces|nextMaxWorkspaces/.test(line),
+    );
+    assert.ok(valueSites.length >= 3, `expected the route to set maxWorkspaces, found ${valueSites.length}`);
+    for (const site of valueSites) {
+      assert.match(
+        site,
+        /maxFullWorkspacesForTier\(/,
+        `a maxWorkspaces value is not catalog-derived: ${site}`,
+      );
+    }
+  });
+});

--- a/packages/crm/tests/unit/web-onboarding/owned-workspace-count.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/owned-workspace-count.spec.ts
@@ -10,6 +10,8 @@
 // fully unit-testable. The shape we mock matches the actual query.
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { countOwnedWorkspacesFromRows } from "../../../src/lib/web-onboarding/owned-workspace-count";
 
@@ -64,5 +66,46 @@ describe("countOwnedWorkspacesFromRows", () => {
       assert.equal(countOwnedWorkspacesFromRows(rows, null), 2);
       assert.equal(countOwnedWorkspacesFromRows(rows, undefined), 2);
     });
+  });
+});
+
+// 2026-08-07 — call-site coverage. The exclusion above only defends the
+// operator's own org if every caller actually PASSES excludeOrgId. #182
+// threaded it through run-create-from-url / run-create-from-paste and #183
+// through lib/billing/orgs.ts, but the dashboard header CTA still called
+// the one-argument form — so the displayed "used / limit" badge and the
+// gate that blocks the build would silently disagree the moment any write
+// path inserts an org_members owner row for a primary org (exactly what
+// the exclusion exists to defend against). The identifier must be the
+// operator's PRIMARY org (`user.orgId`), never the cookie-backed ACTIVE
+// org (`orgId`) — when an operator has switched into a client workspace
+// the active org IS a counted tenant workspace, and excluding it would
+// under-count.
+describe("getOwnedWorkspaceCount call sites all pass excludeOrgId", () => {
+  function src(relativePath: string): string {
+    return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+  }
+
+  test("the dashboard header CTA passes the operator's own primary org", () => {
+    const page = src("../../../src/app/(dashboard)/dashboard/page.tsx");
+    const calls = page.match(/getOwnedWorkspaceCount\([^)]*\)/g) ?? [];
+    assert.ok(calls.length >= 1, "expected the dashboard to count owned workspaces");
+    for (const call of calls) {
+      assert.match(
+        call,
+        /getOwnedWorkspaceCount\(\s*user\.id\s*,\s*user\.orgId \?\? null\s*\)/,
+        `dashboard call site must exclude the operator's own primary org: ${call}`,
+      );
+    }
+  });
+
+  test("the MCP path (lib/billing/orgs.ts) still passes it — #183, unchanged", () => {
+    const orgs = src("../../../src/lib/billing/orgs.ts");
+    const calls = orgs.match(/getOwnedWorkspaceCount\((?!\s*$)[^)]*\)/g) ?? [];
+    const invocations = calls.filter((c) => /\(\s*user\.id/.test(c));
+    assert.ok(invocations.length >= 1, "expected at least one invocation in orgs.ts");
+    for (const call of invocations) {
+      assert.match(call, /user\.orgId \?\? null/, `orgs.ts call site regressed: ${call}`);
+    }
   });
 });


### PR DESCRIPTION
Closes the bug class behind #182 and #183. A retired per-tier workspace-cap table was copied in four places; #182 fixed `limits.ts` (the gate), #183 fixed `orgs.ts` (display + the MCP gate). This fixes the remaining write sites.

## Why this matters
The original table — `tier === "agency" ? -1 : tier === "workspace" ? 1 : 0` — predates the 2026-07-08 pricing ladder and never learned the five sellable tier ids. Everything else fell into the `: 0` branch. In `limits.ts` that cost you **every signup for 16 days**. Here it "only" writes a wrong number to the record, but it is the same drift, and the fourth copy is how it comes back.

## Changes
**Item 1 — `dashboard/page.tsx:347`**: `getOwnedWorkspaceCount(user.id)` → `(user.id, user.orgId ?? null)`, matching the `excludeOrgId` argument #182 added at every other call site. Both forms return the same number today; without it, this badge and the gate that blocks the build would silently disagree the moment any write path inserts an `org_members` owner row for a primary org.

**Item 2 — `stripe/webhook/route.ts`**: five write sites (254, 457, 525, 596, 606 — two more than the three originally identified, same file, same table) now use `maxFullWorkspacesForTier(tier)`.

### Persisted `maxWorkspaces`, before → after
| tier | paying | before | after | catalog |
|---|---|---|---|---|
| `inactive` | no | 0 | **1** | first-workspace-free allowance |
| `builder` $29 | yes | 0 | **-1** | plans.ts:164 |
| `managed` $49 | yes | 0 | **1** | plans.ts:207 |
| `agency_starter` $99 | yes | 0 | **-1** | plans.ts:247 |
| `agency_growth` $199 | yes | 0 | **-1** | plans.ts:293 |
| `agency_scale` $299 | yes | 0 | **-1** | plans.ts:333 |
| `workspace` (grandfathered) | yes | 1 | 1 | unchanged |
| `agency` (grandfathered) | yes | -1 | -1 | unchanged |

No paying tier's cap decreases; every change is `0 → the value the catalog already stated`.

## The `-1` sentinel — checked, not assumed
`-1` means unlimited, so a naive substitution could have written a negative cap. Verified repo-wide: the persisted value has **no consumer that treats it as a cap** — the only reads are two `console.info` lines. Every functional cap derives from the *tier* and handles `-1` explicitly (`limits.ts:112`, `entitlements.ts:43`, `orgs.ts:244`, `dashboard/page.tsx:373`). The new spec also pins the JSONB round-trip trap (`POSITIVE_INFINITY` → `null`).

## Review
Adversarial verification: **zero blocking**. It flagged that the new dashboard comment claimed parity the call site doesn't have (it excludes the primary org but gates on the cookie-backed *active* org — pre-existing, untouched); corrected in 56f94df1b rather than left to mislead.

## Gates
`tsc --noEmit` clean · `check:use-server` green · `tests/unit/billing/**` + `tests/unit/web-onboarding/**` **321/321** · 14 named billing specs 200/200 (1 pre-existing env-gated skip in an untouched file).

## Known, not done here
- `features.ts` `TIER_FEATURES[*].maxWorkspaces` is a **fourth** copy. It has no consumer today (`git grep '\.maxWorkspaces'` finds none), so it is dead — but it is the next drift if it gains one.
- No backfill: rows written before this commit still carry the old values. Harmless (no functional consumer) but the record is only truthful going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)