### PR TITLE
Align programmatic agent pages with agency positioning

### DIFF
--- a/packages/crm/src/app/(public)/ai-agents/[job]/for/[vertical]/page.tsx
+++ b/packages/crm/src/app/(public)/ai-agents/[job]/for/[vertical]/page.tsx
@@ -44,8 +44,8 @@ export async function generateMetadata({ params }: RouteParams): Promise<Metadat
   return {
     title: copy.title,
     description: copy.metaDescription,
-    // canonical + the Markdown twin so DOM-parsing crawlers discover the `.md`.
-    alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+    // Do not advertise a Markdown twin until this dynamic route serves one.
+    alternates: { canonical },
     openGraph: {
       title: `${job.name} for ${vertical.plural}`,
       description: copy.metaDescription,

--- a/packages/crm/src/app/(public)/ai-agents/[job]/page.tsx
+++ b/packages/crm/src/app/(public)/ai-agents/[job]/page.tsx
@@ -32,8 +32,8 @@ export async function generateMetadata({ params }: RouteParams): Promise<Metadat
   return {
     title: copy.title,
     description: copy.metaDescription,
-    // canonical + the Markdown twin so DOM-parsing crawlers discover the `.md`.
-    alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+    // Do not advertise a Markdown twin until this dynamic route serves one.
+    alternates: { canonical },
     openGraph: {
       title: `${job.name} — deploy a working agent in 60 seconds`,
       description: copy.metaDescription,

--- a/packages/crm/src/components/analytics/structured-data.tsx
+++ b/packages/crm/src/components/analytics/structured-data.tsx
@@ -20,7 +20,18 @@
 //     Those workspaces ship their own LocalBusiness schema generated
 //     per workspace — not SeldonFrame's Organization schema.
 //
-// The allowlist is identical to GA's: same hosts, same rationale.
+// Product facts come from the same dependency-free public claims module used by
+// the homepage and docs. That prevents stale JSON-LD from silently advertising
+// a retired pricing ladder after the visible product has moved on.
+
+import {
+  AGENCY_PLAN_FACTS,
+  AGENCY_POSITIONING,
+  LICENSE_LABEL,
+} from "@/lib/marketing/public-claims";
+
+const MARKETING_ORIGIN = "https://www.seldonframe.com";
+const ORGANIZATION_ID = `${MARKETING_ORIGIN}/#org`;
 
 /**
  * Allowlist of hosts where the SeldonFrame-marketing JSON-LD is
@@ -49,11 +60,11 @@ export function shouldRenderMarketingStructuredData(host: string): boolean {
 const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
+  "@id": ORGANIZATION_ID,
   name: "SeldonFrame",
-  url: "https://seldonframe.com",
-  logo: "https://seldonframe.com/brand/seldonframe-icon.svg",
-  description:
-    "Open-source alternative to GoHighLevel. SeldonFrame generates a pre-wired client operations stack — CRM, booking page, intake form, and AI chatbot — that agencies deploy per client in minutes. Built for freelance web designers and small agencies serving local service businesses.",
+  url: MARKETING_ORIGIN,
+  logo: `${MARKETING_ORIGIN}/brand/seldonframe-icon.svg`,
+  description: AGENCY_POSITIONING,
   sameAs: [
     "https://github.com/seldonframe/seldonframe",
     "https://www.npmjs.com/package/@seldonframe/mcp",
@@ -65,49 +76,30 @@ const organizationSchema = {
 const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
+  "@id": `${MARKETING_ORIGIN}/#website`,
   name: "SeldonFrame",
-  url: "https://seldonframe.com",
-  publisher: {
-    "@type": "Organization",
-    name: "SeldonFrame",
-  },
+  url: MARKETING_ORIGIN,
+  publisher: { "@id": ORGANIZATION_ID },
 };
 
 const softwareApplicationSchema = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
+  "@id": `${MARKETING_ORIGIN}/#software`,
   name: "SeldonFrame",
   applicationCategory: "BusinessApplication",
-  operatingSystem: "Web, Self-hosted (Next.js, AGPL-3.0)",
-  description:
-    "Open-source alternative to GoHighLevel. SeldonFrame is a pre-wired client operations stack — CRM, booking page, intake form, and AI chatbot — that agencies deploy per client in minutes via Claude Code and the @seldonframe/mcp server. Everything is connected on generation: the chatbot books against the real calendar, the intake form writes to the real CRM, the booking page respects the client's hours and timezone. No Zapier, no integration work. Built for freelance web designers and small agencies serving local service businesses including HVAC contractors, plumbers, electricians, dental practices, salons, and roofers.",
-  offers: [
-    {
-      "@type": "Offer",
-      name: "Builder",
-      price: "19",
-      priceCurrency: "USD",
-      description:
-        "Builder: up to 10 standalone landing pages with your own domain and branding.",
-    },
-    {
-      "@type": "Offer",
-      name: "Workspace",
-      price: "49",
-      priceCurrency: "USD",
-      description:
-        "Workspace: one complete workspace — website, booking, intake, CRM, and AI chat — with an optional AI voice receptionist add-on.",
-    },
-    {
-      "@type": "Offer",
-      name: "Agency",
-      price: "297",
-      priceCurrency: "USD",
-      description:
-        "Agency (white-label): your brand on the platform, with client workspaces you resell at your own markup. Flat monthly pricing, no metered bills.",
-    },
-  ],
-  url: "https://seldonframe.com",
+  operatingSystem: `Web, Self-hosted (${LICENSE_LABEL})`,
+  description: AGENCY_POSITIONING,
+  offers: AGENCY_PLAN_FACTS.map((plan) => ({
+    "@type": "Offer",
+    name: plan.name,
+    price: String(plan.priceMonthly),
+    priceCurrency: "USD",
+    description: plan.audience,
+    url: `${MARKETING_ORIGIN}/pricing?plan=${plan.id}`,
+  })),
+  provider: { "@id": ORGANIZATION_ID },
+  url: MARKETING_ORIGIN,
 };
 
 /**

--- a/packages/crm/src/components/seo/agent-page-cta.tsx
+++ b/packages/crm/src/components/seo/agent-page-cta.tsx
@@ -25,6 +25,8 @@ export type AgentPageCtaProps = {
   agentName: string;
   /** The build-flow href carrying the agent (built by the page server side). */
   deployHref: string;
+  /** Agency-first CTA copy, composed by the server page for its vertical. */
+  deployLabel: string;
   /** The public Rent-via-MCP endpoint for this agent. */
   mcpEndpoint: string;
   /** A copyable MCP client-config snippet pointing at the endpoint. */
@@ -37,6 +39,7 @@ export type AgentPageCtaProps = {
 export function AgentPageCta({
   agentName,
   deployHref,
+  deployLabel,
   mcpEndpoint,
   mcpSnippet,
   marketplaceSlug,
@@ -95,14 +98,14 @@ export function AgentPageCta({
             color: MKT.paper,
           }}
         >
-          Get your {agentName} working today.{" "}
+          Build and deliver {agentName} for a client.{" "}
           <span style={{ fontFamily: MKT.fontSerif, fontStyle: "italic", fontWeight: 400, color: MKT.greenLight }}>
             Two ways in.
           </span>
         </h2>
         <p style={{ margin: "10px 0 24px", fontSize: 15.5, lineHeight: 1.55, color: "rgba(246,242,234,0.66)", maxWidth: 520 }}>
-          Deploy it into your own hosted workspace — grounded in your services, hours, and pricing — or rent it over MCP
-          and call it from any agent. No card required to start.
+          Deploy it into a branded client workspace — grounded in that client’s services, hours, and pricing — or rent it
+          over MCP and call it from any agent. No card required to start.
         </p>
 
         <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
@@ -129,7 +132,7 @@ export function AgentPageCta({
             }}
           >
             <MarketplaceIcon name="package" size={19} />
-            Deploy it for my business
+            {deployLabel}
             <MarketplaceIcon name="arrowRight" size={17} />
           </Link>
 

--- a/packages/crm/src/components/seo/agent-page.tsx
+++ b/packages/crm/src/components/seo/agent-page.tsx
@@ -29,7 +29,7 @@ import { MarketplaceIcon } from "@/components/marketplace/marketplace-icons";
 import { MKT, SURFACE_META, mcpEndpointFor, mcpSnippetFor } from "@/components/marketplace/marketplace-data";
 import { AgentPageCta } from "@/components/seo/agent-page-cta";
 import { ToolLogoRow } from "@/components/seo/tool-marks";
-import { MarkdownPointer } from "@/components/seo/markdown-pointer";
+import { AGENCY_PLAN_FACTS } from "@/lib/marketing/public-claims";
 import {
   composePageCopy,
   deployHrefFor,
@@ -57,7 +57,9 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
   // specific, not generic. (Task B)
   const steps = job.howItWorks;
   const related = relatedJobsForVertical(job.slug, 5);
-  const verticalLabel = vertical ? vertical.plural : "your business";
+  const deployLabel = vertical
+    ? `Build this for ${aOrAnLower(vertical.name)} ${vertical.name} client`
+    : "Build this for a client";
   // Review-agent cluster (PR 2, Part 1c): on a kept google-review-agent Tier-2
   // page, cross-link the tool that builds the review link this agent sends,
   // plus the other kept verticals for the SAME job (siblings) — every folded
@@ -72,12 +74,6 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
   // render their composed copy inline so the content lives on the hub instead
   // of vanishing with the page.
   const byIndustry = !vertical ? VERTICALS : [];
-  // The public `.md` twin of THIS page (Tier-1 or Tier-2) — pointed at by the
-  // visually-hidden Markdown pointer for the human-pastes-URL-into-an-LLM flow.
-  const markdownHref = vertical
-    ? `/ai-agents/${job.slug}/for/${vertical.slug}.md`
-    : `/ai-agents/${job.slug}.md`;
-
   // ── schema.org: SoftwareApplication (the agent) + FAQPage (the registry FAQ).
   // Two graphs, emitted as JSON-LD so search engines + LLMs can cite the page.
   const softwareLd = {
@@ -87,8 +83,14 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
     applicationCategory: "BusinessApplication",
     operatingSystem: "SeldonFrame",
     description: copy.metaDescription,
-    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
-    provider: { "@type": "Organization", name: "SeldonFrame", url: "https://seldonframe.com" },
+    offers: AGENCY_PLAN_FACTS.map((plan) => ({
+      "@type": "Offer",
+      name: plan.name,
+      price: String(plan.priceMonthly),
+      priceCurrency: "USD",
+      description: plan.audience,
+    })),
+    provider: { "@id": "https://www.seldonframe.com/#org" },
   };
   const faqLd = {
     "@context": "https://schema.org",
@@ -107,7 +109,6 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
     >
       <MarketplaceStyles />
       <AgentPageStyles />
-      <MarkdownPointer href={markdownHref} />
       {/* GEO: structured data — SoftwareApplication + FAQPage. */}
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
@@ -139,7 +140,7 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
         {/* ── HERO: semantic h1 + one-liner + the cited stat, rendered prominently ── */}
         <header style={{ paddingBottom: 30, borderBottom: "1px solid rgba(34,29,23,0.10)" }}>
           <div style={{ fontSize: 12, fontWeight: 600, letterSpacing: "0.12em", textTransform: "uppercase", color: MKT.green, marginBottom: 12 }}>
-            {vertical ? `AI agent for ${vertical.plural}` : "Deploy a working agent in 60 seconds"}
+            {vertical ? `Agency playbook · ${vertical.plural}` : "Agency-ready agent · deploy in 60 seconds"}
           </div>
           <h1 className="sf-ap-h1" style={{ margin: 0, fontSize: 44, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.05, maxWidth: 760 }}>
             {copy.h1}
@@ -199,7 +200,7 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
               }}
             >
               <MarketplaceIcon name="package" size={19} />
-              Deploy it for {verticalLabel === "your business" ? "my business" : `my ${vertical?.name}`}
+              {deployLabel}
               <MarketplaceIcon name="arrowRight" size={17} />
             </Link>
           </div>
@@ -459,9 +460,11 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
         {/* ── FLYWHEEL: "more agents for [vertical]" cross-links ── */}
         {related.length > 0 ? (
           <section style={SECTION}>
-            <h2 style={{ ...H2, marginBottom: 4 }}>More agents for {verticalLabel}</h2>
+            <h2 style={{ ...H2, marginBottom: 4 }}>
+              More agents for {vertical ? `${vertical.plural} clients` : "client businesses"}
+            </h2>
             <p style={{ margin: "0 0 18px", fontSize: 14.5, color: "rgba(34,29,23,0.55)" }}>
-              Every one deploys a working agent into your own workspace in about a minute.
+              Every one deploys into a branded client workspace in about a minute.
             </p>
             <div className="sf-ap-related">
               {related.map((r) => (
@@ -508,6 +511,7 @@ export function AgentPage({ job, vertical }: AgentPageProps): ReactElement {
           <AgentPageCta
             agentName={job.name}
             deployHref={deployHref}
+            deployLabel={deployLabel}
             mcpEndpoint={mcpEndpoint}
             mcpSnippet={mcpSnippet}
             marketplaceSlug={job.marketplaceSlug}

--- a/packages/crm/src/lib/marketplace/render-ai-agents-markdown.ts
+++ b/packages/crm/src/lib/marketplace/render-ai-agents-markdown.ts
@@ -21,6 +21,14 @@ import {
   type AgentJob,
   type Vertical,
 } from "@/lib/seo/agent-pages";
+import { AGENCY_PLAN_FACTS } from "@/lib/marketing/public-claims";
+
+const agencyPricing = AGENCY_PLAN_FACTS.filter((plan) => plan.id.startsWith("agency_"))
+  .map((plan) => `${plan.name} $${plan.priceMonthly}/mo`)
+  .join(", ");
+const operatorPricing = AGENCY_PLAN_FACTS.filter((plan) => !plan.id.startsWith("agency_"))
+  .map((plan) => `${plan.name} $${plan.priceMonthly}/mo`)
+  .join(", ");
 
 /** The canonical public origin for absolute links in the Markdown. Mirrors the
  *  site's metadataBase (sitemap.siteBaseUrl / llms.txt), so a pasted `.md`
@@ -153,7 +161,7 @@ function renderAgentBody(job: AgentJob, vertical: Vertical | undefined, baseUrl:
   if (vertical) {
     lines.push(`- **Industry:** ${vertical.plural}`);
   }
-  lines.push("- **Pricing:** $29/mo flat, unlimited workspaces, cancel anytime (your AI key billed at cost by the provider).");
+  lines.push(`- **Pricing:** First workspace free; ${agencyPricing}. Running your own businesses: ${operatorPricing}.`);
   lines.push("");
 
   // FAQ — the SAME array the HTML FAQPage JSON-LD is built from (job FAQ +

--- a/packages/crm/src/lib/seo/agent-pages.spec.ts
+++ b/packages/crm/src/lib/seo/agent-pages.spec.ts
@@ -298,6 +298,10 @@ test("Tier-2 composition tailors the headline + intro to the vertical", () => {
     "Tier-2 intro should mention the vertical example service",
   );
   assert.ok(copy.intro.includes(job.painStat.text), "Tier-2 intro should weave the cited stat");
+  assert.match(copy.intro, /agenc(?:y|ies)/i, "Tier-2 intro should speak to the agency buyer");
+  assert.match(copy.intro, /client/i, "Tier-2 intro should frame the vertical as a client outcome");
+  assert.match(copy.metaDescription, /agenc(?:y|ies)|white-label/i);
+  assert.doesNotMatch(copy.intro, /Deploy one for your plumber business/i);
   // The first FAQ is localized to the trade.
   assert.match(copy.faq[0].q, /plumbers/);
 });

--- a/packages/crm/src/lib/seo/agent-pages.ts
+++ b/packages/crm/src/lib/seo/agent-pages.ts
@@ -681,7 +681,7 @@ export const VALUE_FRAME_FAQ: FaqItem[] = [
   },
   {
     q: "How much does it cost?",
-    a: "$29/mo flat, with unlimited workspaces and cancel anytime — no card to start building. Your AI key is billed by the provider directly at cost (usually pennies a day); we never mark it up or add a usage tax on top.",
+    a: "Build the first workspace free. Agencies start with Agency Starter at $99/mo for 10 client sub-accounts, full white-label, and branded client portals; Growth is $199/mo for 30 clients and Scale is $299/mo for unlimited clients. Running only your own businesses? Builder is $29/mo BYOK and Managed is $49/mo on SeldonFrame's keys. Cancel anytime, with no card required to start building.",
   },
   {
     q: "How much can it save me?",
@@ -899,7 +899,8 @@ export function composePageCopy(job: AgentJob, vertical?: Vertical): ComposedPag
 
   const pluralCased = headlineCasePlural(vertical.plural);
   const h1 = `${job.name} for ${pluralCased}`;
-  const intro = `For ${vertical.plural}, ${vertical.painHook}. ${aOrAn(job.name)} ${job.name} closes that gap: it ${job.verticalLede}. ${job.painStat.text} Deploy one for your ${ownBusinessPhrase(vertical)} in about 60 seconds, grounded in your own services, hours, and pricing — including ${vertical.exampleService}.`;
+  const clientArticle = aOrAn(vertical.name).toLowerCase();
+  const intro = `For agencies serving ${vertical.plural}, ${vertical.painHook}. ${aOrAn(job.name)} ${job.name} closes that gap: it ${job.verticalLede}. ${job.painStat.text} Build and white-label one for ${clientArticle} ${vertical.name} client in about 60 seconds, grounded in the client's services, hours, and pricing — including ${vertical.exampleService}.`;
 
   // Localize only the first FAQ question to the trade; answers already generalize.
   // The shared value-frame block is appended AFTER, unchanged (it's vertical-
@@ -916,7 +917,7 @@ export function composePageCopy(job: AgentJob, vertical?: Vertical): ComposedPag
     title: `${job.name} for ${pluralCased} — ${shortPromise(job)} | SeldonFrame`,
     h1,
     metaDescription: clampDescription(
-      `${job.name} for ${vertical.plural}: ${job.oneLiner} Deploy a working agent in 60 seconds.`,
+      `${job.name} for ${vertical.plural}: build and white-label a working client agent from one agency workspace in about 60 seconds.`,
     ),
     intro,
     faq,
@@ -927,16 +928,6 @@ export function composePageCopy(job: AgentJob, vertical?: Vertical): ComposedPag
  *  first letter (good enough for our names: "AI…" → "An", "Quote…" → "A"). */
 function aOrAn(name: string): string {
   return /^[aeiou]/i.test(name.trim()) ? "An" : "A";
-}
-
-/** "your plumber business" but "your HVAC company" (not "company business") —
- *  avoids doubling when the vertical noun already ends in business/company/etc. */
-function ownBusinessPhrase(vertical: Vertical): string {
-  const name = vertical.name.trim();
-  if (/\b(business|company|companies|firm|practice|shop|spa|salon|barbershop|restaurant|agent)\b/i.test(name)) {
-    return name;
-  }
-  return `${name} business`;
 }
 
 /** A terse vertical-page promise for the <title> tail. */

--- a/packages/crm/tests/unit/marketing/structured-data.spec.tsx
+++ b/packages/crm/tests/unit/marketing/structured-data.spec.tsx
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MarketingStructuredData } from "../../../src/components/analytics/structured-data";
+import {
+  AGENCY_PLAN_FACTS,
+  AGENCY_POSITIONING,
+} from "../../../src/lib/marketing/public-claims";
+
+type JsonLd = Record<string, unknown>;
+
+function renderSchemas(): JsonLd[] {
+  const html = renderToStaticMarkup(createElement(MarketingStructuredData));
+  return [...html.matchAll(/<script type="application\/ld\+json">([^<]+)<\/script>/g)].map(
+    (match) => JSON.parse(match[1] ?? "{}") as JsonLd,
+  );
+}
+
+test("marketing JSON-LD derives every sellable offer from the public plan facts", () => {
+  const software = renderSchemas().find((schema) => schema["@type"] === "SoftwareApplication");
+  assert.ok(software, "SoftwareApplication schema must render");
+
+  const offers = software.offers as Array<Record<string, unknown>>;
+  assert.deepEqual(
+    offers.map((offer) => ({
+      name: offer.name,
+      priceMonthly: Number(offer.price),
+      audience: offer.description,
+    })),
+    AGENCY_PLAN_FACTS.map((plan) => ({
+      name: plan.name,
+      priceMonthly: plan.priceMonthly,
+      audience: plan.audience,
+    })),
+  );
+});
+
+test("marketing JSON-LD uses one canonical agency entity on the www host", () => {
+  const schemas = renderSchemas();
+  const organization = schemas.find((schema) => schema["@type"] === "Organization");
+  const website = schemas.find((schema) => schema["@type"] === "WebSite");
+  const software = schemas.find((schema) => schema["@type"] === "SoftwareApplication");
+
+  assert.equal(organization?.["@id"], "https://www.seldonframe.com/#org");
+  assert.equal(organization?.url, "https://www.seldonframe.com");
+  assert.equal(organization?.description, AGENCY_POSITIONING);
+  assert.deepEqual(website?.publisher, { "@id": "https://www.seldonframe.com/#org" });
+  assert.deepEqual(software?.provider, { "@id": "https://www.seldonframe.com/#org" });
+});

--- a/packages/crm/tests/unit/marketplace/render-ai-agents-markdown.spec.ts
+++ b/packages/crm/tests/unit/marketplace/render-ai-agents-markdown.spec.ts
@@ -148,8 +148,9 @@ describe("renderAiAgentJobMarkdown (Tier-1)", () => {
     assert.match(md, /### How does it answer my calls\?/);
     // A value-frame question (appended by composePageCopy for every page).
     assert.match(md, /### How much does it cost\?/);
-    // The real pricing fact carried in the value-frame answer.
-    assert.match(md, /\$29\/mo flat/);
+    // The real agency-first pricing ladder carried in the value-frame answer.
+    assert.match(md, /Agency Starter at \$99\/mo/);
+    assert.match(md, /Builder is \$29\/mo/);
   });
 
   test("rent-via-MCP hint + marketplace cross-link render when a listing exists", () => {
@@ -183,12 +184,14 @@ describe("renderAiAgentJobVerticalMarkdown (Tier-2)", () => {
 
     // Tier-2 H1 is "<job> for <Plural>".
     assert.match(md, /^# AI Receptionist for Plumbers/);
-    // The intro weaves the vertical pain hook + plural.
-    assert.match(md, /For plumbers,/);
+    // The intro preserves the trade query while speaking to the agency buyer.
+    assert.match(md, /For agencies serving plumbers,/);
     // Industry line in Details.
     assert.match(md, /\*\*Industry:\*\* plumbers/);
     // The cited stat is still present with its source.
     assert.match(md, /> "An estimated 62% of calls/);
+    assert.match(md, /\*\*Pricing:\*\* First workspace free; Agency Starter \$99\/mo/);
+    assert.doesNotMatch(md, /\*\*Pricing:\*\* \$29\/mo flat, unlimited workspaces/);
     assert.match(md, /> — Source: \[BrightLocal/);
   });
 

--- a/packages/crm/tests/unit/seo/agent-page-agency.spec.tsx
+++ b/packages/crm/tests/unit/seo/agent-page-agency.spec.tsx
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AgentPage } from "../../../src/components/seo/agent-page";
+import { getJob, getVertical } from "../../../src/lib/seo/agent-pages";
+
+test("a vertical agent page sells an agency-delivered client outcome", () => {
+  const html = renderToStaticMarkup(
+    createElement(AgentPage, {
+      job: getJob("missed-call-text-back"),
+      vertical: getVertical("barbers"),
+    }),
+  );
+
+  assert.match(html, /agency/i);
+  assert.match(html, /Build this for a barbershop client/);
+  assert.doesNotMatch(html, /Deploy it for my barbershop/);
+  assert.match(html, /Agency Starter/);
+  assert.match(html, /\$99/);
+});

--- a/packages/crm/tests/unit/seo/agent-page-metadata.spec.ts
+++ b/packages/crm/tests/unit/seo/agent-page-metadata.spec.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { generateMetadata as generateJobMetadata } from "../../../src/app/(public)/ai-agents/[job]/page";
+import { generateMetadata as generateVerticalMetadata } from "../../../src/app/(public)/ai-agents/[job]/for/[vertical]/page";
+
+test("agent metadata does not advertise a missing Markdown alternate", async () => {
+  const jobMetadata = await generateJobMetadata({
+    params: Promise.resolve({ job: "missed-call-text-back" }),
+  });
+  const verticalMetadata = await generateVerticalMetadata({
+    params: Promise.resolve({ job: "missed-call-text-back", vertical: "barbers" }),
+  });
+
+  assert.equal(jobMetadata.alternates?.canonical, "/ai-agents/missed-call-text-back");
+  assert.equal(jobMetadata.alternates?.types, undefined);
+  assert.equal(
+    verticalMetadata.alternates?.canonical,
+    "/ai-agents/missed-call-text-back/for/barbers",
+  );
+  assert.equal(verticalMetadata.alternates?.types, undefined);
+});


### PR DESCRIPTION
## What changed
- derive canonical Organization, WebSite, SoftwareApplication, and offer schema from current public product facts
- make agent-by-vertical pages and CTAs agency-first while preserving service-business search intent
- keep HTML and Markdown/AEO pricing aligned with the five sellable plans
- stop advertising dynamic Markdown alternates that currently return 404
- add regressions for agency copy, structured pricing, and metadata integrity

## Why
The public programmatic agent pages mixed end-business positioning, retired pricing, and broken Markdown discovery links. That weakened agency conversion and created contradictory facts for search engines and answer engines.

## Validation
- production monorepo build passed, including the server-boundary check and 560 generated pages
- TypeScript passed
- changed-file lint passed
- 132 focused tests passed
- 786 runnable unit-test files passed; the existing generated-block staleness test remains red on main

## Known baseline debt
Repository-wide lint remains red on existing unrelated findings. This PR adds no changed-file lint errors.