### PR TITLE
persona-loop: /try's "describe your business instead" CTA lands back on the URL tab it just failed

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -78,6 +78,36 @@ function clearStoredSeed(): void {
   }
 }
 
+// 2026-08-08 — persona-loop fix. "Describe your business instead" (the
+// extraction_failed CTA below) sent visitors to bare /signup, which DOES
+// land a new account on /clients/new (buildSignupNextPath's default), but
+// that page's IdleScene defaults to its URL tab unless the marketing-hero
+// seed carries kind:"biz" (see clients-new-form.tsx's initialTab + mount-
+// effect hydration). Without this, a visitor whose URL just failed to
+// extract would land back on an empty URL box — the exact input that just
+// failed them — never seeing the description tab the CTA promised.
+//
+// Fix stays inside this file only (no auth/signup-redirect changes, per
+// CLAUDE.md's security-sensitive-code rule): write the SAME
+// 'sf-workspace-seed' localStorage seed the marketing hero already writes
+// for its biz tab, seeded with the URL the visitor already gave us (real
+// data, not fabricated copy) so /clients/new's EXISTING hydration effect
+// picks it up unchanged and opens straight to the biz tab, pre-filled with
+// something to build the description from instead of a blank box.
+function storeBizSeedFromFailedUrl(failedUrl: string): void {
+  if (typeof window === "undefined") return;
+  const value = failedUrl.trim();
+  if (value.length < 3) return;
+  try {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ kind: "biz", value, at: Date.now() } satisfies StoredSeed),
+    );
+  } catch {
+    // Quota/permission errors — non-fatal, visitor just lands on the URL tab.
+  }
+}
+
 export function TryClient({ initialUrl }: { initialUrl: string }) {
   const [url, setUrl] = useState(initialUrl);
   const [descriptionSeed, setDescriptionSeed] = useState<string | null>(null);
@@ -360,6 +390,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                     </button>
                     <a
                       href="/signup"
+                      onClick={() => storeBizSeedFromFailedUrl(url)}
                       className="inline-flex items-center gap-1.5 rounded-[11px] bg-[#1F2B24] px-4 py-2 text-[13.5px] font-[600] text-[#FFFDFA]"
                     >
                       Describe your business instead

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -63,6 +63,41 @@ describe("TryClient — SSE error honesty", () => {
     cleanup();
   });
 
+  // 2026-08-08 — persona-loop fix. "Describe your business instead" used to
+  // send visitors to bare /signup with no seed, so /clients/new's IdleScene
+  // opened on its URL tab (the exact input that just failed them) instead of
+  // the description tab the CTA promised. Reusing the SAME 'sf-workspace-seed'
+  // localStorage bridge the marketing hero already writes lets /clients/new's
+  // existing hydration effect open straight to the biz tab.
+  test("extraction_failed CTA seeds the biz-tab localStorage with the failed URL before navigating", async () => {
+    window.localStorage.removeItem("sf-workspace-seed");
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("https://mikes-electric-stockton.com");
+    });
+
+    await act(async () => {
+      FakeEventSource.last!.fire("error", {
+        code: 422,
+        reason: "extraction_failed",
+        message: "We read that site but couldn't find the basics we need.",
+      });
+    });
+
+    const cta = screen.getByText("Describe your business instead");
+    fireEvent.click(cta);
+
+    const stored = window.localStorage.getItem("sf-workspace-seed");
+    assert.ok(stored, "clicking the CTA must write the biz seed before navigating");
+    const seed = JSON.parse(stored!);
+    assert.equal(seed.kind, "biz", "seed must target the biz tab, not the url tab");
+    assert.equal(
+      seed.value,
+      "https://mikes-electric-stockton.com",
+      "seed carries forward the URL the visitor already gave us",
+    );
+  });
+
   test("credits_exhausted error shows the server message and NO 'Try again' button", async () => {
     render(<TryClient initialUrl="" />);
     await act(async () => {


### PR DESCRIPTION
## Summary

**Persona:** Saturday → solo electrician (non-technical, impatient, skeptical, on a phone).

**Funnel step:** `/try` — the public, ungated "paste a URL, watch it build" flow (`SF_WEB_UNGATED_BUILD` on in production, confirmed live). This is the real self-serve on-ramp for a solo tradesperson (the homepage hero is deliberately agency-voiced — SMB self-serve lives on `/try`).

**First failure found:** a real electrician's only web presence is often thin — a one-page site, a Facebook page, a listing with no phone number Firecrawl can read. That hits `/try`'s `extraction_failed` state, whose error card offers two honest-sounding paths: "Try a different URL" or **"Describe your business instead."** The second one doesn't do what it says.

### Verbatim evidence

Live production, `try-client.tsx` (fetched from `main`, confirmed unchanged before this fix):

```html
<a href="/signup" class="...">Describe your business instead</a>
```

Bare `/signup` *does* land a new account on `/clients/new` (its `buildSignupNextPath` default), so the visitor isn't hard-blocked. But `/clients/new`'s `IdleScene` has two tabs — URL and description — and it only opens on the description tab when a `sf-workspace-seed` localStorage seed with `kind: "biz"` is present (`clients-new-form.tsx`'s `initialTab = prefillBiz && !prefillUrl ? "biz" : "url"`, and its mount-effect hydration reads the same seed). This CTA writes nothing, so the visitor signs up, waits for the magic link, and lands back on… an empty **URL** box — the exact input that just failed them five minutes ago. "Describe your business instead" was a promise the code never kept.

### Root cause

`try-client.tsx`'s `extraction_failed` branch never wrote the `sf-workspace-seed` localStorage seed the marketing hero's own "biz" tab already writes before this exact same `/signup` hop (`marketing-hero.tsx`'s `submit()`). `/clients/new` has always been able to open on the description tab — this CTA just never fed it the signal.

### Fix

Smallest change that reuses the existing pipeline instead of building a new one:
- Added `storeBizSeedFromFailedUrl()` to `try-client.tsx`, which writes the *same* `sf-workspace-seed` key/shape the marketing hero already writes (`{ kind: "biz", value, at }`), seeded with the URL the visitor already gave us — real data, not fabricated copy.
- Wired it to the CTA's `onClick`, before the existing `/signup` navigation.
- `/clients/new`'s hydration effect (unchanged) now picks this up and opens on the biz tab, pre-filled with their URL as a starting point instead of a blank box.

No changes to `/signup`, `signup-redirect.ts`, `/clients/new`, or any auth-adjacent file — per CLAUDE.md's rule against touching security-sensitive/auth code, the fix stays entirely inside the one client component that owns the CTA.

## Type of change

- [x] Bug fix

## Related issue

N/A

## Testing

- [x] Targeted unit test added (`extraction_failed CTA seeds the biz-tab localStorage with the failed URL before navigating`) in `packages/crm/tests/unit/web-onboarding/try-client.spec.tsx` — asserts the click writes `kind: "biz"` with the visitor's URL as the value.
- [x] `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx` — 3/3 pass
- [x] `node --import tsx --test tests/unit/web-onboarding/*.spec.ts tests/unit/web-onboarding/*.spec.tsx` — 125/125 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors
- [x] `bash scripts/check-use-server.sh src` — clean
- [x] `node scripts/check-migrations-journaled.mjs` — clean (no migrations touched)
- [ ] Manually verified the change in the browser (if UI) — not run; verified via targeted RTL test tracing the exact `clients-new-form.tsx` hydration logic this seed feeds, plus live `curl`/read of the production `try-client.tsx` for the evidence above.

## Notes for reviewers

Scoped to one file's CTA click-handler (`try-client.tsx`) plus its test. Does not touch `/signup`, `signup-redirect.ts`, `/clients/new`, or the SSRF guard/rate limiter.

Also worth flagging while I'm here (not fixed in this PR, out of scope): there are currently **15 open, unmerged `persona-loop` PRs** (#82 through #174) stacked up from prior nightly runs, none reviewed or merged yet, plus open gate-failure issues (#154/#156/#159/#172) reporting `main` itself red for 11+ days on a trivial copy-drift test assertion + one unrelated `tsc` error in `copilot/turn/route.ts`. None of that blocks this PR (this branch's gates are green), but the backlog means this fix — like the 15 before it — won't reach production until someone reviews the queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_019Prn88XhPnH4woSkt22v7s)_