### PR TITLE
persona-loop: describe-business tab silently requires signup, unlike paste-URL

### DIFF
--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -401,6 +401,20 @@ export function MarketingHero({
             aria-label="Describe the business"
             className="block max-h-60 min-h-[110px] w-full resize-none border-0 bg-transparent font-sans text-[15px] leading-[1.55] tracking-[-0.005em] text-[#221D17] caret-[#1F2B24] outline-none placeholder:text-[#9A9183]"
           />
+          {/* persona-loop 2026-08-14: heroSubmitTarget always routes "biz" to
+              /signup (there's no public anonymous describe-build route — see
+              that file's header), while "url" gets the ungated /try build
+              when the flag is on. Same tab bar, same "Build workspace"
+              button, same "Spinning up your workspace…" overlay for both —
+              nothing disclosed this asymmetry before submit, so a visitor
+              who types a paragraph here hits a signup wall the URL path
+              never shows. */}
+          {ungatedBuildEnabled ? (
+            <p className="pb-1 text-left text-[12px] text-[#9A9183]">
+              Free account required for description-based builds — paste a URL instead for an
+              instant, no-signup build.
+            </p>
+          ) : null}
         </div>
 
         {/* Bottom action row */}


### PR DESCRIPTION
## Summary

**Persona:** Friday = dentist office manager (non-technical, impatient, on a phone). **Funnel step:** the homepage hero form (`www.seldonframe.com/`), which offers two visually equal tabs — "Paste a URL" and "Describe the business" — before any signup.

**First failure:** the "Describe the business" tab looks and behaves identically to "Paste a URL" up through submit (same "Build workspace" button, same "Spinning up your workspace…" full-screen overlay), but silently sends the visitor to `/signup` instead of building anything, while the URL tab gets a real, ungated, no-signup build on `/try`. Nothing before submit discloses this asymmetry.

**Verbatim evidence:**
- `packages/crm/src/components/landing/hero-submit-target.ts`'s own header comment: *"The biz tab must NOT go to /try: it would dead-end on a read-only echo of the description... It routes to /signup?intent=build"* — confirming this is known, deliberate routing, just never surfaced in the UI copy.
- Live-traced the actual anonymous build API (`GET /api/v1/web/build/stream?url=...`, an SSE stream) directly against `https://www.seldonframe.com` to confirm the URL path really is ungated and functional today (tested with `https://example.com/` and a nonexistent domain — both returned clean, honest error events, e.g. `{"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need..."}`). No equivalent public endpoint exists for the "biz" (describe) mode.
- `marketing-hero.tsx`'s `/try` no-signup promise ("Watch it build — no signup required") is real for URL-paste, but a visitor who instead types a paragraph describing their business — e.g. someone with no website, or who's cautious about pasting a URL — gets the exact same loading state, then lands on a signup wall with zero warning.

**Root cause:** `heroSubmitTarget()` (`hero-submit-target.ts`) always routes `tab === "biz"` to `/signup?intent=build`, because there's no public anonymous "describe your business" build route (a documented, deliberate scope cut from the 2026-07-14 extraction-failed-honesty design doc). That's a reasonable engineering call, but `marketing-hero.tsx` never told the visitor about it before they invested effort typing a description.

**Fix:** smallest honest fix, no new route, no architecture change — add a one-line disclosure under the "Describe the business" textarea (shown only when the ungated-build flag is on, since that's the only state where the two tabs actually diverge): *"Free account required for description-based builds — paste a URL instead for an instant, no-signup build."* Sets the expectation before submit instead of after.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

N/A — found via the nightly persona-loop routine, not a filed issue.

## Testing

- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors on `main`, 0 new errors on this branch (diffed both logs)
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (unrelated to this change, no migrations touched)
- [ ] No component/unit test exists for `marketing-hero.tsx` or `hero-submit-target.ts` today (verified via grep); this is a pure conditional-render addition with no logic change to the pure `heroSubmitTarget()` helper, so no new spec was added — same precedent the try-client.tsx extraction-failed fix followed ("no new DOM spec... the logic delta is a conditional render").
- [ ] Manual browser verification — **not possible in this sandbox**: headless Chromium cannot complete a TLS handshake through the sandbox's egress proxy to `www.seldonframe.com` (`net_error -101`, confirmed independent of certificate trust — `curl` to the same host succeeds fine). Verified instead by: (a) reading the exact conditional-render branch against the component source, (b) tracing the real anonymous build API directly with `curl`/SSE against production, (c) reading `hero-submit-target.ts`'s own routing logic and header comment. Recommend a human or the next persona-loop run confirm the rendered note visually.

## Screenshots / GIFs

Not captured — see the manual-verification note above (sandbox can't render the live page). Static evidence (API traces, source reads) is in the Summary section.

## Notes for reviewers

- Gated behind the existing `ungatedBuildEnabled` prop — when that flag is off, both tabs already route to `/signup` equally, so no disclosure is shown (nothing to disclose).
- Touches copy only, not pricing, positioning, or any security-sensitive path (no SSRF/auth/org-scoping code touched), per the persona-loop routine's hard rules.
- Please have someone confirm the note renders/reads well in the actual browser — this PR was written and gate-checked without live browser access to the deployed site.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ETsidmXXCuQNe2MedE7ouG)_