### PR TITLE
persona-loop: free-try rate limit is charged for invalid URLs before any build work runs

### DIFF
--- a/packages/crm/src/app/api/v1/web/build/stream/route.ts
+++ b/packages/crm/src/app/api/v1/web/build/stream/route.ts
@@ -195,26 +195,8 @@ export async function GET(request: Request): Promise<Response> {
   const url = new URL(request.url).searchParams.get("url");
   const ip = getClientIp(request);
 
-  const gate = await resolveWebBuildGate({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD }, ip, () =>
-    checkRateLimit(
-      `web-build:${ip}`,
-      resolveWebBuildRateLimit({ SF_WEB_BUILD_RATE_LIMIT: process.env.SF_WEB_BUILD_RATE_LIMIT }),
-      WEB_BUILD_RATE_WINDOW_MS,
-    ),
-  );
-
-  if (gate.kind === "not_found") {
+  if (!isWebUngatedBuildOn({ SF_WEB_UNGATED_BUILD: process.env.SF_WEB_UNGATED_BUILD })) {
     return new Response(null, { status: 404 });
-  }
-
-  if (gate.kind === "rate_limited") {
-    const sse = createSseStream();
-    sse.emit("error", {
-      code: "rate_limited",
-      message: "You've built a few workspaces today — sign up to keep building.",
-    });
-    sse.close();
-    return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
   }
 
   // SSRF hardening on the now-public path (final review 2026-07-04): resolve +
@@ -228,6 +210,15 @@ export async function GET(request: Request): Promise<Response> {
   // rejects it (generic "Something broke" for any schemeless direct paste on
   // /try — the hero always passed full https URLs, masking it). The build must
   // receive the SAME normalized URL we vetted.
+  //
+  // 2026-08-23 persona-loop fix: this validation now runs BEFORE the rate
+  // limit check below (previously after). A malformed or unreachable URL is
+  // rejected here at zero cost — no Firecrawl/Anthropic call is ever made —
+  // so it must not consume one of the visitor's 3/24h free tries. Before this
+  // fix, checkRateLimit() ran unconditionally ahead of this block, meaning a
+  // mistyped domain or a copy-pasted bad link burned a real attempt on
+  // nothing, silently shrinking the "free to try, no signup required" promise
+  // for exactly the visitors most likely to fat-finger a URL on a phone.
   let buildUrl = url;
   if (url) {
     const trimmed = url.trim();
@@ -244,6 +235,22 @@ export async function GET(request: Request): Promise<Response> {
       return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
     }
     buildUrl = candidate;
+  }
+
+  const allowed = await checkRateLimit(
+    `web-build:${ip}`,
+    resolveWebBuildRateLimit({ SF_WEB_BUILD_RATE_LIMIT: process.env.SF_WEB_BUILD_RATE_LIMIT }),
+    WEB_BUILD_RATE_WINDOW_MS,
+  );
+
+  if (!allowed) {
+    const sse = createSseStream();
+    sse.emit("error", {
+      code: "rate_limited",
+      message: "You've built a few workspaces today — sign up to keep building.",
+    });
+    sse.close();
+    return new Response(sse.stream, { headers: SSE_RESPONSE_HEADERS });
   }
 
   return runAnonymousBuild(buildUrl);


### PR DESCRIPTION
## Persona

Sunday → hair-salon owner: non-technical, impatient, on her phone between clients.

## Funnel step

The public "no signup required, free to try" build wedge at `/try` (public homepage → "Paste a URL" tab → `/try?url=...` → `GET /api/v1/web/build/stream`).

## Verbatim evidence

`/try`'s own copy promises: *"Watch it build — no signup required"* and *"free to try, nothing to sign up for yet."* The build stream is capped at 3 builds / 24h per IP (`resolveWebBuildRateLimit`).

Live repro against `www.seldonframe.com` (no workspace created, side-effect-free):

```
$ curl "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fthis-domain-should-not-resolve-persona-loop-test-12345.invalid"
event: error
data: {"code":"invalid_url","message":"That URL can't be reached — double-check it and try again."}
```

That request returns `invalid_url` — no Firecrawl scrape, no Anthropic call, no workspace. But in `route.ts`'s `GET` handler (pre-fix), `checkRateLimit()` ran *before* the SSRF/URL-validation block, so this "free" rejected attempt still incremented the visitor's 3/24h counter. A salon owner typing her own site's URL on a phone (typo, bare domain, unreachable link) can burn all 3 tries on nothing and land on "You've built a few workspaces today — sign up to keep building" without ever seeing a real build — directly contradicting the page's own "free to try, no signup required" promise.

(Also spot-checked the extraction-failed path — a Facebook-only business page — which is already handled honestly with a non-retryable message, so that path is fine as-is and out of scope here.)

## Root cause

`packages/crm/src/app/api/v1/web/build/stream/route.ts`'s `GET` handler called `resolveWebBuildGate(...)` (which runs the rate-limit check) **before** the SSRF/URL-normalization block. Any request — including one rejected as unreachable/malformed — consumed a rate-limit slot.

## Fix

Reordered `GET()`: the feature-flag check runs first (free), then URL validation (`assertPublicHttpUrl`), then `checkRateLimit()` only for URLs that pass validation. `resolveWebBuildGate` and its existing unit tests are untouched — only the call order in the route moved. Smallest change that fixes the root cause; no new abstractions.

## Gate results (from `packages/crm`)

- `node --import tsx --test tests/unit/web-build-stream-route.spec.ts` → 3/3 pass
- `node_modules/.bin/tsc -p tsconfig.json --noEmit` → 0 errors
- `bash scripts/check-use-server.sh src` → clean
- `node scripts/check-migrations-journaled.mjs` → OK, 0 orphans

Note: the anonymous `/try` build path is URL-only and derives the business name from the scraped site content, so it has no way to seed a controllable test business name — I could not produce a real successful build named "PersonaLoop Test ..." without hosting external content for that sole purpose, so this run's testing was limited to non-mutating probes (as shown above) plus code review, and no test workspace was created.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JyPBB2MepWn6pbh8TXUV7U)_