### PR TITLE
persona-loop: /try shows a doomed "Try again" for invalid_url, burning a build attempt

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -99,6 +99,26 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
   // anthropic-error-map.ts) — a "Try again" button would be a lie. The
   // server's `message` explains it; we just suppress the retry affordance.
   const [creditsExhausted, setCreditsExhausted] = useState(false);
+  // 2026-08-20 — invalid_url honesty fix (persona-loop finding). This route
+  // is URL-only (no signup, no "describe your business" tab — see the
+  // file-header deviation note), so a first-time visitor who doesn't
+  // realize this box wants a URL specifically (they land straight on /try,
+  // or the input reads like a chat box) commonly types their business name
+  // or something else that isn't a URL. That hits the SAME invalid_url
+  // response every time for the identical string (route.ts's
+  // assertPublicHttpUrl check is deterministic on its input) — exactly the
+  // "would just fail identically" condition that extraction_failed and
+  // credits_exhausted were already special-cased for above. Before this
+  // fix the default branch rendered a "Try again" button that resubmitted
+  // the exact same invalid string via startBuild(url), which (a) always
+  // fails again and (b) burns one more of the visitor's 3 free
+  // builds/24h — checkRateLimit's Redis INCR happens before the URL-shape
+  // check runs, so even a doomed request counts against the cap. The fix
+  // is to route this into the same "Back" pattern as credits_exhausted:
+  // reset() returns to the idle form with their typed text still in the
+  // box (not cleared) so they can actually edit it, instead of blindly
+  // resubmitting.
+  const [invalidUrl, setInvalidUrl] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const autoSubmittedRef = useRef(false);
 
@@ -159,6 +179,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       setRateLimited(data.code === "rate_limited");
       setExtractionFailed(isExtractionFailed);
       setCreditsExhausted(data.reason === "credits_exhausted");
+      setInvalidUrl(data.code === "invalid_url");
       setError(
         data.message ??
           (isExtractionFailed
@@ -190,6 +211,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
     setRateLimited(false);
     setExtractionFailed(false);
     setCreditsExhausted(false);
+    setInvalidUrl(false);
     setBuildInput(null);
   }
 
@@ -377,6 +399,21 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                   >
                     Back
                   </button>
+                ) : invalidUrl ? (
+                  // invalid_url is deterministic for the exact string
+                  // submitted — a "Try again" that resubmits the same text
+                  // would fail identically (and burn another of the 3
+                  // free builds/24h). Send them back to the editable input
+                  // (their text is preserved, not cleared) instead.
+                  <div className="mt-3 flex flex-wrap items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={reset}
+                      className="rounded-[11px] bg-[#1F2B24] px-4 py-2 text-[13.5px] font-[600] text-[#FFFDFA]"
+                    >
+                      Edit and try again
+                    </button>
+                  </div>
                 ) : (
                   <button
                     type="button"

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -87,6 +87,29 @@ describe("TryClient — SSE error honesty", () => {
     );
   });
 
+  test("invalid_url error shows the server message and NO 'Try again' button", async () => {
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("Green Thumb Landscaping Sacramento");
+    });
+
+    const message = "That URL can't be reached — double-check it and try again.";
+    await act(async () => {
+      FakeEventSource.last!.fire("error", { code: "invalid_url", message });
+    });
+
+    assert.ok(screen.queryAllByText(message).length > 0, "honest server message must be shown");
+    assert.equal(
+      screen.queryAllByText("Try again").length,
+      0,
+      "invalid_url is deterministic for the same string — no Try again button",
+    );
+    assert.ok(
+      screen.queryAllByText("Edit and try again").length > 0,
+      "must offer a way back to the editable input instead",
+    );
+  });
+
   test("internal_error still shows the generic copy WITH a 'Try again' button", async () => {
     render(<TryClient initialUrl="" />);
     await act(async () => {


### PR DESCRIPTION
## Summary

**Persona:** landscaper (Thursday's persona-loop rotation), non-technical, on a phone, walking the live `/try` funnel at seldonframe.com.

**Funnel step:** the public, unauthenticated anonymous build (`/try` → `GET /api/v1/web/build/stream`) — the "paste a URL, watch it build, no signup" first-run wedge.

**First failure:** a first-time visitor who types their business name instead of a URL into the `/try` input (a natural mistake — this surface is URL-only with no visible "describe your business" affordance until *after* they fail) hits an `invalid_url` error, then gets a generic **"Try again"** button that resubmits the identical string and fails identically every time.

### Verbatim evidence

Direct API probe simulating the mistake:

```
$ curl -sN "https://www.seldonframe.com/api/v1/web/build/stream?url=Green%20Thumb%20Landscaping%20Sacramento"
event: error
data: {"code":"invalid_url","message":"That URL can't be reached — double-check it and try again."}
```

The client (`try-client.tsx`) only special-cases `rate_limited`, `extraction_failed`, and `credits_exhausted` as non-retryable. `invalid_url` fell through to the generic branch, which renders a plain "Try again" button wired to `startBuild(url)` — resubmitting the exact same (still invalid) string.

Compounding this: `checkRateLimit`'s Redis `INCR` (packages/crm/src/lib/utils/rate-limit.ts) runs **before** the URL-shape/SSRF check in `route.ts`, so even a doomed request consumes one of the visitor's 3 free builds/24h. A visitor who mistypes twice, then hits "Try again" believing it might work, can burn all 3 attempts without ever seeing a real build — and the UI never surfaces the "sign up to keep building" path shown for `rate_limited`, since it doesn't know it's about to hit that wall.

### Root cause

`extraction_failed` (2026-07-04) and `credits_exhausted` (2026-07-16) were already given this exact honesty fix in this file, per their own code comments: both are permanent-for-this-input conditions, so a "Try again" that can only fail identically was removed in favor of an honest message + a real next step. `invalid_url` is equally deterministic (`assertPublicHttpUrl` on the same string always returns the same verdict) but was missed.

### Fix

Added an `invalidUrl` state (mirroring the existing `extractionFailed`/`creditsExhausted` pattern) and a render branch that, instead of the doomed "Try again," offers **"Edit and try again"** — calling `reset()`, which returns to the idle form with their originally-typed text still in the box (not cleared) so they can see and fix their mistake rather than blindly resubmitting it.

Scope kept minimal: no changes to `route.ts`, the SSRF guard, or rate-limit ordering (security-sensitive, out of scope per CLAUDE.md — flagging the rate-limit-consumed-before-validation behavior below as a possible follow-up, not fixed here).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] Targeted unit test added (`invalid_url error shows the server message and NO 'Try again' button`), mirroring the existing `credits_exhausted` test — `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx` → 3/3 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` → 0 errors
- [x] `bash scripts/check-use-server.sh src` → pass
- [x] `node scripts/check-migrations-journaled.mjs` → pass
- [x] Manually verified against production (`curl` against `www.seldonframe.com`) to confirm the exact server response this fix handles

## Notes for reviewers

Follow-up worth considering separately (not touched here, since it brushes the rate-limit/SSRF gate ordering flagged as security-sensitive by CLAUDE.md): should a request that fails the URL-shape check before any build work even starts still consume a rate-limit slot? Right now it does.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W3Qu5ZwoPB78kJwEyu3Kfk)_