### PR TITLE
Fix homepage agency navigation smoke selector

### DIFF
--- a/packages/crm/e2e/funnel-smoke.spec.ts
+++ b/packages/crm/e2e/funnel-smoke.spec.ts
@@ -67,7 +67,12 @@ test.describe("render tier (GET-only, safe everywhere)", () => {
     if (isProductionMarketingHost(FLOW_BASE_URL)) {
       expect(new URL(page.url()).pathname).toBe("/");
       await expect(page.getByRole("heading", { name: /Sell AI front offices/i })).toBeVisible();
-      await expect(page.getByRole("link", { name: "For agencies", exact: true })).toHaveAttribute("href", "/agencies");
+      await expect(
+        page.locator('header[aria-label="Primary navigation"]').getByRole("link", {
+          name: "For agencies",
+          exact: true,
+        }),
+      ).toHaveAttribute("href", "/agencies");
     } else {
       expect(new URL(page.url()).pathname).toBe("/login");
       await expect(page.getByRole("heading", { name: "Welcome to SeldonFrame" })).toBeVisible();


### PR DESCRIPTION
One-line follow-up regression fix after PR #188.

Production safe E2E found two For agencies links on the homepage (primary navigation and footer). Scope the homepage assertion to the primary header so the test verifies the intended conversion path.

Production smoke after the fix: 7 passed, 1 data-creating flow skipped by design.