### PR TITLE
persona-loop: BuildWidget promises a JSON export anonymous visitors can't get

### DIFF
--- a/packages/crm/src/components/seo/build-widget.tsx
+++ b/packages/crm/src/components/seo/build-widget.tsx
@@ -118,8 +118,18 @@ export function BuildWidget({
           {error}
         </p>
       ) : (
+        // 2026-08-21 — persona-loop finding: this reassurance used to add
+        // "Your data exports as JSON if you leave." This widget routes an
+        // anonymous visitor (no signup yet — see heroSubmitTarget) into the
+        // build flow; the only export capability in the app is
+        // exportSoulAction (lib/soul/export-actions.ts), which calls
+        // getOrgId() and throws "Unauthorized" without a session. A visitor
+        // who builds here and never signs up has no session and no way to
+        // export anything — the claim was false for the exact audience this
+        // widget targets. Dropped rather than reworded to avoid promising a
+        // pre-signup export path that doesn't exist.
         <p style={{ margin: "8px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.5)" }}>
-          No card. No call. Your data exports as JSON if you leave.
+          No card. No call.
         </p>
       )}
     </section>


### PR DESCRIPTION
## Persona

Friday persona: dentist office manager — non-technical, impatient, skeptical, on her phone. Following the primary build path (paste-your-website funnel), a level deeper into the SEO/comparison-page on-ramp per the run's brief ("go one level deeper" once the homepage happy path checked out clean).

## Funnel step

The `BuildWidget` component (`packages/crm/src/components/seo/build-widget.tsx`) — the "See it built for YOUR business" CTA embedded on comparison/alternative/best-of SEO pages. It reuses the same anonymous build flow as the homepage hero (`heroSubmitTarget`) and explicitly promises the build is **"free, before you ever sign up."**

## Verbatim evidence

The reassurance line directly under the submit button, shown whenever there's no input-validation error:

```
No card. No call. Your data exports as JSON if you leave.
```

The only export capability that exists in the codebase is `exportSoulAction` (`packages/crm/src/lib/soul/export-actions.ts`):

```ts
export async function exportSoulAction() {
  const orgId = await getOrgId();
  if (!orgId) {
    throw new Error("Unauthorized");
  }
  ...
  return exportSoulConfig(orgId, org.soul as unknown as Record<string, unknown>);
}
```

`getOrgId()` requires an authenticated session. A visitor who uses this exact widget — anonymous, no signup, per its own "before you ever sign up" promise — and then leaves has no session and no account, so this action throws `Unauthorized` for them. There is no anonymous/pre-signup export path anywhere in the app. The widget promises a safety net to the exact audience for whom that safety net cannot possibly exist.

## Root cause

Copy drift: the reassurance line asserts a capability (anonymous data export) that was never wired up for the anonymous build flow this widget exists to sell. It's a factual claim, not a positioning/pricing claim, so it's fixable in code rather than a judgment call.

## Fix

Dropped the false sub-claim rather than reword it into a different unverified promise (e.g. claiming export becomes available "once you sign up" — not verified in this pass, and out of scope for a minimal fix). The line now reads:

```
No card. No call.
```

which is accurate and still reassuring, without asserting a capability the anonymous flow doesn't have.

## Gate results (from `packages/crm`)

- `node --import tsx --test tests/unit/seo/alternative-pages-extras.spec.ts` (only existing spec touching this file, via `normalizeSiteInput`) — **23/23 pass**
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` — **0 errors**
- `bash scripts/check-use-server.sh src` — **pass**
- `node scripts/check-migrations-journaled.mjs` — **pass** (0 orphans)

No new tests added — this is a static JSX copy change with no branching logic to cover, and no existing test asserted the removed string.

Checked against the ~20 open `persona-loop` PRs already in this repo (including #200, which touches the same file's signup-promise line but a different sentence) to avoid duplicating prior findings — confirmed distinct.

Per the run's hard rules, this PR is **not** merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqFVAvYeEnPANWerFwFTae)_