### PR TITLE
Make the public experience agency-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # SeldonFrame
 
-**Build almost any AI agent — from your IDE.**
+**Sell AI front offices. Deploy them in minutes.**
 
-The open-source platform that gives your coding agent the primitives real production agents need: triggers, skills, channels, tools, an owned memory (the Brain), guardrails, evals, one-command deploy, and built-in money rails. Describe an agent in one sentence — minutes later it's answering a real business's phone, chat, and SMS, and booking real appointments. Free to build.
+SeldonFrame is the agent-native, open-source alternative to GoHighLevel for agencies serving local businesses. Give your coding agent a client's URL and it can create a branded website, booking flow, intake, CRM, and AI agent in one workspace. Run evals, publish, and hand it off — then operate every client from one agency view.
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-1FAE85.svg)](LICENSE)
 [![npm version](https://img.shields.io/npm/v/@seldonframe/mcp.svg?color=1FAE85)](https://www.npmjs.com/package/@seldonframe/mcp)
@@ -15,7 +15,7 @@ The open-source platform that gives your coding agent the primitives real produc
 [![X](https://img.shields.io/badge/follow-%40themaxthule-1d9bf0.svg)](https://x.com/themaxthule)
 [![smithery badge](https://smithery.ai/badge/maximehoule100/seldonframe)](https://smithery.ai/servers/maximehoule100/seldonframe)
 
-[Website](https://seldonframe.com) · [For builders](https://seldonframe.com/build) · [Docs](https://seldonframe.com/docs) · [Discord](https://discord.gg/sbVUu976NW)
+[Website](https://seldonframe.com) · [For agencies](https://seldonframe.com/agencies) · [For builders](https://seldonframe.com/build) · [Docs](https://seldonframe.com/docs) · [Discord](https://discord.gg/sbVUu976NW)
 
 **Live demos:** [HVAC](https://j-marin-heating-air-conditioning-9599.app.seldonframe.com/) · [Med spa](https://app.seldonframe.com/w/metro-medspa-9d24) · [Med spa](https://app.seldonframe.com/w/skinney-medspa) · [Weight loss](https://app.seldonframe.com/w/vive-ageless-weight-loss-center)
 
@@ -23,7 +23,7 @@ The open-source platform that gives your coding agent the primitives real produc
 
 ---
 
-## Ship your first agent in 60 seconds
+## Ship your first client front office
 
 ```bash
 claude mcp add seldonframe -- npx -y @seldonframe/mcp
@@ -37,12 +37,12 @@ Or as an auto-updating Claude Code plugin:
 ```
 
 ```
-> Build me an AI receptionist for an HVAC company in New Orleans.
+> Build a branded AI front office for my HVAC client in New Orleans.
 
-  ✓ Live at acme-hvac.app.seldonframe.com
+  ✓ Workspace ready at acme-hvac.app.seldonframe.com
 ```
 
-No API key. No signup form. **Your first workspace is free forever.** That one sentence stands up a hosted front office — website, booking page, intake form, CRM — with an AI agent already answering on chat and booking against the real calendar. Add a phone number and it answers calls too.
+Build the first client workspace before paying. Hosted Managed uses SeldonFrame's keys; Builder and Agency plans are BYOK. Your agency owns the client relationship, workspace data, and delivery margin.
 
 **See a real one — a live workspace, not a mockup:**
 
@@ -81,6 +81,17 @@ And here's the agent on that site handling a real inbound — checking the live 
 </table>
 
 Click any screenshot — [this HVAC workspace](https://j-marin-heating-air-conditioning-9599.app.seldonframe.com/) is live and books real appointments. More live workspaces: [Metro MedSpa](https://app.seldonframe.com/w/metro-medspa-9d24) · [SKINNEY Medspa](https://app.seldonframe.com/w/skinney-medspa) · [Vive Ageless Weight Loss](https://app.seldonframe.com/w/vive-ageless-weight-loss-center) — and more on [seldonframe.com](https://seldonframe.com).
+
+---
+
+## The agency delivery loop
+
+1. **Start with the client URL.** SeldonFrame extracts the business facts and creates the workspace.
+2. **Apply your agency playbook.** Brand the site, booking flow, intake, CRM, and agent.
+3. **Verify before handoff.** Run evals and complete a real test booking.
+4. **Publish and operate.** Give the client a branded portal while your agency keeps the master view.
+
+The same loop works from the dashboard, Claude Code, Cursor, Windsurf, or any MCP-compatible agent. See the [agency workflow](https://seldonframe.com/agencies).
 
 ---
 
@@ -158,9 +169,9 @@ Agents that do real work end up touching real money — so the rails are platfor
 
 ---
 
-## Use SeldonFrame from any IDE
+## Operate every client from any IDE
 
-One npm package — [`@seldonframe/mcp`](https://www.npmjs.com/package/@seldonframe/mcp) — runs as a local MCP server in every major AI-native editor. Pick yours, paste the snippet, and ask your agent to build a workspace — your own website, booking page, intake form, and CRM, with the agent wired in. **First workspace is free and needs no API key.**
+One npm package — [`@seldonframe/mcp`](https://www.npmjs.com/package/@seldonframe/mcp) — runs as a local MCP server in every major AI-native editor. Pick yours, paste the snippet, and ask your agent to create or update a client workspace — website, booking page, intake form, CRM, and agent in one pass.
 
 <details>
 <summary><strong>Claude Code</strong></summary>
@@ -269,7 +280,7 @@ Or one line: `codex mcp add seldonframe -- npx -y @seldonframe/mcp`
 Once connected, restart your IDE (MCP connectors load at session start), then just say:
 
 ```
-> Build a workspace for [business name]. [city, state]. [services]. [phone, optional].
+> Build a workspace for my client: [business name]. [city, state]. [services]. [phone, optional].
 ```
 
 See the same six snippets, kept in sync, at [seldonframe.com/build](https://seldonframe.com/build#install).
@@ -290,19 +301,22 @@ Brings up Postgres, migrations, and the app on `localhost:3000` — the same das
 
 ---
 
-## When you're ready to sell
+## When you're ready to scale
 
-Your builder hub is **[seldonframe.com/build](https://seldonframe.com/build)** — publish an agent, set the price (monthly, per-call, per-outcome, or one-time), and any LLM can rent it over MCP. **Every published agent gets a free storefront**: a public listing page with schema.org markup, a markdown twin, and `llms.txt` coverage — so both humans *and* AI agents can discover and buy it. We ship the commodity agents as everyone's free floor, we never build vertical agents that compete with yours, and we never train on your prompts or data.
+Your agency hub is **[seldonframe.com/agencies](https://seldonframe.com/agencies)** — deploy branded client workspaces, set your own client pricing, and keep the master view. Builders can still publish portable agents through **[seldonframe.com/build](https://seldonframe.com/build)** and let other LLMs rent them over MCP.
 
 ## Pricing — no surprises
 
 | | |
 |---|---|
 | **Self-host** | $0 — AGPL-3.0, the entire monorepo · [`docker compose up`](QUICKSTART.md#self-host) and you're running |
-| **Hosted — first workspace** | Free forever, no card |
-| **Hosted — unlimited workspaces** | $29/mo flat (white-label + voice included) |
-| **Your AI tokens** | Bring your own key — we never mark up usage |
-| **When you sell** | 5% only when the marketplace brings the buyer · ~2% through your own storefront · **$0 anywhere else** |
+| **Builder** | $29/mo · BYOK · workspaces for businesses you operate |
+| **Managed** | $49/mo · SeldonFrame-managed AI · one workspace |
+| **Agency Starter** | $99/mo · white-label · 10 client workspaces · 0% GMV |
+| **Agency Growth** | $199/mo · 30 client workspaces · 0% GMV |
+| **Agency Scale** | $299/mo · unlimited client workspaces · API/MCP + marketplace access · 0% GMV |
+| **Build before checkout** | Create the first client workspace free, then choose the hosted plan that matches your delivery needs |
+| **Marketplace sales** | 5% only when the marketplace brings the buyer |
 ## Tech stack
 
 - **Next.js 16** (App Router) + **React 19** + **TypeScript** — one deployable app: dashboard, generated public sites, and API

--- a/docs/strategy/agency-first-public-experience.md
+++ b/docs/strategy/agency-first-public-experience.md
@@ -59,4 +59,3 @@ Product and marketing measurement use the canonical lifecycle events already def
 - Creating an automated outbound email system.
 - Rewriting the entire SEO comparison library.
 - Claiming features that are only roadmap items.
-

--- a/docs/strategy/agency-first-public-experience.md
+++ b/docs/strategy/agency-first-public-experience.md
@@ -1,0 +1,62 @@
+# Agency-first public experience
+
+## Decision
+
+SeldonFrame's primary public audience is agencies and independent operators who sell and operate AI front offices for local-service businesses.
+
+The positioning is:
+
+> SeldonFrame is the agent-native, open-source alternative to GoHighLevel for agencies serving local businesses.
+
+The agency is the customer. The service business is the deployment target.
+
+## Customer job
+
+An agency needs to turn a client's website and business facts into a branded, working front office that it can deploy, operate, and resell. The deliverable is not an abstract agent. It is a client workspace containing a website, booking flow, intake, CRM, follow-up, and an agent that can act across the client's channels.
+
+## Message hierarchy
+
+1. Outcome: sell and deploy AI front offices in minutes.
+2. Deliverable: website, booking, CRM, intake, agent, and client portal in one workspace.
+3. Agency advantage: repeatable delivery, white-label branding, owned data, and room for agency margin.
+4. Mechanism: agent-native MCP/API, Brain/Soul, guardrails, evals, and deployable workspaces.
+5. Openness: AGPL-3.0, portable data, and no platform lock-in.
+
+Technology appears after the agency outcome. Builders and self-hosters remain important secondary audiences and get dedicated paths through `/build`, GitHub, and developer documentation.
+
+## Surface roles
+
+| Surface | Job | Primary CTA |
+| --- | --- | --- |
+| `/` | Make the agency value legible in one screen | Build your first client front office |
+| `/agencies` | Explain delivery workflow, white-labeling, and economics | See agency plans |
+| `/docs` | Help an agency reach first deployment without guessing | Build your first workspace |
+| GitHub README | Help a technical agency install, evaluate, self-host, or contribute | Install the MCP |
+
+## Promise contract
+
+The public surfaces must agree on the following facts:
+
+- License: AGPL-3.0 for the repository.
+- Hosted plan ladder: Builder $29/mo, Managed $49/mo, Agency Starter $99/mo, Agency Growth $199/mo, Agency Scale $299/mo.
+- Hosted Managed includes managed AI; Builder and Agency plans are BYOK.
+- The first workspace can be built free; paid plans unlock the relevant hosted capacity and agency features. No copy should call this a trial unless it explains the exact boundary.
+- “Live” means the workspace has a public URL and its configured public surface is reachable. A first booking is a separate activation milestone.
+- “Minutes” is a directional promise backed by the onboarding funnel; it is not a guarantee for every provider, industry, or customization.
+
+## Proof loop
+
+The first proof story is an agency onboarding a real HVAC, dental, or medspa client:
+
+`client URL → workspace build → brand/customize → eval → publish → first test booking → client handoff`
+
+Product and marketing measurement use the canonical lifecycle events already defined in the onboarding funnel. The homepage should eventually show proof from real workspaces and first-booking outcomes rather than feature counts alone.
+
+## Out of scope for this slice
+
+- Rebuilding the application shell or dashboard.
+- Changing plan prices or billing behavior.
+- Creating an automated outbound email system.
+- Rewriting the entire SEO comparison library.
+- Claiming features that are only roadmap items.
+

--- a/docs/superpowers/plans/2026-08-11-agency-first-public-experience.md
+++ b/docs/superpowers/plans/2026-08-11-agency-first-public-experience.md
@@ -1,0 +1,191 @@
+# Agency-first public experience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Align SeldonFrame's public website, `/docs`, and GitHub README around agencies selling AI front offices to local-service businesses.
+
+**Architecture:** Keep the existing landing components and routes, but replace conflicting claims with one agency-first message hierarchy. Centralize the public positioning and hosted plan facts in a dependency-free marketing module, then reuse those facts in the homepage metadata, hero, docs, and README. Fix known license/pricing/API-key contradictions and add lightweight consistency tests.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, Vitest-compatible repository unit runner, Markdown documentation, pnpm/Turbo.
+
+## Global Constraints
+
+- Preserve the current onboarding, Stripe, PostHog, and GA changes from `a07cf9d7f`.
+- Do not change plan prices or billing behavior in this slice.
+- The repository license is AGPL-3.0; do not describe the repo as MIT.
+- Hosted Managed uses SeldonFrame-managed AI; Builder and Agency plans are BYOK.
+- The primary buyer is an agency; builders and self-hosters remain secondary paths.
+- Do not claim roadmap-only capabilities as shipped.
+
+---
+
+### Task 1: Add the public positioning contract
+
+**Files:**
+- Create: `packages/crm/src/lib/marketing/public-claims.ts`
+- Create: `packages/crm/tests/unit/marketing/public-claims.spec.ts`
+- Modify: `packages/crm/src/app/(public)/home-copy.ts`
+
+**Interfaces:**
+- Produces `AGENCY_POSITIONING`, `AGENCY_HERO_HEADLINE`, `AGENCY_HERO_SUBHEAD`, `AGENCY_PLAN_FACTS`, and `LICENSE_LABEL` for public surfaces.
+
+- [ ] **Step 1: Write the failing test**
+
+Assert that the positioning names agencies and AI front offices, the plan facts contain exactly Builder/Managed/Agency Starter/Agency Growth/Agency Scale with prices 29/49/99/199/299, and the license label is `AGPL-3.0`.
+
+- [ ] **Step 2: Run the focused test**
+
+Run `pnpm test:unit -- packages/crm/tests/unit/marketing/public-claims.spec.ts` and confirm it fails because the module does not exist.
+
+- [ ] **Step 3: Implement the contract**
+
+Use a plain TypeScript module with readonly data and no React or server imports. Update `POSITIONING_ONE_LINER` to consume the canonical agency positioning and avoid introducing a second pricing claim.
+
+- [ ] **Step 4: Run the focused test**
+
+Run the same command and confirm it passes.
+
+- [ ] **Step 5: Commit**
+
+Commit as `feat(marketing): add agency public positioning contract`.
+
+### Task 2: Reframe the homepage for agency conversion
+
+**Files:**
+- Modify: `packages/crm/src/components/landing/marketing-hero.tsx`
+- Modify: `packages/crm/src/components/landing/marketing-build-steps.tsx`
+- Modify: `packages/crm/src/components/landing/marketing-nav.tsx`
+- Modify: `packages/crm/src/app/(public)/unified-landing.tsx`
+- Modify: `packages/crm/src/app/(public)/agencies/page.tsx`
+- Modify: `packages/crm/src/components/landing/marketing-footer.tsx`
+- Modify: `packages/crm/src/app/(marketing)/marketing-shell.tsx`
+
+**Interfaces:**
+- Consumes the Task 1 positioning contract.
+- Preserves existing CTA routing, pricing event hooks, and landing-mode behavior.
+
+- [ ] **Step 1: Replace hero copy**
+
+Use the approved agency promise: “Sell AI front offices. Deploy them in minutes.” Explain the client deliverable and make “Build your first client front office” the primary CTA while preserving the existing form target.
+
+- [ ] **Step 2: Make the build loop agency-specific**
+
+Change the build-step examples to `client URL → workspace → brand/customize → eval → publish → handoff`, while retaining the existing describe/record UI and reduced-motion behavior.
+
+- [ ] **Step 3: Improve navigation and section order**
+
+Expose `/agencies`, `/docs`, `/build`, pricing, and GitHub through accessible navigation or resource links. Put the agency proof/economics section before lower-priority builder/marketplace material.
+
+- [ ] **Step 4: Correct legal and pricing language**
+
+Replace MIT footer language with AGPL-3.0 and remove any stale “$19”, “$297”, or contradictory hosted-key statements in the touched marketing surfaces.
+
+- [ ] **Step 5: Run lint on touched files**
+
+Run `pnpm --filter @seldonframe/crm lint` and fix only issues introduced by this task.
+
+- [ ] **Step 6: Commit**
+
+Commit as `feat(marketing): make agency front offices the primary story`.
+
+### Task 3: Repair the docs information architecture and claims
+
+**Files:**
+- Modify: `packages/crm/src/app/docs/page.tsx`
+- Modify: `packages/crm/src/app/docs/getting-started/what-is-seldonframe/page.tsx`
+- Modify: `packages/crm/src/app/docs/getting-started/first-workspace/page.tsx`
+- Modify: `packages/crm/src/app/docs/getting-started/connect-claude-code/page.tsx`
+- Modify: `packages/crm/src/app/docs/billing/pricing/page.tsx`
+- Modify: `packages/crm/src/app/docs/billing/tiers/page.tsx`
+- Modify: `packages/crm/src/app/(marketing)/docs/quickstart/page.tsx`
+- Modify: `packages/crm/src/app/(marketing)/docs/mcp-servers/page.tsx`
+
+**Interfaces:**
+- Docs links must resolve to existing article routes or external URLs.
+- Pricing and BYOK copy must match the Task 1 contract and the current billing implementation.
+
+- [ ] **Step 1: Rewrite the docs homepage hero**
+
+Describe the agency job and add three explicit entry points: agency operator, client workspace operator, and builder/API developer. Replace stale anchor-only “popular” cards with real article routes where those routes exist.
+
+- [ ] **Step 2: Rewrite getting-started content**
+
+Make the first workspace guide agency-led: create a client workspace, brand it, configure booking/CRM, run agent evals, publish, and hand off. Keep the direct operator path available.
+
+- [ ] **Step 3: Correct pricing and plan tiers**
+
+Use the five current hosted plans and remove the retired Builder $19 / Workspace $49 / Agency $297 ladder. Explain Managed versus BYOK and distinguish free building from paid hosted capacity without calling it an undefined trial.
+
+- [ ] **Step 4: Correct quickstart and integration prerequisites**
+
+Hosted users should not be told an Anthropic key is required. Self-hosting documentation may require a provider key. Correct MIT references to AGPL-3.0 and keep provider-specific keys in integration/self-hosting sections.
+
+- [ ] **Step 5: Verify links and copy**
+
+Run a repository search for `open source under MIT`, `Builder ($19`, `Agency ($297`, `Workspace ($49`, and `Anthropic API key` in hosted quickstarts. The first three must return no results; the remaining occurrences must be explicitly self-hosted/provider setup references.
+
+- [ ] **Step 6: Commit**
+
+Commit as `docs: align public docs with agency-first product contract`.
+
+### Task 4: Rewrite the GitHub README for agencies and builders
+
+**Files:**
+- Modify: `README.md`
+
+**Interfaces:**
+- README links must point to the existing website, `/agencies`, `/build`, `/docs`, and license files.
+
+- [ ] **Step 1: Replace the opening promise**
+
+Lead with agencies selling AI front offices, then explain that SeldonFrame is AGPL-3.0, MCP-native, and open source.
+
+- [ ] **Step 2: Add an agency golden path**
+
+Show the concrete flow: install MCP, paste a client URL, create workspace, customize, run evals, publish, and hand off. Keep the existing technical MCP snippets and live demos as proof.
+
+- [ ] **Step 3: Reorder technical detail**
+
+Move the agent model, Brain, guardrails, money rails, self-hosting, and contribution details after the agency outcome. Preserve accurate shipped/roadmap labels.
+
+- [ ] **Step 4: Normalize commercial language**
+
+Use the current five-plan names/prices and agency 0% GMV claim only where it is already implemented. Remove conflicting “first workspace free forever” or trial language where it would contradict the hosted billing contract.
+
+- [ ] **Step 5: Validate Markdown links and claims**
+
+Run a local link/heading check using the repository’s existing scripts if available, then run `rg` checks for stale license and retired pricing phrases.
+
+- [ ] **Step 6: Commit**
+
+Commit as `docs: position GitHub for agency builders`.
+
+### Task 5: Verify the public-surface slice
+
+**Files:**
+- Modify only files required by verification fixes.
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run `pnpm test:unit -- packages/crm/tests/unit/marketing/public-claims.spec.ts`.
+
+- [ ] **Step 2: Run typecheck and lint**
+
+Run `pnpm typecheck` and `pnpm lint` from the worktree root. Record unrelated baseline failures separately from new failures.
+
+- [ ] **Step 3: Run the CRM production build**
+
+Run `pnpm build:crm` and verify that the public homepage, `/agencies`, `/docs`, `/docs/getting-started/first-workspace`, and `/docs/billing/tiers` compile.
+
+- [ ] **Step 4: Run browser smoke verification**
+
+Run `pnpm e2e:smoke` if the environment supports the existing Playwright setup. Verify visible agency headline, primary CTA target, `/agencies`, `/docs`, and GitHub links.
+
+- [ ] **Step 5: Review the final diff**
+
+Run `git diff --check`, inspect the changed-file list, and ensure no telemetry, billing, auth, generated, or unrelated user changes entered the branch.
+
+- [ ] **Step 6: Commit verification fixes**
+
+Commit only genuine verification fixes as `chore: verify agency public surfaces`.
+

--- a/docs/superpowers/plans/2026-08-11-agency-first-public-experience.md
+++ b/docs/superpowers/plans/2026-08-11-agency-first-public-experience.md
@@ -188,4 +188,3 @@ Run `git diff --check`, inspect the changed-file list, and ensure no telemetry, 
 - [ ] **Step 6: Commit verification fixes**
 
 Commit only genuine verification fixes as `chore: verify agency public surfaces`.
-

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -64,6 +64,7 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
   });
 
   test("GET /agencies exposes the agency delivery path", async ({ page }) => {
+    test.skip(!isMarketingHost(FLOW_BASE_URL), "marketing surface check requires the marketing host");
     const response = await page.goto("/agencies");
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { name: /Deploy one playbook/i })).toBeVisible();
@@ -73,6 +74,7 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
   });
 
   test("GET /docs exposes the agency-first docs hub", async ({ page }) => {
+    test.skip(!isMarketingHost(FLOW_BASE_URL), "marketing surface check requires the marketing host");
     const response = await page.goto("/docs");
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { name: "SeldonFrame Docs" })).toBeVisible();

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -33,28 +33,51 @@ function isProductionHost(rawBaseUrl: string | undefined): boolean {
   }
 }
 
+function isMarketingHost(rawBaseUrl: string | undefined): boolean {
+  if (!rawBaseUrl) return false;
+  try {
+    const host = new URL(rawBaseUrl).hostname.toLowerCase();
+    return host === "seldonframe.com" || host === "www.seldonframe.com";
+  } catch {
+    return false;
+  }
+}
+
 const FLOW_BASE_URL = process.env.E2E_BASE_URL;
 const FLOW_IS_PRODUCTION = isProductionHost(FLOW_BASE_URL);
 
 test.describe("render tier (GET-only, safe everywhere)", () => {
   test("GET / is healthy", async ({ page }) => {
-    // Reality check (verified live 2026-08-06): src/proxy.ts treats
-    // app.seldonframe.com / localhost / 127.0.0.1 / *.vercel.app as the
-    // "app host" and unconditionally redirects `/` there to /login
-    // (anonymous) or /dashboard (authenticated) BEFORE the marketing
-    // landing page ((public)/page.tsx) is ever reached — that page only
-    // renders at `/` on the marketing host (seldonframe.com /
-    // www.seldonframe.com), which E2E_BASE_URL does not target here.
-    // So on every environment this suite actually runs against, `/`
-    // resolving to a healthy /login is the correct sentinel, not
-    // landing-page nav copy.
     const response = await page.goto("/");
     expect(response?.status()).toBe(200);
-    expect(new URL(page.url()).pathname).toBe("/login");
-    await expect(page.getByRole("heading", { name: "Welcome to SeldonFrame" })).toBeVisible();
+    if (isMarketingHost(FLOW_BASE_URL)) {
+      expect(new URL(page.url()).pathname).toBe("/");
+      await expect(page.getByRole("heading", { name: /Sell AI front offices/i })).toBeVisible();
+      await expect(page.getByRole("link", { name: "For agencies", exact: true })).toHaveAttribute("href", "/agencies");
+    } else {
+      expect(new URL(page.url()).pathname).toBe("/login");
+      await expect(page.getByRole("heading", { name: "Welcome to SeldonFrame" })).toBeVisible();
+    }
 
     const body = await page.content();
     expect(body).not.toMatch(BROKEN_PAGE_PATTERN);
+  });
+
+  test("GET /agencies exposes the agency delivery path", async ({ page }) => {
+    const response = await page.goto("/agencies");
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: /Deploy one playbook/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /See agency plans/i })).toHaveAttribute("href", "/pricing-public");
+  });
+
+  test("GET /docs exposes the agency-first docs hub", async ({ page }) => {
+    const response = await page.goto("/docs");
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: "SeldonFrame Docs" })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Agency delivery loop/i })).toHaveAttribute(
+      "href",
+      "/docs/getting-started/first-workspace",
+    );
   });
 
   test("GET /api/auth/providers exposes at least one provider (AUTH_SECRET sentinel)", async ({

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -37,7 +37,11 @@ function isMarketingHost(rawBaseUrl: string | undefined): boolean {
   if (!rawBaseUrl) return false;
   try {
     const host = new URL(rawBaseUrl).hostname.toLowerCase();
-    return host === "seldonframe.com" || host === "www.seldonframe.com";
+    return (
+      host === "seldonframe.com" ||
+      host === "www.seldonframe.com" ||
+      (host.startsWith("crm-git-") && host.endsWith(".vercel.app"))
+    );
   } catch {
     return false;
   }

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -67,7 +67,9 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
     const response = await page.goto("/agencies");
     expect(response?.status()).toBe(200);
     await expect(page.getByRole("heading", { name: /Deploy one playbook/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /See agency plans/i })).toHaveAttribute("href", "/pricing-public");
+    await expect(
+      page.locator('a[href="/pricing-public"]').filter({ hasText: /See agency plans/i }),
+    ).toHaveAttribute("href", "/pricing-public");
   });
 
   test("GET /docs exposes the agency-first docs hub", async ({ page }) => {

--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -47,6 +47,16 @@ function isMarketingHost(rawBaseUrl: string | undefined): boolean {
   }
 }
 
+function isProductionMarketingHost(rawBaseUrl: string | undefined): boolean {
+  if (!rawBaseUrl) return false;
+  try {
+    const host = new URL(rawBaseUrl).hostname.toLowerCase();
+    return host === "seldonframe.com" || host === "www.seldonframe.com";
+  } catch {
+    return false;
+  }
+}
+
 const FLOW_BASE_URL = process.env.E2E_BASE_URL;
 const FLOW_IS_PRODUCTION = isProductionHost(FLOW_BASE_URL);
 
@@ -54,7 +64,7 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
   test("GET / is healthy", async ({ page }) => {
     const response = await page.goto("/");
     expect(response?.status()).toBe(200);
-    if (isMarketingHost(FLOW_BASE_URL)) {
+    if (isProductionMarketingHost(FLOW_BASE_URL)) {
       expect(new URL(page.url()).pathname).toBe("/");
       await expect(page.getByRole("heading", { name: /Sell AI front offices/i })).toBeVisible();
       await expect(page.getByRole("link", { name: "For agencies", exact: true })).toHaveAttribute("href", "/agencies");

--- a/packages/crm/src/app/(marketing)/docs/mcp-servers/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/mcp-servers/page.tsx
@@ -193,7 +193,7 @@ export default function McpServersPage() {
               >
                 Star the repo &rarr;
               </a>
-              <span className="text-[#71717a]"> — open source under MIT</span>
+              <span className="text-[#71717a]"> — open source under AGPL-3.0</span>
             </li>
           </ul>
         </section>

--- a/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
@@ -1,4 +1,4 @@
-// /docs/quickstart — the "Start for $0" CTA destination.
+// /docs/quickstart — the agency-first install and first-client path.
 // Three steps. Step 1 has two install paths (app vs terminal) for users
 // who aren't terminal-comfortable. Steps 2-3 are natural-language prompts
 // that work in either path — no fake CLI commands.
@@ -9,7 +9,7 @@ import { MarketingShell } from "../../marketing-shell";
 export const metadata: Metadata = {
   title: "Quickstart — SeldonFrame",
   description:
-    "Install SeldonFrame in 30 seconds, then describe your business in natural language. Works from the Claude Code desktop app or the terminal.",
+    "Install SeldonFrame once, then build and operate branded client front offices from Claude Code.",
 };
 
 const Section = ({
@@ -75,12 +75,12 @@ export default function QuickstartPage() {
         <header className="mb-10">
           <p className="text-[12px] uppercase tracking-[0.12em] text-[#71717a] font-mono mb-2">Docs · Quickstart</p>
           <h1 className="text-[clamp(30px,4vw,42px)] font-bold tracking-[-0.03em] text-[#fafafa] mb-4 leading-[1.15]">
-            Install once. Describe your business. Ship in minutes.
+            Install once. Ship your first client front office.
           </h1>
           <p className="text-[16px] text-[#a1a1aa] leading-[1.7]">
-            SeldonFrame plugs into Claude Code as an MCP server. After install, you describe
-            your business in natural language and Claude orchestrates the workspace creation,
-            block installs, and customization — same flow whether you&apos;re in the
+            SeldonFrame plugs into Claude Code as an MCP server. After install, you give it a
+            client URL and Claude orchestrates workspace creation, block installs, branding,
+            and customization — same flow whether you&apos;re in the
             Claude Code desktop app or the terminal.
           </p>
         </header>
@@ -104,10 +104,6 @@ export default function QuickstartPage() {
             <li className="flex items-start gap-2">
               <span className="text-[#F6F2EA] text-[12px] font-bold mt-[3px] shrink-0">✓</span>
               <span>Node.js 18 or newer (Node 20 recommended)</span>
-            </li>
-            <li className="flex items-start gap-2">
-              <span className="text-[#F6F2EA] text-[12px] font-bold mt-[3px] shrink-0">✓</span>
-              <span>An Anthropic API key (BYO — SeldonFrame doesn&apos;t margin on tokens)</span>
             </li>
           </ul>
         </section>
@@ -205,21 +201,21 @@ export default function QuickstartPage() {
 
           <Section
             number={2}
-            title="Describe your business"
+            title="Describe your client"
             body="Paste this template into Claude Code (app or terminal — same prompt) and fill in your details:"
             code={`Create a workspace for my business:
-- Business name: [your business name]
+- Business name: [your client business name]
 - Industry: [hvac, dental, legal, coaching, real-estate, salon, ...]
 - Location: [city, state]
 - Operating hours: [Mon-Sat 7am-7pm]
 - Team size: [number]
 - Services offered: [3-5 main ones]
-- Website: [URL, optional]`}
+- Website: [client URL, optional]`}
           />
           <Section
             number={3}
-            title="Watch Claude build it"
-            body="Claude Code chains the right tool calls automatically: creates the workspace, installs an industry-matched vertical pack, configures booking availability, seeds your Soul from your website (if provided), and customizes the intake form. Returns live URLs you can share immediately. Your first workspace builds free — it's $29/mo flat for unlimited workspaces when you're ready to go live, and you can cancel anytime."
+            title="Test, publish, and hand it off"
+            body="Claude Code chains the right tool calls automatically: creates the workspace, installs an industry-matched vertical pack, configures booking availability, seeds the client's Soul from their website, and customizes the intake form. Run the agent evals, complete a test booking, publish the live URLs, and hand the client their branded portal. Build the first client workspace free; agency plans start at $99/mo and carry 0% GMV."
             code={`https://your-business.app.seldonframe.com           ← public home
 https://your-business.app.seldonframe.com/book      ← booking
 https://your-business.app.seldonframe.com/intake    ← intake form
@@ -257,7 +253,7 @@ https://app.seldonframe.com/switch-workspace?...    ← admin dashboard`}
               >
                 Star the repo &rarr;
               </a>
-              <span className="text-[#71717a]"> — open source under MIT</span>
+              <span className="text-[#71717a]"> — open source under AGPL-3.0</span>
             </li>
           </ul>
         </section>

--- a/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
+++ b/packages/crm/src/app/(marketing)/docs/quickstart/page.tsx
@@ -203,14 +203,15 @@ export default function QuickstartPage() {
             number={2}
             title="Describe your client"
             body="Paste this template into Claude Code (app or terminal — same prompt) and fill in your details:"
-            code={`Create a workspace for my business:
+            code={`Create a workspace for my client:
 - Business name: [your client business name]
 - Industry: [hvac, dental, legal, coaching, real-estate, salon, ...]
 - Location: [city, state]
 - Operating hours: [Mon-Sat 7am-7pm]
 - Team size: [number]
 - Services offered: [3-5 main ones]
-- Website: [client URL, optional]`}
+- Website: [client URL, optional]
+- Agency brand: [your agency name, logo, portal style]`}
           />
           <Section
             number={3}

--- a/packages/crm/src/app/(marketing)/marketing-shell.tsx
+++ b/packages/crm/src/app/(marketing)/marketing-shell.tsx
@@ -70,7 +70,7 @@ export function MarketingShell({ children }: { children: ReactNode }) {
           ))}
         </div>
         <div className="text-[11px] text-[#3f3f46]">
-          © 2026 SeldonFrame. Open source under MIT License.
+          © 2026 SeldonFrame. Open source under AGPL-3.0.
         </div>
       </footer>
     </>

--- a/packages/crm/src/app/(marketing)/pricing-public/page.tsx
+++ b/packages/crm/src/app/(marketing)/pricing-public/page.tsx
@@ -1,8 +1,7 @@
 // packages/crm/src/app/(marketing)/pricing-public/page.tsx
 //
-// New marketing pricing page (2026-06-18; flat-model rewrite 2026-06-22).
-// Standalone deep-dive on pricing — light warm theme, the flat $29/mo
-// model + GMV explainer + FAQ. Unauthenticated visitors can reach this
+// Standalone deep-dive on agency pricing — light warm theme, white-label
+// tiers, GMV explainer + FAQ. Unauthenticated visitors can reach this
 // from the nav or "Learn more about pricing" links.
 //
 // Route: /pricing-public
@@ -16,23 +15,16 @@ import { LandingMarketingFaqSection } from "@/components/landing/marketing-faq-s
 import { MarketingFinalCta } from "@/components/landing/marketing-final-cta";
 import { MarketingFooter } from "@/components/landing/marketing-footer";
 
-/** SF_TIER_LADDER (2026-07-08) — same strict-"1" contract as the other
- *  dark-by-default flags. Duplicated locally (also in
- *  app/pricing/page.tsx + app/(public)/page.tsx) rather than added to
- *  lib/web-build/policy.ts, which is outside this task's touched-files
- *  list. */
-function isTierLadderOn(env: { SF_TIER_LADDER?: string | undefined }): boolean {
-  return env.SF_TIER_LADDER?.trim() === "1";
-}
-
 export const metadata: Metadata = {
   title: "Pricing — SeldonFrame",
   description:
-    "$29/mo flat · unlimited workspaces · cancel anytime. No metered bills — plus a flat 2% fee only when SeldonFrame is your sales channel.",
+  "Agency plans from $99/mo with white-label client workspaces, branded portals, and 0% GMV. Builder and Managed plans cover your own operation.",
 };
 
 export default function PricingPublicPage() {
-  const tierLadderOn = isTierLadderOn({ SF_TIER_LADDER: process.env.SF_TIER_LADDER });
+  // Public pricing must show the current sellable agency ladder even when
+  // the legacy homepage flag is absent in a preview environment.
+  const tierLadderOn = true;
   return (
     <div className="min-h-screen bg-[#F6F2EA] text-[#221D17] selection:bg-[#1F2B24]/20 selection:text-[#1F2B24]">
       <MarketingNav />
@@ -46,15 +38,15 @@ export default function PricingPublicPage() {
               <span className="h-px w-4 bg-[#1F2B24] opacity-50" aria-hidden />
             </div>
             <h1 className="mx-auto mt-3.5 max-w-[20ch] text-[clamp(34px,4.8vw,56px)] font-[500] leading-[1.04] tracking-[-0.025em] text-[#221D17]">
-              $29 a month.{" "}
+              Agency plans from $99/mo.{" "}
               <em className="font-[Newsreader,Georgia,serif] font-normal not-italic text-[#6E665A]">
                 We only make money when you do.
               </em>
             </h1>
             <p className="mx-auto mt-4 max-w-[54ch] text-[16px] leading-[1.55] text-[#6E665A]">
-              One flat monthly price — unlimited workspaces, no metered bills, no surprise fees.
-              Build it free, and cancel anytime. We add a flat 2% fee only when SeldonFrame is your
-              sales channel — so we only make money when you do.
+              Deploy branded client workspaces from one repeatable delivery loop. Agency plans
+              include white-label, branded client portals, and 0% GMV. Build the first client
+              workspace before checkout and cancel anytime.
             </p>
           </div>
         </section>

--- a/packages/crm/src/app/(public)/agencies/page.tsx
+++ b/packages/crm/src/app/(public)/agencies/page.tsx
@@ -1,6 +1,6 @@
 // packages/crm/src/app/(public)/agencies/page.tsx
 //
-// Standalone builders/agencies page (2026-07-06 Shopify-homepage redesign).
+// Standalone agency page (agency-first public experience).
 // The builder/agency reseller pitch (MarketingAgencyMath — margin calculator
 // + "Build an agent once, sell it to thousands" section) was previously
 // embedded on the homepage; it's moved here to keep the homepage to one
@@ -16,13 +16,13 @@ import { MarketingAgencyOwnership } from "@/components/landing/marketing-agency-
 import { MarketingFooter } from "@/components/landing/marketing-footer";
 
 export const metadata: Metadata = {
-  title: "For builders & agencies — SeldonFrame",
+  title: "For agencies — SeldonFrame",
   // Pricing-truth fix 2026-07-15: white-label client sub-accounts are the
   // agency tiers ($99/$199/$299), not the $29 Builder tier — the old
   // "unlimited client workspaces under your own brand for $29" claim
   // described the retired grandfathered agency tier.
   description:
-    "Build an AI agent once, list it on the marketplace, or run client front offices. Build from $29/mo; white-label client workspaces + branded portals on agency plans from $99/mo with 0% GMV.",
+    "Sell AI front offices to local businesses with SeldonFrame. Deploy branded client workspaces, booking, CRM, intake, and agents from $99/mo with 0% GMV on agency plans.",
 };
 
 export default function AgenciesPage() {

--- a/packages/crm/src/app/(public)/agencies/page.tsx
+++ b/packages/crm/src/app/(public)/agencies/page.tsx
@@ -33,6 +33,15 @@ export default function AgenciesPage() {
         <MarketingAgencyMath />
         <MarketingAgencyOwnership />
 
+        <section aria-label="Agency plans" className="border-t border-[rgba(34,29,23,.08)] bg-[#F6F2EA] px-5 py-12 text-center md:px-8 lg:px-12">
+          <Link
+            href="/pricing-public"
+            className="inline-flex items-center gap-2 rounded-[11px] bg-[#1F2B24] px-6 py-3.5 text-[15px] font-[600] text-[#F6F2EA] transition-transform hover:-translate-y-px"
+          >
+            See agency plans →
+          </Link>
+        </section>
+
         {/* Guides for agency builders — cross-links into the supply-side content library. */}
         <section aria-label="Guides for agency builders" className="border-t border-[rgba(34,29,23,.08)] px-5 py-16 md:px-8 lg:px-12">
           <div className="mx-auto max-w-[1120px]">

--- a/packages/crm/src/app/(public)/home-copy.ts
+++ b/packages/crm/src/app/(public)/home-copy.ts
@@ -7,7 +7,8 @@
 // the line WITHOUT pulling the server page component (and its auth() call) into
 // its module graph.
 
+import { AGENCY_POSITIONING, AGENCY_HERO_SUBHEAD } from "@/lib/marketing/public-claims";
+
 /** The one-line product positioning used in the homepage metadata/description
  *  and quoted verbatim at the top of /home.md. */
-export const POSITIONING_ONE_LINER =
-  "SeldonFrame — the platform agencies use to sell AI front offices: website, booking, CRM, payments, and AI agents that do the work, built from a client's URL in 3 minutes. Build it free, then $29/mo, cancel anytime.";
+export const POSITIONING_ONE_LINER = `${AGENCY_POSITIONING} ${AGENCY_HERO_SUBHEAD}`;

--- a/packages/crm/src/app/(public)/page.tsx
+++ b/packages/crm/src/app/(public)/page.tsx
@@ -46,12 +46,10 @@ import { auth } from "@/auth";
 import { isWebUngatedBuildOn } from "@/lib/web-build/policy";
 import { isRecordToAgentOn } from "@/lib/recordings/policy";
 
-/** SF_TIER_LADDER (2026-07-08) — same strict-"1" contract as the other
- *  dark-by-default flags. Duplicated locally (also in
- *  app/pricing/page.tsx) rather than added to lib/web-build/policy.ts,
- *  which is outside this task's touched-files list. */
+/** Public marketing uses the current agency ladder by default. Set the
+ *  flag explicitly to "0" only for a controlled legacy rollback. */
 function isTierLadderOn(env: { SF_TIER_LADDER?: string | undefined }): boolean {
-  return env.SF_TIER_LADDER?.trim() === "1";
+  return env.SF_TIER_LADDER?.trim() !== "0";
 }
 
 import { UnifiedLanding } from "./unified-landing";
@@ -61,10 +59,10 @@ import { resolveLandingMode } from "./landing-mode";
 import { POSITIONING_ONE_LINER } from "./home-copy";
 
 export const metadata: Metadata = {
-  title: "SeldonFrame — Your entire service business, live in 3 minutes.",
+  title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
   description: POSITIONING_ONE_LINER,
   openGraph: {
-    title: "SeldonFrame — Your entire service business, live in 3 minutes.",
+    title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
     description: POSITIONING_ONE_LINER,
     type: "website",
     url: "https://seldonframe.com",
@@ -72,7 +70,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "SeldonFrame — Your entire service business, live in 3 minutes.",
+    title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
     description: POSITIONING_ONE_LINER,
     images: ["/brand/twitter-card.png"],
   },

--- a/packages/crm/src/app/(public)/record/page.tsx
+++ b/packages/crm/src/app/(public)/record/page.tsx
@@ -29,12 +29,10 @@ import { isDraftApprovalsOn } from "@/lib/agent-drafts/policy";
 import { redirectToAppHostIfNeeded } from "@/lib/auth/app-host-redirect";
 import { UnifiedLanding } from "../unified-landing";
 
-/** SF_TIER_LADDER (2026-07-08) — same strict-"1" contract as the other
- *  dark-by-default flags. Duplicated locally (also in app/(public)/page.tsx
- *  and app/pricing/page.tsx) rather than added to lib/web-build/policy.ts,
- *  which is outside this task's touched-files list. */
+/** Public marketing uses the current agency ladder by default. Set the
+ *  flag explicitly to "0" only for a controlled legacy rollback. */
 function isTierLadderOn(env: { SF_TIER_LADDER?: string | undefined }): boolean {
-  return env.SF_TIER_LADDER?.trim() === "1";
+  return env.SF_TIER_LADDER?.trim() !== "0";
 }
 
 export const metadata: Metadata = {

--- a/packages/crm/src/app/(public)/unified-landing.tsx
+++ b/packages/crm/src/app/(public)/unified-landing.tsx
@@ -13,6 +13,7 @@ import { MarketingNav } from "@/components/landing/marketing-nav";
 import { MarketingHero } from "@/components/landing/marketing-hero";
 import { MarketingProofStrip } from "@/components/landing/marketing-proof-strip";
 import { MarketingBuildSteps } from "@/components/landing/marketing-build-steps";
+import { MarketingAgencyOwnership } from "@/components/landing/marketing-agency-ownership";
 import { MarketingIdeStrip } from "@/components/landing/marketing-ide-strip";
 import { MarketingAgentOrbit } from "@/components/landing/marketing-agent-orbit";
 import { MarketingModules, MarketingAgents } from "@/components/landing/marketing-modules";
@@ -73,6 +74,7 @@ export function UnifiedLanding({
               office") → the agent catalog, kept adjacent so the two-ways idea
               pays off immediately. */}
           <MarketingBuildSteps />
+          <MarketingAgencyOwnership />
           <MarketingModules />
           <MarketingAgents />
           {/* "Get paid" (2% GMV) section REMOVED 2026-07-16 (Max's call) —

--- a/packages/crm/src/app/docs/billing/pricing/page.tsx
+++ b/packages/crm/src/app/docs/billing/pricing/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
       category="Billing & plans"
       categoryHref="/docs"
       title="Pricing"
-      lede="Five flat plans, no metered usage wallet — BYOK on Builder/Agency keeps AI cost at provider price, Managed runs on SeldonFrame's keys (fair use). You always know what the bill is."
+      lede="Five flat plans for operators and agencies. Managed runs on SeldonFrame's keys; Builder and Agency plans are BYOK. You always know what the platform bill is."
       githubPath="app/docs/billing/pricing/page.tsx"
     >
       <h2>The plans</h2>
@@ -65,9 +65,9 @@ export default function Page() {
       <h2>No contract</h2>
       <p>
         Plans are month-to-month — upgrade, downgrade, or cancel anytime.
-        Your front office is live in 60 seconds from a URL, and you only
-        move up a plan when you want more (client sub-accounts, white-label,
-        higher sub-account limits).
+        Your first client workspace can be built free. Move up when you need
+        client sub-accounts, white-labeling, higher sub-account limits, or
+        Managed AI.
       </p>
 
       <h2>Next</h2>

--- a/packages/crm/src/app/docs/billing/tiers/page.tsx
+++ b/packages/crm/src/app/docs/billing/tiers/page.tsx
@@ -8,21 +8,21 @@ export default function Page() {
       category="Billing & plans"
       categoryHref="/docs"
       title="Plan tiers"
-      lede="What's included at each plan and what triggers a move up. Detailed feature breakdown. Every hosted plan includes managed AI — no key, no usage wallet."
+      lede="What's included at each plan and what triggers a move up. Choose Builder or Managed for your own operation; choose Agency when you deploy client workspaces."
       githubPath="app/docs/billing/tiers/page.tsx"
     >
-      <h2>Builder ($19/mo)</h2>
+      <h2>Builder ($29/mo)</h2>
       <ul>
         <li>Up to 10 landing pages</li>
         <li>Your own custom domain</li>
         <li>Your branding (logo, colors, fonts)</li>
         <li>Edit your whole site by chatting — no code</li>
-        <li>Managed AI included (no key to paste)</li>
-        <li>No CRM, booking, or AI agents (move to Workspace for those)</li>
+        <li>Bring your own AI key at provider cost</li>
+        <li>Full CRM, booking, intake, and AI agents for businesses you operate</li>
         <li>Community support (Discord)</li>
       </ul>
 
-      <h2>Workspace ($49/mo)</h2>
+      <h2>Managed ($49/mo)</h2>
       <ul>
         <li>One full AI front office: website + booking + intake + CRM + chatbot</li>
         <li>Custom domain + your branding</li>
@@ -30,27 +30,32 @@ export default function Page() {
         <li>Booking page + intake forms, wired to the CRM</li>
         <li>Website chatbot that books against the real calendar</li>
         <li>Missed-call text-back so you never lose a lead</li>
-        <li>Managed AI included (no key, no usage wallet)</li>
+        <li>Managed AI on SeldonFrame's keys under fair use</li>
         <li>Email support (24h response)</li>
       </ul>
 
-      <h2>Agency ($297/mo)</h2>
+      <h2>Agency Starter ($99/mo)</h2>
       <ul>
-        <li>10 client workspaces included, +$10/mo each beyond</li>
+        <li>10 client workspaces included</li>
         <li>White-label brand (your name + logo across the dashboard your clients see)</li>
         <li>Per-workspace custom domains</li>
-        <li>Optional AI voice receptionist at +$99/mo per agent</li>
-        <li>Bulk operations across client workspaces</li>
-        <li>Managed AI included on every client workspace</li>
-        <li>Priority support (4h response)</li>
+        <li>0% GMV on agency resale</li>
+        <li>BYOK AI at provider cost</li>
+      </ul>
+
+      <h2>Agency Growth ($199/mo) and Agency Scale ($299/mo)</h2>
+      <ul>
+        <li>Growth includes 30 client sub-accounts and one-click deploy operations.</li>
+        <li>Scale includes unlimited client sub-accounts, API + MCP access, and marketplace rent-out.</li>
+        <li>Both plans include full white-label, branded client portals, and 0% GMV.</li>
       </ul>
 
       <h2>What triggers a move up</h2>
       <ul>
-        <li>Needing a CRM, booking, and a chatbot — not just landing pages (Builder → Workspace).</li>
-        <li>Wanting to white-label and resell to clients (→ Agency).</li>
-        <li>Going past 10 client workspaces (+$10/mo each on Agency).</li>
-        <li>Adding an AI voice receptionist that answers the phone (+$99/mo per agent).</li>
+        <li>Wanting SeldonFrame-managed AI instead of your own provider key (Builder → Managed).</li>
+        <li>Wanting to white-label and resell to clients (→ Agency Starter).</li>
+        <li>Going past 10 client workspaces (Agency Starter → Agency Growth).</li>
+        <li>Going past 30 client workspaces or needing API/MCP and marketplace access (Agency Growth → Agency Scale).</li>
       </ul>
 
       <h2>Switching tiers</h2>

--- a/packages/crm/src/app/docs/getting-started/connect-claude-code/page.tsx
+++ b/packages/crm/src/app/docs/getting-started/connect-claude-code/page.tsx
@@ -4,7 +4,7 @@ import { ArticleShell, Callout, CodeBlock, InAppLink, Step } from "../../article
 
 export const metadata = {
   title: "Connect Claude Code · Docs",
-  description: "Plug Claude Code into your SeldonFrame workspace via MCP. One token, two minutes, and you're driving your CRM and agents from the terminal.",
+  description: "Plug Claude Code into SeldonFrame via MCP and operate branded client workspaces from the terminal.",
 };
 
 export default function Page() {
@@ -13,7 +13,7 @@ export default function Page() {
       category="Getting started"
       categoryHref="/docs"
       title="Connect Claude Code"
-      lede="SeldonFrame ships with an MCP server. Paste your token into Claude Code and it can read your CRM, build pages, ship agents — all from natural language."
+      lede="SeldonFrame ships with an MCP server. Paste your token into Claude Code and build, test, publish, and operate client workspaces from natural language."
       githubPath="app/docs/getting-started/connect-claude-code/page.tsx"
     >
       <h2>What you'll get</h2>
@@ -21,10 +21,10 @@ export default function Page() {
         Once Claude Code is connected, you can say things like:
       </p>
       <ul>
-        <li><em>"Build me a website chatbot for my HVAC business that can book appointments."</em></li>
-        <li><em>"Add John Smith (john@acme.com) to my CRM with stage 'qualified.'"</em></li>
-        <li><em>"Run evals on my customer-support agent and publish if ≥90% pass."</em></li>
-        <li><em>"Show me my agent's last 10 conversations and flag any that asked for a refund."</em></li>
+        <li><em>"Build a branded website and booking flow for my HVAC client."</em></li>
+        <li><em>"Add John Smith (john@acme.com) to the client's CRM with stage 'qualified.'"</em></li>
+        <li><em>"Run evals on this client agent and publish if ≥90% pass."</em></li>
+        <li><em>"Show me the client's last 10 conversations and flag refund requests."</em></li>
       </ul>
 
       <Step n={1} title="Get your MCP token">

--- a/packages/crm/src/app/docs/getting-started/first-workspace/page.tsx
+++ b/packages/crm/src/app/docs/getting-started/first-workspace/page.tsx
@@ -4,7 +4,7 @@ import { ArticleShell, Callout, InAppLink, Step } from "../../article-shell";
 
 export const metadata = {
   title: "Build your first workspace · Docs",
-  description: "Create a SeldonFrame workspace in 60 seconds. Pick a template, set your brand, and you're live.",
+  description: "Create a branded SeldonFrame client workspace, run the agent evals, and hand it off from one repeatable workflow.",
 };
 
 export default function Page() {
@@ -12,51 +12,52 @@ export default function Page() {
     <ArticleShell
       category="Getting started"
       categoryHref="/docs"
-      title="Build your first workspace"
-      lede="60 seconds. Pick a template, set your name and color, and your dashboard, public site, and agent are wired up and ready."
+      title="Build your first client workspace"
+      lede="Start with a client URL, apply their brand and service facts, run the agent evals, publish, and hand off the workspace."
       githubPath="app/docs/getting-started/first-workspace/page.tsx"
     >
       <h2>Step-by-step</h2>
 
-      <Step n={1} title="Sign up">
+      <Step n={1} title="Sign up as the agency operator">
         Go to <InAppLink href="/signup">/signup</InAppLink> and create your
-        account with email or Google. You land on the dashboard with one
-        starter workspace already created.
+        account with email or Google. You land on the dashboard with your
+        agency workspace ready to create the first client workspace.
       </Step>
 
-      <Step n={2} title="Pick a template">
-        Open <InAppLink href="/templates">Templates</InAppLink>. Each
-        template is a starter Soul (HVAC, dentist, coach, agency, e-commerce,
-        consultant) — it pre-fills your CRM fields, pipeline stages,
-        booking types, and a starter chatbot tuned for that vertical. You
-        can swap or customize anything later.
+      <Step n={2} title="Start from the client's URL">
+        Open <InAppLink href="/templates">Templates</InAppLink> or connect
+        Claude Code. Give SeldonFrame the client's URL, industry, services,
+        hours, and brand direction. The starter Soul pre-fills CRM fields,
+        pipeline stages, booking types, and the first agent.
       </Step>
 
-      <Step n={3} title="Name it & set your brand">
+      <Step n={3} title="Brand the client workspace">
         Open <InAppLink href="/settings/branding">Branding</InAppLink>.
-        Give your business a name, upload a logo, and pick a primary
-        color. The dashboard, your public site, and your chatbot all
-        re-skin from this in real time.
+        Give the client workspace a name, upload their logo, and pick a
+        primary color. The public site, booking flow, portal, and agent
+        inherit the same brand.
       </Step>
 
-      <Step n={4} title="Add your first contact">
-        Open <InAppLink href="/contacts">Customers</InAppLink> and click
-        "Add customer." Or import a CSV. Or — most fun — open Claude Code
-        and say <em>"add Jane Doe (jane@example.com, 555-0100) to my CRM"</em>.
+      <Step n={4} title="Run evals and test a booking">
+        Open the agent test surface, run the safety evals, and complete one
+        non-template booking. This is the agency's proof that the client
+        front office is ready before publishing.
       </Step>
 
-      <Step n={5} title="Go live">
-        Your public site is already live at{" "}
+      <Step n={5} title="Publish and hand off">
+        The public site is available at{" "}
         <code>your-workspace.app.seldonframe.com</code>. Want a custom
-        domain like <code>www.yourbiz.com</code>? See{" "}
+        domain like <code>www.clientbiz.com</code>? See{" "}
         <InAppLink href="/docs/your-business/custom-domains">Custom domains</InAppLink>.
+        Keep the agency master view and invite the client to their branded
+        portal.
       </Step>
 
       <Callout variant="tip" title="Skip the click-through">
-        Step 2 onward is faster through Claude Code — see{" "}
+          Step 2 onward is faster through Claude Code — see{" "}
         <a href="/docs/getting-started/connect-claude-code">Connect Claude Code</a>.
-        It can pick a template, brand, add contacts, and even build a
-        chatbot in one back-and-forth.
+          It can create the client workspace, brand it, build the agent, and
+          prepare the handoff in one back-and-forth.
       </Callout>
 
       <h2>What's wired up automatically</h2>

--- a/packages/crm/src/app/docs/getting-started/what-is-seldonframe/page.tsx
+++ b/packages/crm/src/app/docs/getting-started/what-is-seldonframe/page.tsx
@@ -4,7 +4,7 @@ import { ArticleShell, Callout, InAppLink } from "../../article-shell";
 
 export const metadata = {
   title: "What is SeldonFrame · Docs",
-  description: "SeldonFrame is an AI-native Business OS — a CRM, website, agents, and automations all in one workspace, built and updated through natural language.",
+  description: "SeldonFrame is the agent-native, open-source front-office platform agencies use to deploy branded client workspaces.",
 };
 
 export default function Page() {
@@ -13,25 +13,23 @@ export default function Page() {
       category="Getting started"
       categoryHref="/docs"
       title="What is SeldonFrame"
-      lede="Your AI front office — website, booking, AI receptionist, intake, CRM, and chatbot, wired together and live in 60 seconds from a URL. Edit your whole site by chatting; missed-call text-back so you never lose a lead."
+      lede="The agent-native, open-source alternative to GoHighLevel for agencies: deploy a branded website, booking flow, CRM, intake, and agent for every client from one workspace."
       githubPath="app/docs/getting-started/what-is-seldonframe/page.tsx"
     >
       <h2>The short version</h2>
       <p>
-        Most local-service businesses end up paying for five tools — a
-        CRM, a website builder, an email tool, a chatbot, and a scheduler
-        — that don't talk to each other. SeldonFrame gives you all of
-        that as one AI front office. Your website, booking page, AI
-        receptionist, intake form, CRM, and reminders share the same
-        database, the same brand, and the same admin — live in 60 seconds
-        from a URL, with no code.
+        Agencies usually stitch together a CRM, website builder, scheduler,
+        forms, messaging, and an AI layer for every client. SeldonFrame
+        turns that delivery work into one repeatable client workspace:
+        branded website, booking page, AI receptionist, intake form, CRM,
+        reminders, and client portal sharing the same data and operating
+        surface.
       </p>
 
-      <Callout variant="tip" title="Never lose a lead">
-        When a call comes in that you can't pick up, missed-call
-        text-back fires automatically — the caller gets a friendly text
-        so the lead doesn't go cold. And you edit the whole site just by
-        chatting; you don't have to be technical.
+      <Callout variant="tip" title="Deliver, then operate">
+        Start from the client's URL, apply their brand and service facts,
+        run the agent evals, and publish a live workspace. Your agency keeps
+        the master view while the client gets a branded portal.
       </Callout>
 
       <h2>What you get on day one</h2>
@@ -41,7 +39,7 @@ export default function Page() {
         </li>
         <li>
           <strong>A public website</strong> at <code>your-name.app.seldonframe.com</code>{" "}
-          (or your own custom domain) with landing pages, intake forms, and
+          (or the client's custom domain) with landing pages, intake forms, and
           booking pages.
         </li>
         <li>
@@ -57,9 +55,9 @@ export default function Page() {
 
       <h2>What makes it AI-native</h2>
       <p>
-        Two things. First, the same workspace any operator clicks through
-        is also exposed as an MCP server — so Claude Code (or any
-        MCP-aware agent) can read and write your CRM, build pages, and
+        Two things. First, the same workspace any agency operates in the
+        dashboard is also exposed as an MCP server — so Claude Code (or any
+        MCP-aware agent) can read and write the client CRM, build pages, and
         ship agents through natural language. You can say{" "}
         <em>"build me a chatbot for my HVAC business"</em> in Claude Code
         and watch it happen.
@@ -80,10 +78,10 @@ export default function Page() {
 
       <h2>Who it's for</h2>
       <p>
-        Two audiences. Solo operators (HVAC owner, dentist, coach, agency
-        of one) who want a single tool that runs their entire customer
-        operation. And agencies — the "Acme AI" of the world — who white-label
-        the platform, host their clients on it, and bill them.
+        Agencies and independent operators who sell AI front offices to
+        service businesses. Solo operators can run their own workspace too;
+        agencies get the white-label client workspaces, branded portals, and
+        repeatable delivery workflow.
       </p>
 
       <h2>Next steps</h2>

--- a/packages/crm/src/app/docs/page.tsx
+++ b/packages/crm/src/app/docs/page.tsx
@@ -10,10 +10,9 @@
 // Card hover lifts subtly (border tint shift + scale-up icon). Generous
 // padding. No badges, no marketing fluff — just clean information.
 //
-// All links use anchor IDs (#chatbot, #workspaces, etc.) since
-// individual article pages aren't built yet. As articles get written,
-// the anchors get replaced with real /docs/<slug> routes — same nav
-// structure, just deeper.
+// The homepage is an agency-oriented map of the existing article routes.
+// Keep the first click concrete: an agency should be able to move from
+// promise → first workspace → client handoff without guessing.
 
 import Link from "next/link";
 import {
@@ -42,11 +41,10 @@ export default function DocsHome() {
           SeldonFrame Docs
         </h1>
         <p className="text-lg text-muted-foreground max-w-2xl">
-          Everything you need to stand up an AI front office — website,
-          booking, AI receptionist, intake, CRM, and chatbot, wired
-          together and live in 60 seconds from a URL. Edit your whole
-          site by chatting; missed-call text-back so you never lose a
-          lead.
+          Everything an agency needs to sell and operate AI front offices:
+          branded website, booking, intake, CRM, client portal, and agents
+          in repeatable workspaces. Start from a client URL, run the evals,
+          publish, and hand it off without rebuilding the stack every time.
         </p>
       </header>
 
@@ -56,27 +54,27 @@ export default function DocsHome() {
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           <BigCard
             icon={<Sparkles className="size-5" />}
-            title="3-minute demo"
-            description="Type a prompt in Claude Code, watch a full business OS provision live"
-            href="/docs#demo"
+            title="Agency delivery loop"
+            description="Take a client URL from workspace build to tested, branded handoff"
+            href="/docs/getting-started/first-workspace"
           />
           <BigCard
             icon={<Bot className="size-5" />}
             title="Build a chatbot"
-            description="One MCP call creates a website chatbot with FAQ + booking + safety evals"
-            href="/docs#chatbot"
+            description="One MCP call creates a website chatbot with FAQ, booking, and evals"
+            href="/docs/agents/build-chatbot"
           />
           <BigCard
             icon={<Building2 className="size-5" />}
             title="Your first workspace"
-            description="Live website + CRM + booking on a real subdomain in under 60 seconds"
-            href="/docs#first-workspace"
+            description="Create a client workspace with website, CRM, booking, and a public URL"
+            href="/docs/getting-started/first-workspace"
           />
           <BigCard
             icon={<Code2 className="size-5" />}
             title="Claude Code MCP"
-            description="Connect SeldonFrame to Claude Code and build with natural language"
-            href="/docs#claude-code"
+            description="Connect the MCP and operate client workspaces in natural language"
+            href="/docs/getting-started/connect-claude-code"
           />
         </div>
       </section>
@@ -93,20 +91,20 @@ export default function DocsHome() {
           />
           <Step
             num={2}
-            title="Build your workspace"
-            body="Tell Claude Code about your business — name, industry, services, hours. Seldon generates a public website, booking page, intake form, CRM pipeline, and AI agents tuned to your industry."
-            code='"Build me a workspace for Cypress Pine HVAC in Phoenix — services: AC repair, install, maintenance. Mon-Sat 7a-7p."'
+            title="Build a client workspace"
+            body="Give Claude Code the client's URL, industry, services, and hours. Seldon generates the public website, booking page, intake form, CRM pipeline, and agent foundation."
+            code='"Build a workspace for Cypress Pine HVAC in Phoenix — services: AC repair, install, maintenance. Mon-Sat 7a-7p."'
           />
           <Step
             num={3}
             title="Add a chatbot"
-            body="One MCP call wires a chatbot into your website. Pass FAQ + pricing + greeting; Seldon runs the safety evals, generates the embed snippet, gives you a sandbox URL."
+            body="One MCP call wires a chatbot into the client website. Pass FAQ, pricing facts, and greeting; Seldon runs the safety evals and gives you a publishable embed."
             code="build_website_chatbot({ workspace_id, name, faq, pricing_facts, greeting })"
           />
           <Step
             num={4}
             title="Customize from the dashboard"
-            body="Open the dashboard at app.seldonframe.com — every concept (customers, deals, bookings, agents, pages, email, automations) is editable inline. Or keep iterating from Claude Code with update_website_chatbot, update_agent_blueprint, etc."
+            body="Open the dashboard at app.seldonframe.com, apply the client's brand, review the evals, and publish the workspace. Hand the client their branded portal while you keep the agency view."
             isLast
           />
         </div>
@@ -161,10 +159,10 @@ export default function DocsHome() {
           icon={<Bot className="size-5" />}
           title="AI Agents"
           items={[
-            { title: "Build a chatbot", description: "configure_llm + create_agent + publish in one call", href: "/docs#chatbot" },
-            { title: "Eval gate", description: "8 platform-owned safety probes; ≥87.5% to go live", href: "/docs#evals" },
-            { title: "Update an agent", description: "Edit FAQ / pricing / greeting / capabilities inline", href: "/docs#update-agent" },
-            { title: "Embed on your site", description: "Single <script> tag, mobile-first, brand-inheriting", href: "/docs#embed" },
+            { title: "Build a chatbot", description: "configure_llm + create_agent + publish in one call", href: "/docs/agents/build-chatbot" },
+            { title: "Eval gate", description: "Run safety probes before the client-facing agent goes live", href: "/docs/agents/eval-gate" },
+            { title: "Update an agent", description: "Edit FAQ / pricing / greeting / capabilities inline", href: "/docs/agents/update-agent" },
+            { title: "Embed on your site", description: "Single <script> tag, mobile-first, brand-inheriting", href: "/docs/agents/embed" },
           ]}
         />
 
@@ -172,10 +170,10 @@ export default function DocsHome() {
           icon={<Layout className="size-5" />}
           title="Pages & website"
           items={[
-            { title: "Public pages", description: "Hero, services, FAQ, CTA — composed from your Soul", href: "/docs#pages" },
-            { title: "Forms", description: "Lead capture; submissions become customers automatically", href: "/docs#forms" },
-            { title: "Booking pages", description: "Slot picker tied to your availability + appointment types", href: "/docs#booking-pages" },
-            { title: "Custom domains", description: "Use yourdomain.com instead of the Seldon subdomain", href: "/docs#domains" },
+            { title: "Public pages", description: "Hero, services, FAQ, CTA — composed from the client's Soul", href: "/docs/pages/public-pages" },
+            { title: "Forms", description: "Lead capture; submissions become customers automatically", href: "/docs/pages/forms" },
+            { title: "Booking pages", description: "Slot picker tied to availability + appointment types", href: "/docs/pages/booking" },
+            { title: "Custom domains", description: "Use the client's domain instead of a Seldon subdomain", href: "/docs/your-business/custom-domains" },
           ]}
         />
 
@@ -216,7 +214,7 @@ export default function DocsHome() {
           icon={<CreditCard className="size-5" />}
           title="Billing"
           items={[
-            { title: "Pricing", description: "Builder ($19/mo), Workspace ($49/mo), Agency ($297/mo)", href: "/docs/billing/pricing" },
+            { title: "Pricing", description: "Builder $29, Managed $49, Agency $99/$199/$299", href: "/docs/billing/pricing" },
             { title: "Managed AI included", description: "AI is bundled on every plan — no key to paste, no usage wallet", href: "/docs/billing/pricing" },
             { title: "Invoices", description: "Stripe customer portal for receipts + payment methods", href: "/docs/billing/invoices" },
           ]}

--- a/packages/crm/src/app/layout.tsx
+++ b/packages/crm/src/app/layout.tsx
@@ -46,9 +46,9 @@ const newsreader = Newsreader({
 // removed in this commit) but no longer referenced from layout meta.
 export const metadata: Metadata = {
   metadataBase: new URL("https://www.seldonframe.com"),
-  title: "SeldonFrame — Open-source alternative to GoHighLevel",
+  title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
   description:
-    "A complete AI front office — website, booking, CRM, intake, and AI chatbot — wired together in minutes. For your business or your clients'. Plans from $29/mo. AGPL-3.0, no Zapier required.",
+    "The agent-native, open-source alternative to GoHighLevel for agencies selling AI front offices to local businesses. Deploy branded client workspaces, booking, CRM, intake, and agents from one repeatable delivery loop.",
   manifest: "/brand/manifest.webmanifest",
   icons: {
     icon: [
@@ -60,16 +60,16 @@ export const metadata: Metadata = {
     apple: [{ url: "/brand/favicon-180.png", sizes: "180x180" }],
   },
   openGraph: {
-    title: "SeldonFrame — Open-source alternative to GoHighLevel",
+    title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
     description:
-      "Pre-wired client ops stack agencies deploy per client in minutes. CRM, booking, intake, AI chatbot — already connected.",
+      "The agent-native, open-source alternative to GoHighLevel for agencies selling AI front offices to local businesses.",
     images: [{ url: "/brand/og-image.png", width: 1200, height: 630 }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "SeldonFrame — Open-source alternative to GoHighLevel",
+    title: "SeldonFrame — Sell AI front offices. Deploy them in minutes.",
     description:
-      "Pre-wired client ops stack agencies deploy per client in minutes. CRM, booking, intake, AI chatbot — already connected.",
+      "Deploy branded client workspaces, booking, CRM, intake, and agents from one repeatable agency delivery loop.",
     images: ["/brand/twitter-card.png"],
   },
 };

--- a/packages/crm/src/components/landing/footer.tsx
+++ b/packages/crm/src/components/landing/footer.tsx
@@ -13,7 +13,7 @@
 // leans on (open-source section above, FAQ §6 isolation answer, the
 // pricing page's "BYOK on all tiers" rail).
 //
-// GitHub repo: seldonframe/crm (matches nav.tsx and the rest of Cut C).
+// GitHub repo: seldonframe/seldonframe.
 
 import Link from "next/link";
 import { GitFork, ExternalLink } from "lucide-react";
@@ -32,17 +32,17 @@ const PRODUCT_LINKS: readonly FooterLink[] = [
 const RESOURCE_LINKS: readonly FooterLink[] = [
   {
     label: "Claude Code MCP",
-    href: "https://github.com/seldonframe/crm#claude-code-mcp",
+    href: "https://github.com/seldonframe/seldonframe#claude-code-mcp",
     external: true,
   },
   {
     label: "GitHub Issues",
-    href: "https://github.com/seldonframe/crm/issues",
+    href: "https://github.com/seldonframe/seldonframe/issues",
     external: true,
   },
   {
     label: "Changelog",
-    href: "https://github.com/seldonframe/crm/releases",
+    href: "https://github.com/seldonframe/seldonframe/releases",
     external: true,
   },
 ];
@@ -90,7 +90,7 @@ export function LandingFooter() {
             </p>
           </div>
           <Link
-            href="https://github.com/seldonframe/crm"
+            href="https://github.com/seldonframe/seldonframe"
             target="_blank"
             rel="noopener noreferrer"
             // a11y: zinc-950 on teal #1F2B24 = 7.2:1 (white-on-teal
@@ -111,7 +111,7 @@ export function LandingFooter() {
               <br />
               Open source under{" "}
               <Link
-                href="https://github.com/seldonframe/crm/blob/main/LICENSE"
+                href="https://github.com/seldonframe/seldonframe/blob/main/LICENSE"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="underline decoration-zinc-700 underline-offset-2 transition-colors hover:text-zinc-300 hover:decoration-zinc-500"

--- a/packages/crm/src/components/landing/github-stars-badge.tsx
+++ b/packages/crm/src/components/landing/github-stars-badge.tsx
@@ -10,9 +10,7 @@
 // parse fail). The badge renders gracefully without a count — the
 // link itself is the value, the count is a nice-to-have proof.
 //
-// Repo path: seldonframe/crm (verified May 2026 against nav.tsx and
-// LICENSE — the public mirror's name is `crm`, not the older
-// `seldonframe/seldonframe` placeholder some early docs used).
+// Repo path: seldonframe/seldonframe.
 
 import Link from "next/link";
 import { Star, GitFork } from "lucide-react";
@@ -25,7 +23,7 @@ function formatStars(stars: number): string {
     const k = stars / 1000;
     // 1.0k–99.9k → one decimal ("1.2k", "12.4k"); 100k+ → integer
     // ("134k") to keep the badge from getting wider than the
-    // "seldonframe/crm" slug it sits next to.
+    // "seldonframe/seldonframe" slug it sits next to.
     return k >= 100 ? `${Math.round(k)}k` : `${k.toFixed(1)}k`;
   }
   return String(stars);
@@ -34,13 +32,13 @@ function formatStars(stars: number): string {
 export function GitHubStarsBadge({ stars }: { stars: number | null }) {
   return (
     <Link
-      href="https://github.com/seldonframe/crm"
+      href="https://github.com/seldonframe/seldonframe"
       target="_blank"
       rel="noopener noreferrer"
       aria-label={
         stars !== null
-          ? `Star seldonframe/crm on GitHub — ${stars} stars`
-          : "View seldonframe/crm on GitHub"
+          ? `Star seldonframe/seldonframe on GitHub — ${stars} stars`
+          : "View seldonframe/seldonframe on GitHub"
       }
       // design-critique May 2026: demoted from CTA-styled button to
       // chip — transparent surface, thin border. Reads as proof of
@@ -49,7 +47,7 @@ export function GitHubStarsBadge({ stars }: { stars: number | null }) {
       className="inline-flex items-center gap-2 rounded-[11px] border border-zinc-700/60 bg-transparent px-4 py-2.5 text-sm font-medium text-zinc-300 transition-colors hover:border-zinc-500 hover:text-zinc-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1F2B24]"
     >
       <GitFork size={16} aria-hidden="true" />
-      <span>seldonframe/crm</span>
+      <span>seldonframe/seldonframe</span>
       {stars !== null ? (
         <span
           className="flex items-center gap-1 text-zinc-400"
@@ -70,7 +68,7 @@ export function GitHubStarsBadge({ stars }: { stars: number | null }) {
  */
 export async function fetchStarCount(): Promise<number | null> {
   try {
-    const res = await fetch("https://api.github.com/repos/seldonframe/crm", {
+    const res = await fetch("https://api.github.com/repos/seldonframe/seldonframe", {
       next: { revalidate: 3600 }, // 1 hour
       headers: { Accept: "application/vnd.github+json" },
     });

--- a/packages/crm/src/components/landing/marketing-agency-math.tsx
+++ b/packages/crm/src/components/landing/marketing-agency-math.tsx
@@ -45,10 +45,10 @@ export function MarketingAgencyMath() {
         <div className="mb-12 border-b border-[rgba(255,255,255,.12)] pb-8 text-center md:mb-14">
           <span className="inline-flex items-center gap-2.5 rounded-full border border-[rgba(246, 242, 234,.30)] bg-[rgba(246, 242, 234,.10)] px-4 py-1.5 text-[11.5px] font-[700] uppercase tracking-[0.14em] text-[#F6F2EA]">
             <span className="size-1.5 rounded-full bg-[#F6F2EA]" aria-hidden />
-            For builders &amp; agencies
+            For agencies
           </span>
           <p className="mx-auto mt-4 max-w-[48ch] font-[Newsreader,Georgia,serif] text-[clamp(18px,2.4vw,24px)] italic leading-[1.35] text-[rgba(246,242,234,.82)]">
-            Build agents for a living? List them — or run client workspaces under your own brand on the Agency plan.
+            Turn your delivery playbook into a repeatable, white-label client service.
           </p>
         </div>
 
@@ -57,18 +57,17 @@ export function MarketingAgencyMath() {
           <div>
             <div className="inline-flex items-center gap-2.5 text-[12px] font-[600] uppercase tracking-[0.09em] text-[rgba(246, 242, 234,.9)]">
               <span className="h-px w-4 bg-[rgba(246, 242, 234,.5)]" aria-hidden />
-              Build &amp; sell
+              Agency delivery
             </div>
             <h2 className="mt-3.5 text-[clamp(27px,4.2vw,40px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#F6F2EA]">
-              Build an agent once.{" "}
+              Deploy one playbook.{" "}
               <em className="font-[Newsreader,Georgia,serif] font-normal not-italic text-[rgba(246,242,234,.75)]">
-                Sell it to thousands.
+                Repeat it for every client.
               </em>
             </h2>
             <p className="mt-4 max-w-[50ch] text-[15.5px] leading-[1.55] text-[rgba(246,242,234,.74)]">
-              Build an AI agent for your business — then list it so other businesses can install it.
-              The marketplace puts it in front of them; you earn without marketing it. On the Agency
-              plan (from{" "}
+              Start from a client URL, then ship the same reliable delivery loop across your book of business.
+              On the Agency plan (from{" "}
               <strong className="font-[600] text-[#F6F2EA]">$99/mo</strong>), run client workspaces
               under your own brand — white-label, branded client portal, 10 sub-accounts included.
             </p>
@@ -76,8 +75,8 @@ export function MarketingAgencyMath() {
             {/* Builder perks list */}
             <ul className="mt-6 flex flex-col gap-3">
               {[
-                "List your agent on the marketplace — earn without marketing it",
-                "Build any agent in the Studio, in plain English — voice, SMS, chat & email",
+                "Create a branded client workspace from a URL",
+                "Build agents in plain English — voice, SMS, chat & email",
                 "From $99/mo: your brand on the entire platform — clients never see SeldonFrame",
                 "Set your own per-client pricing and keep the spread",
                 "10 client sub-accounts on Agency Starter ($99/mo) — 30 on Growth, unlimited on Scale",

--- a/packages/crm/src/components/landing/marketing-build-steps.tsx
+++ b/packages/crm/src/components/landing/marketing-build-steps.tsx
@@ -47,7 +47,7 @@ const PATHS: readonly Path[] = [
         <em className="font-[Newsreader,Georgia,serif] font-normal not-italic">Describe it.</em>
       </>
     ),
-    steps: ["Paste your client's URL or describe their business", "Watch it build — site, booking, CRM, agent", "Go live on your client's domain"],
+    steps: ["Paste your client's URL or describe their business", "Brand the site, booking, CRM, and agent", "Run evals, publish, and hand it off"],
     mock: <ScanMock />,
     figure: <IntegrationBeam />,
   },
@@ -81,9 +81,9 @@ export function MarketingBuildSteps() {
             How it works
           </div>
           <h2 className="mt-3.5 text-[clamp(27px,4.2vw,42px)] font-[500] leading-[1.08] tracking-[-0.025em] text-[#221D17]">
-            Two ways in.{" "}
+            From client URL to handoff.{" "}
             <em className="font-[Newsreader,Georgia,serif] font-normal not-italic">
-              Both live in minutes.
+              One repeatable delivery loop.
             </em>
           </h2>
         </div>

--- a/packages/crm/src/components/landing/marketing-final-cta.tsx
+++ b/packages/crm/src/components/landing/marketing-final-cta.tsx
@@ -56,8 +56,8 @@ export function MarketingFinalCta({
 
         <p className="mx-auto mt-5 max-w-[50ch] text-[16.5px] leading-[1.55] text-[color-mix(in_oklab,var(--lp-cta-slab-ink)_74%,transparent)]">
           Paste a client&rsquo;s URL or describe the business. We build the website, booking,
-          AI receptionist, intake, and CRM — all wired together and live in 3 minutes.
-          For your clients&rsquo; businesses, or your own.
+          AI receptionist, intake, and CRM — all wired together for your agency to brand,
+          publish, and hand off.
         </p>
 
         <div className="mt-9 flex flex-wrap items-center justify-center gap-4">
@@ -73,7 +73,7 @@ export function MarketingFinalCta({
               href="/#hero-form"
               className="inline-flex items-center gap-2.5 rounded-[11px] bg-[var(--lp-cta-slab-ink)] px-7 py-4 text-[15px] font-[500] text-[var(--lp-cta-slab)] shadow-[0_1px_2px_rgba(0,0,0,.2),0_12px_30px_rgba(0,0,0,.25),inset_0_1.5px_0_rgba(255,255,255,.6)] transition-all hover:-translate-y-[1.5px] active:translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--lp-accent)]"
             >
-              Build it free →
+              Build your first client front office →
             </Link>
           )}
           <Link
@@ -85,7 +85,7 @@ export function MarketingFinalCta({
         </div>
 
         <p className="mt-6 font-sans text-[13px] text-[color-mix(in_oklab,var(--lp-cta-slab-ink)_45%,transparent)]">
-          Build it free · $29/mo · unlimited workspaces · cancel anytime · your data exports as JSON
+          Build the first client workspace free · agency plans from $99/mo · 0% GMV · cancel anytime
         </p>
       </div>
     </section>

--- a/packages/crm/src/components/landing/marketing-footer.tsx
+++ b/packages/crm/src/components/landing/marketing-footer.tsx
@@ -3,7 +3,7 @@
 // Redesign 2026-06-18 — warm light aesthetic.
 // Seven-column footer on md+ (brand + 6 link columns incl. the Compare/Free-tools/
 // Pricing-guides SEO mesh, PostPlanify-style). Paper-soft background, warm ink
-// typography. Dual CTA strip above the columns — SMB + agency paths.
+// typography. Agency-first CTA strip above the columns.
 //
 // 2026-07-17: added the "Pricing guides" column (indexation-consolidation
 // Part 1c — the homepage/footer previously linked zero pricing pages despite
@@ -28,7 +28,7 @@ const COLUMNS: readonly Column[] = [
       { label: "Marketplace", href: "/marketplace" },
       { label: "Sell AI agents", href: "/sell" },
       { label: "For agencies", href: "/agencies" },
-      { label: "Changelog", href: "https://github.com/seldonframe/crm/releases", external: true },
+      { label: "Changelog", href: "https://github.com/seldonframe/seldonframe/releases", external: true },
     ],
   },
   {
@@ -37,10 +37,10 @@ const COLUMNS: readonly Column[] = [
       { label: "Docs", href: "/docs" },
       { label: "Guides", href: "/guides" },
       { label: "Blog", href: "/blog" },
-      { label: "MCP / Claude Code", href: "https://github.com/seldonframe/crm#claude-code-mcp", external: true },
+      { label: "MCP / Claude Code", href: "https://github.com/seldonframe/seldonframe#claude-code-mcp", external: true },
       { label: "API", href: "/docs" },
       { label: "Live demos", href: "#demos" },
-      { label: "Status", href: "https://github.com/seldonframe/crm", external: true },
+      { label: "Status", href: "https://github.com/seldonframe/seldonframe", external: true },
     ],
   },
   {
@@ -95,7 +95,7 @@ const COLUMNS: readonly Column[] = [
     links: [
       { label: "Contact", href: "mailto:hello@seldonframe.com" },
       { label: "Partnerships", href: "mailto:partner@seldonframe.com" },
-      { label: "GitHub", href: "https://github.com/seldonframe/crm", external: true },
+      { label: "GitHub", href: "https://github.com/seldonframe/seldonframe", external: true },
       { label: "Terms", href: "https://app.seldonframe.com/terms", external: true },
       { label: "Privacy", href: "https://app.seldonframe.com/policy", external: true },
     ],
@@ -118,7 +118,7 @@ export function MarketingFooter() {
               <BrandMark size={22} />
             </Link>
             <p className="m-0 text-[13.5px] leading-[1.55] text-[var(--lp-muted)]">
-              The complete front office — website, booking, AI receptionist, intake, and CRM —
+              The agency-owned front office — website, booking, AI receptionist, intake, and CRM —
               wired together so your clients never miss a lead.
             </p>
             <div className="flex flex-col gap-2.5">
@@ -167,7 +167,7 @@ export function MarketingFooter() {
         </div>
 
         <div className="mt-14 flex flex-wrap items-center justify-between gap-3.5 border-t border-[var(--lp-border-soft)] pt-5 font-mono text-[11.5px] text-[var(--lp-faint)]">
-          <span>© 2026 SeldonFrame, Inc. All rights reserved.</span>
+          <span>© 2026 SeldonFrame, Inc. · AGPL-3.0</span>
           <span className="lp-record-only items-center text-[13.5px] text-[var(--lp-muted)]">
             Recordings stay private — they train your agent only.
           </span>
@@ -181,7 +181,7 @@ export function MarketingFooter() {
               X
             </Link>
             <Link
-              href="https://github.com/seldonframe/crm"
+              href="https://github.com/seldonframe/seldonframe"
               target="_blank"
               rel="noopener noreferrer"
               className="text-[var(--lp-faint)] transition-colors hover:text-[var(--lp-ink)]"

--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -39,6 +39,10 @@ import { heroSubmitTarget } from "@/components/landing/hero-submit-target";
 import { BorderBeam } from "@/components/ui/border-beam";
 import { Highlighter } from "@/components/ui/highlighter";
 import { AnimatedShinyText } from "@/components/ui/magic/animated-shiny-text";
+import {
+  AGENCY_HERO_HEADLINE,
+  AGENCY_HERO_SUBHEAD,
+} from "@/lib/marketing/public-claims";
 
 // Re-exported for callers that only need the pure routing decision (e.g.
 // tests) without pulling in this "use client" component.
@@ -250,29 +254,20 @@ export function MarketingHero({
       <p className="inline-flex items-center gap-2.5 font-sans text-[12.5px] tracking-[0.04em] text-[#6E665A]">
         <span className="inline-block h-px w-4 bg-[#9A9183]" aria-hidden />
         <span className="sf-blink-dot inline-block size-1.5 rounded-full bg-[#1F2B24]" aria-hidden />
-        Each client built in 3 minutes — No coding
+        The agency delivery loop — live in minutes
       </p>
 
       {/* Headline — outcome + mechanism (the Postiz formula) */}
       <h1 className="mt-3 max-w-[22ch] text-balance font-sans text-[clamp(34px,4.8vw,56px)] font-[500] leading-[1.04] tracking-[-0.025em] text-[#221D17]">
-        Sell AI front offices that run{" "}
-        <em className="font-[Newsreader,Georgia,serif] font-normal not-italic tracking-[-0.01em]">
-          on autopilot
-        </em>
+        {AGENCY_HERO_HEADLINE}
       </h1>
 
       {/* Subhead — what runs on autopilot, concretely, then the openness line */}
       <p className="mx-auto mt-4 max-w-[68ch] text-pretty text-[clamp(15.5px,1.6vw,17.5px)] leading-[1.55] text-[#6E665A]">
         <Highlighter repeat color="rgba(31, 43, 36,0.18)">
-          Every client gets an agent that answers every call, texts back every lead,
-          books the job, and asks for the review
+          {AGENCY_HERO_SUBHEAD}
         </Highlighter>{" "}
-        — across{" "}
-        <strong className="font-[500] text-[#221D17]">
-          voice, SMS, email, and web chat
-        </strong>{" "}
-        — plus the website, bookings, and CRM in one dashboard. You charge the retainer,
-        on a platform you own.
+        You keep the client relationship, the data, and the margin.
       </p>
       {/* Primary CTA — routes to the chatbox, not /signup: the label promises
           a build, and the ungated build IS the trial (route-by-promise,
@@ -291,7 +286,7 @@ export function MarketingHero({
           }}
           className="inline-flex items-center gap-2.5 rounded-[11px] bg-[#1F2B24] px-6 py-3.5 text-[15px] font-[500] text-[#F6F2EA] shadow-[0_1px_2px_rgba(34,29,23,.10),0_6px_16px_rgba(34,29,23,.10),0_18px_40px_rgba(34,29,23,.06),inset_0_1.5px_0_rgba(255,255,255,.12)] transition-all hover:-translate-y-[1.5px] hover:shadow-[0_2px_4px_rgba(34,29,23,.12),0_12px_26px_rgba(34,29,23,.14),inset_0_1.5px_0_rgba(255,255,255,.14)] active:translate-y-px"
         >
-          Build it free →
+          Build your first client front office →
         </a>
       </div>
 
@@ -448,7 +443,7 @@ export function MarketingHero({
 
       {/* Proof checklist */}
       <ul className="mt-6 flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
-        {["Start free", "Each client live in 3 minutes", "Yours to keep — open source"].map((item) => (
+        {["Start with a client URL", "Publish a tested workspace", "AGPL-3.0 and yours to keep"].map((item) => (
           <li key={item} className="flex items-center gap-2 text-[13.5px] text-[#6E665A]">
             <span className="flex size-[17px] items-center justify-center rounded-full bg-[rgba(31, 43, 36,.12)] text-[10px] font-[700] text-[#1F2B24]" aria-hidden>✓</span>
             {item}

--- a/packages/crm/src/components/landing/marketing-nav.tsx
+++ b/packages/crm/src/components/landing/marketing-nav.tsx
@@ -86,8 +86,20 @@ export function MarketingNav() {
           <BrandMark withPathChip />
         </Link>
 
-        {/* Right cluster — Resources dropdown + subtle Log in + one primary CTA */}
+        {/* Agency-first navigation plus Resources, login, and the primary CTA. */}
         <div className="inline-flex items-center gap-2 md:gap-3">
+          <Link
+            href="/agencies"
+            className="hidden h-[34px] items-center whitespace-nowrap rounded-[11px] px-3 text-[13.5px] font-semibold text-[var(--lp-ink)] transition-colors hover:text-[var(--lp-accent)] md:inline-flex"
+          >
+            For agencies
+          </Link>
+          <Link
+            href="/docs"
+            className="hidden h-[34px] items-center whitespace-nowrap rounded-[11px] px-3 text-[13.5px] font-medium text-[var(--lp-muted)] transition-colors hover:text-[var(--lp-ink)] md:inline-flex"
+          >
+            Docs
+          </Link>
           <div ref={resourcesRef} className="relative hidden md:block">
             <button
               type="button"

--- a/packages/crm/src/components/landing/marketing-nav.tsx
+++ b/packages/crm/src/components/landing/marketing-nav.tsx
@@ -100,6 +100,12 @@ export function MarketingNav() {
           >
             Docs
           </Link>
+          <Link
+            href="/pricing-public"
+            className="hidden h-[34px] items-center whitespace-nowrap rounded-[11px] px-3 text-[13.5px] font-medium text-[var(--lp-muted)] transition-colors hover:text-[var(--lp-ink)] md:inline-flex"
+          >
+            Pricing
+          </Link>
           <div ref={resourcesRef} className="relative hidden md:block">
             <button
               type="button"

--- a/packages/crm/src/components/landing/nav.tsx
+++ b/packages/crm/src/components/landing/nav.tsx
@@ -33,7 +33,7 @@ type NavLink = { href: string; label: string; external?: boolean };
 
 const NAV_LINKS: NavLink[] = [
   { href: "/pricing", label: "Pricing" },
-  { href: "https://github.com/seldonframe/crm", label: "GitHub", external: true },
+  { href: "https://github.com/seldonframe/seldonframe", label: "GitHub", external: true },
   { href: "/login", label: "Sign In" },
 ];
 

--- a/packages/crm/src/components/landing/record/record-faq.tsx
+++ b/packages/crm/src/components/landing/record/record-faq.tsx
@@ -42,7 +42,7 @@ const FAQS: readonly FaqItem[] = [
   {
     question: "What does it cost?",
     answer:
-      "Recording, compiling, and testing are free — no signup to start. It's $29/mo when you switch your agent on. Cancel anytime.",
+      "Recording, compiling, and testing are free — build the first client workspace before checkout. Agency plans start at $99/mo, carry 0% GMV, and can be cancelled anytime.",
   },
 ];
 

--- a/packages/crm/src/components/landing/record/record-what-you-get.tsx
+++ b/packages/crm/src/components/landing/record/record-what-you-get.tsx
@@ -19,7 +19,7 @@ const CARDS = [
   },
   {
     title: "Yours, flat price",
-    body: "Recording and compiling are free with no signup. $29/mo when you switch it on. Cancel anytime.",
+    body: "Recording and compiling are free while you build the first client workspace. Agency plans start at $99/mo with 0% GMV. Cancel anytime.",
   },
 ] as const;
 

--- a/packages/crm/src/components/landing/social-proof.tsx
+++ b/packages/crm/src/components/landing/social-proof.tsx
@@ -4,7 +4,7 @@ export function LandingSocialProof() {
       <div className="mx-auto flex max-w-5xl flex-wrap justify-center gap-8 px-6 text-[10px] font-semibold uppercase tracking-widest text-zinc-600 md:gap-12 md:text-xs">
         <span>Open Source</span>
         <span className="hidden h-4 w-px bg-zinc-800 md:block"></span>
-        <span>MIT Licensed</span>
+        <span>AGPL-3.0</span>
         <span className="hidden h-4 w-px bg-zinc-800 md:block"></span>
         <span>Free to start</span>
       </div>

--- a/packages/crm/src/lib/demo/constants.ts
+++ b/packages/crm/src/lib/demo/constants.ts
@@ -1,9 +1,9 @@
-export const DEMO_REPO_URL = "https://github.com/seldonframe/crm";
+export const DEMO_REPO_URL = "https://github.com/seldonframe/seldonframe";
 
 export const DEMO_DEPLOY_URL =
-  "https://vercel.com/new/clone?repository-url=https://github.com/seldonframe/crm&env=DATABASE_URL,NEXTAUTH_SECRET&envDescription=Set%20up%20your%20Neon%20database%20and%20auth%20secret&envLink=https://github.com/seldonframe/crm#environment-variables";
+  "https://vercel.com/new/clone?repository-url=https://github.com/seldonframe/seldonframe&env=DATABASE_URL,NEXTAUTH_SECRET&envDescription=Set%20up%20your%20Neon%20database%20and%20auth%20secret&envLink=https://github.com/seldonframe/seldonframe#environment-variables";
 
-export const DEMO_CLOUD_WAITLIST_URL = "https://github.com/seldonframe/crm/discussions";
+export const DEMO_CLOUD_WAITLIST_URL = "https://github.com/seldonframe/seldonframe/discussions";
 
 export const DEMO_BLOCK_MESSAGE = "This is a live demo. Fork SeldonFrame to build your own.";
 

--- a/packages/crm/src/lib/marketing/public-claims.ts
+++ b/packages/crm/src/lib/marketing/public-claims.ts
@@ -1,0 +1,26 @@
+/**
+ * Public-facing product facts shared by the website, docs, and generated
+ * marketing surfaces. Keep this module dependency-free so it can be imported
+ * from both server and client components.
+ */
+
+export const LICENSE_LABEL = "AGPL-3.0" as const;
+
+export const AGENCY_POSITIONING =
+  "SeldonFrame is the agent-native, open-source alternative to GoHighLevel for agencies selling AI front offices to local businesses." as const;
+
+export const AGENCY_HERO_HEADLINE = "Sell AI front offices. Deploy them in minutes." as const;
+
+export const AGENCY_HERO_SUBHEAD =
+  "Build a branded website, booking flow, CRM, intake, and AI agent for every client from one workspace—then operate it under your agency brand." as const;
+
+export const AGENCY_PLAN_FACTS = [
+  { id: "builder", name: "Builder", priceMonthly: 29, audience: "one business you operate" },
+  { id: "managed", name: "Managed", priceMonthly: 49, audience: "one managed workspace" },
+  { id: "agency_starter", name: "Agency Starter", priceMonthly: 99, audience: "10 client workspaces" },
+  { id: "agency_growth", name: "Agency Growth", priceMonthly: 199, audience: "30 client workspaces" },
+  { id: "agency_scale", name: "Agency Scale", priceMonthly: 299, audience: "unlimited client workspaces" },
+] as const;
+
+export const HOSTED_AI_POLICY =
+  "Managed uses SeldonFrame's keys; Builder and Agency plans are BYOK." as const;

--- a/packages/crm/tests/unit/landing/footer.spec.ts
+++ b/packages/crm/tests/unit/landing/footer.spec.ts
@@ -50,7 +50,7 @@ describe("LandingFooter — Cut C Phase 7 refresh", () => {
     // The block heading + the View-on-GitHub link both signal the
     // top-of-footer treatment from the Phase 7 spec.
     assert.match(text, /Open source on GitHub/i);
-    assert.match(text, /github\.com\/seldonframe\/crm/);
+    assert.match(text, /github\.com\/seldonframe\/seldonframe/);
   });
 
   test("license line says AGPL-3.0 (not MIT)", () => {

--- a/packages/crm/tests/unit/marketing/public-claims.spec.ts
+++ b/packages/crm/tests/unit/marketing/public-claims.spec.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AGENCY_HERO_HEADLINE,
+  AGENCY_POSITIONING,
+  AGENCY_PLAN_FACTS,
+  HOSTED_AI_POLICY,
+  LICENSE_LABEL,
+} from "../../../src/lib/marketing/public-claims";
+
+test("public positioning names the agency outcome", () => {
+  assert.match(AGENCY_POSITIONING, /agencies/i);
+  assert.match(AGENCY_POSITIONING, /AI front offices/i);
+  assert.match(AGENCY_POSITIONING, /GoHighLevel/i);
+  assert.match(AGENCY_HERO_HEADLINE, /front offices/i);
+});
+
+test("public plan facts match the hosted sellable ladder", () => {
+  assert.deepEqual(
+    AGENCY_PLAN_FACTS.map(({ id, name, priceMonthly }) => ({ id, name, priceMonthly })),
+    [
+      { id: "builder", name: "Builder", priceMonthly: 29 },
+      { id: "managed", name: "Managed", priceMonthly: 49 },
+      { id: "agency_starter", name: "Agency Starter", priceMonthly: 99 },
+      { id: "agency_growth", name: "Agency Growth", priceMonthly: 199 },
+      { id: "agency_scale", name: "Agency Scale", priceMonthly: 299 },
+    ],
+  );
+});
+
+test("public legal and AI claims are explicit", () => {
+  assert.equal(LICENSE_LABEL, "AGPL-3.0");
+  assert.match(HOSTED_AI_POLICY, /Managed/);
+  assert.match(HOSTED_AI_POLICY, /BYOK/);
+});
+

--- a/packages/crm/tests/unit/marketing/public-claims.spec.ts
+++ b/packages/crm/tests/unit/marketing/public-claims.spec.ts
@@ -15,7 +15,6 @@ test("public positioning names the agency outcome", () => {
   assert.match(AGENCY_POSITIONING, /GoHighLevel/i);
   assert.match(AGENCY_HERO_HEADLINE, /front offices/i);
 });
-
 test("public plan facts match the hosted sellable ladder", () => {
   assert.deepEqual(
     AGENCY_PLAN_FACTS.map(({ id, name, priceMonthly }) => ({ id, name, priceMonthly })),
@@ -34,4 +33,3 @@ test("public legal and AI claims are explicit", () => {
   assert.match(HOSTED_AI_POLICY, /Managed/);
   assert.match(HOSTED_AI_POLICY, /BYOK/);
 });
-


### PR DESCRIPTION
## What changed

- Reposition the public SeldonFrame experience around agencies selling AI front offices to local businesses.
- Update homepage, `/agencies`, public pricing discovery, metadata, navigation, footer links, and legal/license claims.
- Align `/docs`, quickstart, billing, and README with the agency delivery loop and current five-plan ladder.
- Add a canonical public-claims contract and regression tests.
- Extend safe Playwright smoke coverage for `/agencies` and the agency-first docs hub.

## Why

The product already supports the agency delivery loop, but the public story was split between a generic business-builder pitch, stale pricing/license language, and an agency page that was hard to discover. This makes the buyer and delivery model explicit: build a branded client front office, validate it, publish it, and hand it off from one agency workspace.

## Validation

- Focused marketing tests: 22 passed.
- CRM typecheck: passed.
- Production Next build (direct Next invocation): passed; 560 static pages generated.
- `git diff --check`: passed.
- Safe production E2E: unchanged auth/signup/login/pricing checks passed; new agency/docs checks correctly fail against the currently deployed pre-change site and should be rerun against this branch's Vercel preview.
- Full lint remains blocked by the repository's existing baseline (680 errors / 357 warnings); no unrelated lint cleanup was included.

## Deploy note

Do not merge until the preview is live and the new `/agencies`, `/pricing-public`, and `/docs` assertions pass. Then rerun the agency-first conversion smoke and review the rendered pages before promoting to production.