### PR TITLE
persona-loop: SEO page CTAs bypass their own working build widget

### DIFF
--- a/packages/crm/src/components/seo/alternative-page.tsx
+++ b/packages/crm/src/components/seo/alternative-page.tsx
@@ -39,9 +39,18 @@ import {
   SF_PROS,
   SF_CONS,
   SWITCH_STEPS,
-  START_HREF,
   DEMO_HREF,
 } from "@/lib/seo/alternative-pages-extras";
+
+// The "Start for free" CTAs on this page sit alongside the on-page
+// BuildWidget (the actual working self-serve build flow — see
+// build-widget.tsx). They used to point at the shared START_HREF
+// ("/#hero-form"), which navigates away to the agency-voiced homepage hero
+// instead of the widget already on THIS page — a visitor who read "paste a
+// business's website, free before signup" copy would land on "Sell AI
+// front offices" / "paste your client's URL" copy instead. Anchoring to the
+// widget keeps the promise the page just made. (persona-loop finding, 2026-08-12)
+const BUILD_WIDGET_HREF = "#build-widget";
 
 /** Small muted "prices checked" trust line with an outbound link to the
  *  competitor's own pricing page — shared by all three comparison templates
@@ -341,7 +350,7 @@ export function AlternativePage({ competitor }: { competitor: Competitor }): Rea
                 : "$29/mo flat for unlimited workspaces."}
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 22 }}>
-            <a href={START_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            <a href={BUILD_WIDGET_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
               Start for free
             </a>
             <a href={DEMO_HREF} style={{ border: "1.5px solid rgba(246,242,234,0.3)", color: MKT.paper, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
@@ -409,7 +418,7 @@ function CtaRow(): ReactElement {
 function CtaButtons(): ReactElement {
   return (
     <>
-      <a href={START_HREF} style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+      <a href={BUILD_WIDGET_HREF} style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
         Start for free
       </a>
       <a href={DEMO_HREF} style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>

--- a/packages/crm/src/components/seo/best-page.tsx
+++ b/packages/crm/src/components/seo/best-page.tsx
@@ -28,8 +28,19 @@ import {
   type BestAudience,
   type BestContender,
 } from "@/lib/seo/best-pages";
-import { START_HREF, DEMO_HREF } from "@/lib/seo/alternative-pages-extras";
+import { DEMO_HREF } from "@/lib/seo/alternative-pages-extras";
 import { getCompetitor, sfPriceAnchor } from "@/lib/seo/alternative-pages";
+
+// Both "Start for free" CTAs on this page sit alongside the on-page
+// BuildWidget (the actual working self-serve build flow for this SMB-voiced
+// page — see build-widget.tsx). They used to point at the shared
+// START_HREF ("/#hero-form"), which navigates away to the agency-voiced
+// homepage hero instead of the widget already on THIS page — a visitor who
+// read "paste your website, free before signup" copy would land on "Sell
+// AI front offices" / "paste your client's URL" copy instead. Anchoring to
+// the widget keeps the promise the page just made. (persona-loop finding,
+// 2026-08-12)
+const BUILD_WIDGET_HREF = "#build-widget";
 
 /** Best-pages are category-based, not tied to one competitor's audience band
  *  (contenders here aren't joined to the alternative-pages registry by slug).
@@ -303,7 +314,7 @@ export function BestPage({ slug }: { slug: string }): ReactElement {
               <span>Build it free in ~3 minutes before signup</span>
             </div>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 20 }}>
-              <a href={START_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              <a href={BUILD_WIDGET_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
                 Start for free
               </a>
               <a href={DEMO_HREF} style={{ border: `1.5px solid ${MKT.green}`, color: MKT.green, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
@@ -451,7 +462,7 @@ export function BestPage({ slug }: { slug: string }): ReactElement {
             about 3 minutes — free, before you sign up. Then it&apos;s $29/mo flat solo, or $99–$299/mo for agency white-label.
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 22 }}>
-            <a href={START_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            <a href={BUILD_WIDGET_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
               Start for free
             </a>
             <a href={DEMO_HREF} style={{ border: "1.5px solid rgba(246,242,234,0.3)", color: MKT.paper, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>

--- a/packages/crm/src/components/seo/build-widget.tsx
+++ b/packages/crm/src/components/seo/build-widget.tsx
@@ -51,6 +51,7 @@ export function BuildWidget({
 
   return (
     <section
+      id="build-widget"
       aria-label="Build your own workspace"
       style={{
         marginTop: 36,

--- a/packages/crm/src/components/seo/seldonframe-vs-page.tsx
+++ b/packages/crm/src/components/seo/seldonframe-vs-page.tsx
@@ -41,9 +41,18 @@ import {
   SF_PROS,
   SF_CONS,
   SWITCH_STEPS,
-  START_HREF,
   DEMO_HREF,
 } from "@/lib/seo/alternative-pages-extras";
+
+// The "Start for free" CTAs on this page sit alongside the on-page
+// BuildWidget (the actual working self-serve build flow — see
+// build-widget.tsx). They used to point at the shared START_HREF
+// ("/#hero-form"), which navigates away to the agency-voiced homepage hero
+// instead of the widget already on THIS page — a visitor who read "paste a
+// business's website, free before signup" copy would land on "Sell AI
+// front offices" / "paste your client's URL" copy instead. Anchoring to the
+// widget keeps the promise the page just made. (persona-loop finding, 2026-08-12)
+const BUILD_WIDGET_HREF = "#build-widget";
 
 /** Distinct intro paragraphs for the vs family — composed from registry facts,
  *  NOT c.intro (the /alternative-to page owns those verbatim), so the two
@@ -438,7 +447,7 @@ export function SeldonFrameVsPage({ competitor }: { competitor: Competitor }): R
                 : "$29/mo flat for unlimited workspaces."}
           </p>
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 22 }}>
-            <a href={START_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            <a href={BUILD_WIDGET_HREF} style={{ background: MKT.green, color: "#fff", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
               Start for free
             </a>
             <a href={DEMO_HREF} style={{ border: "1.5px solid rgba(246,242,234,0.3)", color: MKT.paper, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
@@ -504,7 +513,7 @@ export function SeldonFrameVsPage({ competitor }: { competitor: Competitor }): R
 function CtaRow(): ReactElement {
   return (
     <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center", marginTop: 28 }}>
-      <a href={START_HREF} style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+      <a href={BUILD_WIDGET_HREF} style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
         Start for free
       </a>
       <a href={DEMO_HREF} style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>


### PR DESCRIPTION
## Summary

Nightly persona-loop run (Wednesday → med-spa owner persona). Walked the live funnel at seldonframe.com to find the first point of confusion a self-serve small-business owner would hit.

**Finding.** The homepage hero is deliberately agency-voiced ("Sell AI front offices... your client's URL" — see `marketing-hero.tsx`'s own 2026-07-15 repositioning comment), with "the SMB self-serve pitch lives on the SEO pages" instead. That split is intentional and out of scope here. But the SEO pages meant to carry that SMB pitch — `/best/ai-receptionist-for-med-spas`, `/alternative-to-*`, `/compare/seldonframe-vs-*` — already ship a working inline `BuildWidget` ("Paste your website... free, before you ever sign up") right there on the page. Yet every "Start for free" CTA on those same pages (top hero, mid-page rows, final CTA) linked to the shared `START_HREF` constant, `"/#hero-form"` — which navigates away to the *homepage's* hero form instead of using the widget already on the page the visitor is reading.

**Verbatim evidence.** On `/best/ai-receptionist-for-med-spas` (a page whose own copy says `"$29/mo flat solo"` and `"Build it free in ~3 minutes before signup"`), the final-CTA section reads:

> "Paste your website (or describe your business) and SeldonFrame builds the site, CRM, booking calendar and AI receptionist in about 3 minutes — free, before you sign up."

directly above a "Start for free" button whose `href` was `/#hero-form` — landing on `www.seldonframe.com`'s hero, headlined "Sell AI front offices. Deploy them in minutes," with the URL field labeled `aria-label="Paste your client's website URL"` and placeholder `https://your-clients-medspa.com`. A solo med-spa owner who isn't reselling to any "clients" reads copy written for a different audience at the exact moment they expected the promised build to start. (Live-funnel testing of the actual `/try` build pipeline — Facebook-only business, schemeless URL, unreachable domain — was clean and honest in all three cases; this CTA mismatch was the first real friction found.)

## Root cause

`START_HREF = "/#hero-form"` (`lib/seo/alternative-pages-extras.ts`) is used uniformly for every "Start for free" button across the SEO template family, including on the three templates (`best-page.tsx`, `alternative-page.tsx`, `seldonframe-vs-page.tsx`) that already render `<BuildWidget>` inline. The widget was added later as "the highest-intent conversion seam" (per its own header comment) but the pre-existing CTAs were never repointed to it.

## Fix

- `build-widget.tsx`: give the widget's wrapping `<section>` `id="build-widget"`.
- `best-page.tsx`, `alternative-page.tsx`, `seldonframe-vs-page.tsx`: point their "Start for free" CTAs at `#build-widget` (same-page anchor, same idiom the homepage already uses for `#hero-form`) instead of `START_HREF`.
- `vs-page.tsx` and `pricing-page.tsx`, which don't render `BuildWidget`, are untouched — kept the diff scoped to the three templates where the fix is actually correct.
- Left the Markdown twin generator (`best-markdown.ts`, which emits `${BASE}${START_HREF}` as an absolute link for LLM/agent consumption) alone — threading the ungated-build flag into that pure static renderer is a separate, larger change outside this fix's blast radius.

No pricing numbers, positioning copy, or security-sensitive code touched.

## Type of change

- [x] Bug fix

## Testing

- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors (from `packages/crm`)
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)
- [x] Targeted unit tests: `node --import tsx --test tests/unit/seo/best-pages.spec.ts tests/unit/seo/alternative-pages-extras.spec.ts tests/unit/seo/seldonframe-vs.spec.ts` — 143/143 pass
- [ ] Manually verified in a browser — not possible from this sandbox (no browser access to the live/preview deployment); verified via source read + live curl of the current production HTML/CTA hrefs instead

## Notes for reviewers

This does not change the intentional agency-vs-SMB homepage/SEO-page copy split (`marketing-hero.tsx`'s 2026-07-15 repositioning) — only where these specific CTAs route.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Mnp6Lyvzy6go97aipYW3fi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mnp6Lyvzy6go97aipYW3fi)_