### PR TITLE
persona-loop: describe-business tab silently ambushes visitors with a signup wall

### DIFF
--- a/packages/crm/src/components/landing/marketing-hero.tsx
+++ b/packages/crm/src/components/landing/marketing-hero.tsx
@@ -401,6 +401,18 @@ export function MarketingHero({
             aria-label="Describe the business"
             className="block max-h-60 min-h-[110px] w-full resize-none border-0 bg-transparent font-sans text-[15px] leading-[1.55] tracking-[-0.005em] text-[#221D17] caret-[#1F2B24] outline-none placeholder:text-[#9A9183]"
           />
+          {/* persona-loop 2026-08-24: the url tab builds instantly with no
+              account (routes to /try); this tab silently lands on /signup
+              instead (hero-submit-target.ts — description builds aren't
+              wired to a public anonymous route). Without this line the
+              visitor sees an identical "Build workspace" button on both
+              tabs, then gets dropped on a generic signup screen with no
+              context — reads as a bait-and-switch paywall, not the free
+              account it actually is. Root-cause note, not a route change. */}
+          <p className="pb-1 text-[12px] text-[#9A9183]">
+            No website? We&apos;ll ask you to create a free account (no card) first — or switch to
+            &ldquo;Paste a URL&rdquo; for an instant preview with no signup.
+          </p>
         </div>
 
         {/* Bottom action row */}


### PR DESCRIPTION
## Summary

**Persona:** Monday's persona-loop persona — a skeptical, impatient plumber on his phone, likely without an existing business website (very common for solo trades).

**Funnel step:** The homepage hero form (`#hero-form`) at `www.seldonframe.com`. It has two tabs sharing one "Build workspace" button:
- **Paste a URL** — builds instantly, no account, routes client-side to `/try` (the anonymous SSE build).
- **Describe the business** — for a visitor with no website — silently routes to `/signup?intent=build` instead, with **zero forewarning**.

**Verbatim evidence:**
- `packages/crm/src/components/landing/hero-submit-target.ts`: `if (ungatedBuildEnabled && tab === "url") return /try?...; ... return /signup?intent=build...` — confirms the biz tab never reaches the anonymous build, regardless of flag state.
- Live `GET https://www.seldonframe.com/try?url=...` → `200`, "Watch it build — no signup required."
- Live `GET https://www.seldonframe.com/signup?intent=build&url=...` (297 → app host) → `200`, page copy is exactly:
  > **Welcome to SeldonFrame**
  > Your website, booking, CRM, and AI receptionist — live in minutes.

  No mention of "free," no reference to what the visitor just typed, no reassurance that no card is required.

**Root cause:** Both tabs present an identical CTA ("Build workspace") with no visual or copy distinction, but only one of the two paths is the "instant, no-signup" experience the page promises. A visitor without a website — plausibly our persona — naturally reaches for the "Describe the business" tab, types their info, hits the button, and is dropped on a generic account-creation screen with no context. To a skeptical first-time visitor this reads as a bait-and-switch paywall, not the free account it actually is (per the code's own comments, first-workspace builds run on the platform key at no cost).

Wiring a fully anonymous description-build route is out of scope for a minimal fix (would need a new public SSE endpoint, its own extraction path, its own rate limiting — the existing code comments already call this out as a known, deliberate deviation). The honest, minimal fix is to set the right expectation *before* the click instead of ambushing the visitor *after* it.

## Type of change

- [x] Bug fix (UX/trust — misleading affordance, not a positioning or pricing change)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Fix

Added a short caption under the "Describe the business" textarea in `marketing-hero.tsx`:

> No website? We'll ask you to create a free account (no card) first — or switch to "Paste a URL" for an instant preview with no signup.

Single file, no routing/behavior change — purely sets honest expectations at the point of the decision.

## Testing

- [x] Targeted unit tests: `node --import tsx --test tests/unit/marketing-hero-target.spec.ts tests/unit/landing/landing-mode-shell.spec.tsx` — 8/8 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass
- [ ] Manually verified in a live browser (sandboxed session couldn't reach the live site through a real browser; verified via direct curl/SSE against the production endpoints instead — see evidence above)

## Notes for reviewers

- No pricing, positioning, or security-sensitive code touched.
- The homepage's agency-first copy/positioning (a related but separate observation from this same walkthrough) is a documented, deliberate 2026-07-15 decision ("Max's call" — see `marketing-hero.tsx` file header) and is **not** re-litigated here.

🤖 Generated by the SeldonFrame nightly persona-loop routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VVdz3NL5TahgkHc6gVnC2Y)_