### PR TITLE
feat(growth): signup attribution — hear-about question + first-touch UTM on signed_up

### DIFF
--- a/packages/crm/src/app/(auth)/signup/signup-form.tsx
+++ b/packages/crm/src/app/(auth)/signup/signup-form.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
+import posthog from "posthog-js";
 import { sendMagicLinkAction } from "./actions";
 import { googleSignInAction } from "../oauth-actions";
 import { DEMO_BLOCK_MESSAGE } from "@/lib/demo/constants";
 import { useDemoToast } from "@/components/shared/demo-toast-provider";
+import { HEAR_ABOUT_OPTIONS, normalizeHearAbout } from "@/lib/analytics/signup-attribution";
 
 export function SignupForm({
   redirectTo,
@@ -16,6 +18,14 @@ export function SignupForm({
 }) {
   const { showDemoToast } = useDemoToast();
   const [state, action, pending] = useActionState(sendMagicLinkAction, {});
+  // 2026-08-23 — optional attribution question ("make the next wave
+  // attributable"). Analytics-only: the answer is captured straight to
+  // PostHog on the ANONYMOUS person ($set_once hear_about) the moment
+  // it's chosen, so it applies to both the Google and magic-link paths
+  // and never gates or delays signup. The anonymous person merges into
+  // the new user via the identity bridge and the server-side alias in
+  // events.createUser, so hear_about survives as a person property.
+  const [hearAbout, setHearAbout] = useState("");
   // 2026-07-04 — redirectTo is computed server-side in page.tsx from the
   // ?url= / ?biz= / ?intent= query params (or /claim?token=... for claim
   // flows). The default path lands the visitor on /clients/new with url/biz
@@ -31,6 +41,36 @@ export function SignupForm({
 
   return (
     <div className="space-y-5 text-foreground">
+      <div className="space-y-1">
+        <label htmlFor="hear-about" className="text-label text-foreground">
+          How did you hear about us?{" "}
+          <span className="font-normal text-[hsl(var(--color-text-secondary))]">(optional)</span>
+        </label>
+        <select
+          id="hear-about"
+          value={hearAbout}
+          onChange={(event) => {
+            const value = event.target.value;
+            setHearAbout(value);
+            const channel = normalizeHearAbout(value);
+            if (channel) {
+              posthog.capture("signup_survey_answered", {
+                channel,
+                $set_once: { hear_about: channel },
+              });
+            }
+          }}
+          className="crm-input h-10 w-full px-3"
+        >
+          <option value="">Choose one…</option>
+          {HEAR_ABOUT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
       {googleEnabled ? (
         <>
           <form action={googleSignInAction}>

--- a/packages/crm/src/lib/analytics/funnel.ts
+++ b/packages/crm/src/lib/analytics/funnel.ts
@@ -20,9 +20,12 @@ export type FunnelPropertyValue = string | number | boolean | null;
 export type FunnelEvent = {
   event: string;
   distinctId: string;
-  /** Flat properties, plus PostHog's nested $set for person-property writes. */
+  /** Flat properties, plus PostHog's nested $set / $set_once for
+   *  person-property writes ($set_once = first-touch attribution that a
+   *  later value must never overwrite). */
   properties: Record<string, FunnelPropertyValue> & {
     $set?: Record<string, FunnelPropertyValue>;
+    $set_once?: Record<string, FunnelPropertyValue>;
   };
 };
 
@@ -43,6 +46,16 @@ export type BuildSignedUpEventInput = {
    *  null, when unknown — keeps the property absent rather than noisy. */
   method?: string | null;
   email?: string | null;
+  /** 2026-08-23 — first-touch attribution parsed from the posthog-js
+   *  cookie by events.createUser (see lib/analytics/signup-attribution).
+   *  utm keys land BOTH flat on the event (event-level breakdowns) and
+   *  as $initial_* under $set_once (person-level first-touch that later
+   *  sessions can't overwrite). Absent/empty → no properties added. */
+  attribution?: {
+    initialUrl?: string | null;
+    initialReferrer?: string | null;
+    utm?: Record<string, string>;
+  } | null;
 };
 
 /**
@@ -70,6 +83,23 @@ export function buildSignedUpEvent(input: BuildSignedUpEventInput): FunnelEvent 
 
   if (input.email) {
     properties.$set = { email: input.email };
+  }
+
+  if (input.attribution) {
+    const setOnce: Record<string, FunnelPropertyValue> = {};
+    for (const [key, value] of Object.entries(input.attribution.utm ?? {})) {
+      properties[key] = value;
+      setOnce[`$initial_${key}`] = value;
+    }
+    if (input.attribution.initialReferrer) {
+      setOnce.$initial_referrer = input.attribution.initialReferrer;
+    }
+    if (input.attribution.initialUrl) {
+      setOnce.$initial_current_url = input.attribution.initialUrl;
+    }
+    if (Object.keys(setOnce).length > 0) {
+      properties.$set_once = setOnce;
+    }
   }
 
   return { event: "signed_up", distinctId, properties };
@@ -203,6 +233,34 @@ export function aliasOrgToUser(userId: string | null | undefined, orgId: string 
 
     void ph
       .aliasImmediate({ distinctId: trimmedUserId, alias: trimmedOrgId })
+      .catch(() => {
+        // Swallow — an alias failure must be invisible to the caller.
+      });
+  } catch {
+    // Never let an alias-construction bug reach the caller's request path.
+  }
+}
+
+/**
+ * 2026-08-23 — alias the ANONYMOUS browser distinct id (from the
+ * posthog-js cookie) to the new user id at signup time. The client-side
+ * identity bridge already merges these two persons — but only if the user
+ * survives to a bridge-mounted page (/clients/new, /dashboard, /pricing).
+ * Users who open the magic link elsewhere or drop before first paint stay
+ * split forever, which is exactly how the Aug-22 surge stayed
+ * unattributable. Same fire-and-forget posture as aliasOrgToUser.
+ */
+export function aliasAnonToUser(userId: string | null | undefined, anonDistinctId: string | null | undefined): void {
+  const trimmedUserId = userId?.trim();
+  const trimmedAnonId = anonDistinctId?.trim();
+  if (!trimmedUserId || !trimmedAnonId || trimmedUserId === trimmedAnonId) return;
+
+  try {
+    const ph = getPosthogClient();
+    if (!ph) return;
+
+    void ph
+      .aliasImmediate({ distinctId: trimmedUserId, alias: trimmedAnonId })
       .catch(() => {
         // Swallow — an alias failure must be invisible to the caller.
       });

--- a/packages/crm/src/lib/analytics/signup-attribution.ts
+++ b/packages/crm/src/lib/analytics/signup-attribution.ts
@@ -1,0 +1,114 @@
+// 2026-08-23 — signup attribution (the "make the next wave attributable"
+// wave; the Aug-22 traffic surge was 81% direct/no-UTM and unattributable).
+// Pure helpers, no I/O and no posthog imports, so both the client signup
+// form and the server auth event path can use them; unit-tested in
+// tests/unit/analytics/signup-attribution.spec.ts.
+//
+// Two jobs:
+//  1. Normalize the optional "How did you hear about us?" answer the
+//     signup form captures (allowlist clamp — free-text or tampered
+//     values are dropped, never stored).
+//  2. Parse posthog-js's persistence cookie so the SERVER-side signed_up
+//     event can carry first-touch attribution ($initial_utm_*,
+//     $initial_referrer) and stitch the anonymous browser person to the
+//     new user id even when the user never renders a bridge-mounted page
+//     after signup (magic link opened in a different browser, drop-off
+//     before /clients/new paints). Cookie shape (posthog-js with
+//     cross_subdomain persistence on .seldonframe.com):
+//     ph_<PROJECT_KEY>_posthog = URI-encoded JSON carrying distinct_id
+//     and $initial_person_info { u: first-touch URL, r: referrer }.
+
+export const HEAR_ABOUT_OPTIONS = [
+  { value: "youtube", label: "YouTube" },
+  { value: "x", label: "X / Twitter" },
+  { value: "google", label: "Google search" },
+  { value: "chatgpt", label: "ChatGPT / AI assistant" },
+  { value: "reddit", label: "Reddit" },
+  { value: "github", label: "GitHub" },
+  { value: "friend", label: "Friend or colleague" },
+  { value: "other", label: "Somewhere else" },
+] as const;
+
+export type HearAboutChannel = (typeof HEAR_ABOUT_OPTIONS)[number]["value"];
+
+/** Allowlist clamp for the survey answer. Anything not exactly one of the
+ *  option values (after trim/lowercase) returns null — reject, don't
+ *  store, per the Optimistic Path rule (CLAUDE.md §3.1). */
+export function normalizeHearAbout(value: unknown): HearAboutChannel | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  const match = HEAR_ABOUT_OPTIONS.find((option) => option.value === trimmed);
+  return match ? match.value : null;
+}
+
+export type PosthogCookieInfo = {
+  anonDistinctId: string | null;
+  initialUrl: string | null;
+  initialReferrer: string | null;
+};
+
+const EMPTY_COOKIE_INFO: PosthogCookieInfo = {
+  anonDistinctId: null,
+  initialUrl: null,
+  initialReferrer: null,
+};
+
+/** posthog-js persistence cookie name for a project key, or null when the
+ *  key is unset (PostHog disabled — attribution is then a no-op). */
+export function posthogCookieName(projectKey: string | null | undefined): string | null {
+  const key = projectKey?.trim();
+  return key ? `ph_${key}_posthog` : null;
+}
+
+/** Best-effort parse of the posthog-js cookie value. Any malformed input
+ *  (missing, not JSON, unexpected shape) returns the empty info object —
+ *  attribution is enrichment and must never throw into the auth path. */
+export function parsePosthogCookieValue(raw: string | null | undefined): PosthogCookieInfo {
+  if (!raw || typeof raw !== "string") return EMPTY_COOKIE_INFO;
+
+  try {
+    const parsed = JSON.parse(decodeURIComponent(raw)) as {
+      distinct_id?: unknown;
+      $initial_person_info?: { u?: unknown; r?: unknown } | null;
+    };
+    const distinctId =
+      typeof parsed.distinct_id === "string" && parsed.distinct_id.trim()
+        ? parsed.distinct_id
+        : null;
+    const info = parsed.$initial_person_info;
+    return {
+      anonDistinctId: distinctId,
+      initialUrl: typeof info?.u === "string" && info.u ? info.u : null,
+      initialReferrer: typeof info?.r === "string" && info.r ? info.r : null,
+    };
+  } catch {
+    return EMPTY_COOKIE_INFO;
+  }
+}
+
+const UTM_KEYS = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+] as const;
+
+/** Extract utm_* params from a first-touch URL. Invalid/absent URLs (and
+ *  URLs with no utm params) return {} — callers treat that as "nothing to
+ *  attach", never an error. */
+export function extractUtmParams(url: string | null | undefined): Record<string, string> {
+  if (!url) return {};
+
+  try {
+    const parsed = new URL(url);
+    const out: Record<string, string> = {};
+    for (const key of UTM_KEYS) {
+      const value = parsed.searchParams.get(key)?.trim();
+      if (value) out[key] = value;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}

--- a/packages/crm/src/lib/auth/config.ts
+++ b/packages/crm/src/lib/auth/config.ts
@@ -429,8 +429,41 @@ export const authConfig = {
         const orgId = typeof (user as { orgId?: unknown }).orgId === "string" ? (user as { orgId: string }).orgId : null;
         const userId = typeof user.id === "string" ? user.id : null;
         const email = typeof user.email === "string" ? user.email : null;
-        const { buildSignedUpEvent, captureFunnelEvent } = await import("@/lib/analytics/funnel");
-        captureFunnelEvent(buildSignedUpEvent({ userId, orgId, email }));
+
+        // 2026-08-23 — first-touch attribution. posthog-js persists the
+        // anonymous distinct id + first-touch URL/referrer in a cookie on
+        // .seldonframe.com; reading it here lets signed_up carry
+        // $initial_utm_* server-side AND stitches the anonymous browser
+        // person to the new user without depending on the user surviving
+        // to a bridge-mounted page (the Aug-22 surge was 81% direct and
+        // unattributable partly because of this gap). Best-effort: the
+        // inner try means a cookie-read failure (e.g. outside a request
+        // scope) silently degrades to the pre-2026-08-23 behavior.
+        let attribution: { initialUrl?: string | null; initialReferrer?: string | null; utm?: Record<string, string> } | null = null;
+        let anonDistinctId: string | null = null;
+        try {
+          const { cookies } = await import("next/headers");
+          const { posthogCookieName, parsePosthogCookieValue, extractUtmParams } = await import(
+            "@/lib/analytics/signup-attribution"
+          );
+          const cookieName = posthogCookieName(process.env.NEXT_PUBLIC_POSTHOG_KEY);
+          const raw = cookieName ? (await cookies()).get(cookieName)?.value : undefined;
+          const info = parsePosthogCookieValue(raw);
+          anonDistinctId = info.anonDistinctId;
+          if (info.initialUrl || info.initialReferrer) {
+            attribution = {
+              initialUrl: info.initialUrl,
+              initialReferrer: info.initialReferrer,
+              utm: extractUtmParams(info.initialUrl),
+            };
+          }
+        } catch {
+          // Attribution is enrichment only — signup capture proceeds bare.
+        }
+
+        const { buildSignedUpEvent, captureFunnelEvent, aliasAnonToUser } = await import("@/lib/analytics/funnel");
+        captureFunnelEvent(buildSignedUpEvent({ userId, orgId, email, attribution }));
+        aliasAnonToUser(userId, anonDistinctId);
       } catch (err) {
         console.warn(
           `[auth][events.createUser] signed_up capture threw (swallowed): ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/crm/tests/unit/analytics/signup-attribution.spec.ts
+++ b/packages/crm/tests/unit/analytics/signup-attribution.spec.ts
@@ -1,0 +1,143 @@
+// 2026-08-23 — signup attribution helpers (lib/analytics/signup-attribution)
+// plus the buildSignedUpEvent attribution extension (lib/analytics/funnel).
+// Pure-function tests, no DB, no PostHog client.
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  HEAR_ABOUT_OPTIONS,
+  extractUtmParams,
+  normalizeHearAbout,
+  parsePosthogCookieValue,
+  posthogCookieName,
+} from "@/lib/analytics/signup-attribution";
+import { buildSignedUpEvent } from "@/lib/analytics/funnel";
+
+describe("normalizeHearAbout — allowlist clamp", () => {
+  test("accepts every declared option value verbatim", () => {
+    for (const option of HEAR_ABOUT_OPTIONS) {
+      assert.equal(normalizeHearAbout(option.value), option.value);
+    }
+  });
+
+  test("trims and lowercases before matching", () => {
+    assert.equal(normalizeHearAbout("  YouTube "), "youtube");
+    assert.equal(normalizeHearAbout("GITHUB"), "github");
+  });
+
+  test("rejects free text, empty, and non-strings", () => {
+    assert.equal(normalizeHearAbout("my cousin's newsletter"), null);
+    assert.equal(normalizeHearAbout(""), null);
+    assert.equal(normalizeHearAbout(null), null);
+    assert.equal(normalizeHearAbout(undefined), null);
+    assert.equal(normalizeHearAbout(42), null);
+    assert.equal(normalizeHearAbout({ value: "youtube" }), null);
+  });
+});
+
+describe("posthogCookieName", () => {
+  test("builds ph_<key>_posthog from the project key", () => {
+    assert.equal(posthogCookieName("phc_abc123"), "ph_phc_abc123_posthog");
+  });
+
+  test("returns null for unset/blank keys (PostHog disabled)", () => {
+    assert.equal(posthogCookieName(undefined), null);
+    assert.equal(posthogCookieName(null), null);
+    assert.equal(posthogCookieName("   "), null);
+  });
+});
+
+describe("parsePosthogCookieValue — best-effort, never throws", () => {
+  test("parses distinct_id and $initial_person_info from URI-encoded JSON", () => {
+    const cookie = encodeURIComponent(
+      JSON.stringify({
+        distinct_id: "anon-device-123",
+        $initial_person_info: {
+          u: "https://www.seldonframe.com/?utm_source=youtube&utm_medium=video_description",
+          r: "https://www.youtube.com/",
+        },
+      }),
+    );
+    const info = parsePosthogCookieValue(cookie);
+    assert.equal(info.anonDistinctId, "anon-device-123");
+    assert.equal(
+      info.initialUrl,
+      "https://www.seldonframe.com/?utm_source=youtube&utm_medium=video_description",
+    );
+    assert.equal(info.initialReferrer, "https://www.youtube.com/");
+  });
+
+  test("missing fields degrade to nulls, not throws", () => {
+    const info = parsePosthogCookieValue(encodeURIComponent(JSON.stringify({ distinct_id: "anon-1" })));
+    assert.equal(info.anonDistinctId, "anon-1");
+    assert.equal(info.initialUrl, null);
+    assert.equal(info.initialReferrer, null);
+  });
+
+  test("garbage input returns the empty shape", () => {
+    for (const raw of [undefined, null, "", "not-json", "%7Bbroken", encodeURIComponent("[1,2,3]")]) {
+      const info = parsePosthogCookieValue(raw);
+      assert.equal(info.anonDistinctId, null);
+      assert.equal(info.initialUrl, null);
+      assert.equal(info.initialReferrer, null);
+    }
+  });
+});
+
+describe("extractUtmParams", () => {
+  test("pulls only utm_* keys, trimmed", () => {
+    const utm = extractUtmParams(
+      "https://seldonframe.com/try?utm_source=x&utm_medium=post&utm_campaign=launch&ref=abc",
+    );
+    assert.deepEqual(utm, { utm_source: "x", utm_medium: "post", utm_campaign: "launch" });
+  });
+
+  test("no params / invalid URL / null all return {}", () => {
+    assert.deepEqual(extractUtmParams("https://seldonframe.com/"), {});
+    assert.deepEqual(extractUtmParams("not a url"), {});
+    assert.deepEqual(extractUtmParams(null), {});
+    assert.deepEqual(extractUtmParams(undefined), {});
+  });
+});
+
+describe("buildSignedUpEvent — attribution extension", () => {
+  const base = { userId: "user-1", orgId: "org-1", email: "a@b.com" };
+
+  test("utm lands flat on the event AND as $initial_* under $set_once", () => {
+    const event = buildSignedUpEvent({
+      ...base,
+      attribution: {
+        initialUrl: "https://seldonframe.com/?utm_source=youtube",
+        initialReferrer: "https://www.youtube.com/",
+        utm: { utm_source: "youtube" },
+      },
+    });
+    assert.ok(event);
+    assert.equal(event!.properties.utm_source, "youtube");
+    assert.deepEqual(event!.properties.$set_once, {
+      $initial_utm_source: "youtube",
+      $initial_referrer: "https://www.youtube.com/",
+      $initial_current_url: "https://seldonframe.com/?utm_source=youtube",
+    });
+  });
+
+  test("attribution with no usable fields adds no $set_once", () => {
+    const event = buildSignedUpEvent({ ...base, attribution: { utm: {} } });
+    assert.ok(event);
+    assert.equal(event!.properties.$set_once, undefined);
+  });
+
+  test("absent attribution keeps the pre-2026-08-23 event shape exactly", () => {
+    const event = buildSignedUpEvent(base);
+    assert.ok(event);
+    assert.deepEqual(event, {
+      event: "signed_up",
+      distinctId: "user-1",
+      properties: {
+        org_id: "org-1",
+        $set: { email: "a@b.com" },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Why
The Aug-22 surge (76 uniques, 3x baseline) was 81% direct / no-UTM and structurally unattributable: `signed_up` carried no attribution, and anonymous->user stitching depended on the client identity bridge (lost when the magic link opens elsewhere or the user drops before first paint).

## What
1. **Optional one-question survey on /signup** — 'How did you hear about us?' select above both auth paths. Analytics-only: captured immediately to the anonymous PostHog person (`signup_survey_answered` + `$set_once hear_about`), merges into the user person via bridge + server alias. Never blocks or gates signup (per the repo's no-interstitial law — /signup/billing was a measured 100% drop-off wall).
2. **Server-side first-touch attribution** — `events.createUser` parses the posthog-js cookie (`ph_<key>_posthog`): `signed_up` now carries flat `utm_*` + `$set_once $initial_utm_* / $initial_referrer / $initial_current_url`, and new `aliasAnonToUser` stitches the anonymous person server-side. Best-effort everywhere; failures degrade to prior behavior.
3. **New pure module** `lib/analytics/signup-attribution.ts` — allowlist clamp (8 channels), cookie parse, utm extraction.

## Tests
35/35: new signup-attribution.spec.ts + existing funnel-events.spec.ts (untouched, green — exact back-compat pin asserts the no-attribution event shape is byte-identical).

## Post-deploy smoke
Sign up from an incognito tab reached via `https://seldonframe.com/?utm_source=smoketest`, answer the survey, then check the PostHog person for `hear_about` + `$initial_utm_source=smoketest` and the `signed_up` event for flat `utm_source`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)