### PR TITLE
persona-loop: public intake form leaks SeldonFrame branding instead of the client's

### DIFF
--- a/packages/crm/src/app/forms/[id]/[formSlug]/page.tsx
+++ b/packages/crm/src/app/forms/[id]/[formSlug]/page.tsx
@@ -1,5 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { db } from "@/db";
 import { intakeForms, organizations } from "@/db/schema";
 import { PublicForm } from "@/components/forms/public-form";
@@ -14,6 +15,45 @@ import { getPublicOrgThemeBySlug } from "@/lib/theme/actions";
 // Shiloh"), not the agency name ("Max agency"). Operator dogfood
 // feedback: customer received an intake form with the agency logo at
 // the top instead of the actual roofing company, which was confusing.
+
+// persona-loop finding (2026-08-19): this route had no generateMetadata
+// export, so Next.js fell back to the root layout's <title>/OG tags —
+// SeldonFrame's own marketing copy ("Sell AI front offices. Deploy them
+// in minutes.") — on the client's own public intake form. A med-spa
+// customer opening their intake link would see SeldonFrame's agency
+// pitch in the browser tab and link preview instead of the med spa's
+// name. Same root cause already fixed for the booking page in
+// app/book/[orgSlug]/[bookingSlug]/page.tsx — mirrored here.
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string; formSlug: string }>;
+}): Promise<Metadata> {
+  const { id: orgSlug, formSlug } = await params;
+
+  const [org] = await db
+    .select({ id: organizations.id, name: organizations.name })
+    .from(organizations)
+    .where(eq(organizations.slug, orgSlug))
+    .limit(1);
+  if (!org) return {};
+
+  const [form] = await db
+    .select({ name: intakeForms.name })
+    .from(intakeForms)
+    .where(and(eq(intakeForms.orgId, org.id), eq(intakeForms.slug, formSlug)))
+    .limit(1);
+  if (!form) return {};
+
+  const title = `${form.name} — ${org.name}`;
+  const description = `Fill out ${form.name} for ${org.name}.`;
+
+  return {
+    title,
+    description,
+    openGraph: { title, description, type: "website" },
+  };
+}
 
 export default async function PublicIntakePage({
   params,


### PR DESCRIPTION
## Persona

Wednesday → med-spa owner. Non-technical, skeptical, on a phone.

## Funnel step

Walking the live funnel from `https://www.seldonframe.com/`: the homepage's hero `#hero-form` "Paste a URL" tab routes (via `heroSubmitTarget`, `SF_WEB_UNGATED_BUILD=1` confirmed live in prod — `/try` returns 200, not 404) to the ungated `/try` build. From there I checked one of the site's own live demo workspaces — `Metro Medspa`, linked from the homepage's live-demo marquee — and walked its own generated CRM surfaces (booking, intake) the way an operator/customer would, since CLAUDE.md promises "full CRM, Cal.diy booking, Formbricks intake" as core value.

## Verbatim evidence

```
$ curl -sS https://metro-medspa-9d24.app.seldonframe.com/intake
HTTP_STATUS:200

<title>SeldonFrame — Sell AI front offices. Deploy them in minutes.</title>
<meta name="description" content="The agent-native, open-source alternative to GoHighLevel for
  agencies selling AI front offices to local businesses. Deploy branded client workspaces,
  booking, CRM, intake, and agents from one repeatable delivery loop."/>
<meta property="og:title" content="SeldonFrame — Sell AI front offices. Deploy them in minutes."/>
```

The public intake form for "Metro Medspa" — a page the med spa's own customers land on to book a treatment — shows SeldonFrame's own agency-recruiting marketing copy in the browser tab and in any link preview, instead of "Metro Medspa" or the form's name.

## Root cause

`packages/crm/src/app/forms/[id]/[formSlug]/page.tsx` (the public intake-form route reached via the workspace-subdomain proxy rewrite in `proxy.ts`'s `/intake` → `/forms/${slug}/${defaultFormSlug}` rule) has no `generateMetadata` export, so Next.js falls back to the root layout's SeldonFrame marketing `<title>`/OG tags.

This is the exact same bug class already diagnosed and fixed for the sibling booking route in **#148** ("public booking page leaks SeldonFrame's own branding instead of the client's", commit `2d477ab0`, still open/unmerged) — but in a different, still-unfixed file. I checked all persona-loop branches; none touch `forms/[id]/[formSlug]/page.tsx`, so this is a distinct finding, not a duplicate.

Worth a founder note independent of this PR: #148 has been open since 2026-07-19 and this exact class of bug is still live in production a month later because it was never merged — same for a growing backlog of other still-open persona-loop PRs.

## The fix

Added a `generateMetadata` export to `forms/[id]/[formSlug]/page.tsx`, mirroring #148's pattern for the booking page: look up the org + form by slug, and title the page `"${form.name} — ${org.name}"` with a matching description/OG tag. Falls back to `{}` (default metadata) when the org or form isn't found, matching the booking-page precedent.

## Gate results (from `packages/crm`, after `pnpm install`)

- `node --import tsx --test tests/unit/forms-slug-uuid-guard.spec.ts` (nearest existing coverage for this route family) — **7/7 pass**
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` — **0 errors**
- `bash scripts/check-use-server.sh src` — **✓ pass**
- `node scripts/check-migrations-journaled.mjs` — **✓ pass** (0 orphans)

No new test added — mirrors #148, which shipped this same fix pattern without one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DmzB8cWPFXpV88ubX7wHKu)_