### PR TITLE
persona-loop: honest CTA copy for the "Describe the business" tab

### DIFF
--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -169,6 +169,11 @@ export function MarketingHero({
 
   const activeValue = tab === "url" ? urlValue : bizValue;
   const canSubmit = activeValue.trim().length >= 3;
+  // The "biz" tab (and the "url" tab when the ungated-build flag is off)
+  // isn't wired to the free anonymous build — it routes to /signup?intent=
+  // build (see hero-submit-target.ts). Label the button honestly instead
+  // of promising an instant build the click won't deliver.
+  const willRequireAccount = tab === "biz" || !ungatedBuildEnabled;
 
   const handleTab = useCallback((next: TabKind) => {
     setTab(next);
@@ -413,10 +418,12 @@ export function MarketingHero({
           <button
             type="submit"
             disabled={!canSubmit || submitting}
-            aria-label="Build workspace"
+            aria-label={willRequireAccount ? "Create free account to build" : "Build workspace"}
             className="group inline-flex h-10 items-center justify-center gap-2 rounded-[10px] bg-[#1F2B24] px-4 text-[13.5px] font-[600] text-[#FFFDFA] shadow-[0_6px_20px_rgba(31, 43, 36,.28)] transition-all hover:-translate-y-px hover:bg-[#16201B] hover:shadow-[0_8px_24px_rgba(31, 43, 36,.34)] active:translate-y-px disabled:cursor-not-allowed disabled:opacity-50 disabled:shadow-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1F2B24]"
           >
-            <AnimatedShinyText base="rgba(246,242,234,.82)" shine="#FFFFFF" shimmerWidth={90}>Build workspace</AnimatedShinyText>
+            <AnimatedShinyText base="rgba(246,242,234,.82)" shine="#FFFFFF" shimmerWidth={90}>
+              {willRequireAccount ? "Create free account to build" : "Build workspace"}
+            </AnimatedShinyText>
             <ArrowRight size={14} className="transition-transform group-hover:translate-x-0.5" aria-hidden />
           </button>
         </div>


### PR DESCRIPTION
## Summary

Nightly activation-persona loop (persona: solo electrician, Saturday). Fixes the first trust-killer found walking the live homepage build funnel: the hero form's two tabs promise the same thing but don't deliver the same thing.

## Persona & funnel step

Solo electrician, no real website (very common for solo trades — many run entirely on a Facebook page or Google Business Profile, no URL to paste). On `https://www.seldonframe.com/`, the hero form (`#hero-form`) has two tabs, "Paste a URL" and "Describe the business." This persona has nothing to paste, so they use "Describe the business."

## Verbatim evidence

- Both tabs share one CTA button, currently labeled `Build workspace` regardless of tab (`packages/crm/src/components/landing/marketing-hero.tsx`, pre-fix).
- Routing logic (`packages/crm/src/components/landing/hero-submit-target.ts`): when the ungated-build flag is on, the `url` tab routes to `/try?url=...` (the anonymous, no-signup build). The `biz` tab *always* routes to `/signup?intent=build`, flag on or off — confirmed in the file's own comment: *"the biz tab must NOT go to /try: it would dead-end on a read-only echo of the description."*
- Confirmed live against production:
  - `curl -o /dev/null -w '%{http_code}' 'https://www.seldonframe.com/try?url=https://example.com'` → `200` (serves the anonymous build page directly, no auth).
  - `curl -o /dev/null -w '%{http_code}' 'https://www.seldonframe.com/signup?intent=build&url=https://example.com'` → `307` → `Location: https://app.seldonframe.com/signup?intent=build&url=...`
  - That `app.seldonframe.com/signup` page renders an email/password + "Continue with Google" account-creation form — i.e. the "Describe the business" tab silently walks the visitor into a signup wall before any workspace is built.

This contradicts CLAUDE.md §1's locked vision: *"No guest mode, no local:// paths, no claim step, no upfront API key"* and *"type natural language → instantly get a real hosted workspace."* Describing the business in natural language is exactly the "biz" tab's job, and it's the one path that isn't ungated.

## Root cause

`try-client.tsx`'s own header comment documents this as a known, deliberate deviation: the public anonymous build route (`/api/v1/web/build/stream`) is URL-only; wiring a matching anonymous route for free-text business descriptions "would require a second public anonymous route this task doesn't create." That's a real backend scope decision, not something to force into a nightly persona-loop PR — so this PR does **not** attempt to build biz-mode into `/try`.

What *is* in scope and root-cause-fixable today: the CTA button lies about what happens next. It says "Build workspace" on both tabs, but only one tab builds a workspace — the other creates an account first. That mismatch is the actual trust-killer a first-time visitor hits.

## The fix

`marketing-hero.tsx`: compute `willRequireAccount = tab === "biz" || !ungatedBuildEnabled` and use it to label the CTA (`aria-label` + visible button text) as `"Create free account to build"` instead of `"Build workspace"` whenever the click will land on the signup wall, on either tab. No behavior change, no new route, no backend touch — just making the existing button honest about its own destination.

## Gate results (from `packages/crm`)

- `node --import tsx --test tests/unit/marketing-hero-target.spec.ts tests/unit/landing/landing-mode-shell.spec.tsx` → 8/8 pass
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` → 0 errors on `main`, 0 errors after the change (no new lines)
- `bash scripts/check-use-server.sh src` → pass
- `node scripts/check-migrations-journaled.mjs` → pass (no migrations touched)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] `pnpm typecheck` passes (via targeted `tsc --noEmit`, 0 new errors)
- [x] `pnpm test:unit` passes (targeted specs above)
- [x] Manually verified the change is copy-only, no new logic paths beyond the existing `heroSubmitTarget` truth table (already covered by `marketing-hero-target.spec.ts`)
- [ ] `pnpm lint` — not run in this session; no new imports/patterns introduced

## Notes for reviewers

- No PR is opened for the underlying "biz-mode build isn't ungated" gap itself — that's a real product decision (build a second anonymous SSE route, or don't) that belongs to a human, not a nightly loop. Happy to file that as a separate issue if wanted.
- One test build limit for this run was not needed — the finding surfaced from reading the funnel/routing code plus live `curl` checks against production, no test workspace was created.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JCiwFDmxLMfPrBFwg6qDWy)_