### PR TITLE
persona-loop: warn before the biz-tab silently requires signup

### DIFF
--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -401,6 +401,24 @@ export function MarketingHero({
             aria-label="Describe the business"
             className="block max-h-60 min-h-[110px] w-full resize-none border-0 bg-transparent font-sans text-[15px] leading-[1.55] tracking-[-0.005em] text-[#221D17] caret-[#1F2B24] outline-none placeholder:text-[#9A9183]"
           />
+          {/* Persona-loop honesty fix (2026-08-15): the URL tab builds
+              instantly with no signup (ungatedBuildEnabled routes it to
+              /try), but this tab always routes to /signup — heroSubmitTarget
+              can't send a description to the anonymous build route (URL-only,
+              see hero-submit-target.ts). Without warning, a visitor who picks
+              this identically-styled tab types a whole description expecting
+              the same live build, then gets silently redirected to signup.
+              Same pattern as the extraction_failed/credits_exhausted honesty
+              fixes in try-client.tsx: tell them up front instead of letting
+              them find out after typing. Only shown when the URL tab is
+              actually the free path — when the flag is off both tabs go to
+              signup, so there is no discrepancy to flag. */}
+          {ungatedBuildEnabled ? (
+            <p className="pb-1 pt-2 text-left text-[12px] leading-[1.5] text-[#9A9183]">
+              Building from a description needs a free account — paste your website URL above to
+              build instantly with no signup.
+            </p>
+          ) : null}
         </div>
 
         {/* Bottom action row */}

--- a/packages/crm/tests/unit/landing/marketing-hero-biz-disclaimer.spec.tsx
+++ b/packages/crm/tests/unit/landing/marketing-hero-biz-disclaimer.spec.tsx
@@ -1,0 +1,55 @@
+// packages/crm/tests/unit/landing/marketing-hero-biz-disclaimer.spec.tsx
+//
+// Persona-loop finding (2026-08-15): the homepage hero's "Paste a URL" and
+// "Describe the business" tabs are styled identically, but only the URL tab
+// is the ungated no-signup build (heroSubmitTarget always routes "biz" to
+// /signup — see hero-submit-target.ts and marketing-hero-target.spec.ts).
+// A visitor with no website (a very common case for solo trades) who picks
+// "Describe the business" gets silently redirected to signup after typing a
+// whole description, with no warning beforehand. This spec locks in the
+// honesty-fix disclaimer added to the biz pane.
+import "../../setup-dom";
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import React from "react";
+import { renderToString } from "react-dom/server";
+// MarketingHero calls next/navigation's useRouter() unconditionally.
+// renderToString has no App Router mounted, so useRouter throws unless an
+// AppRouterContext.Provider wraps the tree — same stub-router convention as
+// landing-mode-shell.spec.tsx (this repo avoids mock.module for CJS-interop
+// reliability — see tests/unit/theme/save-theme.spec.ts).
+import { AppRouterContext } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import { MarketingHero } from "../../../src/components/landing/marketing-hero";
+
+const STUB_ROUTER = {
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+  push: () => {},
+  replace: () => {},
+  prefetch: () => {},
+};
+
+function renderHero(ungatedBuildEnabled: boolean) {
+  return renderToString(
+    <AppRouterContext.Provider value={STUB_ROUTER}>
+      <MarketingHero ungatedBuildEnabled={ungatedBuildEnabled} />
+    </AppRouterContext.Provider>,
+  );
+}
+
+describe("MarketingHero — biz-tab signup disclaimer", () => {
+  test("ungated build on: biz pane warns it needs a free account before the URL-only free build", () => {
+    const html = renderHero(true);
+    assert.match(
+      html,
+      /Building from a description needs a free account/,
+      "visitor must be warned before typing a description that only the URL tab is the free, no-signup build",
+    );
+  });
+
+  test("ungated build off: no disclaimer (both tabs already route to signup — no discrepancy to flag)", () => {
+    const html = renderHero(false);
+    assert.doesNotMatch(html, /Building from a description needs a free account/);
+  });
+});


### PR DESCRIPTION
## Summary

**Persona:** solo electrician (Saturday rotation), non-technical, on a phone, no real website — just a Facebook page for the business, which is extremely common for solo trades.

**Funnel step:** homepage hero (`/`) → `#hero-form` → "Describe the business" tab → submit.

**Verbatim evidence:**
- `www.seldonframe.com/` returns `200`; the hero form (`marketing-hero.tsx`) renders two tabs, styled identically and switched with plain buttons: "Paste a URL" and "Describe the business." Neither carries any hint that they behave differently.
- Confirmed live: `GET https://www.seldonframe.com/try?url=...` returns `200` — the URL tab really is the free, no-signup "watch it build" flow (`SF_WEB_UNGATED_BUILD=1` in prod). Hit the real SSE endpoint directly (no workspace ever created — extraction failed before any workspace step, so this stayed within the "at most one test build" rule by using zero):
  ```
  GET /api/v1/web/build/stream?url=https://example.com
  event: fetching
  event: error
  data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
  ```
- In code, `heroSubmitTarget` (`hero-submit-target.ts`) always routes the "biz" tab to `/signup?intent=build`, even when the URL tab is routed to the ungated `/try` build. This is intentional and already tested (`marketing-hero-target.spec.ts`) — the public anonymous SSE route is URL-only, and `try-client.tsx`'s file header explicitly records this as a scope-cut deviation from the original design (`docs/superpowers/specs/2026-07-03-web-activation-design.md` §1 originally specified both URL *and* description as ungated).
- Net effect: a visitor with no website — like this persona, who only has a Facebook page — naturally reaches for "Describe the business" (presented as an equally valid, equally free option right next to "Paste a URL"), types out a real description, hits the identical "Build workspace" button, and is silently redirected to `/signup` with zero warning. That breaks CLAUDE.md §1's "no guest mode... zero-friction first run" promise and is exactly the kind of moment where a skeptical, impatient owner on a phone bounces and loses trust.

**Root cause:** the UI gives no signal that the two tabs diverge in cost (free build vs. signup-gated build) until *after* the user has already invested effort typing a description.

**Fix:** the smallest honest fix — no routing/backend change (that would need a whole new public anonymous description-build route, out of scope for this task and already recorded as a deliberate deviation). Instead, add a one-line disclaimer under the "Describe the business" textarea, shown only when the URL tab is actually the free path (`ungatedBuildEnabled`), telling the visitor up front:

> "Building from a description needs a free account — paste your website URL above to build instantly with no signup."

This follows the same "honesty fix" pattern already established in this codebase for `extraction_failed` / `credits_exhausted` (`try-client.tsx`, 2026-07-14 / 2026-07-16 comments): tell the user the truth before they invest effort, don't let them find out after.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

N/A — found via the nightly persona-loop routine, not a pre-filed issue.

## Testing

- [x] Targeted unit test added: `packages/crm/tests/unit/landing/marketing-hero-biz-disclaimer.spec.tsx` (2 cases — disclaimer shown when `ungatedBuildEnabled`, absent when not)
- [x] `node --import tsx --test` on the touched spec + `marketing-hero-target.spec.ts` + `landing-mode-shell.spec.tsx` — 10/10 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — clean, 0 errors
- [x] `bash scripts/check-use-server.sh src` — clean
- [x] `node scripts/check-migrations-journaled.mjs` — clean (no migrations touched)
- [ ] Manually verified the change in the browser — not run (no local dev server in this sandbox); verified via SSR `renderToString` unit test instead, matching this component's existing test convention

## Screenshots / GIFs

N/A — one-line text addition, no layout change. SSR test asserts the copy renders in the "biz" tab pane.

## Notes for reviewers

- No behavior change to routing/build logic — `heroSubmitTarget`'s existing (tested, intentional) routing is untouched.
- The underlying gap (no ungated description-build path) is real but out of scope for a "smallest honest fix" — it would need a new public anonymous SSE route. Worth a follow-up if the description-tab conversion rate looks bad in analytics.
- Disclaimer only renders when `ungatedBuildEnabled` is true; when the flag is off both tabs already go to `/signup`, so there's no discrepancy to flag and no UI change in that state.


---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kMn9MMDveFMW2RPU6gJv)_