### PR TITLE
persona-loop: BuildWidget promises a signup-free build the flag doesn't deliver

### DIFF
--- a/packages/crm/src/components/seo/build-widget.tsx
+++ b/packages/crm/src/components/seo/build-widget.tsx
@@ -63,7 +63,8 @@ export function BuildWidget({
       <h2 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em", color: INK }}>{heading}</h2>
       <p style={{ margin: "8px 0 14px", fontSize: 14.5, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 620 }}>
         Don't take the table's word for it. Paste your website and get <strong>your own</strong> site, booking calendar,
-        CRM and AI receptionist built in about <strong>3 minutes</strong> — free, before you ever sign up.
+        CRM and AI receptionist built in about <strong>3 minutes</strong>{" "}
+        {ungatedBuildEnabled ? "— free, before you ever sign up." : "— free, right after a quick sign-up."}
       </p>
       <form
         onSubmit={(e) => {


### PR DESCRIPTION
## Summary

**Persona:** Monday = plumber — non-technical, skeptical, comparison-shopping on a phone.

**Funnel step:** SEO comparison/tool pages that embed `BuildWidget` (e.g. `/tools/gohighlevel-cost-calculator`, `/tools/hubspot-pricing-calculator`, `/tools/voice-ai-cost-calculator`, `alternative-page.tsx`, `best-page.tsx`, `seldonframe-vs-page.tsx`) — exactly the pages a plumber lands on searching "SeldonFrame vs GoHighLevel" or similar.

**Verbatim evidence (live, `https://www.seldonframe.com/tools/gohighlevel-cost-calculator`, HTTP 200, indexable — no `noindex`):**

> "Don't take the table's word for it. Paste your website and get **your own** site, booking calendar, CRM and AI receptionist built in about **3 minutes** — free, before you ever sign up."
> Button: **"Build mine free →"**

Confirmed live that `SF_WEB_UNGATED_BUILD` is currently **off** in production: `https://www.seldonframe.com/try` returns `HTTP 200` with the Next.js not-found body ("This page could not be found") — i.e. the `notFound()` branch in `try/page.tsx` (gated by `isWebUngatedBuildOn`) is firing.

Submitting the widget calls `heroSubmitTarget("url", url, ungatedBuildEnabled)`, which with the flag off resolves to `/signup?intent=build&url=...`. Verified live: `https://www.seldonframe.com/signup?intent=build&url=...` → 307 → `https://app.seldonframe.com/signup`, a page requiring an email (or Google OAuth) **before any workspace is built**.

So the widget tells the plumber "free, before you ever sign up," they click "Build mine free," and land straight on an email-gated signup wall — the opposite of the promise, verbatim.

**Root cause:** `packages/crm/src/components/seo/build-widget.tsx` already receives `ungatedBuildEnabled` as a prop (every caller wires it correctly from `isWebUngatedBuildOn(process.env)`) and uses it correctly for *routing*. But the promise paragraph and button copy were hardcoded strings that never branched on that same flag, so when the flag is off the copy lies about what happens next.

**Fix:** Branch the trailing promise clause on the flag the component already has:
- `ungatedBuildEnabled === true` → "— free, before you ever sign up." (unchanged, accurate when `/try` is live)
- `ungatedBuildEnabled === false` (current prod state) → "— free, right after a quick sign-up." (accurate — first workspace is still free forever per product pricing; only the "before you ever sign up" claim was false)

No routing, pricing, or positioning change — this only corrects copy to match behavior the code already branches on.

## Type of change

- [x] Bug fix

## Testing

- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — clean, no new errors
- [x] `bash scripts/check-use-server.sh src` — ✓ All 'use server' files export only async functions / types.
- [x] `node scripts/check-migrations-journaled.mjs` — OK, 0 orphans
- [ ] No existing unit test covers this presentational component (no `*.test.*` exists under `src/components/` for any SEO widget in this repo — consistent with repo convention); the change is a 2-line conditional string branch on a prop already exercised by `heroSubmitTarget`'s existing coverage.

## Notes for reviewers

No env/schema changes. Scoped to `build-widget.tsx` only — the same widget is reused across 10 SEO pages, so this one fix propagates everywhere the false claim was showing.


---
_Generated by [Claude Code](https://claude.ai/code/session_012QauV8aKWvjC9DNEAXykaS)_