### PR TITLE
feat(growth): UTM-tag controlled outbound links + link kit

### DIFF
--- a/docs/marketing/utm-link-kit.md
+++ b/docs/marketing/utm-link-kit.md
@@ -1,0 +1,53 @@
+# UTM link kit
+
+Copy-paste tagged URLs for channels Max posts by hand. For links SF renders
+programmatically (badges, embeds, emails, registry listings), the tagging is
+already baked into the code — see the PR that introduced this file for the
+full surface-by-surface inventory.
+
+## Taxonomy
+
+- `utm_source` = the surface / channel (where the click came from)
+- `utm_medium` = the mechanism (what kind of placement it was)
+- `utm_campaign` / `utm_content` used sparingly, only where a specific push
+  or sub-surface needs to be distinguished
+- **Never tag agency-whitelabeled URLs.** Any link that substitutes an
+  agency's own domain or `supportUrl` must stay untouched — UTM params only
+  go on SeldonFrame-owned fallback URLs.
+
+## Target URLs
+
+- `https://seldonframe.com/`
+- `https://seldonframe.com/try`
+
+## Hand-posted channels
+
+| Channel | utm_source | utm_medium | Example (root) |
+| --- | --- | --- | --- |
+| YouTube video description | `youtube` | `video_description` | `https://seldonframe.com/?utm_source=youtube&utm_medium=video_description` |
+| X post | `x` | `post` | `https://seldonframe.com/?utm_source=x&utm_medium=post` |
+| Reddit post | `reddit` | `post` | `https://seldonframe.com/?utm_source=reddit&utm_medium=post` |
+| ChatGPT apps directory listing | `chatgpt_app` | `listing` | `https://seldonframe.com/?utm_source=chatgpt_app&utm_medium=listing` |
+| Glama / MCP registry | `mcp_registry` | `listing` | already covered — see `skills/mcp-server/server.json` `websiteUrl` |
+| npm README | `npm` | `readme` | `https://seldonframe.com/?utm_source=npm&utm_medium=readme` |
+| GitHub README | `github` | `readme` | `https://seldonframe.com/?utm_source=github&utm_medium=readme` |
+
+Same table, pointed at `/try` instead of `/`:
+
+| Channel | Example (/try) |
+| --- | --- |
+| YouTube video description | `https://seldonframe.com/try?utm_source=youtube&utm_medium=video_description` |
+| X post | `https://seldonframe.com/try?utm_source=x&utm_medium=post` |
+| Reddit post | `https://seldonframe.com/try?utm_source=reddit&utm_medium=post` |
+| ChatGPT apps directory listing | `https://seldonframe.com/try?utm_source=chatgpt_app&utm_medium=listing` |
+| npm README | `https://seldonframe.com/try?utm_source=npm&utm_medium=readme` |
+| GitHub README | `https://seldonframe.com/try?utm_source=github&utm_medium=readme` |
+
+## Rules
+
+1. `utm_source` = surface, `utm_medium` = mechanism. Don't swap them.
+2. Never tag an agency-whitelabeled URL (customer-facing white-label emails
+   and portals substitute the agency's own domain/support URL — those stay
+   bare).
+3. Reuse the same `utm_source` value across every SF-controlled surface for
+   that channel so PostHog/GA can roll them up without a mapping table.

--- a/packages/core/src/virality/embeddable-widget.tsx
+++ b/packages/core/src/virality/embeddable-widget.tsx
@@ -15,7 +15,7 @@ export function EmbeddableWidget({
       <div className="overflow-hidden rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--card))]">
         <iframe src={iframeSrc} title={title ?? "Embeddable widget"} className="h-[640px] w-full" loading="lazy" />
       </div>
-      <PoweredByBadge removeBranding={removeBranding} />
+      <PoweredByBadge removeBranding={removeBranding} source="embed_widget" />
     </section>
   );
 }

--- a/packages/core/src/virality/powered-by-badge.tsx
+++ b/packages/core/src/virality/powered-by-badge.tsx
@@ -52,13 +52,29 @@ function SeldonFrameMark({ className = "" }: { className?: string }) {
   );
 }
 
+// Default outbound href for the badge, UTM-tagged so clicks from other
+// people's surfaces are attributable back to the surface that sent them.
+// `source` maps to utm_content (e.g. "workspace_site", "embed_widget") —
+// pass it whenever the caller knows which surface is rendering the badge.
+function buildDefaultHref(source?: string): string {
+  const url = new URL("https://seldonframe.com");
+  url.searchParams.set("utm_source", "powered_by");
+  url.searchParams.set("utm_medium", "badge");
+  if (source) {
+    url.searchParams.set("utm_content", source);
+  }
+  return url.toString();
+}
+
 export function PoweredByBadge({
-  href = "https://seldonframe.com",
+  href,
+  source,
   label = "Powered by SeldonFrame",
   removeBranding = false,
   variant = "light",
 }: {
   href?: string;
+  source?: string;
   label?: string;
   removeBranding?: boolean;
   variant?: "light" | "dark";
@@ -73,7 +89,7 @@ export function PoweredByBadge({
 
   return (
     <a
-      href={href}
+      href={href ?? buildDefaultHref(source)}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={label}

--- a/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
+++ b/packages/crm/src/app/(public)/s/[orgSlug]/[...slug]/page.tsx
@@ -417,7 +417,7 @@ export default async function PublicSPage({ params }: PageProps) {
               backgroundColor: "color-mix(in oklab, var(--sf-bg) 92%, var(--sf-accent) 8%)",
             }}
           >
-            <PoweredByBadge />
+            <PoweredByBadge source="workspace_site" />
           </div>
         ) : null}
         {chatbotEmbed ? (

--- a/packages/crm/src/app/a/[slug]/page.tsx
+++ b/packages/crm/src/app/a/[slug]/page.tsx
@@ -63,7 +63,7 @@ export default async function PublicShareCardPage({
       </div>
 
       <a
-        href={`/record?ref=share-${encodeURIComponent(slug)}`}
+        href={`/record?ref=share-${encodeURIComponent(slug)}&utm_source=share_card&utm_medium=referral`}
         className="inline-flex items-center gap-2 rounded-[11px] bg-[#F6F2EA] px-6 py-3 text-sm font-semibold text-[#1F2B24] transition-opacity hover:opacity-90"
       >
         Build yours from a screen recording →

--- a/packages/crm/src/app/api/v1/public/agent/[slug]/embed.js/route.ts
+++ b/packages/crm/src/app/api/v1/public/agent/[slug]/embed.js/route.ts
@@ -177,6 +177,7 @@ export async function GET(
     googleFontUrl,
     orgName,
     logoUrl,
+    orgSlug: orgSlugPart,
   });
 
   return new NextResponse(script, {
@@ -196,6 +197,7 @@ function renderEmbedScript(input: {
   googleFontUrl: string | null;
   orgName: string;
   logoUrl: string | null;
+  orgSlug: string;
 }): string {
   // bodyFontStack is the CSS font-family value the panel uses. The
   // workspace's body font (from the archetype OR stored theme.fontFamily)
@@ -218,6 +220,7 @@ function renderEmbedScript(input: {
     googleFontUrl: input.googleFontUrl,
     orgName: input.orgName,
     logoUrl: input.logoUrl,
+    orgSlug: input.orgSlug,
   };
   // The embed runs as an IIFE. Self-contained — no framework deps.
   // Renders shadow-DOM-free for max compatibility (works inside iframes,
@@ -378,7 +381,7 @@ function renderEmbedScript(input: {
     '<textarea class="sf-agent-input" id="sf-agent-input" rows="1" placeholder="Type a message..." aria-label="Type a message"></textarea>',
     '<button class="sf-agent-send" type="submit" aria-label="Send message">Send</button>',
     '</form>',
-    '<div class="sf-agent-footer">Powered by <a href="https://seldonframe.com" target="_blank" rel="noopener">SeldonFrame</a></div>'
+    '<div class="sf-agent-footer">Powered by <a href="https://seldonframe.com?utm_source=chat_widget&utm_medium=embed&utm_content=' + encodeURIComponent(CFG.orgSlug) + '" target="_blank" rel="noopener">SeldonFrame</a></div>'
   ].join("");
 
   function escapeHtml(s){return String(s).replace(/[&<>"']/g, function(c){return ({"&":"&amp;","<":"&lt;",">":"&gt;","\\"":"&quot;","'":"&#39;"})[c];});}

--- a/packages/crm/src/app/book/[orgSlug]/[bookingSlug]/page.tsx
+++ b/packages/crm/src/app/book/[orgSlug]/[bookingSlug]/page.tsx
@@ -205,7 +205,7 @@ export default async function PublicBookingPage({
         {(showBadge || isTestMode) ? (
           <div className="flex flex-col items-center gap-2 py-3">
             {isTestMode ? <TestModePublicBadge testMode={true} /> : null}
-            {showBadge ? <PoweredByBadge /> : null}
+            {showBadge ? <PoweredByBadge source="booking_page" /> : null}
           </div>
         ) : null}
       </div>

--- a/packages/crm/src/app/forms/[id]/[formSlug]/page.tsx
+++ b/packages/crm/src/app/forms/[id]/[formSlug]/page.tsx
@@ -105,7 +105,7 @@ export default async function PublicIntakePage({
         <div dangerouslySetInnerHTML={{ __html: form.contentHtml! }} />
         {showBadge ? (
           <div className="flex justify-center py-2">
-            <PoweredByBadge />
+            <PoweredByBadge source="workspace_form" />
           </div>
         ) : null}
       </>
@@ -151,7 +151,7 @@ export default async function PublicIntakePage({
           />
           {showBadge ? (
             <div className="flex justify-center pt-2">
-              <PoweredByBadge />
+              <PoweredByBadge source="workspace_form" />
             </div>
           ) : null}
         </div>

--- a/packages/crm/src/app/l/[orgSlug]/[slug]/page.tsx
+++ b/packages/crm/src/app/l/[orgSlug]/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function PublicLandingPage({
           <PageRenderer sections={sections} />
           {showBadge ? (
             <div className="flex justify-center py-4" style={{ borderTop: "1px solid var(--sf-border)", backgroundColor: "color-mix(in oklab, var(--sf-bg) 92%, var(--sf-accent) 8%)" }}>
-              <PoweredByBadge />
+              <PoweredByBadge source="workspace_landing" />
             </div>
           ) : null}
           <VisitBeacon pageId={payload.page.id} />
@@ -90,7 +90,7 @@ export default async function PublicLandingPage({
           <div dangerouslySetInnerHTML={{ __html: payload.page.contentHtml }} />
           {showBadge ? (
             <div className="flex justify-center py-4" style={{ borderTop: "1px solid var(--sf-border)", backgroundColor: "color-mix(in oklab, var(--sf-bg) 92%, var(--sf-accent) 8%)" }}>
-              <PoweredByBadge />
+              <PoweredByBadge source="workspace_landing" />
             </div>
           ) : null}
           <VisitBeacon pageId={payload.page.id} />
@@ -109,7 +109,7 @@ export default async function PublicLandingPage({
         <PageRenderer sections={[]} />
         {showBadge ? (
           <div className="flex justify-center py-4" style={{ borderTop: "1px solid var(--sf-border)", backgroundColor: "color-mix(in oklab, var(--sf-bg) 92%, var(--sf-accent) 8%)" }}>
-            <PoweredByBadge />
+            <PoweredByBadge source="workspace_landing" />
           </div>
         ) : null}
         <VisitBeacon pageId={payload.page.id} />

--- a/packages/crm/src/app/portal/approvals/[token]/page.tsx
+++ b/packages/crm/src/app/portal/approvals/[token]/page.tsx
@@ -93,7 +93,7 @@ export default async function CustomerApprovalPage({
           {(showBadge || isTestMode) ? (
             <div className="flex flex-col items-center gap-2 pt-4">
               {isTestMode ? <TestModePublicBadge testMode={true} /> : null}
-              {showBadge ? <PoweredByBadge /> : null}
+              {showBadge ? <PoweredByBadge source="client_portal" /> : null}
             </div>
           ) : null}
         </div>
@@ -222,7 +222,7 @@ function DisabledShell() {
           you&apos;re expecting to act on a request, please contact the sender.
         </p>
         <div className="pt-4">
-          <PoweredByBadge />
+          <PoweredByBadge source="client_portal" />
         </div>
       </section>
     </main>

--- a/packages/crm/src/components/customer-portal/customer-portal-shell.tsx
+++ b/packages/crm/src/components/customer-portal/customer-portal-shell.tsx
@@ -167,7 +167,7 @@ export function CustomerPortalShell({
             <span>
               Powered by{" "}
               <a
-                href="https://seldonframe.com"
+                href="https://seldonframe.com?utm_source=customer_portal&utm_medium=footer"
                 style={{ color: "#666" }}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/packages/crm/src/components/landing-r1/powered-by-badge.tsx
+++ b/packages/crm/src/components/landing-r1/powered-by-badge.tsx
@@ -20,6 +20,7 @@ export function buildPoweredByHref(workspaceId: string): string {
   const url = new URL("https://www.seldonframe.com/build");
   url.searchParams.set("ref", workspaceId);
   url.searchParams.set("utm_source", "powered_by");
+  url.searchParams.set("utm_medium", "workspace_badge");
   return url.toString();
 }
 

--- a/packages/crm/src/components/operator-portal/operator-portal-shell.tsx
+++ b/packages/crm/src/components/operator-portal/operator-portal-shell.tsx
@@ -118,7 +118,7 @@ export function OperatorPortalShell({
             <span>
               Powered by{" "}
               <a
-                href="https://seldonframe.com"
+                href="https://seldonframe.com?utm_source=operator_portal&utm_medium=footer"
                 style={{ color: "#666" }}
                 target="_blank"
                 rel="noopener noreferrer"

--- a/packages/crm/src/lib/blueprint/renderers/calcom-month-v1.ts
+++ b/packages/crm/src/lib/blueprint/renderers/calcom-month-v1.ts
@@ -499,7 +499,7 @@ function renderFooter(
     </div>
   </div>
   <div class="sf-footer__bottom">
-    ${opts.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
+    ${opts.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com?utm_source=workspace_footer&utm_medium=badge" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
   </div>
 </footer>`;
 }

--- a/packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts
+++ b/packages/crm/src/lib/blueprint/renderers/formbricks-stack-v1.ts
@@ -459,7 +459,7 @@ function renderFooter(
     </div>
   </div>
   <div class="sf-footer__bottom">
-    ${opts.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
+    ${opts.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com?utm_source=workspace_footer&utm_medium=badge" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
   </div>
 </footer>`;
 }

--- a/packages/crm/src/lib/blueprint/renderers/general-service-v1.ts
+++ b/packages/crm/src/lib/blueprint/renderers/general-service-v1.ts
@@ -1236,7 +1236,7 @@ function renderFooter(section: SectionFooter, blueprint: Blueprint, ctx: RenderC
   <div class="sf-footer__bottom">
     ${social}
     ${legal}
-    ${ctx.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
+    ${ctx.removePoweredBy ? "" : `<p class="sf-footer__poweredby">Powered by <a href="https://seldonframe.com?utm_source=workspace_footer&utm_medium=badge" target="_blank" rel="noopener noreferrer">SeldonFrame</a></p>`}
   </div>
 </footer>`;
 }

--- a/packages/crm/src/lib/chatgpt-app/deps.ts
+++ b/packages/crm/src/lib/chatgpt-app/deps.ts
@@ -114,7 +114,7 @@ async function buildWorkspace(
   const results = await Promise.all(checks.map((c) => checkRateLimit(c.key, c.limit, c.windowMs)));
   if (results.some((ok) => !ok)) {
     throw new FriendlyToolError(
-      "Workspace creation is limited to 3 per hour and 10 per day. Please try again later, or sign up at app.seldonframe.com to create more.",
+      "Workspace creation is limited to 3 per hour and 10 per day. Please try again later, or sign up at https://app.seldonframe.com/signup?utm_source=chatgpt_app&utm_medium=tool_message to create more.",
     );
   }
 

--- a/packages/crm/src/lib/emails/device-auth.ts
+++ b/packages/crm/src/lib/emails/device-auth.ts
@@ -93,7 +93,7 @@ export function renderDeviceAuthEmailHtml(req: DeviceAuthEmailRequest): string {
 <p style="margin:24px 0 0;color:#999;font-size:12px;">If the button doesn't work, paste this URL into your browser:<br /><span style="word-break:break-all;">${safeUrl}</span></p>
 </td></tr>
 </table>
-<p style="margin:16px 0 0;color:#999;font-size:12px;">SeldonFrame · <a href="https://seldonframe.com" style="color:#666;">seldonframe.com</a></p>
+<p style="margin:16px 0 0;color:#999;font-size:12px;">SeldonFrame · <a href="https://seldonframe.com?utm_source=email&utm_medium=device_auth_footer" style="color:#666;">seldonframe.com</a></p>
 </td></tr>
 </table>
 </body>
@@ -113,7 +113,7 @@ export function renderDeviceAuthEmailText(req: DeviceAuthEmailRequest): string {
     "",
     `Didn't make this request? You can safely ignore this email — without your click, nothing happens.`,
     "",
-    `— SeldonFrame · seldonframe.com`,
+    `— SeldonFrame · seldonframe.com?utm_source=email&utm_medium=device_auth_footer`,
   ].join("\n");
 }
 

--- a/packages/crm/src/lib/emails/operator-magic-link.ts
+++ b/packages/crm/src/lib/emails/operator-magic-link.ts
@@ -124,10 +124,10 @@ function renderFooter(req: OperatorMagicLinkEmailRequest): string {
     const safeBrand = escapeHtml(req.brandName);
     const supportUrl = req.supportUrl
       ? escapeHtml(req.supportUrl)
-      : "https://seldonframe.com";
+      : "https://seldonframe.com?utm_source=email&utm_medium=magic_link_footer";
     return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on ${safeBrand} · <a href="${supportUrl}" style="color:#666;">${escapeHtml(req.supportUrl ?? "")}</a></p>`;
   }
-  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame · <a href="https://seldonframe.com" style="color:#666;">seldonframe.com</a></p>`;
+  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame · <a href="https://seldonframe.com?utm_source=email&utm_medium=magic_link_footer" style="color:#666;">seldonframe.com</a></p>`;
 }
 
 export function renderOperatorMagicLinkEmailText(

--- a/packages/crm/src/lib/emails/portal-access-code.ts
+++ b/packages/crm/src/lib/emails/portal-access-code.ts
@@ -117,10 +117,10 @@ function renderFooter(req: PortalAccessCodeEmailRequest): string {
     const safeBrand = escapeHtml(req.brandName);
     const supportUrl = req.supportUrl
       ? escapeHtml(req.supportUrl)
-      : "https://seldonframe.com";
+      : "https://seldonframe.com?utm_source=email&utm_medium=portal_access_footer";
     return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on ${safeBrand} · <a href="${supportUrl}" style="color:#666;">${escapeHtml(req.supportUrl ?? "")}</a></p>`;
   }
-  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame · <a href="https://seldonframe.com" style="color:#666;">seldonframe.com</a></p>`;
+  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame · <a href="https://seldonframe.com?utm_source=email&utm_medium=portal_access_footer" style="color:#666;">seldonframe.com</a></p>`;
 }
 
 export function renderPortalAccessCodeEmailText(

--- a/packages/crm/src/lib/emails/portal-invite-magic-link.ts
+++ b/packages/crm/src/lib/emails/portal-invite-magic-link.ts
@@ -137,10 +137,10 @@ function renderFooter(req: PortalInviteMagicLinkEmailRequest): string {
     const safeBrand = escapeHtml(req.brandName);
     const supportUrl = req.supportUrl
       ? escapeHtml(req.supportUrl)
-      : "https://seldonframe.com";
+      : "https://seldonframe.com?utm_source=email&utm_medium=portal_invite_footer";
     return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on ${safeBrand} &middot; <a href="${supportUrl}" style="color:#666;">${escapeHtml(req.supportUrl ?? "")}</a></p>`;
   }
-  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame &middot; <a href="https://seldonframe.com" style="color:#666;">seldonframe.com</a></p>`;
+  return `<p style="margin:16px 0 0;color:#999;font-size:12px;">${safeWorkspace} on SeldonFrame &middot; <a href="https://seldonframe.com?utm_source=email&utm_medium=portal_invite_footer" style="color:#666;">seldonframe.com</a></p>`;
 }
 
 export function renderPortalInviteMagicLinkEmailText(

--- a/packages/crm/src/lib/emails/templates.ts
+++ b/packages/crm/src/lib/emails/templates.ts
@@ -76,7 +76,7 @@ export function renderPlainEmailTemplate({
     : "";
 
   const poweredByBlock = showPoweredBy
-    ? `<div style="margin-top:16px;font-size:11px;color:#94a3b8;text-align:center;">Powered by SeldonFrame</div>`
+    ? `<div style="margin-top:16px;font-size:11px;color:#94a3b8;text-align:center;">Powered by <a href="https://seldonframe.com?utm_source=email&utm_medium=powered_by_footer" style="color:#94a3b8;">SeldonFrame</a></div>`
     : "";
 
   // 2026-05-18 — color-scheme meta + style tag forces light rendering

--- a/packages/crm/src/lib/emails/welcome.ts
+++ b/packages/crm/src/lib/emails/welcome.ts
@@ -251,7 +251,7 @@ function renderSellBlock(): string {
         <div style="font-size:14px;color:#374151;line-height:1.55;margin-bottom:8px;">
           You didn't just get a workspace — you built an AI agent. List it on the SeldonFrame marketplace and earn on every install or rental. You keep 95%; we take a sliver only when it sells.
         </div>
-        <a href="https://seldonframe.com/marketplace" style="color:#1a73e8;text-decoration:none;font-size:13px;font-weight:600;">Browse the marketplace →</a>
+        <a href="https://seldonframe.com/marketplace?utm_source=email&utm_medium=welcome&utm_campaign=marketplace" style="color:#1a73e8;text-decoration:none;font-size:13px;font-weight:600;">Browse the marketplace →</a>
       </td></tr>
     </table>
   </td></tr>`;
@@ -443,7 +443,7 @@ Next steps:
 Sell what you just built:
   You didn't just get a workspace — you built an AI agent. List it on the SeldonFrame
   marketplace and earn on every install or rental. You keep 95%; we take a sliver only
-  when it sells. https://seldonframe.com/marketplace
+  when it sells. https://seldonframe.com/marketplace?utm_source=email&utm_medium=welcome&utm_campaign=marketplace
 ${renderUpgradeBlockText(req)}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Join the SeldonFrame builder community on Discord:

--- a/packages/crm/tests/unit/landing/powered-by-badge.spec.ts
+++ b/packages/crm/tests/unit/landing/powered-by-badge.spec.ts
@@ -74,7 +74,7 @@ describe("buildPoweredByHref", () => {
     const href = buildPoweredByHref("ws_abc123");
     assert.equal(
       href,
-      "https://www.seldonframe.com/build?ref=ws_abc123&utm_source=powered_by",
+      "https://www.seldonframe.com/build?ref=ws_abc123&utm_source=powered_by&utm_medium=workspace_badge",
     );
   });
 
@@ -93,7 +93,7 @@ describe("buildPoweredByHref", () => {
     const href = buildPoweredByHref("ws-plain-slug-123");
     assert.equal(
       href,
-      "https://www.seldonframe.com/build?ref=ws-plain-slug-123&utm_source=powered_by",
+      "https://www.seldonframe.com/build?ref=ws-plain-slug-123&utm_source=powered_by&utm_medium=workspace_badge",
     );
   });
 
@@ -123,7 +123,7 @@ describe("PoweredByBadge", () => {
     const hrefs = links.map((el) => (el.props as { href: string }).href);
     assert.ok(
       hrefs.includes(
-        "https://www.seldonframe.com/build?ref=ws_abc123&utm_source=powered_by",
+        "https://www.seldonframe.com/build?ref=ws_abc123&utm_source=powered_by&utm_medium=workspace_badge",
       ),
       `expected a link to the ref-attributed build URL, got: ${JSON.stringify(hrefs)}`,
     );
@@ -190,7 +190,7 @@ describe("SiteShell — powered-by badge mount", () => {
     assert.equal(badgeLinks.length, 1, "expected exactly one powered-by link");
     assert.equal(
       (badgeLinks[0]?.props as { href: string }).href,
-      "https://www.seldonframe.com/build?ref=ws_shell_test&utm_source=powered_by",
+      "https://www.seldonframe.com/build?ref=ws_shell_test&utm_source=powered_by&utm_medium=workspace_badge",
     );
   });
 

--- a/skills/mcp-server/package.json
+++ b/skills/mcp-server/package.json
@@ -49,7 +49,7 @@
     "ai-chatbot",
     "missed-call"
   ],
-  "homepage": "https://seldonframe.com",
+  "homepage": "https://seldonframe.com?utm_source=npm&utm_medium=listing",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/seldonframe/seldonframe.git",

--- a/skills/mcp-server/server.json
+++ b/skills/mcp-server/server.json
@@ -8,7 +8,7 @@
     "subfolder": "skills/mcp-server"
   },
   "version": "1.61.0",
-  "websiteUrl": "https://seldonframe.com",
+  "websiteUrl": "https://seldonframe.com?utm_source=mcp_registry&utm_medium=listing",
   "packages": [
     {
       "registryType": "npm",


### PR DESCRIPTION
## Summary

Mechanical sweep adding `utm_source`/`utm_medium` (taxonomy: source=surface, medium=mechanism) to every SF-controlled link back to seldonframe.com that renders on OTHER people's surfaces. Existing `ref=<workspaceId>` params (consumed by `src/lib/growth/referrals.ts` on `/build`) are preserved everywhere they were already in scope.

**Surfaces touched:**
- Landing-r1 workspace badge (`utm_medium=workspace_badge` added alongside existing `utm_source=powered_by` + `ref`)
- Legacy blueprint footers (general-service-v1, calcom-month-v1, formbricks-stack-v1) — `utm_source=workspace_footer&utm_medium=badge`
- `packages/core/src/virality/powered-by-badge.tsx` — default href now carries `utm_source=powered_by&utm_medium=badge`, plus a new optional `source` prop appended as `utm_content` so each call site tags itself: workspace site, workspace landing, workspace form, booking page, client portal, embed widget
- Customer/operator portal shell footers — `utm_source=customer_portal|operator_portal&utm_medium=footer`
- Chat widget embed footer — `utm_source=chat_widget&utm_medium=embed&utm_content=<orgSlug>` (threaded orgSlug through `renderEmbedScript`)
- Share card CTA (`/a/[slug]`) — `utm_source=share_card&utm_medium=referral` appended to the existing `ref=share-<slug>` (the minted share URL itself is untouched, per plan)
- Email footers: `templates.ts` (free-tier "Powered by" now a link), `portal-access-code.ts`, `operator-magic-link.ts`, `portal-invite-magic-link.ts`, `device-auth.ts` (html+text), `welcome.ts` (marketplace link, html+text) — **only the SF fallback URL is tagged in every case; agency-substituted `supportUrl`/whitelabel URLs are left untouched**
- Registry listings: `skills/mcp-server/server.json` websiteUrl, `skills/mcp-server/package.json` homepage
- ChatGPT tool copy (`deps.ts`) — sign-up mention is now a full tagged URL

**New doc:** `docs/marketing/utm-link-kit.md` — copy-paste UTM kit for channels Max posts by hand (YouTube, X, Reddit, ChatGPT apps directory, npm README, GitHub README), targeting `/` and `/try`, plus the taxonomy rule and the never-tag-whitelabel rule.

**Notes:**
- Baked/static HTML: the blueprint footer changes (general-service-v1, calcom-month-v1, formbricks-stack-v1) only affect *newly rendered* pages. Existing workspaces' stored static HTML needs the `lib/blueprint/rerender-org.ts` walk to pick up the new footer — did NOT run it, flagging for Max to decide when to re-render.
- Registry files (`skills/mcp-server/server.json`, `skills/mcp-server/package.json`) take effect on the next `npm publish` / registry sync, not immediately.
- Root `server.json` version numbers were not touched, per plan.
- Whitelabel caution honored: every email template that substitutes an agency's own `supportUrl` (portal-access-code.ts ~118-121, operator-magic-link.ts, portal-invite-magic-link.ts) only has its SF-fallback branch tagged — the agency-URL branch is untouched.
- Updated `tests/unit/landing/powered-by-badge.spec.ts` to match the new `utm_medium=workspace_badge` URL shape (4 assertions).

## Test plan
- [x] `node --import tsx --test` on 10 targeted specs covering every touched surface (powered-by-badge, welcome-email, share-card, portal-customer-embeds, approvals-customer-portal, operator-portal-token, portal-access-case-insensitive, portal-invite, reschedule-email-gate, share-card-actions) — 139/139 pass
- [x] `npx tsc --noEmit -p .` in packages/crm — clean, no errors
- [x] `pnpm check:use-server` in packages/crm — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)