### PR TITLE
feat(seo): nine vertical /best pages + CTR title fixes

### DIFF
--- a/packages/crm/src/app/(public)/best/[slug]/page.tsx
+++ b/packages/crm/src/app/(public)/best/[slug]/page.tsx
@@ -20,11 +20,16 @@ export async function generateMetadata({ params }: RouteParams): Promise<Metadat
   } catch {
     return { title: "Not found — SeldonFrame" };
   }
-  const { category, audience } = resolved;
+  const { page, category, audience } = resolved;
   const total = category.contenders.length + 1;
   const topNames = category.contenders.slice(0, 3).map((c) => c.name).join(", ");
-  const title = `The ${total} Best ${category.nounPlural} for ${audience.label} (2026) — honest comparison`;
-  const description = `SeldonFrame vs ${topNames} and more: an honest, ranked comparison of the best ${category.nounPlural.toLowerCase()} for ${audience.label.toLowerCase()} — pricing, strengths and the real catch for each.`;
+  // 2026-08-24 — the registry may override title/description for CTR on combos
+  // with proven impressions and no clicks (see BestPage.metaTitle). The H1 in
+  // best-page.tsx deliberately stays on the template either way.
+  const title = page.metaTitle ?? `The ${total} Best ${category.nounPlural} for ${audience.label} (2026) — honest comparison`;
+  const description =
+    page.metaDescription ??
+    `SeldonFrame vs ${topNames} and more: an honest, ranked comparison of the best ${category.nounPlural.toLowerCase()} for ${audience.label.toLowerCase()} — pricing, strengths and the real catch for each.`;
   const canonical = `/best/${slug}`;
   const ogUrl = buildOgUrl({ kind: "best", title: `Best ${category.nounPlural}`, aud: `for ${audience.label}`, n: total });
   return {

--- a/packages/crm/src/app/best/ai-receptionist-for-cleaning.md/route.ts
+++ b/packages/crm/src/app/best/ai-receptionist-for-cleaning.md/route.ts
@@ -1,0 +1,17 @@
+// /best/ai-receptionist-for-cleaning.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/ai-receptionist-for-cleaning.md" });
+  const md = renderBestMarkdown("ai-receptionist-for-cleaning");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/ai-receptionist-for-cleaning>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/ai-receptionist-for-law-firms.md/route.ts
+++ b/packages/crm/src/app/best/ai-receptionist-for-law-firms.md/route.ts
@@ -1,0 +1,17 @@
+// /best/ai-receptionist-for-law-firms.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/ai-receptionist-for-law-firms.md" });
+  const md = renderBestMarkdown("ai-receptionist-for-law-firms");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/ai-receptionist-for-law-firms>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/booking-system-for-auto-detailers.md/route.ts
+++ b/packages/crm/src/app/best/booking-system-for-auto-detailers.md/route.ts
@@ -1,0 +1,17 @@
+// /best/booking-system-for-auto-detailers.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/booking-system-for-auto-detailers.md" });
+  const md = renderBestMarkdown("booking-system-for-auto-detailers");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/booking-system-for-auto-detailers>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/booking-system-for-massage-therapists.md/route.ts
+++ b/packages/crm/src/app/best/booking-system-for-massage-therapists.md/route.ts
@@ -1,0 +1,17 @@
+// /best/booking-system-for-massage-therapists.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/booking-system-for-massage-therapists.md" });
+  const md = renderBestMarkdown("booking-system-for-massage-therapists");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/booking-system-for-massage-therapists>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/booking-system-for-pet-groomers.md/route.ts
+++ b/packages/crm/src/app/best/booking-system-for-pet-groomers.md/route.ts
@@ -1,0 +1,17 @@
+// /best/booking-system-for-pet-groomers.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/booking-system-for-pet-groomers.md" });
+  const md = renderBestMarkdown("booking-system-for-pet-groomers");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/booking-system-for-pet-groomers>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/crm-for-med-spas.md/route.ts
+++ b/packages/crm/src/app/best/crm-for-med-spas.md/route.ts
@@ -1,0 +1,17 @@
+// /best/crm-for-med-spas.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/crm-for-med-spas.md" });
+  const md = renderBestMarkdown("crm-for-med-spas");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/crm-for-med-spas>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/crm-for-painters.md/route.ts
+++ b/packages/crm/src/app/best/crm-for-painters.md/route.ts
@@ -1,0 +1,17 @@
+// /best/crm-for-painters.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/crm-for-painters.md" });
+  const md = renderBestMarkdown("crm-for-painters");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/crm-for-painters>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/intake-form-builder-for-law-firms.md/route.ts
+++ b/packages/crm/src/app/best/intake-form-builder-for-law-firms.md/route.ts
@@ -1,0 +1,17 @@
+// /best/intake-form-builder-for-law-firms.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/intake-form-builder-for-law-firms.md" });
+  const md = renderBestMarkdown("intake-form-builder-for-law-firms");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/intake-form-builder-for-law-firms>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/best/website-builder-for-pest-control.md/route.ts
+++ b/packages/crm/src/app/best/website-builder-for-pest-control.md/route.ts
@@ -1,0 +1,17 @@
+// /best/website-builder-for-pest-control.md — Markdown twin of the listicle page.
+import { renderBestMarkdown } from "@/lib/seo/best-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "best_page", mode: "explicit_md", path: "/best/website-builder-for-pest-control.md" });
+  const md = renderBestMarkdown("website-builder-for-pest-control");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/best/website-builder-for-pest-control>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/lib/seo/best-pages.ts
+++ b/packages/crm/src/lib/seo/best-pages.ts
@@ -26,7 +26,20 @@ import { LAST_UPDATED } from "./alternative-pages";
 
 export { LAST_UPDATED };
 
-export type AudienceGroup = "trades" | "beauty" | "medical" | "construction" | "general";
+// 2026-08-24 — "professional", "wellness" and "pets" joined the union with the
+// vertical wave. A group exists so a contender fit note can be written once per
+// buying pattern; a note written for a hair salon reads wrong on a law-firm or
+// pet-grooming page, so those buyers get their own bucket rather than borrowing
+// "beauty".
+export type AudienceGroup =
+  | "trades"
+  | "beauty"
+  | "medical"
+  | "construction"
+  | "general"
+  | "professional"
+  | "wellness"
+  | "pets";
 
 export type BestFaqItem = { q: string; a: string };
 
@@ -86,6 +99,13 @@ export type BestCategory = {
 export type BestPage = {
   category: string;
   audience: string;
+  /** 2026-08-24 — CTR override for the <title> tag only; the on-page H1 stays
+   *  the template's "The N Best …" line so the page still reads as one of the
+   *  family. Set ONLY on combos where Search Console shows real impressions and
+   *  near-zero clicks, so a rewrite can be measured against untouched pages. */
+  metaTitle?: string;
+  /** Companion override for the meta description — same evidence-first rule. */
+  metaDescription?: string;
   /** YouTube video ID to embed under the H1 intro (lite-youtube.tsx) — a seam
    *  only, never set until a real video exists for that combo. */
   videoId?: string;
@@ -181,6 +201,53 @@ export const BEST_AUDIENCES: BestAudience[] = [
     painHook: "a missed call is a new patient who books with the practice down the street instead",
     exampleService: "a new-patient cleaning booking",
   },
+
+  // 2026-08-24 vertical wave. Picked off the Search Console read rather than
+  // guessed: Google already shows this site for trade-qualified variants of the
+  // /best queries, so these are the next verticals with demonstrated volume
+  // behind them. Every hook below names the specific moment the lead is lost.
+  {
+    slug: "law-firms",
+    label: "Law Firms",
+    group: "professional",
+    painHook: "someone with a legal problem calls three firms in one afternoon and retains the first one that actually picks up and takes the details",
+    exampleService: "a new-client consultation booking",
+  },
+  {
+    slug: "painters",
+    label: "Painters",
+    group: "trades",
+    painHook: "the repaint quote goes to whoever gets in front of the homeowner first, and the crew is up a ladder all day with the phone left in the van",
+    exampleService: "an interior repaint estimate",
+  },
+  {
+    slug: "pest-control",
+    label: "Pest Control Companies",
+    group: "trades",
+    painHook: "a wasp nest or a roach sighting is a same-day emergency, and the customer keeps calling down the list until somebody answers",
+    exampleService: "a same-day treatment booking",
+  },
+  {
+    slug: "massage-therapists",
+    label: "Massage Therapists",
+    group: "wellness",
+    painHook: "a therapist with their hands on a client cannot take the booking call, so the caller books the next studio on the map instead",
+    exampleService: "a 60-minute deep tissue booking",
+  },
+  {
+    slug: "pet-groomers",
+    label: "Pet Groomers",
+    group: "pets",
+    painHook: "grooming slots fill weeks ahead, so a client who cannot book online at 9pm just calls the next groomer in town",
+    exampleService: "a full-groom appointment booking",
+  },
+  {
+    slug: "auto-detailers",
+    label: "Auto Detailers",
+    group: "trades",
+    painHook: "a ceramic coating job is worth four figures, and the customer judges the whole shop by how hard it was to get a price and a slot",
+    exampleService: "a full detail booking",
+  },
 ];
 
 export function getBestAudience(slug: string): BestAudience {
@@ -210,7 +277,10 @@ const BOOKING_CONTENDERS: BestContender[] = [
     bestFor: "Service businesses needing intake forms + package pricing at booking time",
     strengths: ["Forms built right into booking", "Handles classes and package deals", "Works closely with Squarespace"],
     watchOut: "It has no website or CRM of its own — you have to connect it to whatever site and contact system you already use.",
-    fitNotes: { beauty: "A common choice for solo stylists, but it's just a booking box, not a full salon system." },
+    fitNotes: {
+      beauty: "A common choice for solo stylists, but it's just a booking box, not a full salon system.",
+      wellness: "One of the most common picks for solo massage therapists, but it's a booking box bolted onto whatever site you already have.",
+    },
     sourceUrl: "https://acuityscheduling.com/pricing.php",
   },
   {
@@ -231,7 +301,11 @@ const BOOKING_CONTENDERS: BestContender[] = [
     bestFor: "Salons, spas and fitness studios wanting an industry-specific booking suite",
     strengths: ["Built for the industry (memberships, retail, staff pay)", "Listed in its own marketplace so new clients can find you", "Tracks client history and sells retail products at checkout"],
     watchOut: "The design feels older next to newer tools, and the price climbs fast once you add staff and marketing extras.",
-    fitNotes: { beauty: "Made for this industry, but your booking box will always look like Vagaro's, not your own site." },
+    fitNotes: {
+      beauty: "Made for this industry, but your booking box will always look like Vagaro's, not your own site.",
+      wellness: "Built for spas and wellness studios, so packages and memberships fit, but the booking box will always look like Vagaro's, not your own site.",
+      pets: "Vagaro sells a pet-grooming version, so the grooming features fit, but the booking box will always look like Vagaro's, not your own site.",
+    },
     sourceUrl: "https://www.vagaro.com/pro/pricing",
   },
   {
@@ -521,6 +595,9 @@ export const BEST_CATEGORIES: BestCategory[] = [
         bestFor: "Professional services wanting a human voice on complex or sensitive calls",
         strengths: ["Genuinely smooth conversations with a human in the loop", "A good fit for sensitive calls (legal, medical)", "24/7 coverage without hiring staff"],
         watchOut: "The bill grows with your call volume forever, and the pricing page is just a contact-sales form, not a price list.",
+        fitNotes: {
+          professional: "The pick on this list built around legal intake, with a human taking the calls that matter — but you pay per call, so the busier the firm gets, the bigger the bill.",
+        },
         sourceUrl: "https://smith.ai/pricing/ai-receptionist",
       },
       {
@@ -607,6 +684,9 @@ export const BEST_CATEGORIES: BestCategory[] = [
         bestFor: "Larger teams needing forms tied into approval workflows and documents",
         strengths: ["Strong approval-workflow automation", "Add-ons that generate documents", "Plans built to meet HIPAA rules"],
         watchOut: "It's priced and built for bigger operations — too much, and too expensive, for a single intake form.",
+        fitNotes: {
+          professional: "The approval workflows and document add-ons fit engagement letters and retainer paperwork, but the price assumes a bigger firm than a two-lawyer practice.",
+        },
         sourceUrl: "https://www.formstack.com/pricing",
       },
     ],
@@ -813,7 +893,18 @@ export function getBestCategory(slug: string): BestCategory {
 export const BEST_PAGES: BestPage[] = [
   // Max's exact-match YouTube targets.
   { category: "crm", audience: "small-business" },
-  { category: "website-builder", audience: "small-business" },
+  {
+    category: "website-builder",
+    audience: "small-business",
+    // 2026-08-24 — the family's biggest impression pool (439 impressions, 2
+    // clicks, hovering around position 30). The generated title buried the year
+    // behind "The 6 Best …" and promised nothing but "honest comparison"; this
+    // one leads with the exact query, then names the thing no other builder on
+    // the list includes.
+    metaTitle: "Best Website Builder for Small Business 2026: booking built in",
+    metaDescription:
+      "Six website builders compared for 2026, with real prices and the honest catch on each. One of them includes booking, a CRM and an AI receptionist at $29/mo flat.",
+  },
   { category: "website-builder", audience: "construction-companies" },
   { category: "booking-system", audience: "small-business" },
   { category: "booking-app", audience: "small-business" },
@@ -838,7 +929,16 @@ export const BEST_PAGES: BestPage[] = [
   { category: "website-builder", audience: "electricians" },
   { category: "website-builder", audience: "roofers" },
   { category: "website-builder", audience: "landscapers" },
-  { category: "website-builder", audience: "cleaning" },
+  {
+    category: "website-builder",
+    audience: "cleaning",
+    // 2026-08-24 — 46 impressions, effectively no clicks. Searchers type "for
+    // cleaning business" (singular); the template renders the "Cleaning
+    // Businesses" label, so the title never matched the query back.
+    metaTitle: "Best Website Builder for Cleaning Business 2026: booking built in",
+    metaDescription:
+      "Six website builders compared for a cleaning business, with real 2026 prices and the honest catch on each. One of them takes the booking and answers the phone too.",
+  },
   { category: "website-builder", audience: "salons" },
   { category: "website-builder", audience: "med-spas" },
   { category: "website-builder", audience: "dentists" },
@@ -859,6 +959,21 @@ export const BEST_PAGES: BestPage[] = [
 
   // LLM-listicle intercept: "what AI agents do SMBs need every day" (2026-07-12).
   { category: "everyday-ai-agent", audience: "small-business" },
+
+  // 2026-08-24 vertical wave, ordered by the evidence behind each pick.
+  // Cleaning is the proven family (Google already serves us for cleaning-
+  // qualified /best queries) and this completes it — crm, website-builder and
+  // booking-system for cleaning already ship. Med spas is a pure combo gap:
+  // both halves were already in the registry. The rest open six new verticals.
+  { category: "ai-receptionist", audience: "cleaning" },
+  { category: "crm", audience: "med-spas" },
+  { category: "ai-receptionist", audience: "law-firms" },
+  { category: "intake-form-builder", audience: "law-firms" },
+  { category: "crm", audience: "painters" },
+  { category: "website-builder", audience: "pest-control" },
+  { category: "booking-system", audience: "massage-therapists" },
+  { category: "booking-system", audience: "pet-groomers" },
+  { category: "booking-system", audience: "auto-detailers" },
 ];
 
 /** URL slug for a category+audience combo: `<category>-for-<audience>`. */

--- a/packages/crm/tests/unit/seo/best-pages.spec.ts
+++ b/packages/crm/tests/unit/seo/best-pages.spec.ts
@@ -6,6 +6,8 @@
 
 import { describe, test } from "node:test";
 import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 import {
   BEST_CATEGORIES,
@@ -21,7 +23,16 @@ import {
 import { renderBestMarkdown } from "../../../src/lib/seo/best-markdown";
 import { monthYearToIso, composeCheapestOption } from "../../../src/components/seo/best-page";
 
-const AUDIENCE_GROUPS: ReadonlySet<AudienceGroup> = new Set(["trades", "beauty", "medical", "construction", "general"]);
+const AUDIENCE_GROUPS: ReadonlySet<AudienceGroup> = new Set([
+  "trades",
+  "beauty",
+  "medical",
+  "construction",
+  "general",
+  "professional",
+  "wellness",
+  "pets",
+]);
 
 // ─── registry shape ─────────────────────────────────────────────────────────
 
@@ -154,8 +165,69 @@ test("all must-ship slugs are present", () => {
   }
 });
 
-test("total combo count is roughly the curated matrix (~30-40)", () => {
-  assert.ok(BEST_PAGES.length >= 30 && BEST_PAGES.length <= 40, `expected 30-40 combos, got ${BEST_PAGES.length}`);
+// Bound raised 2026-08-24 with the vertical wave (39 → 48 combos). The point of
+// the bound is to notice an accidental combinatorial explosion (categories ×
+// audiences is 8 × 18 = 144), not to pin an exact number.
+test("total combo count is roughly the curated matrix (~40-60)", () => {
+  assert.ok(BEST_PAGES.length >= 40 && BEST_PAGES.length <= 60, `expected 40-60 combos, got ${BEST_PAGES.length}`);
+});
+
+// ─── 2026-08-24 vertical wave ───────────────────────────────────────────────
+
+test("the vertical-wave slugs are present", () => {
+  const expected = [
+    "ai-receptionist-for-cleaning",
+    "crm-for-med-spas",
+    "ai-receptionist-for-law-firms",
+    "intake-form-builder-for-law-firms",
+    "crm-for-painters",
+    "website-builder-for-pest-control",
+    "booking-system-for-massage-therapists",
+    "booking-system-for-pet-groomers",
+    "booking-system-for-auto-detailers",
+  ];
+  const have = new Set(allBestSlugs());
+  for (const slug of expected) {
+    assert.ok(have.has(slug), `missing vertical-wave slug: ${slug}`);
+  }
+});
+
+// The two law-firm pages must find each other: the template's cross-links pull
+// same-audience pages, so shipping one without the other strands it.
+test("both law-firm pages ship, so the same-audience cross-link resolves", () => {
+  const lawFirmPages = BEST_PAGES.filter((p) => p.audience === "law-firms");
+  assert.ok(lawFirmPages.length >= 2, `law-firms needs ≥2 pages to cross-link, got ${lawFirmPages.length}`);
+});
+
+// A /best page links its own .md twin (MarkdownPointer + the metadata
+// alternates entry), so a missing static route folder is a linked 404. Mirrors
+// the same guardrail in guides.spec.ts.
+test("every /best page has its Markdown twin route on disk", () => {
+  for (const slug of allBestSlugs()) {
+    assert.ok(
+      existsSync(join(process.cwd(), "src", "app", "best", `${slug}.md`, "route.ts")),
+      `${slug}: missing static Markdown route (src/app/best/${slug}.md/route.ts)`,
+    );
+  }
+});
+
+// CTR overrides are deliberate exceptions, not the default — keep them honest
+// and short enough that Google shows the differentiator instead of cutting it.
+test("metaTitle/metaDescription overrides, where set, are non-empty and search-length sane", () => {
+  for (const page of BEST_PAGES) {
+    const slug = bestSlug(page);
+    if (page.metaTitle !== undefined) {
+      assert.ok(page.metaTitle.trim().length > 0, `${slug}: empty metaTitle`);
+      assert.ok(page.metaTitle.length <= 70, `${slug}: metaTitle is ${page.metaTitle.length} chars, will truncate in results`);
+    }
+    if (page.metaDescription !== undefined) {
+      assert.ok(page.metaDescription.trim().length > 0, `${slug}: empty metaDescription`);
+      assert.ok(
+        page.metaDescription.length <= 170,
+        `${slug}: metaDescription is ${page.metaDescription.length} chars, will truncate in results`,
+      );
+    }
+  }
 });
 
 // ─── markdown twin ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Nine new `/best/<category>-for-<audience>` pages (39 → 48) plus a click-through fix on the two pages that already earn impressions and get almost no clicks.

## Why these nine

Picked off the 2026-08-24 traffic read, not guessed. Google already serves this site for trade-qualified variants of these queries, so the demand is demonstrated:

| Page | Why it |
|---|---|
| `ai-receptionist-for-cleaning` | Cleaning is the GSC-proven family; crm / website-builder / booking-system for cleaning already ship, so this completes it |
| `crm-for-med-spas` | Pure combo gap: both halves were already in the registry |
| `ai-receptionist-for-law-firms` | New audience, and legal intake is the textbook speed-to-lead vertical |
| `intake-form-builder-for-law-firms` | Rides the same new audience; the two cross-link each other |
| `crm-for-painters` | New audience |
| `website-builder-for-pest-control` | New audience |
| `booking-system-for-massage-therapists` | New audience |
| `booking-system-for-pet-groomers` | New audience |
| `booking-system-for-auto-detailers` | New audience |

Six new `BEST_AUDIENCES` entries, each with a pain hook naming the specific moment the lead is lost and a concrete example service, following the existing field shape.

## Three new AudienceGroups

`professional`, `wellness`, `pets`. A group exists so a contender fit note can be written once per buying pattern, and a note written for a hair salon ("a common choice for solo stylists… not a full salon system") reads wrong on a law-firm or pet-grooming page. Rather than borrow `beauty`, each new group earns at least one genuinely true fit note:

- Smith.ai → `professional`: it is the pick on that list built around legal intake, with the honest per-call catch kept.
- Formstack → `professional`: document add-ons genuinely fit engagement letters, priced for a bigger firm.
- Acuity + Vagaro → `wellness`, Vagaro → `pets`: Vagaro sells a pet-grooming version.

Existing pages are unaffected — the additions are new optional keys on shared contenders, and no existing audience uses the new groups.

## CTR fix

`/best/website-builder-for-small-business` earns 439 impressions for 2 clicks at roughly position 30. `/best/website-builder-for-cleaning` earns 46 for effectively none. Both problems are in the title:

- The generated title buried the year behind "The N Best …" and promised nothing but "honest comparison".
- The cleaning page rendered the plural "Cleaning Businesses" label, while searchers type "for cleaning business".

`BestPage` gains optional `metaTitle` / `metaDescription`, wired into `generateMetadata` in `app/(public)/best/[slug]/page.tsx`. Applied to exactly those two pages, deliberately not the other 46, so the rewrite can be measured against an untouched control group. The on-page H1 stays on the template either way.

New titles:
- `Best Website Builder for Small Business 2026: booking built in`
- `Best Website Builder for Cleaning Business 2026: booking built in`

A spec guards override length so a future one cannot silently truncate in results.

## Sitemap: no edit needed, verified

`sitemap.ts` loops `allBestSlugs()` and `llms.txt` loops `BEST_PAGES`, so both pick up all nine pages with no change. Confirmed by reading the loops, not assumed — neither file is touched, nor are tools, guides or competitor-pricing.

## Markdown twins

All 39 existing pages have an `app/best/<slug>.md/route.ts` twin; the nine new ones follow that template exactly. A new spec asserts every `/best` page has its twin on disk (mirroring the same guardrail in `guides.spec.ts`), so a future page cannot ship with a linked 404 on its `.md` alternate.

## Verification

- `node --test --import tsx tests/unit/seo/*.spec.ts tests/unit/seo/*.spec.tsx` → **1726 pass, 0 fail** (31 suites)
- `pnpm exec tsc --noEmit` from `packages/crm` → clean
- Rendered all nine pages through `renderBestMarkdown` and read the output: correct H1s, correct pain hooks, and the new fit notes land on the right pages.

Spec updates: `AUDIENCE_GROUPS` set extended, combo bound raised 30-40 → 40-60 (the bound catches an accidental combinatorial explosion, not an exact count), plus new tests for the wave slugs, the law-firm cross-link pair, twin-on-disk, and override sanity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
