### PR TITLE
feat(seo): seven free tools + single tools registry + md twins

### DIFF
--- a/packages/crm/src/app/(public)/tools/cancellation-policy-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/cancellation-policy-generator/page.tsx
@@ -1,0 +1,171 @@
+// 2026-08-24 — /tools/cancellation-policy-generator — free tool (the
+// PostPlanify free-tools SEO motion): server-rendered GEO copy + FAQ around a
+// client policy composer island.
+//
+// Deliberately paired with /tools/no-show-cost-calculator: that page quantifies
+// the problem in dollars, this one produces the document that reduces it. The
+// two cross-link both ways.
+//
+// HONESTY (house rule never-lies): this generates policy text, not legal advice,
+// and whether you can actually charge a card for a missed appointment depends on
+// the payment processor and local rules. Both the page and the widget say so.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { CancellationPolicyGenerator } from "@/components/seo/cancellation-policy-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Cancellation Policy Generator — free, paste-ready, no signup";
+const DESCRIPTION =
+  "Free cancellation and no-show policy generator for service businesses: set your notice window, late-cancellation fee, no-show fee and deposit rules, and get paste-ready policy text for your website, your reminder texts and your booking form.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Cancellation Policy Generator", hook: "A no-show policy people actually read" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/cancellation-policy-generator",
+    types: { "text/markdown": "/tools/cancellation-policy-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/cancellation-policy-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What notice window should I ask for?",
+    a: "Match it to how fast you can refill the slot. A salon that can fill a chair from a waiting list is fine at <strong>24 hours</strong>. A med spa holding a two-hour room, or a trade routing a van across a city, usually needs <strong>48</strong>. Asking for more notice than you need just makes the policy feel unfair without recovering more revenue.",
+  },
+  {
+    q: "Should the fee be a flat amount or a percentage?",
+    a: "A <strong>percentage</strong> scales with the value of the slot, which is fairer when your services range from a $40 trim to a $400 treatment. A <strong>flat fee</strong> is easier to say out loud and easier to defend at the desk. Pick the one you'll actually enforce.",
+  },
+  {
+    q: "Do deposits really reduce no-shows?",
+    a: "They're the strongest deterrent available, and the one customers push back on hardest. A deposit that's applied to the bill and fully refundable inside the notice window is the version most businesses can hold: it changes behaviour without reading as a penalty for booking.",
+  },
+  {
+    q: "Where should the policy actually live?",
+    a: "In three places, which is why this tool emits three versions. The <strong>full policy</strong> goes on the booking page. The <strong>short version</strong> goes in the confirmation and reminder text, where it's actually read. The <strong>one-line checkbox</strong> goes on the booking form, where agreeing to it is recorded.",
+  },
+  {
+    q: "Can I charge a card for a no-show?",
+    a: "Sometimes, and it depends on things this tool can't see: what your payment processor allows, whether you captured a card and consent at booking, and your local consumer-protection rules. Get the wording and the consent right first, because a fee you can't collect is just a threat.",
+  },
+  {
+    q: "Is this legal advice?",
+    a: "No. It's policy text drafted from your own choices, in plain language. It's a strong starting point for a small service business, but it isn't a lawyer, and anything involving stored payment credentials is worth a real review.",
+  },
+];
+
+export default function CancellationPolicyGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Cancellation policy generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Cancellation Policy Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Set your notice window, your fees and your deposit rule, and get three pieces of paste-ready text: the full
+          policy for your booking page, a short version for the confirmation text, and a one-line checkbox for the
+          booking form. Everything runs in your browser.
+        </p>
+        <CancellationPolicyGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>A policy nobody reads is not a policy</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Most cancellation policies fail the same way: they live on a page the customer visited once, weeks before
+            the appointment. The version that changes behaviour is the one in the{" "}
+            <strong>reminder text the day before</strong>, when the customer is deciding whether to bother. That is why
+            this tool gives you a short version sized for a text message, not just a wall of policy prose.
+          </p>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Know what it is worth first</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Fees are a blunt instrument, and they cost goodwill. Before you set one, it helps to see the number you are
+            trying to recover:{" "}
+            <Link href="/tools/no-show-cost-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              the no-show cost calculator
+            </Link>{" "}
+            quantifies the problem this policy is meant to fix, and{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              the lifetime value calculator
+            </Link>{" "}
+            shows what a customer you annoy into leaving was worth. Plenty of businesses find that reminders plus a
+            visible policy get them most of the way, and the fee is only for repeat offenders.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Show the policy at every booking. Start free.
+            </Link>
+            <Link href="/tools/booking-friction-grader" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Grade your booking flow
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/no-show-cost-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              price your no-shows
+            </Link>
+            , write the{" "}
+            <Link href="/tools/sms-template-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              reminder text that carries this policy
+            </Link>
+            , or{" "}
+            <Link href="/tools/free-booking-page" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              get a free booking page
+            </Link>{" "}
+            to put it on.
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/customer-lifetime-value-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/customer-lifetime-value-calculator/page.tsx
@@ -1,0 +1,200 @@
+// 2026-08-24 — /tools/customer-lifetime-value-calculator — free tool (the
+// PostPlanify free-tools SEO motion): server-rendered GEO copy + FAQ around a
+// client LTV calculator island.
+//
+// This page is the INTERNAL-LINKING HUB for the money calculators. The
+// missed-call, no-show and speed-to-lead pages each price one lost ticket; this
+// one converts a ticket into a lifetime, so all four now link to each other and
+// each can say what a lost CUSTOMER costs rather than a lost job.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { CustomerLifetimeValueCalculator } from "@/components/seo/customer-lifetime-value-calculator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Customer Lifetime Value Calculator for local service businesses — free";
+const DESCRIPTION =
+  "Free customer lifetime value calculator built for local service businesses: average ticket, visits per year, years retained and referrals in, lifetime revenue and lifetime profit out. No subscription-model assumptions, no signup.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Customer Lifetime Value Calculator", hook: "What one local customer is really worth" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/customer-lifetime-value-calculator",
+    types: { "text/markdown": "/tools/customer-lifetime-value-calculator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/customer-lifetime-value-calculator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "How do you calculate customer lifetime value for a service business?",
+    a: "<strong>Average ticket × visits per year × years retained</strong>, then add the lifetimes of the customers they refer. That's it. The subscription formula everyone quotes (monthly revenue divided by churn rate) assumes a recurring fee you don't charge, and it badly understates a business whose customer comes back four times a year for six years.",
+  },
+  {
+    q: "Should I include referrals in lifetime value?",
+    a: "Yes, carefully. Referrals are often the largest single component for a local business, and ignoring them makes every marketing decision look worse than it is. This calculator counts them at <strong>one generation only</strong>: a referred customer is worth one more lifetime, and their own referrals are not compounded on top. That keeps the number defensible.",
+  },
+  {
+    q: "Should I use revenue or profit?",
+    a: "Both, for different decisions. <strong>Lifetime revenue</strong> is the right number for judging what a lost customer cost you. <strong>Lifetime gross profit</strong> is the right number for deciding what you can afford to spend acquiring one. This tool shows both, and the margin slider is what separates them.",
+  },
+  {
+    q: "What is a realistic retention period?",
+    a: "It varies more than most owners expect. A hair salon client might stay <strong>5 to 10 years</strong>. An HVAC customer stays until the system is replaced. A mover is often a genuine one-off. If you have no idea, look at your oldest repeat customers and take the median rather than the best case.",
+  },
+  {
+    q: "Why does this number matter?",
+    a: "Because almost every operational decision quietly compares against it. Whether to answer the phone after 5pm, whether to chase a no-show, whether a $400 ad spend is sane. All of them look completely different when the customer at stake is worth <strong>a lifetime</strong> rather than one ticket.",
+  },
+  {
+    q: "How does this relate to the missed-call and no-show calculators?",
+    a: "Those two price a single lost job. This one prices the <strong>relationship</strong> behind it. A missed call is not a lost $150 appointment; it's a shot at a customer who was going to spend that four times a year and bring a neighbour. Run both and use the pair.",
+  },
+];
+
+export default function CustomerLifetimeValueCalculatorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Customer lifetime value calculator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Customer Lifetime Value Calculator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Built for local service businesses, not subscription software. Average ticket, visits a year, years retained
+          and referrals in. Lifetime revenue and lifetime profit out, with a shareable result card. Nothing leaves your
+          browser.
+        </p>
+        <CustomerLifetimeValueCalculator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Why the usual formula is wrong for you</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            The lifetime value formula in most articles is{" "}
+            <strong>average monthly revenue divided by churn rate</strong>. It was written for software with a
+            subscription and a cancel button. A local service business has neither: the customer does not pay you
+            monthly, and they do not cancel, they just stop calling. Feeding those numbers into a SaaS formula produces
+            an answer that is either nonsense or an accidental undercount.
+          </p>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            The version that works here counts what actually happens: a ticket, some number of times a year, for some
+            number of years, plus the people they send you.
+          </p>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What this number changes</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>What a missed call costs.</strong> Not one job.{" "}
+              <Link href="/tools/missed-call-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+                Price your missed calls
+              </Link>{" "}
+              and multiply by the lifetime figure above.
+            </li>
+            <li>
+              <strong>What a no-show costs.</strong> The burnt slot is the visible part.{" "}
+              <Link href="/tools/no-show-cost-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+                Run the no-show numbers
+              </Link>
+              , then decide whether a fee is worth the relationship.
+            </li>
+            <li>
+              <strong>What a slow reply costs.</strong>{" "}
+              <Link href="/tools/speed-to-lead-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+                The speed-to-lead calculator
+              </Link>{" "}
+              shows how fast a new lead goes cold. Lifetime value is what goes cold with it.
+            </li>
+            <li>
+              <strong>What you can spend to acquire one.</strong> Use the lifetime profit figure, not the revenue one.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Keeping the ones you already have</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Retention is where lifetime value is actually won, and it is mostly operational: answering the phone,
+            confirming appointments, following up when a quote goes quiet, asking for the review while the customer is
+            still happy. SeldonFrame runs those as agents inside your own workspace, and the first workspace is free
+            forever.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Build your AI front office free
+            </Link>
+            <Link href="/tools/sms-template-generator" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Write the follow-up texts
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/missed-call-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              missed-call cost
+            </Link>
+            ,{" "}
+            <Link href="/tools/no-show-cost-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              no-show cost
+            </Link>
+            ,{" "}
+            <Link href="/tools/speed-to-lead-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              speed-to-lead cost
+            </Link>
+            , or{" "}
+            <Link href="/tools/agency-margin-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              agency margin
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/google-business-profile-description-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/google-business-profile-description-generator/page.tsx
@@ -1,0 +1,172 @@
+// 2026-08-24 — /tools/google-business-profile-description-generator — free tool
+// (the PostPlanify free-tools SEO motion): server-rendered GEO copy + FAQ around
+// a client description composer island.
+//
+// CTA goes to /tools/ai-website-generator rather than straight to /signup,
+// because the searcher here already has a Google Business Profile in front of
+// them and the build flow accepts a Google paste directly.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { GoogleBusinessProfileDescriptionGenerator } from "@/components/seo/google-business-profile-description-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Google Business Profile Description Generator — free, 750 characters";
+const DESCRIPTION =
+  "Free Google Business Profile description generator: pick your business type, services, city and tone, and get a description that fits inside Google's 750-character limit, with a live character count and a copy button.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Google Business Profile Description Generator", hook: "Fits Google's 750-character limit, every time" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/google-business-profile-description-generator",
+    types: { "text/markdown": "/tools/google-business-profile-description-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/google-business-profile-description-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "How long can a Google Business Profile description be?",
+    a: "<strong>750 characters</strong>, and Google simply refuses anything longer rather than truncating it politely. Only the first couple of lines show before a reader taps to expand, so the important sentence belongs at the front.",
+  },
+  {
+    q: "Does the description affect my ranking in local search?",
+    a: "No. Google has been clear that the business description is not a ranking factor. It matters for a different reason: it is what a <strong>human</strong> reads when they are deciding between you and the next result, and increasingly what an <strong>AI assistant</strong> reads when summarising you.",
+  },
+  {
+    q: "What is Google not allowed in the description?",
+    a: "Google's guidelines rule out <strong>URLs, phone numbers, prices, promotional offers</strong> and anything misleading. Descriptions that break the rules can be rejected or quietly removed, and repeated violations put the profile at risk. This tool doesn't emit any of them.",
+  },
+  {
+    q: "Should I stuff keywords into it?",
+    a: "No. Since it isn't a ranking factor, keyword stuffing costs you the one thing the field is actually good for: sounding like a business a person would call. Mention your services naturally because that's what a reader wants to know, not to game anything.",
+  },
+  {
+    q: "What should I say if I have no idea where to start?",
+    a: "Five things, in this order: <strong>what you do, who you serve, where, what makes you different, and how to get started</strong>. That's the structure this generator uses, and it's the same structure a good elevator pitch has.",
+  },
+  {
+    q: "Where do I paste it?",
+    a: "In Google Business Profile, open <strong>Edit profile</strong> and then <strong>Business description</strong>. Changes usually appear within a few minutes, though Google occasionally takes longer to review an edit.",
+  },
+];
+
+export default function GoogleBusinessProfileDescriptionGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Google Business Profile description generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Google Business Profile Description Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Google gives you 750 characters and refuses anything longer. Pick your business type, services and city, and
+          this writes a description that fits, in the order a reader actually wants it: what you do, who you serve,
+          where, what makes you different, and how to start.
+        </p>
+        <GoogleBusinessProfileDescriptionGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What Google will not accept</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>URLs and phone numbers.</strong> They belong in their own profile fields, and putting them here can
+              get the description rejected.
+            </li>
+            <li>
+              <strong>Prices and offers.</strong> No &quot;$99 special&quot;, no &quot;20% off this month&quot;. Use
+              Google Posts for promotions instead.
+            </li>
+            <li>
+              <strong>Claims you cannot back.</strong> &quot;Licensed&quot; when you are not, &quot;number one&quot;
+              when nobody ranked you. Profiles get suspended over exactly this.
+            </li>
+            <li>
+              <strong>Keyword stuffing.</strong> It buys you nothing, because the field is not a ranking factor, and it
+              costs you a reader.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Your profile is already most of a website</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            The description you just wrote, your services, your hours and your reviews are the same facts a decent local
+            website needs. SeldonFrame&apos;s builder takes a pasted Google Business Profile and turns it into a real
+            hosted site with a booking page, an intake form and a CRM in about three minutes. The first workspace is
+            free forever.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/tools/ai-website-generator" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Turn your profile into a website
+            </Link>
+            <Link href="/tools/local-business-schema-generator" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Generate matching schema
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/ai-visibility-checker" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              check whether AI can recommend you
+            </Link>
+            , build a{" "}
+            <Link href="/tools/google-review-qr-code-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              review QR code
+            </Link>
+            , or generate{" "}
+            <Link href="/tools/local-business-schema-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              LocalBusiness schema
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/google-review-link-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/google-review-link-generator/page.tsx
@@ -139,7 +139,17 @@ export default function GoogleReviewLinkGeneratorPage(): ReactElement {
               <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
             </details>
           ))}
+          {/* 2026-08-24 — the QR generator is the print-side sibling of this
+              page: same underlying URL, but real physical sizes and PNG/SVG
+              downloads instead of an inline preview. */}
           <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Printing the code rather than texting it?{" "}
+            <Link href="/tools/google-review-qr-code-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              The QR code generator
+            </Link>{" "}
+            exports the same link at table-tent, counter-card and window-decal sizes, as a 300 DPI PNG or a vector SVG.
+          </p>
+          <p style={{ margin: "14px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
             More free tools:{" "}
             <Link href="/tools/review-response-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
               write a review response

--- a/packages/crm/src/app/(public)/tools/google-review-qr-code-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/google-review-qr-code-generator/page.tsx
@@ -1,0 +1,187 @@
+// 2026-08-24 — /tools/google-review-qr-code-generator — free tool (the
+// PostPlanify free-tools SEO motion): server-rendered GEO copy + FAQ around a
+// client QR encoder island.
+//
+// DELIBERATELY NOT a duplicate of /tools/google-review-link-generator. That page
+// owns "google review link" and shows a QR preview; this one owns "google review
+// qr code", where the searcher wants printable artwork. So the copy here is
+// about physical placement, print sizes and file formats, and the two pages
+// cross-link rather than repeat each other.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { GoogleReviewQrCodeGenerator } from "@/components/seo/google-review-qr-code-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Google Review QR Code Generator — print-ready PNG and SVG, free";
+const DESCRIPTION =
+  "Free Google review QR code generator: turn your Place ID into a scannable review QR code sized for table tents, counter cards and window decals. Download PNG or SVG, no signup.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Google Review QR Code Generator", hook: "Print-ready review QR codes, PNG or SVG" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/google-review-qr-code-generator",
+    types: { "text/markdown": "/tools/google-review-qr-code-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/google-review-qr-code-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What size should a Google review QR code be printed at?",
+    a: "It depends on scanning distance. A rough rule: the printed code should be about a tenth of the distance it's scanned from. <strong>2 inches</strong> works on a table tent someone reaches for, <strong>3 inches</strong> on a counter card, <strong>4 inches</strong> on a waiting-room poster, and <strong>6 inches</strong> on a window decal read from the sidewalk.",
+  },
+  {
+    q: "PNG or SVG: which file should I send to a printer?",
+    a: "<strong>SVG</strong>. It's vector, so it stays perfectly sharp at any size, and a print shop can scale it to whatever the job needs. Use the PNG when you're dropping the code straight into a document, a receipt template, or a design tool that won't take vectors.",
+  },
+  {
+    q: "Does the QR code expire or stop working?",
+    a: "No. It encodes a plain Google URL built from your Place ID, and nothing is tracked, redirected or hosted by us. As long as your Google Business Profile exists, the code keeps working, so a decal you print today is still good in three years.",
+  },
+  {
+    q: "What is error correction and which level should I pick?",
+    a: "Error correction is redundancy baked into the code so it still scans when part of it is damaged. For anything printed, <strong>Quartile</strong> is the right default: it survives scuffs, ink bleed and a coffee ring. Pick <strong>High</strong> only if you're placing a logo over the centre of the code.",
+  },
+  {
+    q: "Is this the same as the review link generator?",
+    a: "They share the same underlying link. The <strong>link generator</strong> is for pasting into a text or an email signature. This page is for <strong>print</strong>: real physical sizes, 300 DPI export, and a vector file. Use whichever matches where the ask is happening.",
+  },
+  {
+    q: "Where do QR codes actually get scanned?",
+    a: "The three that work: a <strong>table tent or counter card</strong> at the moment of payment, a <strong>receipt or invoice footer</strong>, and a <strong>van or job-site sign</strong> for trades. The ones that don't work: anything a customer walks past without stopping, and anything behind glass with a glare on it.",
+  },
+];
+
+export default function GoogleReviewQrCodeGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Google review QR code generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Google Review QR Code Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Print-ready review QR codes at real physical sizes. Paste your Place ID, pick where the code is going, and
+          download a 300 DPI PNG or a vector SVG. The code is encoded in your browser, so nothing you type leaves the
+          page.
+        </p>
+        <GoogleReviewQrCodeGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Where to put it</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>Table tent, 2 inches.</strong> On the table or the reception desk, at the moment someone is
+              already sitting still with a phone in their hand.
+            </li>
+            <li>
+              <strong>Counter card, 3 inches.</strong> Next to the card reader. The best five seconds you get with a
+              happy customer is the five seconds after they pay.
+            </li>
+            <li>
+              <strong>Poster or A-frame, 4 inches.</strong> Waiting rooms, where people are bored and looking for
+              something to do.
+            </li>
+            <li>
+              <strong>Window decal, 6 inches.</strong> Door glass and van panels, scanned from further away, so the code
+              has to be bigger than feels necessary.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Why print beats a link, sometimes</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            A texted review link is better when you have the customer&apos;s number and a reason to text them. A printed
+            code is better when you don&apos;t: walk-ins, cash customers, anyone who never gave you a phone number. Most
+            businesses need both, which is why this page and the{" "}
+            <Link href="/tools/google-review-link-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              review link generator
+            </Link>{" "}
+            exist side by side and produce the same underlying URL.
+          </p>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Put the ask on autopilot</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)", maxWidth: 660 }}>
+            A decal on the door works on whoever notices it. A <strong>Google Review Agent</strong> asks every single
+            finished customer, at the right moment, with a follow-up if nobody replies, and routes unhappy customers to
+            you privately first. SeldonFrame deploys one into your own workspace, and the first workspace is free
+            forever.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Build your AI front office free
+            </Link>
+            <Link href="/ai-agents/google-review-agent" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              See the Google Review Agent
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/google-review-link-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              build the review link
+            </Link>
+            ,{" "}
+            <Link href="/tools/review-response-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              write a review response
+            </Link>
+            , or{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              work out what one customer is worth
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/local-business-schema-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/local-business-schema-generator/page.tsx
@@ -1,0 +1,176 @@
+// 2026-08-24 — /tools/local-business-schema-generator — free tool (the
+// PostPlanify free-tools SEO motion): server-rendered GEO copy + FAQ around a
+// client JSON-LD builder island.
+//
+// Structured data is the machine-readable version of the answers an AI
+// assistant needs before it will recommend a business, which is why this page
+// cross-links /tools/ai-visibility-checker rather than sitting alone in an SEO
+// silo.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { LocalBusinessSchemaGenerator } from "@/components/seo/local-business-schema-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "LocalBusiness Schema Generator — free JSON-LD, no signup";
+const DESCRIPTION =
+  "Free LocalBusiness schema generator: fill in your name, address, hours, service area and geo coordinates, and get valid LocalBusiness JSON-LD ready to paste into your site. Empty fields are omitted, so the output always validates.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "LocalBusiness Schema Generator", hook: "Valid JSON-LD, no blanks left in it" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/local-business-schema-generator",
+    types: { "text/markdown": "/tools/local-business-schema-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/local-business-schema-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "What is LocalBusiness schema and why does it matter?",
+    a: "It's a block of <strong>JSON-LD</strong> that states your name, address, phone, hours and service area in a format machines read without guessing. Search engines use it to show hours and location confidently, and AI assistants use it when deciding whether they know enough about you to recommend you.",
+  },
+  {
+    q: "Where do I paste the code?",
+    a: "Inside the <strong>&lt;head&gt;</strong> of your homepage, as a script tag. If your site builder has a \"custom code\" or \"header scripts\" field, that's the one. It only needs to be on the homepage, though putting it on a contact page too does no harm.",
+  },
+  {
+    q: "Does structured data improve my ranking?",
+    a: "Not directly. What it does is remove ambiguity. It stops a search engine having to infer your hours from a badly formatted table, and it makes rich results possible. Treat it as <strong>removing a penalty for being unclear</strong>, not as a ranking boost.",
+  },
+  {
+    q: "Do I need latitude and longitude?",
+    a: "No, and most businesses skip it. It's worth adding if your street address is ambiguous or you're in a large complex. You can read the coordinates off the URL when you drop a pin on Google Maps.",
+  },
+  {
+    q: "What if my business type isn't in the list?",
+    a: "Use the generic <strong>LocalBusiness</strong> type. A more specific subtype is slightly better when one fits exactly, but a wrong subtype is worse than the generic one, so don't force it.",
+  },
+  {
+    q: "How do I know the output is valid?",
+    a: "Two things: this tool <strong>omits every empty field</strong> rather than emitting blanks, which is where most hand-written schema breaks. Then run your live page through Google's Rich Results Test to confirm it parses on the real site.",
+  },
+];
+
+export default function LocalBusinessSchemaGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>LocalBusiness schema generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          LocalBusiness Schema Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Fill in the form, copy valid LocalBusiness JSON-LD. Hours, service area and geo coordinates are included when
+          you provide them and left out entirely when you do not, so what you paste is never a template with holes in
+          it.
+        </p>
+        <LocalBusinessSchemaGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What this block tells a machine</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>Who you are.</strong> Name, business type and website, stated once and unambiguously.
+            </li>
+            <li>
+              <strong>Where you are.</strong> A structured postal address, optionally pinned with coordinates.
+            </li>
+            <li>
+              <strong>When you are open.</strong> Per-day opening hours in a format nothing has to parse from prose.
+            </li>
+            <li>
+              <strong>Who you serve.</strong> A service area, which matters most for businesses that travel to the
+              customer and have no useful storefront address.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Schema is half of being findable by AI</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            When an assistant is asked to recommend a plumber in your city, it needs to be confident about who you are,
+            what you do and whether you are open. Structured data answers the factual half of that.{" "}
+            <Link href="/tools/ai-visibility-checker" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              The AI visibility checker
+            </Link>{" "}
+            grades the other half, and{" "}
+            <Link href="/tools/google-business-profile-description-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              your Google Business Profile description
+            </Link>{" "}
+            is where most assistants read your story from.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Get a site that ships schema automatically
+            </Link>
+            <Link href="/tools/website-grader" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Grade your current website
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/ai-visibility-checker" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              check your AI visibility
+            </Link>
+            , write your{" "}
+            <Link href="/tools/google-business-profile-description-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              Google Business Profile description
+            </Link>
+            , or{" "}
+            <Link href="/tools/website-grader" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              grade your website
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/missed-call-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/missed-call-calculator/page.tsx
@@ -88,6 +88,17 @@ export default function MissedCallCalculatorPage(): ReactElement {
             to the tools you're evaluating. See the{" "}
             <Link href="/charts/missed-revenue-decay" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>decay curve behind this math →</Link>
           </p>
+          {/* 2026-08-24 — the numbers above price ONE lost job. The lifetime
+              value calculator is what turns that into what the lost customer
+              was worth, so the two pages link both ways. */}
+          <p style={{ margin: "14px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            One caveat on the number above: it prices a single lost job. A missed call is really a shot at a customer
+            who would have come back and referred others, so{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              work out what one customer is worth over a lifetime
+            </Link>{" "}
+            and the real cost is a multiple of this one.
+          </p>
         </section>
       </main>
       <MarketplaceFooter />

--- a/packages/crm/src/app/(public)/tools/no-show-cost-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/no-show-cost-calculator/page.tsx
@@ -88,6 +88,21 @@ export default function NoShowCostCalculatorPage(): ReactElement {
             <Link href="/ai-agents/ai-receptionist" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>the AI receptionist</Link>{" "}
             that confirms appointments, texts reminders and rebooks the cancellations for you.
           </p>
+          {/* 2026-08-24 — the number above prices the burnt slot. Lifetime value
+              is what a client who stops coming back actually costs, and the
+              policy generator is the fix that pairs with this diagnosis. */}
+          <p style={{ margin: "14px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            The figure above is the burnt slot. A client who no-shows twice and then stops booking costs you a whole
+            relationship, so it is worth seeing{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              what one customer is worth over a lifetime
+            </Link>{" "}
+            before you set a fee. When you are ready to write one,{" "}
+            <Link href="/tools/cancellation-policy-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              the cancellation policy generator
+            </Link>{" "}
+            produces the paste-ready wording.
+          </p>
         </section>
       </main>
       <MarketplaceFooter />

--- a/packages/crm/src/app/(public)/tools/page.tsx
+++ b/packages/crm/src/app/(public)/tools/page.tsx
@@ -1,120 +1,23 @@
 // /tools — the free-tools hub (PostPlanify motion: high-intent utility pages
-// that rank and convert). Add new tools here + sitemap + llms.txt.
+// that rank and convert).
+//
+// 2026-08-24 — the hand-maintained TOOLS array that used to live here moved to
+// lib/seo/tools-pages.ts, which sitemap.ts and llms.txt/route.ts now read too.
+// Adding a tool is one registry entry plus its page directory; nothing here
+// needs touching.
 import type { Metadata } from "next";
 import type { ReactElement } from "react";
 import Link from "next/link";
 import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
 import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
 import { MKT } from "@/components/marketplace/marketplace-data";
+import { TOOL_PAGES } from "@/lib/seo/tools-pages";
 
 export const metadata: Metadata = {
   title: "Free tools for local service businesses — SeldonFrame",
   description: "Free calculators and tools for service businesses and the agencies that serve them: missed-call cost, AI receptionist ROI, and more.",
   alternates: { canonical: "/tools" },
 };
-
-const TOOLS = [
-  {
-    href: "/tools/ai-visibility-checker",
-    name: "AI Visibility Checker",
-    blurb: "Can ChatGPT recommend your business? Grade your AI visibility and get the exact prompts to test it yourself.",
-  },
-  {
-    href: "/tools/speed-to-lead-calculator",
-    name: "Speed-to-Lead Calculator",
-    blurb: "See the revenue slow lead follow-up costs you — and what replying in under 5 minutes recovers.",
-  },
-  {
-    href: "/tools/no-show-cost-calculator",
-    name: "No-Show Cost Calculator",
-    blurb: "Estimate what no-shows cost your practice each month — and what automated reminders and AI confirmations recover.",
-  },
-  {
-    href: "/tools/ai-receptionist-script-generator",
-    name: "AI Receptionist Script Generator",
-    blurb: "Generate a complete AI receptionist call script for your business — greeting, questions, booking, after-hours. Copy it free.",
-  },
-  {
-    href: "/tools/service-business-faq-generator",
-    name: "Service Business FAQ Generator",
-    blurb: "Generate a ready-to-use customer FAQ for your service business — and your AI agent's knowledge base. Copy free.",
-  },
-  {
-    href: "/tools/booking-friction-grader",
-    name: "Booking Friction Grader",
-    blurb: "Answer 8 questions to score how easy you make it to book — and get the specific fixes losing you appointments.",
-  },
-  {
-    href: "/tools/missed-call-calculator",
-    name: "Missed Call Cost Calculator",
-    blurb: "Estimate the monthly revenue missed calls cost your business — and what an AI receptionist recovers.",
-  },
-  {
-    href: "/tools/ai-receptionist-cost-calculator",
-    name: "AI Receptionist Cost Calculator",
-    blurb: "Compare what a human receptionist, an answering service and per-minute AI really cost per month.",
-  },
-  {
-    href: "/tools/google-review-link-generator",
-    name: "Google Review Link Generator",
-    blurb: "Turn your Google Place ID into a direct review link and a printable QR code — free, no signup.",
-  },
-  {
-    href: "/tools/review-response-generator",
-    name: "Review Response Generator",
-    blurb: "Well-written replies to any Google review — pick the rating, scenario and tone, then copy.",
-  },
-  {
-    href: "/tools/a2p-10dlc-checker",
-    name: "A2P 10DLC Compliance Checker",
-    blurb: "Nine questions to find out whether your business texting is registered right — before carriers filter it.",
-  },
-  {
-    href: "/tools/hubspot-pricing-calculator",
-    name: "HubSpot Pricing Calculator",
-    blurb: "Seats, contacts, hubs and the $3,000 onboarding — see what HubSpot really costs before the sales call.",
-  },
-  {
-    href: "/tools/gohighlevel-cost-calculator",
-    name: "GoHighLevel Cost Calculator",
-    blurb: "Base plan + AI Employee per sub-account + usage, multiplied by your client count — the real agency bill.",
-  },
-  {
-    href: "/tools/voice-ai-cost-calculator",
-    name: "Voice AI Cost Calculator",
-    blurb: "STT + LLM + TTS + telephony stacked per minute — why the advertised $0.05/min is really ~$0.30.",
-  },
-  {
-    href: "/tools/klaviyo-cost-calculator",
-    name: "Klaviyo Cost Calculator",
-    blurb: "Profiles and SMS sends in, monthly bill out — including the suppressed-profiles gotcha.",
-  },
-  {
-    href: "/tools/agency-margin-calculator",
-    name: "Agency Margin Calculator",
-    blurb: "Retainer minus tool stack minus labor — see your real margin per client and what a flat stack changes.",
-  },
-  {
-    href: "/tools/claude-project-brief-generator",
-    name: "Claude Project Brief Generator",
-    blurb: "Generate the complete standing-instructions block (role, tasks, tone, never-list) for a Claude Project — ready to paste.",
-  },
-  {
-    href: "/tools/ai-website-generator",
-    name: "AI Website Generator",
-    blurb: "Paste your Google Business Profile or describe your business — get a real hosted website, booking page, intake form and CRM in 3 minutes. Free.",
-  },
-  {
-    href: "/tools/free-booking-page",
-    name: "Free Booking Page",
-    blurb: "A real online booking page on your own subdomain — appointment types, intake form, and CRM sync. Live in 3 minutes, free.",
-  },
-  {
-    href: "/tools/website-grader",
-    name: "Local Business Website Grader",
-    blurb: "Score your website on the 7 things that actually win local jobs — speed, booking, trust signals, and more.",
-  },
-];
 
 export default function ToolsHubPage(): ReactElement {
   return (
@@ -133,10 +36,10 @@ export default function ToolsHubPage(): ReactElement {
           </Link>
         </p>
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 14, marginTop: 30 }}>
-          {TOOLS.map((t) => (
-            <Link key={t.href} href={t.href} className="sf-link" style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 14, padding: "20px 22px", textDecoration: "none", color: MKT.ink, background: "rgba(255,255,255,0.55)", display: "block" }}>
-              <div style={{ fontSize: 17, fontWeight: 800 }}>{t.name}</div>
-              <p style={{ margin: "8px 0 0", fontSize: 13.5, lineHeight: 1.55, color: "rgba(34,29,23,0.62)" }}>{t.blurb}</p>
+          {TOOL_PAGES.map((t) => (
+            <Link key={t.slug} href={`/tools/${t.slug}`} className="sf-link" style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 14, padding: "20px 22px", textDecoration: "none", color: MKT.ink, background: "rgba(255,255,255,0.55)", display: "block" }}>
+              <div style={{ fontSize: 17, fontWeight: 800 }}>{t.title}</div>
+              <p style={{ margin: "8px 0 0", fontSize: 13.5, lineHeight: 1.55, color: "rgba(34,29,23,0.62)" }}>{t.description}</p>
             </Link>
           ))}
         </div>

--- a/packages/crm/src/app/(public)/tools/sms-template-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/sms-template-generator/page.tsx
@@ -1,0 +1,182 @@
+// 2026-08-24 — /tools/sms-template-generator — free tool (the PostPlanify
+// free-tools SEO motion): server-rendered GEO copy + FAQ around a client
+// template composer island.
+//
+// The wedge: every page ranking for "sms templates for small business" is a
+// static listicle you scroll and retype. This one composes for your message
+// type, industry and tone, keeps the merge fields, and counts segments live.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { SmsTemplateGenerator } from "@/components/seo/sms-template-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "SMS Template Generator for small business — free, no signup";
+const DESCRIPTION =
+  "Free SMS template generator for service businesses: missed-call text-backs, appointment reminders, confirmations, review requests and quote follow-ups, written for your industry and tone, with merge fields and a live 160-character count.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "SMS Template Generator", hook: "Business texts that fit in one segment" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/sms-template-generator",
+    types: { "text/markdown": "/tools/sms-template-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/sms-template-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "Why does the 160-character limit matter?",
+    a: "Carriers bill per <strong>segment</strong>, not per message. A GSM-7 message fits 160 characters in one segment; go one character over and it splits into segments of 153 each, so a 161-character text costs double. At a few thousand sends a month that's real money for no extra value.",
+  },
+  {
+    q: "Why did my message drop to 70 characters?",
+    a: "One non-GSM character does it. A curly apostrophe pasted from a word processor, an emoji, or an en dash flips the whole message to <strong>UCS-2</strong> encoding, where a single segment holds 70 characters instead of 160. The counter on this page tells you which encoding you're in. Retype the punctuation and you get your 160 back.",
+  },
+  {
+    q: "What are merge fields and do I have to use them?",
+    a: "They're placeholders like <strong>{{first_name}}</strong> that your CRM or texting tool fills in per recipient. Most tools use this double-brace format. If yours uses a different one, swap the braces after copying. Merge fields expand at send time, so the real message is a little longer than the count shows.",
+  },
+  {
+    q: "Do I need to register before I can text customers in the US?",
+    a: "Yes, if you're texting from a 10-digit business number. US carriers require <strong>A2P 10DLC registration</strong>, and unregistered traffic gets filtered silently. Your messages look sent but never arrive. Run the free A2P 10DLC checker before you send at volume.",
+  },
+  {
+    q: "Which of these templates is worth setting up first?",
+    a: "The <strong>missed-call text-back</strong>, without much argument. It fires on the calls you already paid to generate and would otherwise lose entirely, and it needs no list, no consent campaign and no schedule. The customer contacted you first.",
+  },
+  {
+    q: "Does this use AI to write the message?",
+    a: "No. Every message is assembled in your browser from a fixed structure and the options you pick, with <strong>no model and no network calls</strong>. The same inputs always produce the same text, which means you can review one template and trust every send after it.",
+  },
+];
+
+export default function SmsTemplateGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>SMS template generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          SMS Template Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Missed-call text-backs, reminders, confirmations, review requests and quote follow-ups, written for your
+          industry and your tone. Merge fields stay intact, and the segment counter tells you before you send whether
+          the message costs one text or two.
+        </p>
+        <SmsTemplateGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>The six texts a service business actually needs</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>Missed-call text-back.</strong> Fires the second a call goes unanswered. The caller already wanted
+              you; this is the cheapest save in the business.
+            </li>
+            <li>
+              <strong>Appointment reminder.</strong> Sent a day out, with a one-key confirm. The single most reliable way
+              to cut no-shows.
+            </li>
+            <li>
+              <strong>Booking confirmation.</strong> Sent immediately, so the appointment lands in the customer&apos;s
+              message thread instead of a forgotten email.
+            </li>
+            <li>
+              <strong>Review request.</strong> Sent while the customer still feels the result, not three weeks later.
+            </li>
+            <li>
+              <strong>Quote follow-up.</strong> Most quotes die of silence rather than price. One text a few days later
+              recovers a surprising share of them.
+            </li>
+            <li>
+              <strong>On my way.</strong> Kills the &quot;where are they&quot; call before the customer makes it.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Templates are the easy half</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            Copying a good template takes a minute. Sending it <strong>every time, at the right moment, without anyone
+            remembering to</strong> is the part that actually changes the numbers. SeldonFrame wires these into the
+            triggers that produce them: a missed call fires the text-back, a booking fires the confirmation, a completed
+            job fires the review request. Before you set that up, it is worth knowing{" "}
+            <Link href="/tools/missed-call-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              what missed calls already cost you
+            </Link>
+            .
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Send these automatically. Start free.
+            </Link>
+            <Link href="/tools/a2p-10dlc-checker" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Check your A2P 10DLC status
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools:{" "}
+            <Link href="/tools/no-show-cost-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              price your no-shows
+            </Link>
+            , write a{" "}
+            <Link href="/tools/cancellation-policy-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              cancellation policy
+            </Link>
+            , or generate an{" "}
+            <Link href="/tools/ai-receptionist-script-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              AI receptionist script
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/(public)/tools/speed-to-lead-calculator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/speed-to-lead-calculator/page.tsx
@@ -88,6 +88,15 @@ export default function SpeedToLeadCalculatorPage(): ReactElement {
             or <Link href="/alternatives" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>how SeldonFrame compares</Link>. See the{" "}
             <Link href="/charts/missed-revenue-decay" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>decay curve behind this math →</Link>
           </p>
+          {/* 2026-08-24 — this page prices one cold lead. Lifetime value turns
+              that into what the lost relationship was worth. */}
+          <p style={{ margin: "14px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            Worth remembering: a lead that goes cold is not one lost job, it is a customer who would have come back.{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              Work out what one customer is worth over a lifetime
+            </Link>{" "}
+            and multiply the figures above by it.
+          </p>
         </section>
       </main>
       <MarketplaceFooter />

--- a/packages/crm/src/app/(public)/tools/voicemail-greeting-generator/page.tsx
+++ b/packages/crm/src/app/(public)/tools/voicemail-greeting-generator/page.tsx
@@ -1,0 +1,176 @@
+// 2026-08-24 — /tools/voicemail-greeting-generator — free tool (the PostPlanify
+// free-tools SEO motion): server-rendered GEO copy + FAQ around a client script
+// composer island.
+//
+// The honest CTA here is not "record a nicer greeting" but "stop sending callers
+// to voicemail entirely" — a voicemail is a lost call with a recording attached,
+// and the page says that plainly instead of pretending the script is the fix.
+import type { Metadata } from "next";
+import type { ReactElement } from "react";
+import Link from "next/link";
+import { MarketplaceNav, MarketplaceFooter } from "@/components/marketplace/marketplace-chrome";
+import { MarketplaceStyles } from "@/components/marketplace/marketplace-styles";
+import { MKT } from "@/components/marketplace/marketplace-data";
+import { VoicemailGreetingGenerator } from "@/components/seo/voicemail-greeting-generator";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+/** FAQ answers use a few <strong> tags for readability; JSON-LD wants plain
+ *  text, so strip tags before embedding in the schema. */
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}
+
+const TITLE = "Voicemail Greeting Generator for business — free scripts, no signup";
+const DESCRIPTION =
+  "Free business voicemail greeting generator: main, after-hours, holiday and emergency scripts written for your business type, with the callback promise and the exact details you want callers to leave.";
+
+const OG_URL = buildOgUrl({ kind: "tool", name: "Voicemail Greeting Generator", hook: "Four greetings your business actually needs" });
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: {
+    canonical: "/tools/voicemail-greeting-generator",
+    types: { "text/markdown": "/tools/voicemail-greeting-generator.md" },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "/tools/voicemail-greeting-generator",
+    type: "website",
+    images: [{ url: OG_URL, width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESCRIPTION, images: [OG_URL] },
+};
+
+// FAQ strings render via dangerouslySetInnerHTML (inline <strong> only).
+// INVARIANT: keep these literal constants — never interpolate user/dynamic input.
+const FAQ = [
+  {
+    q: "How long should a business voicemail greeting be?",
+    a: "Under <strong>20 seconds</strong>. Callers who reach voicemail are already mildly annoyed, and a long greeting is the last push they need to hang up and call the next name on the list. Say who you are, what to leave, and when you'll call back. Everything else is optional.",
+  },
+  {
+    q: "What should a caller be asked to leave?",
+    a: "The details that let you actually return the call usefully: <strong>name, callback number, and the one fact that decides urgency</strong>: the address for a trade, the treatment for a spa, whether they're in pain for a dental office. A message that just says \"call me back\" costs you a whole extra phone tag round.",
+  },
+  {
+    q: "Do I need separate after-hours and holiday greetings?",
+    a: "Yes, and it's the cheapest expectation management there is. An <strong>after-hours</strong> greeting states when you open so nobody waits for a callback at 9pm. A <strong>holiday</strong> greeting names the reopen date, which stops the second and third call from the same person.",
+  },
+  {
+    q: "Should I promise a callback time?",
+    a: "Only one you'll hit. \"We'll call you back within the hour\" is a great greeting and a terrible one if it's not true. The caller now has a specific broken promise instead of a vague wait. Promise <strong>the same day</strong> if that's what you can do, and then do it.",
+  },
+  {
+    q: "What percentage of callers actually leave a voicemail?",
+    a: "Fewer than most owners assume, and the ones who don't usually just call a competitor. That's the honest case against optimising the greeting too hard: the highest-value change is <strong>not sending the caller to voicemail in the first place</strong>.",
+  },
+  {
+    q: "Can an AI receptionist replace this?",
+    a: "For most missed calls, yes. Instead of playing a message, it picks up, asks the same questions this script asks the caller to leave, and books the job into your calendar while they're still on the line. A voicemail greeting is the fallback for when that isn't set up yet, and worth recording either way.",
+  },
+];
+
+export default function VoicemailGreetingGeneratorPage(): ReactElement {
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQ.map((f) => ({ "@type": "Question", name: f.q, acceptedAnswer: { "@type": "Answer", text: stripHtml(f.a) } })),
+  };
+  return (
+    <div className="sf-mkt" style={{ minHeight: "100vh", background: MKT.paper, color: MKT.ink, fontFamily: MKT.fontSans, overflowX: "hidden" }}>
+      <MarketplaceStyles />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <MarketplaceNav />
+      <main style={{ maxWidth: 860, margin: "0 auto", padding: "34px 32px 70px", width: "100%" }}>
+        <nav aria-label="Breadcrumb" style={{ display: "flex", gap: 6, fontSize: 13.5, fontWeight: 600, color: "rgba(34,29,23,0.5)", marginBottom: 20 }}>
+          <Link href="/tools" className="sf-link" style={{ color: "rgba(34,29,23,0.55)", textDecoration: "none" }}>
+            Free tools
+          </Link>
+          <span style={{ color: "rgba(34,29,23,0.3)" }}>/</span>
+          <span style={{ color: "rgba(34,29,23,0.7)" }}>Voicemail greeting generator</span>
+        </nav>
+        <h1 style={{ margin: 0, fontSize: 38, fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.1, maxWidth: 700 }}>
+          Voicemail Greeting Generator
+        </h1>
+        <p style={{ margin: "14px 0 26px", fontSize: 17, lineHeight: 1.55, color: "rgba(34,29,23,0.7)", maxWidth: 660 }}>
+          Word-for-word greeting scripts for the four situations a business actually needs recorded: the main greeting,
+          after hours, a holiday closure, and an emergency overflow. Pick your business type and the script asks callers
+          for the details that make the callback useful.
+        </p>
+        <VoicemailGreetingGenerator />
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>What makes a greeting work</h2>
+          <ul style={{ margin: 0, paddingLeft: 20, fontSize: 15, lineHeight: 1.7, color: "rgba(34,29,23,0.72)" }}>
+            <li>
+              <strong>Name the business first.</strong> Callers who dialled the wrong number hang up immediately instead
+              of leaving you a message meant for someone else.
+            </li>
+            <li>
+              <strong>Ask for specifics, not &quot;a message&quot;.</strong> The greeting is your only chance to
+              structure what you get back.
+            </li>
+            <li>
+              <strong>Give a callback window you can hit.</strong> A promise you miss is worse than no promise.
+            </li>
+            <li>
+              <strong>Offer an escape hatch.</strong> A booking link or an emergency number turns a dead end into a
+              second path.
+            </li>
+            <li>
+              <strong>Keep it under 20 seconds.</strong> Read it out loud once before you record it.
+            </li>
+          </ul>
+        </section>
+
+        <section style={{ padding: "30px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>The uncomfortable part</h2>
+          <p style={{ margin: "0 0 10px", fontSize: 15, lineHeight: 1.65, color: "rgba(34,29,23,0.72)" }}>
+            A voicemail is a call you already lost, with a recording attached. The greeting can soften that, but it
+            cannot undo it: most people who reach voicemail during business hours simply call the next business.{" "}
+            <Link href="/tools/missed-call-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              Put a number on what that costs you
+            </Link>{" "}
+            and then decide whether the answer is a better greeting or something that picks up.
+          </p>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 14 }}>
+            <Link href="/signup" className="sf-link" style={{ background: MKT.ink, color: MKT.paper, padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+              Answer every call. Start free.
+            </Link>
+            <Link href="/tools/ai-receptionist-cost-calculator" className="sf-link" style={{ border: `1.5px solid ${MKT.ink10}`, color: MKT.ink, padding: "12px 24px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none", background: "rgba(255,255,255,0.5)" }}>
+              Compare receptionist costs
+            </Link>
+          </div>
+        </section>
+
+        <section style={{ padding: "40px 0 0" }}>
+          <h2 style={{ margin: "0 0 14px", fontSize: 24, fontWeight: 800, letterSpacing: "-0.02em" }}>Frequently asked questions</h2>
+          {FAQ.map((f) => (
+            <details key={f.q} style={{ border: `1px solid ${MKT.ink10}`, borderRadius: 12, padding: "14px 18px", marginBottom: 10, background: "rgba(255,255,255,0.55)" }}>
+              <summary style={{ fontWeight: 700, fontSize: 15.5, cursor: "pointer" }}>{f.q}</summary>
+              <p style={{ margin: "10px 0 2px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }} dangerouslySetInnerHTML={{ __html: f.a }} />
+            </details>
+          ))}
+          <p style={{ margin: "22px 0 0", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.65)" }}>
+            More free tools: generate an{" "}
+            <Link href="/tools/ai-receptionist-script-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              AI receptionist script
+            </Link>
+            , write your{" "}
+            <Link href="/tools/sms-template-generator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              missed-call text-back
+            </Link>
+            , or see{" "}
+            <Link href="/tools/customer-lifetime-value-calculator" className="sf-link" style={{ color: MKT.green, fontWeight: 700 }}>
+              what one customer is worth over a lifetime
+            </Link>
+            .
+          </p>
+        </section>
+      </main>
+      <MarketplaceFooter />
+    </div>
+  );
+}

--- a/packages/crm/src/app/llms.txt/route.ts
+++ b/packages/crm/src/app/llms.txt/route.ts
@@ -13,6 +13,7 @@ import { VS_PAIRS, vsSlug, isKeptVsPair } from "@/lib/seo/alternative-pages-extr
 import { BEST_PAGES, bestSlug, getBestPage, midSentence } from "@/lib/seo/best-pages";
 import { allGuideSlugs, getGuide } from "@/lib/seo/guides";
 import { allBlogSlugs, getBlogArticle } from "@/lib/seo/blog";
+import { TOOL_PAGES } from "@/lib/seo/tools-pages";
 import { siteBaseUrl } from "@/app/sitemap";
 import { loadStorefrontCatalog } from "@/lib/marketplace/load-storefront";
 import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
@@ -115,68 +116,15 @@ export async function GET(req: Request): Promise<Response> {
   }
   lines.push("");
 
+  // Free tools — rendered from lib/seo/tools-pages.ts, the same registry the
+  // /tools hub and sitemap.xml read, so this list can never drift from what is
+  // actually live.
   lines.push("## Free tools");
   lines.push("");
-  lines.push(
-    `- [Speed-to-Lead Calculator](${base}/tools/speed-to-lead-calculator): estimate the revenue slow lead follow-up costs, and what replying in under 5 minutes recovers.`,
-  );
-  lines.push(
-    `- [No-Show Cost Calculator](${base}/tools/no-show-cost-calculator): estimate the revenue no-shows cost a booking-heavy business, and what automated reminders recover.`,
-  );
-  lines.push(
-    `- [AI Receptionist Script Generator](${base}/tools/ai-receptionist-script-generator): generate a complete AI receptionist call script for any business — greeting, questions, booking, after-hours.`,
-  );
-  lines.push(
-    `- [Service Business FAQ Generator](${base}/tools/service-business-faq-generator): generate a ready customer FAQ (and AI-agent knowledge base) for a service business.`,
-  );
-  lines.push(
-    `- [Booking Friction Grader](${base}/tools/booking-friction-grader): score how easy you make it to book and get the specific fixes losing you appointments.`,
-  );
-  lines.push(
-    `- [AI Visibility Checker](${base}/tools/ai-visibility-checker): grade whether ChatGPT and Google's AI can recommend your business, plus the exact prompts to test it yourself.`,
-  );
-  lines.push(
-    `- [Missed Call Cost Calculator](${base}/tools/missed-call-calculator): estimate the revenue missed calls cost a service business.`,
-  );
-  lines.push(
-    `- [Google Review Link Generator](${base}/tools/google-review-link-generator): create a direct Google review link + printable QR code for any business.`,
-  );
-  lines.push(
-    `- [AI Receptionist Cost Calculator](${base}/tools/ai-receptionist-cost-calculator): compare a human receptionist, an answering service and per-minute AI on real monthly cost.`,
-  );
-  lines.push(
-    `- [A2P 10DLC Compliance Checker](${base}/tools/a2p-10dlc-checker): check whether your business texting meets US carrier registration rules before it gets filtered.`,
-  );
-  lines.push(
-    `- [Review Response Generator](${base}/tools/review-response-generator): well-written replies to any Google review — no signup, no AI required.`,
-  );
-  lines.push(
-    `- [Claude Project Brief Generator](${base}/tools/claude-project-brief-generator): generate the standing-instructions block for a Claude Project (and see how SeldonFrame automates it per client).`,
-  );
-  lines.push(
-    `- [HubSpot Pricing Calculator](${base}/tools/hubspot-pricing-calculator): seats × contacts × hubs × onboarding — what HubSpot really costs.`,
-  );
-  lines.push(
-    `- [GoHighLevel Cost Calculator](${base}/tools/gohighlevel-cost-calculator): base plan + AI Employee per sub-account + usage at N clients.`,
-  );
-  lines.push(
-    `- [Voice AI Cost Calculator](${base}/tools/voice-ai-cost-calculator): the real per-minute cost of a voice AI stack (STT + LLM + TTS + telephony).`,
-  );
-  lines.push(
-    `- [Klaviyo Cost Calculator](${base}/tools/klaviyo-cost-calculator): profiles + SMS sends → your monthly Klaviyo bill.`,
-  );
-  lines.push(
-    `- [Agency Margin Calculator](${base}/tools/agency-margin-calculator): retainer minus tool stack minus labor — your real margin per client.`,
-  );
-  lines.push(
-    `- [AI Website Generator](${base}/tools/ai-website-generator): paste your Google Business Profile or describe your business, and get a real hosted website, booking page, intake form and CRM in about 3 minutes.`,
-  );
-  lines.push(
-    `- [Free Booking Page](${base}/tools/free-booking-page): a real online booking page on your own subdomain, with appointment types, an intake form and CRM sync, live in about 3 minutes.`,
-  );
-  lines.push(
-    `- [Local Business Website Grader](${base}/tools/website-grader): score your website on the 7 things that win local jobs, with a prioritized fix list.`,
-  );
+  lines.push(`- [All free tools](${base}/tools): calculators and generators for local service businesses and the agencies that serve them.`);
+  for (const tool of TOOL_PAGES) {
+    lines.push(`- [${tool.title}](${base}/tools/${tool.slug}): ${tool.summary}.`);
+  }
   lines.push("");
 
   // Live charts — the interactive, re-verified data pages.
@@ -227,6 +175,9 @@ export async function GET(req: Request): Promise<Response> {
   lines.push(`- Each agent page: append \`.md\` (e.g. [${base}/ai-agents/${AGENT_JOBS[0].slug}.md](${base}/ai-agents/${AGENT_JOBS[0].slug}.md)), including the by-industry pages (\`${base}/ai-agents/<job>/for/<vertical>.md\`).`);
   lines.push(`- Each comparison: append \`.md\` to any \`${base}/alternative-to-<name>\` or \`${base}/compare/<a>-vs-<b>\` URL.`);
   lines.push(`- Each best-of guide: append \`.md\` to any \`${base}/best/<slug>\` URL.`);
+  // 2026-08-24 — every free tool now has a twin describing what it computes,
+  // what it takes as input, and what it gives back.
+  lines.push(`- Each free tool: append \`.md\` to any \`${base}/tools/<slug>\` URL (e.g. [${base}/tools/${TOOL_PAGES[0].slug}.md](${base}/tools/${TOOL_PAGES[0].slug}.md)).`);
   lines.push("");
 
   return new Response(lines.join("\n"), {

--- a/packages/crm/src/app/sitemap.ts
+++ b/packages/crm/src/app/sitemap.ts
@@ -20,6 +20,7 @@ import { allBestSlugs } from "@/lib/seo/best-pages";
 import { allGuideSlugs } from "@/lib/seo/guides";
 import { allBlogSlugs } from "@/lib/seo/blog";
 import { allPricingSlugs } from "@/lib/seo/competitor-pricing";
+import { allToolSlugs } from "@/lib/seo/tools-pages";
 import { listMarketplaceAgentsFromDb } from "@/lib/marketplace/agent-listings";
 import { MARKETPLACE_SEED } from "@/components/marketplace/marketplace-seed";
 import { GOHIGHLEVEL_COLLECTION_PATH } from "@/lib/seo/gohighlevel-discovery";
@@ -95,6 +96,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     url: `${base}/sell`,
     lastModified: now,
     changeFrequency: "weekly",
+    priority: 0.8,
+  });
+
+  // The agency landing page — live, indexable, and missing from this map until
+  // 2026-08-24. (/try is deliberately NOT here: it sets robots noindex and
+  // 404s unless SF_WEB_UNGATED_BUILD is on, and a noindex/404-able route must
+  // never be sitemapped — same rule as /record above.)
+  entries.push({
+    url: `${base}/agencies`,
+    lastModified: now,
+    changeFrequency: "monthly",
     priority: 0.8,
   });
 
@@ -177,32 +189,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // Free tools.
+  // Free tools — driven by the registry (2026-08-24), so a new tool can never
+  // ship visible-on-the-hub but absent from the crawl map again.
   entries.push({ url: `${base}/tools`, lastModified: now, changeFrequency: "monthly", priority: 0.7 });
-  for (const tool of [
-    "speed-to-lead-calculator",
-    "no-show-cost-calculator",
-    "ai-receptionist-script-generator",
-    "service-business-faq-generator",
-    "booking-friction-grader",
-    "ai-visibility-checker",
-    "missed-call-calculator",
-    "google-review-link-generator",
-    "ai-receptionist-cost-calculator",
-    "a2p-10dlc-checker",
-    "review-response-generator",
-    "claude-project-brief-generator",
-    "hubspot-pricing-calculator",
-    "gohighlevel-cost-calculator",
-    "voice-ai-cost-calculator",
-    "klaviyo-cost-calculator",
-    "agency-margin-calculator",
-    "ai-website-generator",
-    "free-booking-page",
-    "website-grader",
-  ]) {
+  for (const slug of allToolSlugs()) {
     entries.push({
-      url: `${base}/tools/${tool}`,
+      url: `${base}/tools/${slug}`,
       lastModified: now,
       changeFrequency: "monthly",
       priority: 0.7,

--- a/packages/crm/src/app/tools/a2p-10dlc-checker.md/route.ts
+++ b/packages/crm/src/app/tools/a2p-10dlc-checker.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/a2p-10dlc-checker.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/a2p-10dlc-checker.md" });
+  const md = renderToolMarkdown("a2p-10dlc-checker");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/a2p-10dlc-checker>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/agency-margin-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/agency-margin-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/agency-margin-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/agency-margin-calculator.md" });
+  const md = renderToolMarkdown("agency-margin-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/agency-margin-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/ai-receptionist-cost-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/ai-receptionist-cost-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/ai-receptionist-cost-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/ai-receptionist-cost-calculator.md" });
+  const md = renderToolMarkdown("ai-receptionist-cost-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/ai-receptionist-cost-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/ai-receptionist-script-generator.md/route.ts
+++ b/packages/crm/src/app/tools/ai-receptionist-script-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/ai-receptionist-script-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/ai-receptionist-script-generator.md" });
+  const md = renderToolMarkdown("ai-receptionist-script-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/ai-receptionist-script-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/ai-visibility-checker.md/route.ts
+++ b/packages/crm/src/app/tools/ai-visibility-checker.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/ai-visibility-checker.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/ai-visibility-checker.md" });
+  const md = renderToolMarkdown("ai-visibility-checker");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/ai-visibility-checker>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/ai-website-generator.md/route.ts
+++ b/packages/crm/src/app/tools/ai-website-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/ai-website-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/ai-website-generator.md" });
+  const md = renderToolMarkdown("ai-website-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/ai-website-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/booking-friction-grader.md/route.ts
+++ b/packages/crm/src/app/tools/booking-friction-grader.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/booking-friction-grader.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/booking-friction-grader.md" });
+  const md = renderToolMarkdown("booking-friction-grader");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/booking-friction-grader>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/cancellation-policy-generator.md/route.ts
+++ b/packages/crm/src/app/tools/cancellation-policy-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/cancellation-policy-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/cancellation-policy-generator.md" });
+  const md = renderToolMarkdown("cancellation-policy-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/cancellation-policy-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/claude-project-brief-generator.md/route.ts
+++ b/packages/crm/src/app/tools/claude-project-brief-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/claude-project-brief-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/claude-project-brief-generator.md" });
+  const md = renderToolMarkdown("claude-project-brief-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/claude-project-brief-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/customer-lifetime-value-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/customer-lifetime-value-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/customer-lifetime-value-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/customer-lifetime-value-calculator.md" });
+  const md = renderToolMarkdown("customer-lifetime-value-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/customer-lifetime-value-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/free-booking-page.md/route.ts
+++ b/packages/crm/src/app/tools/free-booking-page.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/free-booking-page.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/free-booking-page.md" });
+  const md = renderToolMarkdown("free-booking-page");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/free-booking-page>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/gohighlevel-cost-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/gohighlevel-cost-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/gohighlevel-cost-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/gohighlevel-cost-calculator.md" });
+  const md = renderToolMarkdown("gohighlevel-cost-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/gohighlevel-cost-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/google-business-profile-description-generator.md/route.ts
+++ b/packages/crm/src/app/tools/google-business-profile-description-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/google-business-profile-description-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/google-business-profile-description-generator.md" });
+  const md = renderToolMarkdown("google-business-profile-description-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/google-business-profile-description-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/google-review-link-generator.md/route.ts
+++ b/packages/crm/src/app/tools/google-review-link-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/google-review-link-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/google-review-link-generator.md" });
+  const md = renderToolMarkdown("google-review-link-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/google-review-link-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/google-review-qr-code-generator.md/route.ts
+++ b/packages/crm/src/app/tools/google-review-qr-code-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/google-review-qr-code-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/google-review-qr-code-generator.md" });
+  const md = renderToolMarkdown("google-review-qr-code-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/google-review-qr-code-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/hubspot-pricing-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/hubspot-pricing-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/hubspot-pricing-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/hubspot-pricing-calculator.md" });
+  const md = renderToolMarkdown("hubspot-pricing-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/hubspot-pricing-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/klaviyo-cost-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/klaviyo-cost-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/klaviyo-cost-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/klaviyo-cost-calculator.md" });
+  const md = renderToolMarkdown("klaviyo-cost-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/klaviyo-cost-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/local-business-schema-generator.md/route.ts
+++ b/packages/crm/src/app/tools/local-business-schema-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/local-business-schema-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/local-business-schema-generator.md" });
+  const md = renderToolMarkdown("local-business-schema-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/local-business-schema-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/missed-call-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/missed-call-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/missed-call-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/missed-call-calculator.md" });
+  const md = renderToolMarkdown("missed-call-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/missed-call-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/no-show-cost-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/no-show-cost-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/no-show-cost-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/no-show-cost-calculator.md" });
+  const md = renderToolMarkdown("no-show-cost-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/no-show-cost-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/review-response-generator.md/route.ts
+++ b/packages/crm/src/app/tools/review-response-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/review-response-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/review-response-generator.md" });
+  const md = renderToolMarkdown("review-response-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/review-response-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/service-business-faq-generator.md/route.ts
+++ b/packages/crm/src/app/tools/service-business-faq-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/service-business-faq-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/service-business-faq-generator.md" });
+  const md = renderToolMarkdown("service-business-faq-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/service-business-faq-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/sms-template-generator.md/route.ts
+++ b/packages/crm/src/app/tools/sms-template-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/sms-template-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/sms-template-generator.md" });
+  const md = renderToolMarkdown("sms-template-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/sms-template-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/speed-to-lead-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/speed-to-lead-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/speed-to-lead-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/speed-to-lead-calculator.md" });
+  const md = renderToolMarkdown("speed-to-lead-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/speed-to-lead-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/voice-ai-cost-calculator.md/route.ts
+++ b/packages/crm/src/app/tools/voice-ai-cost-calculator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/voice-ai-cost-calculator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/voice-ai-cost-calculator.md" });
+  const md = renderToolMarkdown("voice-ai-cost-calculator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/voice-ai-cost-calculator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/voicemail-greeting-generator.md/route.ts
+++ b/packages/crm/src/app/tools/voicemail-greeting-generator.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/voicemail-greeting-generator.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/voicemail-greeting-generator.md" });
+  const md = renderToolMarkdown("voicemail-greeting-generator");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/voicemail-greeting-generator>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tools/website-grader.md/route.ts
+++ b/packages/crm/src/app/tools/website-grader.md/route.ts
@@ -1,0 +1,17 @@
+// /tools/website-grader.md — Markdown twin of the free tool.
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "tool_page", mode: "explicit_md", path: "/tools/website-grader.md" });
+  const md = renderToolMarkdown("website-grader");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tools/website-grader>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/components/seo/cancellation-policy-generator.tsx
+++ b/packages/crm/src/components/seo/cancellation-policy-generator.tsx
@@ -1,0 +1,518 @@
+"use client";
+
+// 2026-08-24 — The cancellation policy generator: the interactive island of
+// /tools/cancellation-policy-generator.
+//
+// Sibling of /tools/no-show-cost-calculator: that page quantifies the problem
+// in dollars, this one produces the document that fixes it. Pure client-side
+// composition, deterministic, no network calls.
+//
+// Three outputs, not one, because a policy only works where the customer
+// actually reads it: the long version for the website, a short version that
+// fits in a confirmation text, and a one-line consent string for the booking
+// form checkbox.
+//
+// HONESTY: this generates policy text, not legal advice. The page says so, and
+// so does the note under the output.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+
+export type PolicyIndustry = "salon" | "medspa" | "dental" | "home-services" | "cleaning" | "auto" | "fitness" | "consulting";
+export type FeeMode = "none" | "flat" | "percent";
+
+export const POLICY_INDUSTRIES: readonly { id: PolicyIndustry; label: string }[] = [
+  { id: "salon", label: "Salon / barber" },
+  { id: "medspa", label: "Med spa" },
+  { id: "dental", label: "Dental" },
+  { id: "home-services", label: "Home services" },
+  { id: "cleaning", label: "Cleaning" },
+  { id: "auto", label: "Auto repair" },
+  { id: "fitness", label: "Fitness / studio" },
+  { id: "consulting", label: "Consulting" },
+] as const;
+
+/** What the appointment is called, and what happens when someone shows up late. */
+const INDUSTRY_TERMS: Record<PolicyIndustry, { visit: string; lateRule: string }> = {
+  salon: {
+    visit: "appointment",
+    lateRule: "If you arrive more than 15 minutes late we may need to shorten or reschedule your service so the guest after you is not delayed.",
+  },
+  medspa: {
+    visit: "appointment",
+    lateRule: "If you arrive more than 15 minutes late we may need to shorten or reschedule your treatment so the rest of the day runs on time.",
+  },
+  dental: {
+    visit: "appointment",
+    lateRule: "If you arrive more than 15 minutes late we may need to reschedule so every other patient is still seen on time.",
+  },
+  "home-services": {
+    visit: "service visit",
+    lateRule: "Our technician waits 15 minutes at the property for access. After that the visit is treated as a no-show.",
+  },
+  cleaning: {
+    visit: "clean",
+    lateRule: "Our team waits 15 minutes for access to the property. After that the visit is treated as a no-show.",
+  },
+  auto: {
+    visit: "service appointment",
+    lateRule: "Vehicles dropped off more than 30 minutes late may be moved to the next available slot.",
+  },
+  fitness: {
+    visit: "session",
+    lateRule: "Doors close 5 minutes after the session starts, for the safety of everyone already warmed up.",
+  },
+  consulting: {
+    visit: "session",
+    lateRule: "Sessions start and end at the scheduled time. Arriving late shortens the session rather than extending it.",
+  },
+};
+
+export interface CancellationPolicyInput {
+  industry: PolicyIndustry;
+  businessName: string;
+  /** How much warning you require, in hours. */
+  noticeHours: number;
+  lateFeeMode: FeeMode;
+  lateFeeValue: number;
+  noShowFeeMode: FeeMode;
+  noShowFeeValue: number;
+  depositRequired: boolean;
+  depositMode: Exclude<FeeMode, "none">;
+  depositValue: number;
+}
+
+export interface CancellationPolicyOutput {
+  /** The long version, for a website or booking page. */
+  full: string;
+  /** The short version, sized for a confirmation or reminder text. */
+  short: string;
+  /** A one-line consent string for the booking form checkbox. */
+  checkbox: string;
+}
+
+/** "18 hours", "24 hours", "7 days" — whichever a human would actually say. */
+export function formatNotice(hours: number): string {
+  const h = Math.max(1, Math.round(hours));
+  if (h >= 96 && h % 24 === 0) return `${h / 24} days`;
+  return `${h} hours`;
+}
+
+/** A fee as words, or null when the fee is switched off. */
+export function formatFee(mode: FeeMode, value: number): string | null {
+  if (mode === "none") return null;
+  if (mode === "percent") return `${Math.round(value)}% of the service price`;
+  return `$${Math.round(value)}`;
+}
+
+/** The same fee, compressed for the SMS version. The short policy has to fit in
+ *  one 160-character segment, and "of the service price" is 20 of them. */
+export function formatFeeShort(mode: FeeMode, value: number): string | null {
+  if (mode === "none") return null;
+  if (mode === "percent") return `${Math.round(value)}% of the service`;
+  return `$${Math.round(value)}`;
+}
+
+/**
+ * Compose the three policy texts. Deterministic, and every switched-off rule is
+ * omitted rather than emitted as an empty clause: a policy that says "a fee of
+ * $0 applies" is worse than no policy at all.
+ */
+export function composeCancellationPolicy(input: CancellationPolicyInput): CancellationPolicyOutput {
+  const terms = INDUSTRY_TERMS[input.industry];
+  // Named business → third person ("Rowan Studio holds…"); unnamed → first
+  // person ("We hold…"), so the text reads right either way.
+  const name = input.businessName.trim();
+  const subject = name || "We";
+  const notice = formatNotice(input.noticeHours);
+  const lateFee = formatFee(input.lateFeeMode, input.lateFeeValue);
+  const noShowFee = formatFee(input.noShowFeeMode, input.noShowFeeValue);
+  const deposit = input.depositRequired ? formatFee(input.depositMode, input.depositValue) : null;
+
+  const full: string[] = [];
+  full.push("Cancellation and no-show policy");
+  full.push("");
+  full.push(
+    `${subject} hold${name ? "s" : ""} your ${terms.visit} time exclusively for you, so we ask for at least ${notice} notice if you need to cancel or reschedule.`,
+  );
+  full.push("");
+  full.push(`Cancelling or rescheduling: free of charge with at least ${notice} notice.`);
+  full.push("");
+  full.push(
+    lateFee
+      ? `Late cancellations: cancelling with less than ${notice} notice is charged ${lateFee}.`
+      : `Late cancellations: there is no fee, but repeated late cancellations may mean we ask for a deposit before your next booking.`,
+  );
+  full.push("");
+  full.push(
+    noShowFee
+      ? `No-shows: missing your ${terms.visit} without letting us know is charged ${noShowFee}.`
+      : `No-shows: there is no fee, but a repeated no-show may mean we can no longer hold time for you in advance.`,
+  );
+  if (deposit) {
+    full.push("");
+    full.push(
+      `Deposits: a ${deposit} deposit is required to hold your ${terms.visit}. It goes toward your final bill, and it is refunded in full if you cancel with at least ${notice} notice.`,
+    );
+  }
+  full.push("");
+  full.push(`Arriving late: ${terms.lateRule}`);
+  full.push("");
+  full.push(
+    `How to cancel: reply to your confirmation message or use the reschedule link in it. Reaching us before the ${notice} mark is what matters, not how you do it.`,
+  );
+
+  // The short version goes in a reminder text, so it is written to survive a
+  // single 160-character SMS segment with the fees spelled out compactly.
+  const lateShort = formatFeeShort(input.lateFeeMode, input.lateFeeValue);
+  const noShowShort = formatFeeShort(input.noShowFeeMode, input.noShowFeeValue);
+  const shortParts: string[] = [];
+  if (lateShort && noShowShort) {
+    shortParts.push(`Reminder: cancelling inside ${notice} is charged ${lateShort}, and no-shows ${noShowShort}.`);
+  } else if (lateShort) {
+    shortParts.push(`Reminder: cancelling inside ${notice} is charged ${lateShort}.`);
+  } else if (noShowShort) {
+    shortParts.push(`Reminder: we need ${notice} notice to cancel. No-shows are charged ${noShowShort}.`);
+  } else {
+    shortParts.push(`Reminder: we need ${notice} notice to cancel or reschedule.`);
+  }
+  shortParts.push("Reply here to reschedule.");
+
+  const checkboxParts: string[] = [`I understand that ${name ? `${name}'s` : "the"} cancellation policy requires ${notice} notice`];
+  if (lateFee && noShowFee) {
+    checkboxParts.push(`, that a late cancellation is charged ${lateFee}, and that a no-show is charged ${noShowFee}.`);
+  } else if (lateFee) {
+    checkboxParts.push(`, and that a late cancellation is charged ${lateFee}.`);
+  } else if (noShowFee) {
+    checkboxParts.push(`, and that a no-show is charged ${noShowFee}.`);
+  } else {
+    checkboxParts.push(".");
+  }
+
+  return {
+    full: full.join("\n"),
+    short: shortParts.join(" "),
+    checkbox: checkboxParts.join(""),
+  };
+}
+
+const NOTICE_PRESETS = [2, 4, 12, 24, 48, 72, 168] as const;
+
+export function CancellationPolicyGenerator(): ReactElement {
+  const [industry, setIndustry] = useState<PolicyIndustry>("salon");
+  const [businessName, setBusinessName] = useState("");
+  const [noticeHours, setNoticeHours] = useState(24);
+  const [lateFeeMode, setLateFeeMode] = useState<FeeMode>("percent");
+  const [lateFeeValue, setLateFeeValue] = useState(50);
+  const [noShowFeeMode, setNoShowFeeMode] = useState<FeeMode>("percent");
+  const [noShowFeeValue, setNoShowFeeValue] = useState(100);
+  const [depositRequired, setDepositRequired] = useState(false);
+  const [depositMode, setDepositMode] = useState<Exclude<FeeMode, "none">>("flat");
+  const [depositValue, setDepositValue] = useState(50);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const policy = useMemo(
+    () =>
+      composeCancellationPolicy({
+        industry,
+        businessName,
+        noticeHours,
+        lateFeeMode,
+        lateFeeValue,
+        noShowFeeMode,
+        noShowFeeValue,
+        depositRequired,
+        depositMode,
+        depositValue,
+      }),
+    [industry, businessName, noticeHours, lateFeeMode, lateFeeValue, noShowFeeMode, noShowFeeValue, depositRequired, depositMode, depositValue],
+  );
+
+  async function copy(text: string, key: string): Promise<void> {
+    const ok = await copyToClipboard(text);
+    if (ok) {
+      setCopied(key);
+      setTimeout(() => setCopied(null), 2000);
+    }
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+        <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>Industry</legend>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Sets what the appointment is called and what the late-arrival rule says.
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {POLICY_INDUSTRIES.map((o) => {
+            const active = o.id === industry;
+            return (
+              <button
+                key={o.id}
+                type="button"
+                onClick={() => setIndustry(o.id)}
+                aria-pressed={active}
+                style={{
+                  border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                  background: active ? GREEN : "rgba(255,255,255,0.6)",
+                  color: active ? "#F6F2EA" : INK,
+                  borderRadius: 999,
+                  padding: "9px 16px",
+                  fontWeight: 700,
+                  fontSize: 13.5,
+                  cursor: "pointer",
+                }}
+              >
+                {o.label}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <label style={{ display: "block", marginTop: 22 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>Business name (optional)</span>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Leave it blank and the policy reads in the first person instead.
+        </div>
+        <input
+          type="text"
+          value={businessName}
+          onChange={(e) => setBusinessName(e.target.value)}
+          placeholder="Rowan Studio"
+          aria-label="Business name"
+          style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, fontFamily: "inherit", boxSizing: "border-box" }}
+        />
+      </label>
+
+      <fieldset style={{ border: "none", padding: 0, margin: "22px 0 0" }}>
+        <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>Notice window</legend>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          How far ahead someone has to cancel to avoid a fee. Currently {formatNotice(noticeHours)}.
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {NOTICE_PRESETS.map((h) => {
+            const active = h === noticeHours;
+            return (
+              <button
+                key={h}
+                type="button"
+                onClick={() => setNoticeHours(h)}
+                aria-pressed={active}
+                style={{
+                  border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                  background: active ? GREEN : "rgba(255,255,255,0.6)",
+                  color: active ? "#F6F2EA" : INK,
+                  borderRadius: 999,
+                  padding: "9px 16px",
+                  fontWeight: 700,
+                  fontSize: 13.5,
+                  cursor: "pointer",
+                }}
+              >
+                {formatNotice(h)}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <FeeRow
+        label="Late cancellation fee"
+        hint="Charged when someone cancels inside the notice window."
+        mode={lateFeeMode}
+        value={lateFeeValue}
+        onModeChange={setLateFeeMode}
+        onValueChange={setLateFeeValue}
+      />
+      <FeeRow
+        label="No-show fee"
+        hint="Charged when nobody shows up and nobody called."
+        mode={noShowFeeMode}
+        value={noShowFeeValue}
+        onModeChange={setNoShowFeeMode}
+        onValueChange={setNoShowFeeValue}
+      />
+
+      <div style={{ marginTop: 22, borderTop: `1px solid ${INK10}`, paddingTop: 20 }}>
+        <label style={{ display: "flex", alignItems: "flex-start", gap: 10, cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={depositRequired}
+            onChange={(e) => setDepositRequired(e.target.checked)}
+            style={{ marginTop: 3, accentColor: GREEN, width: 17, height: 17 }}
+          />
+          <span>
+            <span style={{ fontWeight: 700, fontSize: 14.5 }}>Require a deposit to hold the booking</span>
+            <span style={{ display: "block", fontSize: 12.5, color: "rgba(34,29,23,0.6)", marginTop: 2, lineHeight: 1.5 }}>
+              The strongest no-show deterrent there is, and the one customers push back on hardest. Adds a deposit
+              clause to the policy.
+            </span>
+          </span>
+        </label>
+        {depositRequired && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center", marginTop: 14, paddingLeft: 27 }}>
+            <ModeToggle mode={depositMode} onChange={(m) => setDepositMode(m as Exclude<FeeMode, "none">)} allowNone={false} />
+            <input
+              type="number"
+              min={1}
+              value={depositValue}
+              onChange={(e) => setDepositValue(Math.max(1, Number(e.target.value) || 0))}
+              aria-label="Deposit amount"
+              style={{ width: 110, padding: "9px 12px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit" }}
+            />
+            <span style={{ fontSize: 13.5, fontWeight: 700, color: GREEN }}>{formatFee(depositMode, depositValue)}</span>
+          </div>
+        )}
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24, display: "grid", gap: 22 }}>
+        <Output
+          title="Full policy (website or booking page)"
+          body={policy.full}
+          copied={copied === "full"}
+          onCopy={() => copy(policy.full, "full")}
+        />
+        <Output
+          title="Short version (confirmation or reminder text)"
+          body={policy.short}
+          copied={copied === "short"}
+          onCopy={() => copy(policy.short, "short")}
+        />
+        <Output
+          title="Booking form checkbox"
+          body={policy.checkbox}
+          copied={copied === "checkbox"}
+          onCopy={() => copy(policy.checkbox, "checkbox")}
+        />
+      </div>
+
+      <p style={{ margin: "18px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+        This produces policy text, not legal advice. Charging a card for a missed appointment depends on what your
+        payment processor and your local consumer rules allow, so check both before you switch fees on.
+      </p>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 22 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Put the policy in front of every booking. Start free.
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function FeeRow({
+  label,
+  hint,
+  mode,
+  value,
+  onModeChange,
+  onValueChange,
+}: {
+  label: string;
+  hint: string;
+  mode: FeeMode;
+  value: number;
+  onModeChange: (m: FeeMode) => void;
+  onValueChange: (v: number) => void;
+}): ReactElement {
+  return (
+    <div style={{ marginTop: 22 }}>
+      <div style={{ fontWeight: 700, fontSize: 15 }}>{label}</div>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 10, alignItems: "center" }}>
+        <ModeToggle mode={mode} onChange={onModeChange} allowNone />
+        {mode !== "none" && (
+          <>
+            <input
+              type="number"
+              min={1}
+              value={value}
+              onChange={(e) => onValueChange(Math.max(1, Number(e.target.value) || 0))}
+              aria-label={`${label} amount`}
+              style={{ width: 110, padding: "9px 12px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit" }}
+            />
+            <span style={{ fontSize: 13.5, fontWeight: 700, color: GREEN }}>{formatFee(mode, value)}</span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ModeToggle({ mode, onChange, allowNone }: { mode: FeeMode; onChange: (m: FeeMode) => void; allowNone: boolean }): ReactElement {
+  const options: { id: FeeMode; label: string }[] = allowNone
+    ? [
+        { id: "none", label: "No fee" },
+        { id: "flat", label: "Flat $" },
+        { id: "percent", label: "% of service" },
+      ]
+    : [
+        { id: "flat", label: "Flat $" },
+        { id: "percent", label: "% of service" },
+      ];
+  return (
+    <div style={{ display: "flex", gap: 6 }}>
+      {options.map((o) => {
+        const active = o.id === mode;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => onChange(o.id)}
+            aria-pressed={active}
+            style={{
+              border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+              background: active ? GREEN : "rgba(255,255,255,0.6)",
+              color: active ? "#F6F2EA" : INK,
+              borderRadius: 999,
+              padding: "8px 14px",
+              fontWeight: 700,
+              fontSize: 13,
+              cursor: "pointer",
+            }}
+          >
+            {o.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function Output({ title, body, copied, onCopy }: { title: string; body: string; copied: boolean; onCopy: () => void }): ReactElement {
+  return (
+    <div>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10, marginBottom: 10 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>{title}</div>
+        <button
+          type="button"
+          onClick={onCopy}
+          style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "7px 15px", borderRadius: 9, fontWeight: 700, fontSize: 13, background: "rgba(255,255,255,0.6)", cursor: "pointer", whiteSpace: "nowrap" }}
+        >
+          {copied ? "Copied ✓" : "Copy"}
+        </button>
+      </div>
+      <pre
+        style={{
+          margin: 0,
+          whiteSpace: "pre-wrap",
+          fontFamily: "inherit",
+          fontSize: 14.5,
+          lineHeight: 1.65,
+          color: INK,
+          background: "#fff",
+          border: `1px solid ${INK10}`,
+          borderRadius: 12,
+          padding: "16px 18px",
+        }}
+      >
+        {body}
+      </pre>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/customer-lifetime-value-calculator.tsx
+++ b/packages/crm/src/components/seo/customer-lifetime-value-calculator.tsx
@@ -1,0 +1,427 @@
+"use client";
+/* eslint-disable react-hooks/set-state-in-effect */
+
+// 2026-08-24 — The customer lifetime value calculator: the interactive island
+// of /tools/customer-lifetime-value-calculator.
+//
+// Built for LOCAL SERVICE businesses, not SaaS. Every LTV calculator on the
+// first page of Google assumes a flat monthly subscription and a churn rate,
+// which badly understates a salon whose client comes in eight times a year for
+// a decade and brings her sister. So the inputs here are the ones a service
+// owner actually knows: average ticket, visits a year, years retained, and
+// referrals.
+//
+// This is also the internal-linking hub for the other money calculators: the
+// missed-call, no-show and speed-to-lead pages all quantify losing ONE ticket,
+// and this page is what converts that into what the lost CUSTOMER was worth.
+//
+// Same house idiom as no-show-cost-calculator.tsx: sliders, URL permalink state,
+// shared result card. Pure client math, no network calls.
+
+import { useState, useEffect, useRef, type ReactElement, type CSSProperties } from "react";
+
+import { renderResultCard, buildShareUrl, copyToClipboard, downloadCanvasAsImage, shareResultCard } from "./result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+const AMBER = "#B8860B";
+
+// ─── URL state ────────────────────────────────────────────────────────────
+//
+// Short, stable query keys so shared links stay compact:
+//   lt = avg ticket, lv = visits/yr, ly = years retained, lr = referrals,
+//   lm = gross margin %
+
+export interface ClvState {
+  avgTicket: number;
+  visitsPerYear: number;
+  yearsRetained: number;
+  referrals: number;
+  marginPct: number;
+}
+
+export const CLV_BOUNDS = {
+  avgTicket: { min: 25, max: 5000 },
+  visitsPerYear: { min: 0.5, max: 24 },
+  yearsRetained: { min: 1, max: 20 },
+  referrals: { min: 0, max: 5 },
+  marginPct: { min: 10, max: 90 },
+} as const;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n));
+}
+
+function parseNum(params: URLSearchParams, key: string): number | undefined {
+  const raw = params.get(key);
+  if (raw === null || raw === "") return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function encodeClvState(state: ClvState): string {
+  const params = new URLSearchParams();
+  params.set("lt", String(Math.round(state.avgTicket)));
+  params.set("lv", String(state.visitsPerYear));
+  params.set("ly", String(Math.round(state.yearsRetained)));
+  params.set("lr", String(state.referrals));
+  params.set("lm", String(Math.round(state.marginPct)));
+  return params.toString();
+}
+
+/** Decode + clamp a query string. Out-of-range input is clamped to the slider
+ *  bounds rather than rejected, so a hand-edited URL never crashes the page. */
+export function decodeClvState(search: string): Partial<ClvState> {
+  const params = new URLSearchParams(search);
+  const out: Partial<ClvState> = {};
+
+  const lt = parseNum(params, "lt");
+  if (lt !== undefined) out.avgTicket = clamp(lt, CLV_BOUNDS.avgTicket.min, CLV_BOUNDS.avgTicket.max);
+
+  const lv = parseNum(params, "lv");
+  if (lv !== undefined) out.visitsPerYear = clamp(lv, CLV_BOUNDS.visitsPerYear.min, CLV_BOUNDS.visitsPerYear.max);
+
+  const ly = parseNum(params, "ly");
+  if (ly !== undefined) out.yearsRetained = clamp(ly, CLV_BOUNDS.yearsRetained.min, CLV_BOUNDS.yearsRetained.max);
+
+  const lr = parseNum(params, "lr");
+  if (lr !== undefined) out.referrals = clamp(lr, CLV_BOUNDS.referrals.min, CLV_BOUNDS.referrals.max);
+
+  const lm = parseNum(params, "lm");
+  if (lm !== undefined) out.marginPct = clamp(lm, CLV_BOUNDS.marginPct.min, CLV_BOUNDS.marginPct.max);
+
+  return out;
+}
+
+export interface ClvResult {
+  /** What the customer spends with you directly, over their whole lifetime. */
+  directRevenue: number;
+  /** What the customers they refer spend, at the same lifetime value. */
+  referralRevenue: number;
+  /** directRevenue + referralRevenue. Exact, by construction. */
+  totalRevenue: number;
+  /** 1 + referrals: how many customer-lifetimes one new customer is worth. */
+  referralMultiplier: number;
+  /** Total lifetime revenue at your gross margin. */
+  grossProfitLtv: number;
+  /** Visits the direct customer makes over their lifetime. */
+  visitsOverLifetime: number;
+  /** How many average tickets one lifetime is worth. */
+  ticketMultiple: number;
+}
+
+/**
+ * Lifetime value for a repeat-visit local service business.
+ *
+ * Referrals are counted at ONE generation only: a referred customer is worth
+ * one more direct lifetime, and we do not compound their referrals on top.
+ * Compounding would produce a much bigger and much less defensible number, and
+ * the page says so out loud.
+ *
+ * Inputs are clamped to the slider bounds before any arithmetic, so a
+ * hand-edited permalink can't produce a fantasy number.
+ */
+export function computeCustomerLtv(input: ClvState): ClvResult {
+  const ticket = clamp(input.avgTicket, CLV_BOUNDS.avgTicket.min, CLV_BOUNDS.avgTicket.max);
+  const visits = clamp(input.visitsPerYear, CLV_BOUNDS.visitsPerYear.min, CLV_BOUNDS.visitsPerYear.max);
+  const years = clamp(input.yearsRetained, CLV_BOUNDS.yearsRetained.min, CLV_BOUNDS.yearsRetained.max);
+  const referrals = clamp(input.referrals, CLV_BOUNDS.referrals.min, CLV_BOUNDS.referrals.max);
+  const margin = clamp(input.marginPct, CLV_BOUNDS.marginPct.min, CLV_BOUNDS.marginPct.max);
+
+  const rawDirect = ticket * visits * years;
+  const directRevenue = Math.round(rawDirect);
+  const referralRevenue = Math.round(rawDirect * referrals);
+  // Sum the rounded parts so the three numbers on screen always reconcile.
+  const totalRevenue = directRevenue + referralRevenue;
+
+  return {
+    directRevenue,
+    referralRevenue,
+    totalRevenue,
+    referralMultiplier: 1 + referrals,
+    grossProfitLtv: Math.round(totalRevenue * (margin / 100)),
+    visitsOverLifetime: Math.round(visits * years * 10) / 10,
+    ticketMultiple: Math.round((totalRevenue / ticket) * 10) / 10,
+  };
+}
+
+function money(n: number): string {
+  return n.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+}
+
+export function CustomerLifetimeValueCalculator(): ReactElement {
+  const [avgTicket, setAvgTicket] = useState(150);
+  const [visitsPerYear, setVisitsPerYear] = useState(4);
+  const [yearsRetained, setYearsRetained] = useState(5);
+  const [referrals, setReferrals] = useState(1);
+  const [marginPct, setMarginPct] = useState(55);
+  const replaceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from the URL on mount only — never during SSR (no `window`).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const decoded = decodeClvState(window.location.search);
+    if (decoded.avgTicket !== undefined) setAvgTicket(decoded.avgTicket);
+    if (decoded.visitsPerYear !== undefined) setVisitsPerYear(decoded.visitsPerYear);
+    if (decoded.yearsRetained !== undefined) setYearsRetained(decoded.yearsRetained);
+    if (decoded.referrals !== undefined) setReferrals(decoded.referrals);
+    if (decoded.marginPct !== undefined) setMarginPct(decoded.marginPct);
+  }, []);
+
+  // Keep the address bar in sync (throttled) so the URL is always a shareable
+  // permalink of whatever's on screen.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    replaceTimer.current = setTimeout(() => {
+      const qs = encodeClvState({ avgTicket, visitsPerYear, yearsRetained, referrals, marginPct });
+      window.history.replaceState(null, "", `${window.location.pathname}?${qs}`);
+    }, 150);
+    return () => {
+      if (replaceTimer.current) clearTimeout(replaceTimer.current);
+    };
+  }, [avgTicket, visitsPerYear, yearsRetained, referrals, marginPct]);
+
+  const result = computeCustomerLtv({ avgTicket, visitsPerYear, yearsRetained, referrals, marginPct });
+
+  // ─── Shareable result card ───
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+  const renderTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const canShare = typeof window !== "undefined" && typeof navigator !== "undefined" && typeof navigator.share === "function";
+
+  useEffect(() => {
+    if (renderTimer.current) clearTimeout(renderTimer.current);
+    renderTimer.current = setTimeout(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      renderResultCard(canvas, {
+        headline: "One customer is worth",
+        bigNumber: money(result.totalRevenue),
+        subline: `${money(avgTicket)} × ${visitsPerYear} visits/yr × ${yearsRetained} yrs, plus ${referrals} referral${referrals === 1 ? "" : "s"}`,
+        footer: "built free at seldonframe.com/tools",
+      });
+    }, 150);
+    return () => {
+      if (renderTimer.current) clearTimeout(renderTimer.current);
+    };
+  }, [result.totalRevenue, avgTicket, visitsPerYear, yearsRetained, referrals]);
+
+  const handleCopyLink = async () => {
+    const url = buildShareUrl(window.location.search);
+    const ok = await copyToClipboard(url);
+    setCopyFeedback(ok ? "Copied ✓" : "Copy failed");
+    setTimeout(() => setCopyFeedback(null), 2000);
+  };
+
+  const handleDownload = () => {
+    if (canvasRef.current) downloadCanvasAsImage(canvasRef.current, "customer-lifetime-value.png");
+  };
+
+  const handleNativeShare = async () => {
+    const url = buildShareUrl(window.location.search);
+    await shareResultCard(canvasRef.current, {
+      title: "One customer is worth this much",
+      text: `One of our customers is worth about ${money(result.totalRevenue)} over their lifetime.`,
+      url,
+      filename: "customer-lifetime-value.png",
+    });
+  };
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gap: 22 }}>
+        <Slider
+          label="Average ticket"
+          hint="What one visit or job is worth, before you take costs off it"
+          value={avgTicket}
+          min={CLV_BOUNDS.avgTicket.min}
+          max={CLV_BOUNDS.avgTicket.max}
+          step={25}
+          format={(v) => money(v)}
+          onChange={setAvgTicket}
+        />
+        <Slider
+          label="Visits per year"
+          hint="A salon client might be 8, an HVAC customer 2, a roofer closer to 0.5"
+          value={visitsPerYear}
+          min={CLV_BOUNDS.visitsPerYear.min}
+          max={CLV_BOUNDS.visitsPerYear.max}
+          step={0.5}
+          format={(v) => `${v} / yr`}
+          onChange={setVisitsPerYear}
+        />
+        <Slider
+          label="Years they stay with you"
+          hint="How long an average customer keeps coming back before they move, switch, or stop needing you"
+          value={yearsRetained}
+          min={CLV_BOUNDS.yearsRetained.min}
+          max={CLV_BOUNDS.yearsRetained.max}
+          step={1}
+          format={(v) => `${v} yr${v === 1 ? "" : "s"}`}
+          onChange={setYearsRetained}
+        />
+        <Slider
+          label="Referrals per customer"
+          hint="New customers this one sends you over their whole lifetime. Counted once, never compounded."
+          value={referrals}
+          min={CLV_BOUNDS.referrals.min}
+          max={CLV_BOUNDS.referrals.max}
+          step={0.5}
+          format={(v) => `${v} referral${v === 1 ? "" : "s"}`}
+          onChange={setReferrals}
+        />
+        <Slider
+          label="Gross margin"
+          hint="What you keep after labor and materials. Turns lifetime revenue into lifetime profit."
+          value={marginPct}
+          min={CLV_BOUNDS.marginPct.min}
+          max={CLV_BOUNDS.marginPct.max}
+          step={5}
+          format={(v) => `${v}%`}
+          onChange={setMarginPct}
+        />
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24, display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 16 }}>
+        <Stat label="Direct lifetime revenue" value={money(result.directRevenue)} tone="green" />
+        <Stat label="Plus referrals" value={money(result.referralRevenue)} tone="green" />
+        <Stat label="Total lifetime value" value={money(result.totalRevenue)} tone="hero" />
+        <Stat label={`Lifetime profit at ${marginPct}%`} value={money(result.grossProfitLtv)} tone="green" />
+      </div>
+
+      <p style={{ margin: "18px 0 0", fontSize: 15, lineHeight: 1.6, color: INK }}>
+        One customer is worth <strong>{result.ticketMultiple} average tickets</strong>, across{" "}
+        <strong>{result.visitsOverLifetime} visits</strong> and a{" "}
+        <strong>{result.referralMultiplier}x</strong> referral multiplier. Which means the real cost of losing one is{" "}
+        <strong style={{ color: AMBER }}>{money(result.totalRevenue)}</strong>, not {money(avgTicket)}.
+      </p>
+
+      <p style={{ margin: "14px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+        Referrals are counted at one generation only. A referred customer is worth one more lifetime, and we do not
+        compound the referrals they bring on top of that. Compounding produces a far bigger number and a far weaker
+        argument, so this stays deliberately conservative.
+      </p>
+
+      <div style={{ marginTop: 24, borderTop: `1px solid ${INK10}`, paddingTop: 22 }}>
+        <div style={{ fontSize: 15.5, fontWeight: 800, color: INK }}>Now price the leaks</div>
+        <p style={{ margin: "8px 0 14px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }}>
+          Every missed call, no-show and slow reply is a shot at a customer worth {money(result.totalRevenue)}, not at a{" "}
+          {money(avgTicket)} ticket. Run the same numbers through the other three calculators:
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+          {[
+            { href: "/tools/missed-call-calculator", label: "Missed-call cost" },
+            { href: "/tools/no-show-cost-calculator", label: "No-show cost" },
+            { href: "/tools/speed-to-lead-calculator", label: "Speed-to-lead cost" },
+          ].map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 999, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", textDecoration: "none" }}
+            >
+              {l.label}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 24 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Stop losing customers worth {money(result.totalRevenue)}. Start free.
+        </a>
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 12 }}>
+          Share your result
+        </div>
+        <div style={{ borderRadius: 14, overflow: "hidden", border: `1px solid ${INK10}`, background: "#1F2B24", maxWidth: 640 }}>
+          <canvas ref={canvasRef} style={{ display: "block", width: "100%", height: "auto" }} aria-label="Downloadable result card showing the lifetime value of one customer" />
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14, alignItems: "center" }}>
+          <button
+            type="button"
+            onClick={handleDownload}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+          >
+            ⬇ Download image
+          </button>
+          <button
+            type="button"
+            onClick={handleCopyLink}
+            style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+          >
+            🔗 {copyFeedback ?? "Copy link"}
+          </button>
+          {canShare && (
+            <button
+              type="button"
+              onClick={handleNativeShare}
+              style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 18px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+            >
+              Share
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Slider({
+  label,
+  hint,
+  value,
+  min,
+  max,
+  step,
+  format,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format: (v: number) => string;
+  onChange: (v: number) => void;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>{label}</span>
+        <span style={{ fontWeight: 800, fontSize: 16, color: GREEN, whiteSpace: "nowrap" }}>{format(value)}</span>
+      </div>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ width: "100%", accentColor: GREEN }}
+        aria-label={label}
+      />
+    </label>
+  );
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone: "green" | "hero" }): ReactElement {
+  const hero = tone === "hero";
+  const box: CSSProperties = {
+    border: hero ? `1.5px solid ${GREEN}` : `1px solid ${INK10}`,
+    borderRadius: 14,
+    padding: "16px 18px",
+    background: hero ? "rgba(31, 43, 36,0.06)" : "rgba(255,255,255,0.6)",
+  };
+  return (
+    <div style={box}>
+      <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>{label}</div>
+      <div style={{ fontSize: hero ? 28 : 24, fontWeight: 800, marginTop: 6, color: GREEN }}>{value}</div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/google-business-profile-description-generator.tsx
+++ b/packages/crm/src/components/seo/google-business-profile-description-generator.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+// 2026-08-24 — The Google Business Profile description generator: the
+// interactive island of /tools/google-business-profile-description-generator.
+//
+// Google caps the "from the business" description at 750 characters, and the
+// field silently refuses anything longer, so the useful part of a tool like
+// this is the budget, not the prose. The composer builds sentences in priority
+// order and drops the optional ones from the bottom up when the budget runs
+// out, so you always get a complete description rather than one cut mid-word.
+//
+// Pure client-side composition: no LLM, no network calls, deterministic.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+const AMBER = "#B8860B";
+
+/** Google's published cap on the business description field. */
+export const GBP_DESCRIPTION_LIMIT = 750;
+
+export type GbpTone = "warm" | "professional" | "direct";
+
+export const GBP_TONES: readonly { id: GbpTone; label: string }[] = [
+  { id: "warm", label: "Warm" },
+  { id: "professional", label: "Professional" },
+  { id: "direct", label: "Direct" },
+] as const;
+
+export const GBP_DIFFERENTIATORS: readonly { id: string; label: string; sentence: string }[] = [
+  { id: "licensed", label: "Licensed & insured", sentence: "We are fully licensed and insured." },
+  { id: "family", label: "Family owned", sentence: "We are a family owned and operated business." },
+  { id: "same-day", label: "Same-day service", sentence: "Same-day appointments are available in most cases." },
+  { id: "upfront", label: "Upfront pricing", sentence: "You get upfront pricing before any work begins." },
+  { id: "emergency", label: "24/7 emergency", sentence: "We answer emergency calls around the clock." },
+  { id: "warranty", label: "Warrantied work", sentence: "Our work is backed by a written warranty." },
+  { id: "veteran", label: "Veteran owned", sentence: "We are a veteran owned business." },
+  { id: "free-estimates", label: "Free estimates", sentence: "Estimates are free and come with no obligation." },
+  { id: "bilingual", label: "Bilingual team", sentence: "Our team serves customers in English and Spanish." },
+] as const;
+
+/** Cap on how many differentiators the description will carry. */
+export const MAX_DIFFERENTIATORS = 3;
+/** Cap on how many services the description will list. */
+export const MAX_SERVICES = 5;
+
+export interface GbpInput {
+  businessName: string;
+  businessType: string;
+  city: string;
+  services: string[];
+  yearsInBusiness: number;
+  /** Differentiator ids, in the order they should appear. */
+  differentiators: string[];
+  tone: GbpTone;
+}
+
+export interface GbpOutput {
+  text: string;
+  length: number;
+  remaining: number;
+  /** True when at least one optional sentence had to be dropped to fit. */
+  trimmed: boolean;
+}
+
+/** "a, b and c" — the Oxford-free list a description actually reads well with. */
+function joinList(items: string[]): string {
+  const clean = items.map((s) => s.trim()).filter(Boolean);
+  if (clean.length === 0) return "";
+  if (clean.length === 1) return clean[0];
+  return `${clean.slice(0, -1).join(", ")} and ${clean[clean.length - 1]}`;
+}
+
+/**
+ * Compose the description. Sentence order is fixed; the optional sentences
+ * (differentiators last, then years in business) are dropped from the bottom up
+ * until the whole thing fits inside GBP_DESCRIPTION_LIMIT. Nothing is ever cut
+ * mid-sentence.
+ */
+export function composeGbpDescription(input: GbpInput): GbpOutput {
+  const name = input.businessName.trim() || "Our team";
+  const type = input.businessType.trim() || "local service business";
+  const city = input.city.trim();
+  const services = input.services.map((s) => s.trim()).filter(Boolean).slice(0, MAX_SERVICES);
+  const where = city ? ` in ${city} and the surrounding area` : "";
+
+  const opening =
+    input.tone === "warm"
+      ? `${name} is a ${type}${where}.`
+      : input.tone === "professional"
+        ? `${name} provides ${type} services${where}.`
+        : `${name} does ${type} work${where}.`;
+
+  const serviceSentence = services.length > 0 ? `We handle ${joinList(services)}.` : "";
+
+  const yearsSentence =
+    input.yearsInBusiness >= 1
+      ? city
+        ? `We have been serving ${city} for ${Math.round(input.yearsInBusiness)} years.`
+        : `We have been in business for ${Math.round(input.yearsInBusiness)} years.`
+      : "";
+
+  const diffSentences = input.differentiators
+    .slice(0, MAX_DIFFERENTIATORS)
+    .map((id) => GBP_DIFFERENTIATORS.find((d) => d.id === id)?.sentence)
+    .filter((s): s is string => Boolean(s));
+
+  const closing =
+    input.tone === "warm"
+      ? "Call us or book online and we will take it from there."
+      : input.tone === "professional"
+        ? "Contact us to schedule an appointment."
+        : "Call or book online.";
+
+  // opening + services + closing always survive. The optional sentences are
+  // dropped last-first, so the years line (listed last) is the first to go.
+  const assemble = (keptOptional: string[]): string =>
+    [opening, serviceSentence, ...keptOptional, closing].filter(Boolean).join(" ");
+
+  let kept = [...diffSentences, yearsSentence].filter(Boolean);
+  let text = assemble(kept);
+  let trimmedAny = false;
+  while (text.length > GBP_DESCRIPTION_LIMIT && kept.length > 0) {
+    kept = kept.slice(0, -1);
+    trimmedAny = true;
+    text = assemble(kept);
+  }
+
+  // Still too long with only the required sentences: the service list is the
+  // one required part that can shrink without breaking a sentence.
+  let shrinkingServices = [...services];
+  while (text.length > GBP_DESCRIPTION_LIMIT && shrinkingServices.length > 1) {
+    shrinkingServices = shrinkingServices.slice(0, -1);
+    trimmedAny = true;
+    const shorterServiceSentence = `We handle ${joinList(shrinkingServices)}.`;
+    text = [opening, shorterServiceSentence, closing].join(" ");
+  }
+
+  // Last resort: a business name and type long enough to blow the budget on
+  // their own. Cut on a word boundary rather than emitting an over-limit string.
+  if (text.length > GBP_DESCRIPTION_LIMIT) {
+    text = text.slice(0, GBP_DESCRIPTION_LIMIT).replace(/\s+\S*$/, "");
+    trimmedAny = true;
+  }
+
+  return {
+    text,
+    length: text.length,
+    remaining: GBP_DESCRIPTION_LIMIT - text.length,
+    trimmed: trimmedAny,
+  };
+}
+
+export function GoogleBusinessProfileDescriptionGenerator(): ReactElement {
+  const [businessName, setBusinessName] = useState("");
+  const [businessType, setBusinessType] = useState("plumbing company");
+  const [city, setCity] = useState("");
+  const [serviceText, setServiceText] = useState("drain cleaning, water heater repair, leak detection");
+  const [yearsInBusiness, setYearsInBusiness] = useState(10);
+  const [differentiators, setDifferentiators] = useState<string[]>(["licensed", "same-day"]);
+  const [tone, setTone] = useState<GbpTone>("warm");
+  const [copied, setCopied] = useState(false);
+
+  const services = useMemo(
+    () => serviceText.split(",").map((s) => s.trim()).filter(Boolean),
+    [serviceText],
+  );
+
+  const result = useMemo(
+    () => composeGbpDescription({ businessName, businessType, city, services, yearsInBusiness, differentiators, tone }),
+    [businessName, businessType, city, services, yearsInBusiness, differentiators, tone],
+  );
+
+  function toggleDiff(id: string): void {
+    setDifferentiators((prev) => {
+      if (prev.includes(id)) return prev.filter((d) => d !== id);
+      if (prev.length >= MAX_DIFFERENTIATORS) return prev;
+      return [...prev, id];
+    });
+  }
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(result.text);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  const overBudget = result.remaining < 0;
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(230px, 1fr))", gap: 16 }}>
+        <Field label="Business name" value={businessName} onChange={setBusinessName} placeholder="Northside Plumbing" />
+        <Field label="Business type" hint="How you would describe yourself in three words." value={businessType} onChange={setBusinessType} placeholder="plumbing company" />
+        <Field label="City or area served" value={city} onChange={setCity} placeholder="Portland" />
+      </div>
+
+      <label style={{ display: "block", marginTop: 20 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>Services</span>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Comma-separated, most important first. Up to {MAX_SERVICES} are used ({services.length} entered).
+        </div>
+        <input
+          type="text"
+          value={serviceText}
+          onChange={(e) => setServiceText(e.target.value)}
+          placeholder="drain cleaning, water heater repair, leak detection"
+          aria-label="Services"
+          style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, fontFamily: "inherit", boxSizing: "border-box" }}
+        />
+      </label>
+
+      <label style={{ display: "block", marginTop: 20 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+          <span style={{ fontWeight: 700, fontSize: 15 }}>Years in business</span>
+          <span style={{ fontWeight: 800, fontSize: 16, color: GREEN }}>{yearsInBusiness === 0 ? "not mentioned" : `${yearsInBusiness} years`}</span>
+        </div>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>Set it to zero to leave the sentence out.</div>
+        <input
+          type="range"
+          min={0}
+          max={50}
+          step={1}
+          value={yearsInBusiness}
+          onChange={(e) => setYearsInBusiness(Number(e.target.value))}
+          style={{ width: "100%", accentColor: GREEN }}
+          aria-label="Years in business"
+        />
+      </label>
+
+      <fieldset style={{ border: "none", padding: 0, margin: "22px 0 0" }}>
+        <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>What sets you apart</legend>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Pick up to {MAX_DIFFERENTIATORS}. Only choose what is actually true: Google suspends profiles over claims a
+          reviewer can disprove.
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {GBP_DIFFERENTIATORS.map((d) => {
+            const active = differentiators.includes(d.id);
+            const full = !active && differentiators.length >= MAX_DIFFERENTIATORS;
+            return (
+              <button
+                key={d.id}
+                type="button"
+                onClick={() => toggleDiff(d.id)}
+                aria-pressed={active}
+                disabled={full}
+                style={{
+                  border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                  background: active ? GREEN : "rgba(255,255,255,0.6)",
+                  color: active ? "#F6F2EA" : INK,
+                  opacity: full ? 0.45 : 1,
+                  borderRadius: 999,
+                  padding: "9px 16px",
+                  fontWeight: 700,
+                  fontSize: 13.5,
+                  cursor: full ? "not-allowed" : "pointer",
+                }}
+              >
+                {d.label}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <div style={{ marginTop: 22 }}>
+        <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+          <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>Tone</legend>
+          <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>Changes the opening and closing sentence.</div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+            {GBP_TONES.map((t) => {
+              const active = t.id === tone;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setTone(t.id)}
+                  aria-pressed={active}
+                  style={{
+                    border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                    background: active ? GREEN : "rgba(255,255,255,0.6)",
+                    color: active ? "#F6F2EA" : INK,
+                    borderRadius: 999,
+                    padding: "9px 16px",
+                    fontWeight: 700,
+                    fontSize: 13.5,
+                    cursor: "pointer",
+                  }}
+                >
+                  {t.label}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: 10, marginBottom: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+            Your description
+          </div>
+          <div style={{ fontSize: 13.5, fontWeight: 700, color: overBudget ? AMBER : GREEN }}>
+            {result.length} / {GBP_DESCRIPTION_LIMIT} characters
+          </div>
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            whiteSpace: "pre-wrap",
+            fontFamily: "inherit",
+            fontSize: 15,
+            lineHeight: 1.65,
+            color: INK,
+            background: "#fff",
+            border: `1px solid ${INK10}`,
+            borderRadius: 12,
+            padding: "18px 20px",
+          }}
+        >
+          {result.text}
+        </pre>
+        {result.trimmed && (
+          <p style={{ margin: "10px 0 0", fontSize: 12.5, color: AMBER, fontWeight: 600, lineHeight: 1.55 }}>
+            The description ran past 750 characters, so the lowest-priority sentences were dropped to fit. Shorten your
+            service list if you want a differentiator back.
+          </p>
+        )}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14 }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: INK, color: "#F6F2EA", border: "none", padding: "11px 22px", borderRadius: 10, fontWeight: 700, fontSize: 14, cursor: "pointer" }}
+          >
+            {copied ? "Copied ✓" : "Copy description"}
+          </button>
+        </div>
+        <p style={{ margin: "12px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+          Paste it into Google Business Profile under Edit profile, then Business description. Google does not use this
+          field for ranking, but a human reading your profile does, and so does an AI assistant summarising you.
+        </p>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+        <a href="/tools/ai-website-generator" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Turn that same profile into a real website
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  hint?: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <span style={{ fontWeight: 700, fontSize: 14.5 }}>{label}</span>
+      {hint && <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 8px", lineHeight: 1.45 }}>{hint}</div>}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={label}
+        style={{ width: "100%", padding: "11px 13px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit", boxSizing: "border-box", marginTop: hint ? 0 : 8 }}
+      />
+    </label>
+  );
+}

--- a/packages/crm/src/components/seo/google-review-qr-code-generator.tsx
+++ b/packages/crm/src/components/seo/google-review-qr-code-generator.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+// 2026-08-24 — The Google review QR code generator: the interactive island of
+// /tools/google-review-qr-code-generator.
+//
+// Sibling of google-review-link-generator.tsx, NOT a duplicate of it. That tool
+// answers "what's my review link" and shows a QR preview from a third-party
+// image service. This one answers "give me print-ready QR artwork": the code is
+// encoded in the browser with the `qrcode` package already in this app's
+// dependencies (no third-party image call, so the artwork works offline and the
+// Place ID never leaves the page), sized to a real physical width at 300 DPI,
+// and downloadable as PNG or vector SVG.
+//
+// The Place ID parsing is deliberately copy-pasted from the sibling rather than
+// extracted (CLAUDE.md: Wrong Abstraction — copy twice before extracting; this
+// is copy #2, and the two tools may diverge on what input they accept).
+
+import { useEffect, useMemo, useState, type ReactElement } from "react";
+import QRCode from "qrcode";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+const RED = "#C0392B";
+
+/** Print resolution every commercial printer asks for. */
+export const PRINT_DPI = 300;
+
+export interface PrintSize {
+  id: string;
+  label: string;
+  /** Finished artwork width in inches. */
+  inches: number;
+  /** Where this size actually gets used. */
+  useCase: string;
+}
+
+export const PRINT_SIZES: readonly PrintSize[] = [
+  { id: "table-tent", label: "Table tent", inches: 2, useCase: "A folded card on a table or a reception desk, scanned from about a foot away." },
+  { id: "counter-card", label: "Counter card", inches: 3, useCase: "A standing card at the register or checkout, scanned from arm's length." },
+  { id: "poster", label: "Poster / A-frame", inches: 4, useCase: "A wall poster or waiting-room sign, scanned from a few feet away." },
+  { id: "window-decal", label: "Window decal", inches: 6, useCase: "A door or window sticker, scanned from the sidewalk." },
+] as const;
+
+export type ErrorCorrection = "M" | "Q" | "H";
+
+export const ERROR_CORRECTION_LEVELS: readonly { id: ErrorCorrection; label: string; hint: string }[] = [
+  { id: "M", label: "Medium", hint: "Smallest, densest code. Fine for clean digital use." },
+  { id: "Q", label: "Quartile", hint: "Recommended for print. Survives scuffs and ink bleed." },
+  { id: "H", label: "High", hint: "Most robust. Use if you're placing a logo over the centre." },
+] as const;
+
+/** Pixel width for a given physical width at print resolution. */
+export function printPixels(inches: number, dpi: number = PRINT_DPI): number {
+  return Math.round(inches * dpi);
+}
+
+/** The direct "write a review" URL Google exposes for a Place ID. */
+export function buildReviewUrl(placeId: string): string {
+  return `https://search.google.com/local/writereview?placeid=${encodeURIComponent(placeId)}`;
+}
+
+/** Best-effort extraction of a `place_id` query param from a pasted Google
+ *  Maps URL. Returns null if the input isn't a URL or has no place_id. */
+function extractPlaceIdFromUrl(input: string): string | null {
+  try {
+    const url = new URL(input);
+    return url.searchParams.get("place_id") || url.searchParams.get("placeid");
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeUrl(input: string): boolean {
+  return /^https?:\/\//i.test(input.trim());
+}
+
+/** Trigger a browser download for an already-built object/data URL. */
+function downloadUrl(href: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = href;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+export function GoogleReviewQrCodeGenerator(): ReactElement {
+  const [input, setInput] = useState("");
+  const [sizeId, setSizeId] = useState<string>("counter-card");
+  const [ecLevel, setEcLevel] = useState<ErrorCorrection>("Q");
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
+  const [encodeError, setEncodeError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const size = PRINT_SIZES.find((s) => s.id === sizeId) ?? PRINT_SIZES[1];
+  const pixels = printPixels(size.inches);
+
+  const { placeId, error } = useMemo(() => {
+    const trimmed = input.trim();
+    if (!trimmed) return { placeId: null as string | null, error: null as string | null };
+
+    if (looksLikeUrl(trimmed)) {
+      const extracted = extractPlaceIdFromUrl(trimmed);
+      if (extracted) return { placeId: extracted, error: null };
+      return {
+        placeId: null,
+        error: "That URL doesn't include a place_id query param. Paste your Place ID directly instead.",
+      };
+    }
+
+    if (/\s/.test(trimmed)) {
+      return { placeId: null, error: "A Place ID shouldn't contain spaces. Double-check what you pasted." };
+    }
+
+    return { placeId: trimmed, error: null };
+  }, [input]);
+
+  const reviewUrl = placeId ? buildReviewUrl(placeId) : null;
+
+  // Encode the preview in the browser. Screen preview is a fixed 480px render
+  // of the same data the print file uses — the print file is re-encoded at
+  // download time so a big decal doesn't sit in memory while you're browsing.
+  useEffect(() => {
+    let cancelled = false;
+    if (!reviewUrl) {
+      setPreviewSrc(null);
+      setEncodeError(null);
+      return;
+    }
+    QRCode.toDataURL(reviewUrl, { width: 480, margin: 2, errorCorrectionLevel: ecLevel })
+      .then((url) => {
+        if (!cancelled) {
+          setPreviewSrc(url);
+          setEncodeError(null);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPreviewSrc(null);
+          setEncodeError("Couldn't encode that Place ID as a QR code. Check the value and try again.");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reviewUrl, ecLevel]);
+
+  async function handleCopy(): Promise<void> {
+    if (!reviewUrl) return;
+    const ok = await copyToClipboard(reviewUrl);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  async function handleDownloadPng(): Promise<void> {
+    if (!reviewUrl) return;
+    try {
+      const dataUrl = await QRCode.toDataURL(reviewUrl, { width: pixels, margin: 2, errorCorrectionLevel: ecLevel });
+      downloadUrl(dataUrl, `google-review-qr-${size.id}-${size.inches}in-300dpi.png`);
+    } catch {
+      setEncodeError("Couldn't build the PNG. Try a different error-correction level.");
+    }
+  }
+
+  async function handleDownloadSvg(): Promise<void> {
+    if (!reviewUrl) return;
+    try {
+      const svg = await QRCode.toString(reviewUrl, { margin: 2, errorCorrectionLevel: ecLevel });
+      const blobUrl = URL.createObjectURL(new Blob([svg], { type: "image/svg+xml" }));
+      downloadUrl(blobUrl, "google-review-qr.svg");
+      URL.revokeObjectURL(blobUrl);
+    } catch {
+      setEncodeError("Couldn't build the SVG. Try a different error-correction level.");
+    }
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <label style={{ display: "block" }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>Google Place ID or Maps URL</span>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Paste your business&apos;s Place ID, or a Google Maps URL that contains a <code>place_id</code> parameter.
+        </div>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="ChIJN1t_tDeuEmsRUsoyG83frY4"
+          aria-label="Google Place ID or Maps URL"
+          style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, fontFamily: "inherit", boxSizing: "border-box" }}
+        />
+      </label>
+
+      <fieldset style={{ border: "none", padding: 0, margin: "22px 0 0" }}>
+        <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>Print size</legend>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          The finished width of the printed code. The PNG is exported at {PRINT_DPI} DPI so it stays sharp on paper.
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {PRINT_SIZES.map((s) => {
+            const active = s.id === sizeId;
+            return (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => setSizeId(s.id)}
+                aria-pressed={active}
+                style={{
+                  border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                  background: active ? GREEN : "rgba(255,255,255,0.6)",
+                  color: active ? "#F6F2EA" : INK,
+                  borderRadius: 999,
+                  padding: "9px 16px",
+                  fontWeight: 700,
+                  fontSize: 13.5,
+                  cursor: "pointer",
+                }}
+              >
+                {s.label} · {s.inches}″
+              </button>
+            );
+          })}
+        </div>
+        <p style={{ margin: "10px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.55 }}>
+          {size.useCase} Exports at {pixels} × {pixels} px.
+        </p>
+      </fieldset>
+
+      <fieldset style={{ border: "none", padding: 0, margin: "22px 0 0" }}>
+        <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>Error correction</legend>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          How much of the code can be damaged and still scan.
+        </div>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+          {ERROR_CORRECTION_LEVELS.map((lvl) => {
+            const active = lvl.id === ecLevel;
+            return (
+              <button
+                key={lvl.id}
+                type="button"
+                onClick={() => setEcLevel(lvl.id)}
+                aria-pressed={active}
+                style={{
+                  border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                  background: active ? GREEN : "rgba(255,255,255,0.6)",
+                  color: active ? "#F6F2EA" : INK,
+                  borderRadius: 999,
+                  padding: "9px 16px",
+                  fontWeight: 700,
+                  fontSize: 13.5,
+                  cursor: "pointer",
+                }}
+              >
+                {lvl.label}
+              </button>
+            );
+          })}
+        </div>
+        <p style={{ margin: "10px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.55 }}>
+          {ERROR_CORRECTION_LEVELS.find((l) => l.id === ecLevel)?.hint}
+        </p>
+      </fieldset>
+
+      {(error || encodeError) && (
+        <p role="alert" style={{ marginTop: 18, color: RED, fontWeight: 600, fontSize: 14 }}>
+          {error ?? encodeError}
+        </p>
+      )}
+
+      {reviewUrl && previewSrc && (
+        <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 10 }}>
+            Your print-ready code
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 22, alignItems: "flex-start" }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={previewSrc}
+              alt="QR code that opens the Google review box for your business"
+              width={200}
+              height={200}
+              style={{ borderRadius: 12, border: `1px solid ${INK10}`, background: "#fff", padding: 8 }}
+            />
+            <div style={{ flex: "1 1 280px", minWidth: 260 }}>
+              <div style={{ fontSize: 12.5, fontWeight: 700, color: "rgba(34,29,23,0.55)", marginBottom: 6 }}>Encodes this URL</div>
+              <code style={{ display: "block", fontSize: 13, wordBreak: "break-all", color: INK, border: `1px solid ${INK10}`, borderRadius: 10, padding: "10px 12px", background: "#fff" }}>
+                {reviewUrl}
+              </code>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14 }}>
+                <button
+                  type="button"
+                  onClick={handleDownloadPng}
+                  style={{ background: INK, color: "#F6F2EA", border: "none", padding: "11px 20px", borderRadius: 10, fontWeight: 700, fontSize: 14, cursor: "pointer" }}
+                >
+                  ⬇ PNG · {size.inches}″ at {PRINT_DPI} DPI
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDownloadSvg}
+                  style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 19px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+                >
+                  ⬇ SVG (vector)
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCopy}
+                  style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 19px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+                >
+                  {copied ? "Copied ✓" : "Copy URL"}
+                </button>
+              </div>
+              <p style={{ margin: "12px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+                Encoded in your browser. Nothing you type is sent to SeldonFrame, and no third-party image service is
+                involved. Send the SVG to a printer if you want it larger than a decal.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Ask for the review automatically. Start free.
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/packages/crm/src/components/seo/local-business-schema-generator.tsx
+++ b/packages/crm/src/components/seo/local-business-schema-generator.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+// 2026-08-24 — The LocalBusiness schema generator: the interactive island of
+// /tools/local-business-schema-generator.
+//
+// Builds a schema.org LocalBusiness JSON-LD block from a plain form. The whole
+// point is that the output is VALID: an empty field is omitted from the object
+// entirely rather than emitted as `""`, so what you copy never contains a hole
+// for a crawler to trip on. Pure client-side, no network calls.
+//
+// Structured data is also the machine-readable version of the answers an AI
+// assistant needs to recommend a business, which is why this sits next to
+// /tools/ai-visibility-checker.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+
+/** The schema.org LocalBusiness subtypes worth offering. Anything not listed
+ *  here can still use the plain "LocalBusiness" type without penalty. */
+export const SCHEMA_TYPES: readonly { id: string; label: string }[] = [
+  { id: "LocalBusiness", label: "Local business (generic)" },
+  { id: "Plumber", label: "Plumber" },
+  { id: "HVACBusiness", label: "HVAC" },
+  { id: "Electrician", label: "Electrician" },
+  { id: "RoofingContractor", label: "Roofing" },
+  { id: "HairSalon", label: "Hair salon" },
+  { id: "BeautySalon", label: "Beauty salon / med spa" },
+  { id: "Dentist", label: "Dentist" },
+  { id: "HousePainter", label: "Painter" },
+  { id: "MovingCompany", label: "Movers" },
+  { id: "AutoRepair", label: "Auto repair" },
+  { id: "Attorney", label: "Attorney" },
+  { id: "AccountingService", label: "Accounting" },
+  { id: "ProfessionalService", label: "Professional service" },
+] as const;
+
+/** schema.org day names, in the order the form shows them. */
+export const SCHEMA_DAYS: readonly { id: string; label: string }[] = [
+  { id: "Monday", label: "Mon" },
+  { id: "Tuesday", label: "Tue" },
+  { id: "Wednesday", label: "Wed" },
+  { id: "Thursday", label: "Thu" },
+  { id: "Friday", label: "Fri" },
+  { id: "Saturday", label: "Sat" },
+  { id: "Sunday", label: "Sun" },
+] as const;
+
+export interface DayHours {
+  day: string;
+  closed: boolean;
+  opens: string;
+  closes: string;
+}
+
+export interface SchemaInput {
+  name: string;
+  type: string;
+  url: string;
+  telephone: string;
+  priceRange: string;
+  streetAddress: string;
+  addressLocality: string;
+  addressRegion: string;
+  postalCode: string;
+  addressCountry: string;
+  latitude: string;
+  longitude: string;
+  /** Comma-separated cities or areas served. */
+  areaServed: string;
+  hours: DayHours[];
+}
+
+/** A JSON-LD value can be a string, a number, a nested object or a list. */
+type JsonLdValue = string | number | JsonLdValue[] | { [key: string]: JsonLdValue };
+
+function trimmed(v: string): string {
+  return v.trim();
+}
+
+/**
+ * Build the JSON-LD object. Omits every empty field, every closed day, and
+ * every sub-object that ended up with nothing in it, so the result is always
+ * valid structured data rather than a template with blanks.
+ */
+export function buildLocalBusinessJsonLd(input: SchemaInput): Record<string, JsonLdValue> {
+  const ld: Record<string, JsonLdValue> = {
+    "@context": "https://schema.org",
+    "@type": trimmed(input.type) || "LocalBusiness",
+  };
+
+  if (trimmed(input.name)) ld.name = trimmed(input.name);
+  if (trimmed(input.url)) ld.url = trimmed(input.url);
+  if (trimmed(input.telephone)) ld.telephone = trimmed(input.telephone);
+  if (trimmed(input.priceRange)) ld.priceRange = trimmed(input.priceRange);
+
+  const address: Record<string, JsonLdValue> = { "@type": "PostalAddress" };
+  if (trimmed(input.streetAddress)) address.streetAddress = trimmed(input.streetAddress);
+  if (trimmed(input.addressLocality)) address.addressLocality = trimmed(input.addressLocality);
+  if (trimmed(input.addressRegion)) address.addressRegion = trimmed(input.addressRegion);
+  if (trimmed(input.postalCode)) address.postalCode = trimmed(input.postalCode);
+  if (trimmed(input.addressCountry)) address.addressCountry = trimmed(input.addressCountry);
+  // "@type" alone means nothing was filled in: drop the whole address.
+  if (Object.keys(address).length > 1) ld.address = address;
+
+  const lat = Number(trimmed(input.latitude));
+  const lon = Number(trimmed(input.longitude));
+  if (trimmed(input.latitude) && trimmed(input.longitude) && Number.isFinite(lat) && Number.isFinite(lon)) {
+    ld.geo = { "@type": "GeoCoordinates", latitude: lat, longitude: lon };
+  }
+
+  const areas = input.areaServed
+    .split(",")
+    .map((a) => a.trim())
+    .filter(Boolean);
+  if (areas.length === 1) ld.areaServed = areas[0];
+  else if (areas.length > 1) ld.areaServed = areas;
+
+  const openingHours = input.hours
+    .filter((h) => !h.closed && trimmed(h.opens) && trimmed(h.closes))
+    .map((h) => ({
+      "@type": "OpeningHoursSpecification" as const,
+      dayOfWeek: `https://schema.org/${h.day}`,
+      opens: trimmed(h.opens),
+      closes: trimmed(h.closes),
+    }));
+  if (openingHours.length > 0) ld.openingHoursSpecification = openingHours;
+
+  return ld;
+}
+
+/** The full <script> block, ready to paste into the page head. */
+export function renderSchemaScript(ld: Record<string, JsonLdValue>): string {
+  return `<script type="application/ld+json">\n${JSON.stringify(ld, null, 2)}\n</script>`;
+}
+
+function defaultHours(): DayHours[] {
+  return SCHEMA_DAYS.map((d) => ({
+    day: d.id,
+    closed: d.id === "Sunday",
+    opens: d.id === "Saturday" ? "09:00" : "08:00",
+    closes: d.id === "Saturday" ? "13:00" : "17:00",
+  }));
+}
+
+export function LocalBusinessSchemaGenerator(): ReactElement {
+  const [name, setName] = useState("");
+  const [type, setType] = useState("LocalBusiness");
+  const [url, setUrl] = useState("");
+  const [telephone, setTelephone] = useState("");
+  const [priceRange, setPriceRange] = useState("$$");
+  const [streetAddress, setStreetAddress] = useState("");
+  const [addressLocality, setAddressLocality] = useState("");
+  const [addressRegion, setAddressRegion] = useState("");
+  const [postalCode, setPostalCode] = useState("");
+  const [addressCountry, setAddressCountry] = useState("US");
+  const [latitude, setLatitude] = useState("");
+  const [longitude, setLongitude] = useState("");
+  const [areaServed, setAreaServed] = useState("");
+  const [hours, setHours] = useState<DayHours[]>(defaultHours);
+  const [copied, setCopied] = useState(false);
+
+  const ld = useMemo(
+    () =>
+      buildLocalBusinessJsonLd({
+        name,
+        type,
+        url,
+        telephone,
+        priceRange,
+        streetAddress,
+        addressLocality,
+        addressRegion,
+        postalCode,
+        addressCountry,
+        latitude,
+        longitude,
+        areaServed,
+        hours,
+      }),
+    [name, type, url, telephone, priceRange, streetAddress, addressLocality, addressRegion, postalCode, addressCountry, latitude, longitude, areaServed, hours],
+  );
+  const script = renderSchemaScript(ld);
+
+  function setDay(day: string, patch: Partial<DayHours>): void {
+    setHours((prev) => prev.map((h) => (h.day === day ? { ...h, ...patch } : h)));
+  }
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(script);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(230px, 1fr))", gap: 16 }}>
+        <Field label="Business name" value={name} onChange={setName} placeholder="Northside Plumbing" />
+        <label style={{ display: "block" }}>
+          <span style={{ fontWeight: 700, fontSize: 14.5 }}>Business type</span>
+          <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 8px", lineHeight: 1.45 }}>
+            The schema.org subtype. Generic is always safe.
+          </div>
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            aria-label="Business type"
+            style={{ width: "100%", padding: "11px 13px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit", background: "#fff", boxSizing: "border-box" }}
+          >
+            {SCHEMA_TYPES.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <Field label="Website URL" value={url} onChange={setUrl} placeholder="https://northsideplumbing.com" />
+        <Field label="Phone" value={telephone} onChange={setTelephone} placeholder="+1-555-0142" />
+        <Field label="Price range" hint="Google shows this as $ to $$$$." value={priceRange} onChange={setPriceRange} placeholder="$$" />
+        <Field label="Street address" value={streetAddress} onChange={setStreetAddress} placeholder="120 Mill Street" />
+        <Field label="City" value={addressLocality} onChange={setAddressLocality} placeholder="Portland" />
+        <Field label="State / region" value={addressRegion} onChange={setAddressRegion} placeholder="OR" />
+        <Field label="Postal code" value={postalCode} onChange={setPostalCode} placeholder="97205" />
+        <Field label="Country code" value={addressCountry} onChange={setAddressCountry} placeholder="US" />
+        <Field label="Latitude (optional)" value={latitude} onChange={setLatitude} placeholder="45.5231" />
+        <Field label="Longitude (optional)" value={longitude} onChange={setLongitude} placeholder="-122.6765" />
+      </div>
+
+      <label style={{ display: "block", marginTop: 20 }}>
+        <span style={{ fontWeight: 700, fontSize: 14.5 }}>Service area (optional)</span>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 8px", lineHeight: 1.45 }}>
+          Comma-separated cities or areas. Matters most for businesses that travel to the customer.
+        </div>
+        <input
+          type="text"
+          value={areaServed}
+          onChange={(e) => setAreaServed(e.target.value)}
+          placeholder="Portland, Beaverton, Lake Oswego"
+          aria-label="Service area"
+          style={{ width: "100%", padding: "11px 13px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit", boxSizing: "border-box" }}
+        />
+      </label>
+
+      <div style={{ marginTop: 24 }}>
+        <div style={{ fontWeight: 700, fontSize: 15 }}>Opening hours</div>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 12px" }}>
+          24-hour times. Closed days are left out of the schema entirely.
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          {hours.map((h) => {
+            const label = SCHEMA_DAYS.find((d) => d.id === h.day)?.label ?? h.day;
+            return (
+              <div key={h.day} style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+                <span style={{ width: 46, fontWeight: 700, fontSize: 14 }}>{label}</span>
+                <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 13, cursor: "pointer" }}>
+                  <input
+                    type="checkbox"
+                    checked={h.closed}
+                    onChange={(e) => setDay(h.day, { closed: e.target.checked })}
+                    style={{ accentColor: GREEN, width: 15, height: 15 }}
+                  />
+                  Closed
+                </label>
+                {!h.closed && (
+                  <>
+                    <input
+                      type="time"
+                      value={h.opens}
+                      onChange={(e) => setDay(h.day, { opens: e.target.value })}
+                      aria-label={`${label} opening time`}
+                      style={{ padding: "7px 10px", borderRadius: 9, border: `1.5px solid ${INK10}`, fontSize: 14, fontFamily: "inherit" }}
+                    />
+                    <span style={{ fontSize: 13, color: "rgba(34,29,23,0.5)" }}>to</span>
+                    <input
+                      type="time"
+                      value={h.closes}
+                      onChange={(e) => setDay(h.day, { closes: e.target.value })}
+                      aria-label={`${label} closing time`}
+                      style={{ padding: "7px 10px", borderRadius: 9, border: `1.5px solid ${INK10}`, fontSize: 14, fontFamily: "inherit" }}
+                    />
+                  </>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 28, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10, marginBottom: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+            Your JSON-LD
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: INK, color: "#F6F2EA", border: "none", padding: "9px 18px", borderRadius: 10, fontWeight: 700, fontSize: 13.5, cursor: "pointer" }}
+          >
+            {copied ? "Copied ✓" : "Copy script"}
+          </button>
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            whiteSpace: "pre-wrap",
+            fontFamily: "'DM Mono',monospace",
+            fontSize: 12.5,
+            lineHeight: 1.6,
+            color: INK,
+            background: "#fff",
+            border: `1px solid ${INK10}`,
+            borderRadius: 12,
+            padding: "16px 18px",
+            overflowX: "auto",
+          }}
+        >
+          {script}
+        </pre>
+        <p style={{ margin: "12px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+          Paste it into the <code>&lt;head&gt;</code> of your homepage, then run the page through Google&apos;s Rich
+          Results Test to confirm it parses. Structured data helps search engines and AI assistants state your hours,
+          location and phone number correctly, and it never hurts to be unambiguous.
+        </p>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Get a site that ships this automatically. Start free.
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  hint?: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <span style={{ fontWeight: 700, fontSize: 14.5 }}>{label}</span>
+      {hint && <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 8px", lineHeight: 1.45 }}>{hint}</div>}
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={label}
+        style={{ width: "100%", padding: "11px 13px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit", boxSizing: "border-box", marginTop: hint ? 0 : 8 }}
+      />
+    </label>
+  );
+}

--- a/packages/crm/src/components/seo/sms-template-generator.tsx
+++ b/packages/crm/src/components/seo/sms-template-generator.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+// 2026-08-24 — The SMS template generator: the interactive island of
+// /tools/sms-template-generator.
+//
+// Every page ranking for "sms templates for small business" is a static
+// listicle you scroll and retype. The wedge here is that the message is
+// composed for your message type × industry × tone, keeps its merge fields, and
+// is counted live against the real SMS segment boundaries — because a template
+// that quietly spills past 160 characters doubles what every send costs.
+//
+// Pure client-side string composition: no LLM, no network calls, deterministic
+// (same inputs always produce the same message). Styled on the MKT palette to
+// match the other free-tool pages.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+const AMBER = "#B8860B";
+
+export type SmsKind = "missed-call" | "reminder" | "confirmation" | "review-request" | "quote-followup" | "on-my-way";
+export type SmsIndustry = "home-services" | "hvac" | "salon" | "medspa" | "dental" | "cleaning" | "auto" | "legal";
+export type SmsTone = "warm" | "professional" | "brief";
+
+export const SMS_KINDS: readonly { id: SmsKind; label: string; why: string }[] = [
+  { id: "missed-call", label: "Missed-call text-back", why: "Sent the moment a call goes unanswered. The single highest-leverage business text there is." },
+  { id: "reminder", label: "Appointment reminder", why: "Sent a day out. The cheapest no-show reduction available to a booking business." },
+  { id: "confirmation", label: "Booking confirmation", why: "Sent immediately after booking, so the appointment lands in the customer's thread." },
+  { id: "review-request", label: "Review request", why: "Sent shortly after the job is done, while the customer still feels the result." },
+  { id: "quote-followup", label: "Quote follow-up", why: "Sent a few days after a quote nobody replied to. Most quotes die of silence, not price." },
+  { id: "on-my-way", label: "On my way", why: "Sent when the tech leaves. Kills the 'where are they' call before it happens." },
+] as const;
+
+export const SMS_INDUSTRIES: readonly { id: SmsIndustry; label: string }[] = [
+  { id: "home-services", label: "Home services" },
+  { id: "hvac", label: "HVAC" },
+  { id: "salon", label: "Salon / barber" },
+  { id: "medspa", label: "Med spa" },
+  { id: "dental", label: "Dental" },
+  { id: "cleaning", label: "Cleaning" },
+  { id: "auto", label: "Auto repair" },
+  { id: "legal", label: "Legal" },
+] as const;
+
+export const SMS_TONES: readonly { id: SmsTone; label: string }[] = [
+  { id: "warm", label: "Warm" },
+  { id: "professional", label: "Professional" },
+  { id: "brief", label: "Brief" },
+] as const;
+
+/** The industry-specific nouns the templates slot in. */
+const INDUSTRY_WORDS: Record<SmsIndustry, { job: string; visit: string; person: string }> = {
+  "home-services": { job: "the repair", visit: "service call", person: "technician" },
+  hvac: { job: "heating and cooling", visit: "service call", person: "technician" },
+  salon: { job: "your next look", visit: "appointment", person: "stylist" },
+  medspa: { job: "your treatment", visit: "appointment", person: "provider" },
+  dental: { job: "your dental care", visit: "appointment", person: "hygienist" },
+  cleaning: { job: "the clean", visit: "clean", person: "cleaner" },
+  auto: { job: "your vehicle", visit: "service visit", person: "technician" },
+  legal: { job: "your matter", visit: "consultation", person: "attorney" },
+};
+
+/** The merge fields the templates use, with what each one fills in. */
+export const MERGE_FIELDS: readonly { token: string; fills: string }[] = [
+  { token: "{{first_name}}", fills: "the customer's first name" },
+  { token: "{{business_name}}", fills: "your business name" },
+  { token: "{{appointment_time}}", fills: "the booked date and time" },
+  { token: "{{booking_link}}", fills: "your booking page URL" },
+  { token: "{{review_link}}", fills: "your direct Google review link" },
+  { token: "{{tech_name}}", fills: "whoever is showing up" },
+] as const;
+
+export const OPT_OUT_LINE = " Reply STOP to opt out.";
+
+/**
+ * The message bodies, keyed kind → tone. `{job}`, `{visit}` and `{person}` are
+ * industry slots filled by INDUSTRY_WORDS; everything in {{double braces}} is a
+ * merge field that survives into the output untouched.
+ *
+ * ASCII only, on purpose: a curly apostrophe or an em dash flips the whole
+ * message from GSM-7 to UCS-2 and cuts a single segment from 160 characters to
+ * 70. These templates stay in the cheap encoding.
+ *
+ * Length budget: written so the SENT message (merge fields filled with ordinary
+ * values) fits in one 160-character GSM-7 segment even with the opt-out line
+ * appended. The on-screen count is higher because {{first_name}} occupies 14
+ * characters as a placeholder and about 5 as a name — see the note under the
+ * textarea, and the sent-length test in tests/unit/seo/free-tools.spec.ts.
+ */
+const BODIES: Record<SmsKind, Record<SmsTone, string>> = {
+  "missed-call": {
+    warm: "Hi {{first_name}}, {{business_name}} here - sorry we missed you. Tell us what you need for {job} and we will call right back.",
+    professional: "{{first_name}}, this is {{business_name}} returning your missed call. Reply with what you need and we will get you scheduled.",
+    brief: "{{business_name}} here, sorry we missed you. What do you need? Text back and we will sort it.",
+  },
+  reminder: {
+    warm: "Hi {{first_name}}, quick reminder about your {visit} with {{business_name}} on {{appointment_time}}. Reply C to confirm or R to reschedule.",
+    professional: "{{business_name}}: this is a reminder of your {visit} on {{appointment_time}}. Reply C to confirm or R to reschedule.",
+    brief: "Reminder: {visit} with {{business_name}} on {{appointment_time}}. Reply C to confirm.",
+  },
+  confirmation: {
+    warm: "You are all set, {{first_name}}. Your {visit} with {{business_name}} is booked for {{appointment_time}}. We will remind you the day before.",
+    professional: "{{business_name}}: your {visit} is confirmed for {{appointment_time}}. View or change it here: {{booking_link}}",
+    brief: "Confirmed: {{appointment_time}} with {{business_name}}. Change it here: {{booking_link}}",
+  },
+  "review-request": {
+    warm: "Hi {{first_name}}, thanks for choosing {{business_name}}. If we did right by you, a quick Google review means a lot: {{review_link}}",
+    professional: "{{first_name}}, thank you for your business. Would you take a moment to review {{business_name}} on Google? {{review_link}}",
+    brief: "Thanks {{first_name}}. Mind leaving {{business_name}} a Google review? {{review_link}}",
+  },
+  "quote-followup": {
+    warm: "Hi {{first_name}}, checking in on the quote we sent for {job}. Any questions, or shall we get you on the schedule?",
+    professional: "{{first_name}}, following up on the quote {{business_name}} sent for {job}. Happy to answer questions or book a start date.",
+    brief: "{{first_name}}, still want to move ahead on that quote? Reply YES and we will book it.",
+  },
+  "on-my-way": {
+    warm: "Hi {{first_name}}, {{tech_name}} from {{business_name}} is on the way and should be with you around {{appointment_time}}.",
+    professional: "{{business_name}}: your {person} {{tech_name}} is en route and expected at approximately {{appointment_time}}.",
+    brief: "{{tech_name}} from {{business_name}} is on the way, about {{appointment_time}}.",
+  },
+};
+
+export interface SmsTemplateInput {
+  kind: SmsKind;
+  industry: SmsIndustry;
+  tone: SmsTone;
+  /** Filled into {{business_name}} when present; the merge field is kept otherwise. */
+  businessName?: string;
+  includeOptOut: boolean;
+}
+
+/** Compose one message. Deterministic: same inputs, same string, always. */
+export function composeSmsTemplate(input: SmsTemplateInput): string {
+  const words = INDUSTRY_WORDS[input.industry];
+  let body = BODIES[input.kind][input.tone]
+    .replace(/\{job\}/g, words.job)
+    .replace(/\{visit\}/g, words.visit)
+    .replace(/\{person\}/g, words.person);
+
+  const name = input.businessName?.trim();
+  if (name) body = body.replace(/\{\{business_name\}\}/g, name);
+
+  return input.includeOptOut ? `${body}${OPT_OUT_LINE}` : body;
+}
+
+// ─── Segment counting ────────────────────────────────────────────────────────
+//
+// Carriers bill per segment, not per message. GSM-7 fits 160 characters in one
+// segment (153 each once a message splits, because the concatenation header
+// eats 7). Any character outside the GSM-7 alphabet forces UCS-2, where a
+// segment holds 70 (67 concatenated). One smart quote costs you 90 characters.
+
+const GSM7_BASIC =
+  "@£$¥èéùìòÇ\nØø\rÅåΔ_ΦΓΛΩΠΨΣΘΞÆæßÉ" +
+  " !\"#¤%&'()*+,-./0123456789:;<=>?" +
+  "¡ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÑÜ§" +
+  "¿abcdefghijklmnopqrstuvwxyzäöñüà";
+
+/** Characters that are GSM-7 but cost two units (escape + char). */
+const GSM7_EXTENDED = "^{}\\[~]|€";
+
+export interface SmsCount {
+  /** Characters as typed (UTF-16 code units). */
+  typedLength: number;
+  /** Units the carrier actually bills, after the GSM-7 escape weighting. */
+  billableLength: number;
+  encoding: "GSM-7" | "UCS-2";
+  segments: number;
+  /** Units available in each segment at this message's length. */
+  limitPerSegment: number;
+}
+
+/** Count characters and segments the way a carrier does. */
+export function countSmsSegments(text: string): SmsCount {
+  let gsm = true;
+  let billable = 0;
+
+  for (const char of text) {
+    if (GSM7_EXTENDED.includes(char)) {
+      billable += 2;
+    } else if (GSM7_BASIC.includes(char)) {
+      billable += 1;
+    } else {
+      gsm = false;
+      break;
+    }
+  }
+
+  if (!gsm) {
+    const units = text.length; // UCS-2 bills UTF-16 code units
+    const limit = units <= 70 ? 70 : 67;
+    return {
+      typedLength: text.length,
+      billableLength: units,
+      encoding: "UCS-2",
+      segments: units === 0 ? 0 : Math.ceil(units / limit),
+      limitPerSegment: limit,
+    };
+  }
+
+  const limit = billable <= 160 ? 160 : 153;
+  return {
+    typedLength: text.length,
+    billableLength: billable,
+    encoding: "GSM-7",
+    segments: billable === 0 ? 0 : Math.ceil(billable / limit),
+    limitPerSegment: limit,
+  };
+}
+
+export function SmsTemplateGenerator(): ReactElement {
+  const [kind, setKind] = useState<SmsKind>("missed-call");
+  const [industry, setIndustry] = useState<SmsIndustry>("home-services");
+  const [tone, setTone] = useState<SmsTone>("warm");
+  const [businessName, setBusinessName] = useState("");
+  const [includeOptOut, setIncludeOptOut] = useState(true);
+  const [edited, setEdited] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const generated = useMemo(
+    () => composeSmsTemplate({ kind, industry, tone, businessName, includeOptOut }),
+    [kind, industry, tone, businessName, includeOptOut],
+  );
+  // The textarea is editable, but every control change resets it to the freshly
+  // composed message — the generator is the source of truth, the edit is a tweak.
+  const message = edited ?? generated;
+  const count = countSmsSegments(message);
+  const kindMeta = SMS_KINDS.find((k) => k.id === kind);
+
+  function change<T>(setter: (v: T) => void): (v: T) => void {
+    return (v: T) => {
+      setter(v);
+      setEdited(null);
+    };
+  }
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(message);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <PillGroup label="Message type" hint="Pick the moment this text gets sent." options={SMS_KINDS} value={kind} onChange={change(setKind)} />
+      {kindMeta && (
+        <p style={{ margin: "10px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.55 }}>{kindMeta.why}</p>
+      )}
+
+      <div style={{ marginTop: 22 }}>
+        <PillGroup label="Industry" hint="Changes the words the template uses for the job and the visit." options={SMS_INDUSTRIES} value={industry} onChange={change(setIndustry)} />
+      </div>
+
+      <div style={{ marginTop: 22 }}>
+        <PillGroup label="Tone" hint="Warm reads human, professional reads clinical, brief reads like a busy owner." options={SMS_TONES} value={tone} onChange={change(setTone)} />
+      </div>
+
+      <label style={{ display: "block", marginTop: 22 }}>
+        <span style={{ fontWeight: 700, fontSize: 15 }}>Business name (optional)</span>
+        <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>
+          Leave it blank to keep <code>{"{{business_name}}"}</code> as a merge field for your CRM to fill.
+        </div>
+        <input
+          type="text"
+          value={businessName}
+          onChange={(e) => {
+            setBusinessName(e.target.value);
+            setEdited(null);
+          }}
+          placeholder="Northside Plumbing"
+          aria-label="Business name"
+          style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 15, fontFamily: "inherit", boxSizing: "border-box" }}
+        />
+      </label>
+
+      <label style={{ display: "flex", alignItems: "flex-start", gap: 10, marginTop: 18, cursor: "pointer" }}>
+        <input
+          type="checkbox"
+          checked={includeOptOut}
+          onChange={(e) => {
+            setIncludeOptOut(e.target.checked);
+            setEdited(null);
+          }}
+          style={{ marginTop: 3, accentColor: GREEN, width: 17, height: 17 }}
+        />
+        <span>
+          <span style={{ fontWeight: 700, fontSize: 14.5 }}>Include an opt-out line</span>
+          <span style={{ display: "block", fontSize: 12.5, color: "rgba(34,29,23,0.6)", marginTop: 2, lineHeight: 1.5 }}>
+            US carriers expect a visible opt-out on marketing texts. Check your own A2P 10DLC registration before you
+            send at volume.
+          </span>
+        </span>
+      </label>
+
+      <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: 10, marginBottom: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+            Your message
+          </div>
+          <div style={{ fontSize: 13.5, fontWeight: 700, color: count.segments > 1 ? AMBER : GREEN }}>
+            {count.billableLength} / {count.limitPerSegment} characters · {count.segments} segment{count.segments === 1 ? "" : "s"}
+          </div>
+        </div>
+        <textarea
+          value={message}
+          onChange={(e) => setEdited(e.target.value)}
+          rows={5}
+          aria-label="Generated SMS message"
+          style={{ width: "100%", padding: "14px 16px", borderRadius: 12, border: `1.5px solid ${INK10}`, fontSize: 15, lineHeight: 1.6, fontFamily: "inherit", boxSizing: "border-box", background: "#fff", resize: "vertical" }}
+        />
+        <p style={{ margin: "10px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.55 }}>
+          Encoding: <strong>{count.encoding}</strong>.{" "}
+          {count.encoding === "UCS-2"
+            ? "A non-GSM character (often a curly quote, an emoji or a dash pasted from a word processor) dropped this message into UCS-2, where one segment holds 70 characters instead of 160. Retype the punctuation to get back to 160."
+            : "This counts the text exactly as written. Merge fields change length when you send: a name is usually shorter than {{first_name}}, a link is often longer. Treat the number as an estimate and leave a little room."}
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14 }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: INK, color: "#F6F2EA", border: "none", padding: "11px 22px", borderRadius: 10, fontWeight: 700, fontSize: 14, cursor: "pointer" }}
+          >
+            {copied ? "Copied ✓" : "Copy message"}
+          </button>
+          {edited !== null && (
+            <button
+              type="button"
+              onClick={() => setEdited(null)}
+              style={{ border: `1.5px solid ${INK10}`, color: INK, padding: "10px 21px", borderRadius: 10, fontWeight: 700, fontSize: 14, background: "rgba(255,255,255,0.6)", cursor: "pointer" }}
+            >
+              Reset to generated
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 24, borderTop: `1px solid ${INK10}`, paddingTop: 20 }}>
+        <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)", marginBottom: 10 }}>
+          Merge fields
+        </div>
+        <ul style={{ margin: 0, padding: 0, listStyle: "none", display: "grid", gap: 6 }}>
+          {MERGE_FIELDS.map((f) => (
+            <li key={f.token} style={{ fontSize: 13.5, color: "rgba(34,29,23,0.72)" }}>
+              <code style={{ fontWeight: 700, color: INK }}>{f.token}</code>: {f.fills}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 26 }}>
+        <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+          Send these automatically. Start free.
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function PillGroup<T extends string>({
+  label,
+  hint,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  options: readonly { id: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}): ReactElement {
+  return (
+    <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+      <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>{label}</legend>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {options.map((o) => {
+          const active = o.id === value;
+          return (
+            <button
+              key={o.id}
+              type="button"
+              onClick={() => onChange(o.id)}
+              aria-pressed={active}
+              style={{
+                border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                background: active ? GREEN : "rgba(255,255,255,0.6)",
+                color: active ? "#F6F2EA" : INK,
+                borderRadius: 999,
+                padding: "9px 16px",
+                fontWeight: 700,
+                fontSize: 13.5,
+                cursor: "pointer",
+              }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/crm/src/components/seo/voicemail-greeting-generator.tsx
+++ b/packages/crm/src/components/seo/voicemail-greeting-generator.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+// 2026-08-24 — The voicemail greeting generator: the interactive island of
+// /tools/voicemail-greeting-generator.
+//
+// Pure client-side template composition (same idiom as
+// ai-receptionist-script-generator.tsx): no LLM, no network calls, deterministic
+// output. Four variants because a business needs four recordings, not one:
+// main, after-hours, holiday/closure, and emergency overflow.
+//
+// The honest CTA on this page is not "record a better greeting" but "stop
+// sending callers to voicemail", so the script generator sits above a callout
+// that says exactly that.
+
+import { useMemo, useState, type ReactElement } from "react";
+import { copyToClipboard } from "@/components/seo/result-card";
+
+const INK = "#221D17";
+const GREEN = "#1F2B24";
+const INK10 = "rgba(34,29,23,0.10)";
+
+export type GreetingKind = "main" | "after-hours" | "holiday" | "emergency";
+export type VoicemailBusiness =
+  | "home-services"
+  | "hvac"
+  | "salon"
+  | "medspa"
+  | "dental"
+  | "cleaning"
+  | "auto"
+  | "legal"
+  | "other";
+
+export const GREETING_KINDS: readonly { id: GreetingKind; label: string; why: string }[] = [
+  { id: "main", label: "Main greeting", why: "What plays when nobody picks up during business hours." },
+  { id: "after-hours", label: "After hours", why: "What plays once you are closed, with the next-open time stated out loud." },
+  { id: "holiday", label: "Holiday / closure", why: "A dated message for a stretch you are closed, so callers stop wondering." },
+  { id: "emergency", label: "Emergency overflow", why: "For lines where a genuine emergency needs a route that is not a callback." },
+] as const;
+
+export const VOICEMAIL_BUSINESSES: readonly { id: VoicemailBusiness; label: string }[] = [
+  { id: "home-services", label: "Home services" },
+  { id: "hvac", label: "HVAC" },
+  { id: "salon", label: "Salon / barber" },
+  { id: "medspa", label: "Med spa" },
+  { id: "dental", label: "Dental" },
+  { id: "cleaning", label: "Cleaning" },
+  { id: "auto", label: "Auto repair" },
+  { id: "legal", label: "Legal" },
+  { id: "other", label: "Other" },
+];
+
+/** What the caller should say, per business type. This is the line that turns a
+ *  useless "leave a message" into a voicemail you can actually act on. */
+const WHAT_TO_LEAVE: Record<VoicemailBusiness, string> = {
+  "home-services": "your name, the address, and what is going wrong",
+  hvac: "your name, the service address, and whether the system is not heating or not cooling",
+  salon: "your name, the service you want, and the days that work for you",
+  medspa: "your name, the treatment you are interested in, and the best time to reach you",
+  dental: "your name, whether you are a current patient, and whether you are in any pain",
+  cleaning: "your name, the address, and whether you want a one-time or recurring clean",
+  auto: "your name, the year and model of the vehicle, and what it is doing",
+  legal: "your name, a callback number, and one sentence about the matter",
+  other: "your name, a callback number, and how we can help",
+};
+
+export interface VoicemailInput {
+  kind: GreetingKind;
+  business: VoicemailBusiness;
+  businessName: string;
+  hours: string;
+  /** How fast you promise to call back, in plain words ("the same day"). */
+  callbackWindow: string;
+  /** Optional emergency line to read out. Empty string omits the sentence. */
+  emergencyNumber: string;
+  /** Optional booking URL to read out. Empty string omits the sentence. */
+  bookingLink: string;
+  /** Only used by the holiday variant. */
+  reopenDate: string;
+}
+
+const DEFAULT_NAME = "our office";
+
+/**
+ * Compose one greeting script. Deterministic. Every optional field is either
+ * present and voiced, or absent and silently skipped: no placeholder text ever
+ * ships into a recording script (the "[your name here]" failure mode).
+ */
+export function composeVoicemailGreeting(input: VoicemailInput): string {
+  const name = input.businessName.trim() || DEFAULT_NAME;
+  const hours = input.hours.trim();
+  const callback = input.callbackWindow.trim() || "the next business day";
+  const leave = WHAT_TO_LEAVE[input.business];
+  const lines: string[] = [];
+
+  switch (input.kind) {
+    case "main":
+      lines.push(`Thanks for calling ${name}. We are with a customer right now and can't get to the phone.`);
+      lines.push(`Leave ${leave} after the tone, and we will call you back ${callback}.`);
+      if (hours) lines.push(`Our hours are ${hours}.`);
+      break;
+
+    case "after-hours":
+      lines.push(`You have reached ${name}. We are closed right now.`);
+      if (hours) lines.push(`We are open ${hours}.`);
+      lines.push(`Leave ${leave} after the tone and we will call you back once we open.`);
+      break;
+
+    case "holiday":
+      lines.push(`Thanks for calling ${name}. We are closed for the holiday and will not be checking messages until we reopen.`);
+      if (input.reopenDate.trim()) lines.push(`We reopen on ${input.reopenDate.trim()}.`);
+      lines.push(`Leave ${leave} after the tone and we will work through messages in the order they came in.`);
+      break;
+
+    case "emergency":
+      lines.push(`You have reached ${name}. Nobody is available to take your call.`);
+      lines.push(`If this is a life-safety emergency, hang up and call 911.`);
+      lines.push(`Leave ${leave} after the tone, and we will call you back ${callback}.`);
+      break;
+  }
+
+  if (input.emergencyNumber.trim() && input.kind !== "emergency") {
+    lines.push(`If this is an emergency that can't wait, call ${input.emergencyNumber.trim()}.`);
+  }
+  if (input.emergencyNumber.trim() && input.kind === "emergency") {
+    lines.push(`For an urgent job that can't wait for a callback, call ${input.emergencyNumber.trim()} and someone will pick up.`);
+  }
+  if (input.bookingLink.trim()) {
+    lines.push(`You can also book yourself in at ${input.bookingLink.trim()}, any time of day.`);
+  }
+
+  lines.push("Thanks, and we will talk soon.");
+  return lines.join("\n\n");
+}
+
+/** Rough spoken length. 150 words per minute is a normal, unhurried pace for a
+ *  recorded greeting, so this is words / 2.5 rounded up to whole seconds. */
+export function estimateSpokenSeconds(script: string): number {
+  const words = script.trim().split(/\s+/).filter(Boolean).length;
+  return Math.ceil(words / 2.5);
+}
+
+export function VoicemailGreetingGenerator(): ReactElement {
+  const [kind, setKind] = useState<GreetingKind>("main");
+  const [business, setBusiness] = useState<VoicemailBusiness>("home-services");
+  const [businessName, setBusinessName] = useState("");
+  const [hours, setHours] = useState("Monday through Friday, 8 to 5");
+  const [callbackWindow, setCallbackWindow] = useState("the same day");
+  const [emergencyNumber, setEmergencyNumber] = useState("");
+  const [bookingLink, setBookingLink] = useState("");
+  const [reopenDate, setReopenDate] = useState("");
+  const [copied, setCopied] = useState(false);
+
+  const script = useMemo(
+    () =>
+      composeVoicemailGreeting({ kind, business, businessName, hours, callbackWindow, emergencyNumber, bookingLink, reopenDate }),
+    [kind, business, businessName, hours, callbackWindow, emergencyNumber, bookingLink, reopenDate],
+  );
+  const seconds = estimateSpokenSeconds(script);
+  const kindMeta = GREETING_KINDS.find((k) => k.id === kind);
+
+  async function handleCopy(): Promise<void> {
+    const ok = await copyToClipboard(script);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <div style={{ border: `1px solid ${INK10}`, borderRadius: 20, background: "rgba(255,255,255,0.6)", padding: "28px 28px" }}>
+      <Pills label="Greeting" hint="Record all four eventually. Start with the one that plays most." options={GREETING_KINDS} value={kind} onChange={setKind} />
+      {kindMeta && <p style={{ margin: "10px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.6)", lineHeight: 1.55 }}>{kindMeta.why}</p>}
+
+      <div style={{ marginTop: 22 }}>
+        <Pills label="Business type" hint="Changes what the greeting asks the caller to leave." options={VOICEMAIL_BUSINESSES} value={business} onChange={setBusiness} />
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 16, marginTop: 22 }}>
+        <Field label="Business name" hint="Read out at the top of the greeting." value={businessName} onChange={setBusinessName} placeholder="Northside Plumbing" />
+        <Field label="Callback window" hint="What you actually promise. Do not promise an hour you can't hit." value={callbackWindow} onChange={setCallbackWindow} placeholder="the same day" />
+        <Field label="Business hours" hint="Spoken out loud, so write it the way you would say it." value={hours} onChange={setHours} placeholder="Monday through Friday, 8 to 5" />
+        <Field label="Emergency number (optional)" hint="Left out entirely if you leave this blank." value={emergencyNumber} onChange={setEmergencyNumber} placeholder="555 0142" />
+        <Field label="Booking link (optional)" hint="Read out so callers can book instead of waiting." value={bookingLink} onChange={setBookingLink} placeholder="northsideplumbing.com/book" />
+        {kind === "holiday" && (
+          <Field label="Reopen date" hint="Only used by the holiday greeting." value={reopenDate} onChange={setReopenDate} placeholder="Monday, January 5th" />
+        )}
+      </div>
+
+      <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 24 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", flexWrap: "wrap", gap: 10, marginBottom: 10 }}>
+          <div style={{ fontSize: 12, fontWeight: 700, letterSpacing: "0.06em", textTransform: "uppercase", color: "rgba(34,29,23,0.55)" }}>
+            Your script
+          </div>
+          <div style={{ fontSize: 13.5, fontWeight: 700, color: GREEN }}>about {seconds} seconds spoken</div>
+        </div>
+        <pre
+          style={{
+            margin: 0,
+            whiteSpace: "pre-wrap",
+            fontFamily: "inherit",
+            fontSize: 15,
+            lineHeight: 1.65,
+            color: INK,
+            background: "#fff",
+            border: `1px solid ${INK10}`,
+            borderRadius: 12,
+            padding: "18px 20px",
+          }}
+        >
+          {script}
+        </pre>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10, marginTop: 14 }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            style={{ background: INK, color: "#F6F2EA", border: "none", padding: "11px 22px", borderRadius: 10, fontWeight: 700, fontSize: 14, cursor: "pointer" }}
+          >
+            {copied ? "Copied ✓" : "Copy script"}
+          </button>
+        </div>
+        <p style={{ margin: "12px 0 0", fontSize: 12.5, color: "rgba(34,29,23,0.55)", lineHeight: 1.55 }}>
+          Read it once out loud before you record. If it takes longer than about 20 seconds, cut a sentence: most callers
+          hang up before a long greeting finishes.
+        </p>
+      </div>
+
+      <div style={{ marginTop: 26, borderTop: `1px solid ${INK10}`, paddingTop: 22 }}>
+        <div style={{ fontSize: 15.5, fontWeight: 800, color: INK }}>Or stop sending callers to voicemail entirely</div>
+        <p style={{ margin: "8px 0 14px", fontSize: 14.5, lineHeight: 1.6, color: "rgba(34,29,23,0.72)" }}>
+          The best greeting in the world still asks the caller to wait. A SeldonFrame AI receptionist answers instead:
+          it picks up, asks the same questions this script asks for, and books the job into your calendar while the
+          caller is still on the line.
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
+          <a href="/signup" style={{ background: INK, color: "#F6F2EA", padding: "13px 26px", borderRadius: 12, fontWeight: 700, fontSize: 15.5, textDecoration: "none" }}>
+            Answer every call. Start free.
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Pills<T extends string>({
+  label,
+  hint,
+  options,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  options: readonly { id: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+}): ReactElement {
+  return (
+    <fieldset style={{ border: "none", padding: 0, margin: 0 }}>
+      <legend style={{ fontWeight: 700, fontSize: 15, padding: 0 }}>{label}</legend>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 10px" }}>{hint}</div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {options.map((o) => {
+          const active = o.id === value;
+          return (
+            <button
+              key={o.id}
+              type="button"
+              onClick={() => onChange(o.id)}
+              aria-pressed={active}
+              style={{
+                border: active ? `1.5px solid ${GREEN}` : `1.5px solid ${INK10}`,
+                background: active ? GREEN : "rgba(255,255,255,0.6)",
+                color: active ? "#F6F2EA" : INK,
+                borderRadius: 999,
+                padding: "9px 16px",
+                fontWeight: 700,
+                fontSize: 13.5,
+                cursor: "pointer",
+              }}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  hint: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}): ReactElement {
+  return (
+    <label style={{ display: "block" }}>
+      <span style={{ fontWeight: 700, fontSize: 14.5 }}>{label}</span>
+      <div style={{ fontSize: 12.5, color: "rgba(34,29,23,0.55)", margin: "2px 0 8px", lineHeight: 1.45 }}>{hint}</div>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label={label}
+        style={{ width: "100%", padding: "11px 13px", borderRadius: 10, border: `1.5px solid ${INK10}`, fontSize: 14.5, fontFamily: "inherit", boxSizing: "border-box" }}
+      />
+    </label>
+  );
+}

--- a/packages/crm/src/lib/marketplace/md-analytics.ts
+++ b/packages/crm/src/lib/marketplace/md-analytics.ts
@@ -39,6 +39,7 @@ export type MarkdownSurface =
   | "sf_vs_page" // /compare/seldonframe-vs-<slug>.md  (SeldonFrame head-to-head twin)
   | "pricing_page" // /<slug>-pricing.md  (competitor pricing breakdown twin)
   | "best_page" // /best/<category>-for-<audience>.md  (best-of listicle twin)
+  | "tool_page" // /tools/<slug>.md  (free-tool twin, added 2026-08-24)
   | "guide"; // /guides/<slug>.md  (long-form article twin)
 
 /**

--- a/packages/crm/src/lib/seo/tools-markdown.ts
+++ b/packages/crm/src/lib/seo/tools-markdown.ts
@@ -1,0 +1,102 @@
+// 2026-08-24 — Pure Markdown renderer for the /tools/<slug>.md twins.
+//
+// Every other page family already has Markdown twins (best-of, guides, blog,
+// comparisons, charts); the free tools had none, so an agent asked "what does
+// SeldonFrame's no-show calculator do" had nothing token-light to read. This
+// renders from the SAME registry the hub and sitemap read (tools-pages.ts), so
+// the twin can never describe a tool that isn't listed.
+//
+// Two shapes, deliberately:
+//   • Tools with a verified `markdown` block get the full twin (what it
+//     computes, its inputs, its outputs).
+//   • Tools without one get the short twin — title, summary, link. We do NOT
+//     invent an input list for a widget we haven't audited (house rule:
+//     every claim must be true today).
+//
+// Mirrors best-markdown.ts; served by the static dotted route folders at
+// app/tools/<slug>.md/route.ts.
+
+import { getToolPage, TOOL_PAGES, type ToolPage } from "./tools-pages";
+
+const BASE = "https://www.seldonframe.com";
+
+/** The two CTAs every tool twin ends on — the same pair the HTML pages use. */
+const START_URL = `${BASE}/signup`;
+const TOOLS_URL = `${BASE}/tools`;
+
+function relatedLine(slug: string): string {
+  const tool: ToolPage = getToolPage(slug);
+  return `- [${tool.title}](${BASE}/tools/${tool.slug}): ${tool.summary}.`;
+}
+
+export function renderToolMarkdown(slug: string): string {
+  const tool = getToolPage(slug);
+  const L: string[] = [];
+
+  L.push(`# ${tool.title}`);
+  L.push("");
+  L.push(`> ${tool.description}`);
+  L.push("");
+  L.push(`HTML version: ${BASE}/tools/${slug}`);
+  L.push("");
+  // NOTE: deliberately no blanket "nothing leaves your browser" claim here.
+  // Most of these tools are pure client-side, but /tools/website-grader fetches
+  // and scores the URL you give it through a server route, so the promise would
+  // be a lie for at least one page. Per-tool privacy claims live in the
+  // registry's `markdown.what`, where they can be true one tool at a time.
+  L.push(
+    tool.interactive
+      ? "Free to use, and no signup is required."
+      : "Free to use. This page is a front door to the SeldonFrame build flow, not a calculator.",
+  );
+  L.push("");
+
+  const md = tool.markdown;
+  if (md) {
+    L.push("## What it does");
+    L.push("");
+    L.push(md.what);
+    L.push("");
+
+    L.push("## What you enter");
+    L.push("");
+    for (const input of md.inputs) L.push(`- ${input}`);
+    L.push("");
+
+    L.push("## What you get back");
+    L.push("");
+    for (const output of md.outputs) L.push(`- ${output}`);
+    L.push("");
+
+    if (md.related && md.related.length > 0) {
+      L.push("## Related free tools");
+      L.push("");
+      for (const rel of md.related) L.push(relatedLine(rel));
+      L.push("");
+    }
+  } else {
+    L.push("## What it does");
+    L.push("");
+    L.push(`In one line: ${tool.summary}.`);
+    L.push("");
+    L.push(`Open ${BASE}/tools/${slug} to use it — the interactive version is the tool.`);
+    L.push("");
+  }
+
+  L.push("## About SeldonFrame");
+  L.push("");
+  L.push(
+    "SeldonFrame builds a whole AI front office for a local service business: hosted website, booking page, intake form, CRM and AI agents, in about three minutes. The first workspace is free forever, and paid plans are $29/mo flat solo or $99 to $299/mo agency.",
+  );
+  L.push("");
+  L.push(`- Build one free: ${START_URL}`);
+  L.push(`- Every free tool: ${TOOLS_URL}`);
+  L.push("");
+
+  return L.join("\n");
+}
+
+/** Every slug that has a Markdown twin. Currently: all of them. */
+export function allToolMarkdownSlugs(): string[] {
+  return TOOL_PAGES.map((t) => t.slug);
+}

--- a/packages/crm/src/lib/seo/tools-pages.ts
+++ b/packages/crm/src/lib/seo/tools-pages.ts
@@ -1,0 +1,403 @@
+// 2026-08-24 — The free-tools registry: ONE source of truth for /tools.
+//
+// Before this file the slug list was hand-maintained in three places (the
+// /tools hub, app/sitemap.ts, and app/llms.txt/route.ts), so a new tool could
+// ship visible-but-uncrawlable (or crawlable-but-unlisted) and nobody would
+// notice. All three now read this registry, and tests/unit/seo/free-tools.spec.ts
+// asserts every slug here has a real page directory on disk.
+//
+// Pure data + pure lookups (no React, no I/O) so it imports cleanly from server
+// components, sitemap.ts, llms.txt/route.ts and the /tools/<slug>.md twins.
+
+/** The structured detail a Markdown twin renders (see lib/seo/tools-markdown.ts).
+ *  Present on the tools whose inputs/outputs we have verified against the widget;
+ *  omitted tools get the short generic twin instead of an invented input list. */
+export interface ToolMarkdown {
+  /** One paragraph: what the tool produces, and how it produces it. */
+  what: string;
+  /** Exactly what the visitor types/picks, in the order the widget asks. */
+  inputs: string[];
+  /** Exactly what comes back out. */
+  outputs: string[];
+  /** Sibling tool slugs worth following from the twin. */
+  related?: string[];
+}
+
+export interface ToolPage {
+  /** URL segment under /tools. */
+  slug: string;
+  /** Display name — the hub card heading and the llms.txt link text. */
+  title: string;
+  /** Hub card blurb (sentence case, one or two sentences). */
+  description: string;
+  /** Lowercase one-liner for llms.txt and the Markdown twin's summary line. */
+  summary: string;
+  /**
+   * True when the page's value IS a client-side calculator/generator the
+   * visitor operates in place. False for the pages that are landing surfaces
+   * over a shipped product flow (the build widget), where the interaction is
+   * "start a build", not "compute something".
+   */
+  interactive: boolean;
+  markdown?: ToolMarkdown;
+}
+
+export const TOOL_PAGES: readonly ToolPage[] = [
+  {
+    slug: "ai-visibility-checker",
+    title: "AI Visibility Checker",
+    description:
+      "Can ChatGPT recommend your business? Grade your AI visibility and get the exact prompts to test it yourself.",
+    summary:
+      "grade whether ChatGPT and Google's AI can recommend your business, plus the exact prompts to test it yourself",
+    interactive: true,
+  },
+  {
+    slug: "speed-to-lead-calculator",
+    title: "Speed-to-Lead Calculator",
+    description: "See the revenue slow lead follow-up costs you — and what replying in under 5 minutes recovers.",
+    summary:
+      "estimate the revenue slow lead follow-up costs, and what replying in under 5 minutes recovers",
+    interactive: true,
+  },
+  {
+    slug: "no-show-cost-calculator",
+    title: "No-Show Cost Calculator",
+    description:
+      "Estimate what no-shows cost your practice each month — and what automated reminders and AI confirmations recover.",
+    summary:
+      "estimate the revenue no-shows cost a booking-heavy business, and what automated reminders recover",
+    interactive: true,
+  },
+  {
+    slug: "ai-receptionist-script-generator",
+    title: "AI Receptionist Script Generator",
+    description:
+      "Generate a complete AI receptionist call script for your business — greeting, questions, booking, after-hours. Copy it free.",
+    summary:
+      "generate a complete AI receptionist call script for any business — greeting, questions, booking, after-hours",
+    interactive: true,
+  },
+  {
+    slug: "service-business-faq-generator",
+    title: "Service Business FAQ Generator",
+    description:
+      "Generate a ready-to-use customer FAQ for your service business — and your AI agent's knowledge base. Copy free.",
+    summary: "generate a ready customer FAQ (and AI-agent knowledge base) for a service business",
+    interactive: true,
+  },
+  {
+    slug: "booking-friction-grader",
+    title: "Booking Friction Grader",
+    description:
+      "Answer 8 questions to score how easy you make it to book — and get the specific fixes losing you appointments.",
+    summary: "score how easy you make it to book and get the specific fixes losing you appointments",
+    interactive: true,
+  },
+  {
+    slug: "missed-call-calculator",
+    title: "Missed Call Cost Calculator",
+    description: "Estimate the monthly revenue missed calls cost your business — and what an AI receptionist recovers.",
+    summary: "estimate the revenue missed calls cost a service business",
+    interactive: true,
+  },
+  {
+    slug: "ai-receptionist-cost-calculator",
+    title: "AI Receptionist Cost Calculator",
+    description: "Compare what a human receptionist, an answering service and per-minute AI really cost per month.",
+    summary: "compare a human receptionist, an answering service and per-minute AI on real monthly cost",
+    interactive: true,
+  },
+  {
+    slug: "google-review-link-generator",
+    title: "Google Review Link Generator",
+    description: "Turn your Google Place ID into a direct review link and a printable QR code — free, no signup.",
+    summary: "create a direct Google review link + printable QR code for any business",
+    interactive: true,
+  },
+  {
+    // 2026-08-24 — sibling of the link generator above. Distinct query
+    // ("google review qr code"), distinct job: print-ready artwork you can
+    // hand to a printer, not a link you paste into a text.
+    slug: "google-review-qr-code-generator",
+    title: "Google Review QR Code Generator",
+    description:
+      "Print-ready Google review QR codes for table tents, counter cards and window decals. Download PNG or SVG, free.",
+    summary:
+      "generate a print-ready Google review QR code at real physical sizes and download it as PNG or SVG",
+    interactive: true,
+    markdown: {
+      what:
+        "Builds the direct \"write a review\" URL for a Google Place ID, encodes it as a QR code in your browser, and sizes the artwork for a physical print at 300 DPI. The encoding happens client-side, so nothing you type is sent anywhere.",
+      inputs: [
+        "Google Place ID, or a Google Maps URL containing a place_id parameter",
+        "Print size: table tent (2 in), counter card (3 in), poster (4 in) or window decal (6 in)",
+        "Error-correction level (higher survives more scuffs and ink bleed on printed stock)",
+      ],
+      outputs: [
+        "The direct review URL the QR code encodes",
+        "A PNG sized for the chosen physical width at 300 DPI",
+        "A vector SVG that stays sharp at any print size",
+      ],
+      related: ["google-review-link-generator", "review-response-generator"],
+    },
+  },
+  {
+    slug: "review-response-generator",
+    title: "Review Response Generator",
+    description: "Well-written replies to any Google review — pick the rating, scenario and tone, then copy.",
+    summary: "well-written replies to any Google review — no signup, no AI required",
+    interactive: true,
+  },
+  {
+    slug: "a2p-10dlc-checker",
+    title: "A2P 10DLC Compliance Checker",
+    description: "Nine questions to find out whether your business texting is registered right — before carriers filter it.",
+    summary: "check whether your business texting meets US carrier registration rules before it gets filtered",
+    interactive: true,
+  },
+  {
+    slug: "hubspot-pricing-calculator",
+    title: "HubSpot Pricing Calculator",
+    description: "Seats, contacts, hubs and the $3,000 onboarding — see what HubSpot really costs before the sales call.",
+    summary: "seats × contacts × hubs × onboarding — what HubSpot really costs",
+    interactive: true,
+  },
+  {
+    slug: "gohighlevel-cost-calculator",
+    title: "GoHighLevel Cost Calculator",
+    description: "Base plan + AI Employee per sub-account + usage, multiplied by your client count — the real agency bill.",
+    summary: "base plan + AI Employee per sub-account + usage at N clients",
+    interactive: true,
+  },
+  {
+    slug: "voice-ai-cost-calculator",
+    title: "Voice AI Cost Calculator",
+    description: "STT + LLM + TTS + telephony stacked per minute — why the advertised $0.05/min is really ~$0.30.",
+    summary: "the real per-minute cost of a voice AI stack (STT + LLM + TTS + telephony)",
+    interactive: true,
+  },
+  {
+    slug: "klaviyo-cost-calculator",
+    title: "Klaviyo Cost Calculator",
+    description: "Profiles and SMS sends in, monthly bill out — including the suppressed-profiles gotcha.",
+    summary: "profiles + SMS sends → your monthly Klaviyo bill",
+    interactive: true,
+  },
+  {
+    slug: "agency-margin-calculator",
+    title: "Agency Margin Calculator",
+    description: "Retainer minus tool stack minus labor — see your real margin per client and what a flat stack changes.",
+    summary: "retainer minus tool stack minus labor — your real margin per client",
+    interactive: true,
+  },
+  {
+    slug: "claude-project-brief-generator",
+    title: "Claude Project Brief Generator",
+    description:
+      "Generate the complete standing-instructions block (role, tasks, tone, never-list) for a Claude Project — ready to paste.",
+    summary:
+      "generate the standing-instructions block for a Claude Project (and see how SeldonFrame automates it per client)",
+    interactive: true,
+  },
+  {
+    slug: "ai-website-generator",
+    title: "AI Website Generator",
+    description:
+      "Paste your Google Business Profile or describe your business — get a real hosted website, booking page, intake form and CRM in 3 minutes. Free.",
+    summary:
+      "paste your Google Business Profile or describe your business, and get a real hosted website, booking page, intake form and CRM in about 3 minutes",
+    interactive: false,
+  },
+  {
+    slug: "free-booking-page",
+    title: "Free Booking Page",
+    description:
+      "A real online booking page on your own subdomain — appointment types, intake form, and CRM sync. Live in 3 minutes, free.",
+    summary:
+      "a real online booking page on your own subdomain, with appointment types, an intake form and CRM sync, live in about 3 minutes",
+    interactive: false,
+  },
+  {
+    slug: "website-grader",
+    title: "Local Business Website Grader",
+    description: "Score your website on the 7 things that actually win local jobs — speed, booking, trust signals, and more.",
+    summary: "score your website on the 7 things that win local jobs, with a prioritized fix list",
+    interactive: true,
+  },
+
+  // ─── 2026-08-24 free-tools wave ────────────────────────────────────────────
+  // Seven new client-side tools. Every ranking competitor for these queries is
+  // a static listicle, so an interactive page is the wedge.
+
+  {
+    slug: "sms-template-generator",
+    title: "SMS Template Generator",
+    description:
+      "Missed-call text-backs, reminders, confirmations and review requests, written for your industry and tone, with merge fields and a live character count.",
+    summary:
+      "generate missed-call text-back, reminder, confirmation and review-request SMS templates by industry and tone, with merge fields and a live segment count",
+    interactive: true,
+    markdown: {
+      what:
+        "Composes a ready-to-send business text message from a proven structure for the message type you pick, tuned to your industry and tone, with merge fields left in place so your CRM or texting tool can fill them. It also counts characters and SMS segments as you edit, because a message that spills past 160 characters silently costs twice as much to send. Everything is composed in your browser, with no model and no network call.",
+      inputs: [
+        "Message type: missed-call text-back, appointment reminder, appointment confirmation, review request, quote follow-up or on-my-way",
+        "Industry: home services, HVAC, salon or spa, med spa, dental, cleaning, auto or legal",
+        "Tone: warm, professional or brief",
+        "Business name, and whether to include an opt-out line",
+      ],
+      outputs: [
+        "The message body with {{merge_fields}} intact",
+        "Character count, SMS segment count and the encoding the count assumes",
+        "A copy button, plus the segment warning when the message crosses a boundary",
+      ],
+      related: ["missed-call-calculator", "no-show-cost-calculator", "a2p-10dlc-checker"],
+    },
+  },
+  {
+    slug: "voicemail-greeting-generator",
+    title: "Voicemail Greeting Generator",
+    description:
+      "Business voicemail scripts that actually get callers to leave a message. Main, after-hours, holiday and emergency versions.",
+    summary:
+      "generate business voicemail greeting scripts (main, after-hours, holiday and emergency) for any business type",
+    interactive: true,
+    markdown: {
+      what:
+        "Writes a voicemail greeting script from the structure a good front desk uses: identify the business, set the expectation for a callback, tell the caller exactly what to say, and give an escape hatch for emergencies. Four variants cover the situations a business actually needs recorded. The script is composed in your browser, with no model and no network call.",
+      inputs: [
+        "Greeting type: main, after-hours, holiday or closure, or emergency overflow",
+        "Business type: home services, HVAC, salon or spa, med spa, dental, cleaning, auto, legal or other",
+        "Business name, business hours, and the callback window you promise",
+        "Optional: an emergency number and a booking link to read out",
+      ],
+      outputs: [
+        "A word-for-word greeting script, ready to record",
+        "A length estimate in seconds at normal speaking pace",
+        "A copy button for the script text",
+      ],
+      related: ["ai-receptionist-script-generator", "missed-call-calculator", "ai-receptionist-cost-calculator"],
+    },
+  },
+  {
+    slug: "cancellation-policy-generator",
+    title: "Cancellation Policy Generator",
+    description:
+      "A paste-ready cancellation and no-show policy: your notice window, your late and no-show fees, deposits, and the exact wording to put on the booking page.",
+    summary:
+      "generate a paste-ready cancellation and no-show policy from your notice window, late/no-show fees and deposit rules",
+    interactive: true,
+    markdown: {
+      what:
+        "Turns four policy decisions into policy text you can paste onto a booking page, an intake form and a confirmation text. It emits a full version for your website and a short version that fits in a reminder message, since a policy nobody reads before the appointment does not reduce no-shows. Everything is composed in your browser. This is policy text, not legal advice.",
+      inputs: [
+        "Industry: salon or spa, med spa, dental, home services, cleaning, auto, fitness or consulting",
+        "Notice window in hours (how far ahead a client must cancel to avoid a fee)",
+        "Late-cancellation fee: none, a flat amount, or a percentage of the service",
+        "No-show fee: none, a flat amount, or a percentage of the service",
+        "Deposit required: on or off, with an amount",
+      ],
+      outputs: [
+        "The full policy text for a website or booking page",
+        "A short version sized for a confirmation or reminder text",
+        "A one-line summary for the booking form checkbox",
+      ],
+      related: ["no-show-cost-calculator", "sms-template-generator", "booking-friction-grader"],
+    },
+  },
+  {
+    slug: "local-business-schema-generator",
+    title: "LocalBusiness Schema Generator",
+    description:
+      "Fill in your business details and get valid LocalBusiness JSON-LD with hours, service area and geo coordinates, ready to paste into your site's head.",
+    summary:
+      "produce valid LocalBusiness JSON-LD (hours, service area, geo coordinates) for any local business, ready to paste",
+    interactive: true,
+    markdown: {
+      what:
+        "Builds a schema.org LocalBusiness JSON-LD block from a plain form. Empty fields are omitted rather than emitted as blanks, so what you copy is valid structured data instead of a template with holes in it. Everything runs in your browser.",
+      inputs: [
+        "Business name, type (the schema.org subtype), website URL, phone and price range",
+        "Street address, city, region, postal code and country",
+        "Opening hours per day, with a closed toggle",
+        "Optional: latitude and longitude, and the cities or areas you serve",
+      ],
+      outputs: [
+        "A complete <script type=\"application/ld+json\"> block",
+        "The raw JSON-LD object, formatted",
+        "A copy button, and a note on where in the page to paste it",
+      ],
+      related: ["ai-visibility-checker", "website-grader", "google-business-profile-description-generator"],
+    },
+  },
+  {
+    slug: "google-business-profile-description-generator",
+    title: "Google Business Profile Description Generator",
+    description:
+      "Write the 750-character business description Google asks for, by business type, services and city, with a live character count.",
+    summary:
+      "write a Google Business Profile description inside Google's 750-character limit, by business type, services and city",
+    interactive: true,
+    markdown: {
+      what:
+        "Composes a Google Business Profile description from the structure Google's own guidelines reward: what you do, who you serve, where you serve them, what makes you different, and how to get started. It counts against the 750-character limit as you type and trims the optional sentences first when you run long. Everything is composed in your browser.",
+      inputs: [
+        "Business name, business type and the city or area you serve",
+        "Up to five services, in the order you want them mentioned",
+        "Years in business, and up to three differentiators (licensed, family-owned, same-day, and so on)",
+        "Tone: warm, professional or direct",
+      ],
+      outputs: [
+        "A description within Google's 750-character limit",
+        "A live character count with the remaining budget",
+        "A copy button for pasting straight into Google Business Profile",
+      ],
+      related: ["local-business-schema-generator", "ai-visibility-checker", "ai-website-generator"],
+    },
+  },
+  {
+    slug: "customer-lifetime-value-calculator",
+    title: "Customer Lifetime Value Calculator",
+    description:
+      "What a local service customer is really worth: average ticket × visits per year × years retained, plus the referrals they bring.",
+    summary:
+      "calculate customer lifetime value for a local service business from average ticket, visits per year, years retained and referrals",
+    interactive: true,
+    markdown: {
+      what:
+        "Calculates lifetime value the way a local service business actually earns it: repeat visits over a retention window, plus the customers those clients refer. Most LTV calculators are built for subscription SaaS and assume a flat monthly fee, which understates a business whose customer comes back three times a year for a decade. The arithmetic runs in your browser, and referrals are counted at one generation only rather than compounded.",
+      inputs: [
+        "Average ticket (what one visit or job is worth)",
+        "Visits per year",
+        "Years the average customer stays",
+        "Referrals per customer over that lifetime",
+        "Gross margin percentage (to see profit lifetime value, not just revenue)",
+      ],
+      outputs: [
+        "Direct lifetime revenue, and total lifetime revenue including referrals",
+        "Gross-profit lifetime value at your margin",
+        "The referral multiplier applied, and what a single lost customer costs",
+      ],
+      related: ["missed-call-calculator", "no-show-cost-calculator", "speed-to-lead-calculator"],
+    },
+  },
+] as const;
+
+/** Every tool slug, in hub order. */
+export function allToolSlugs(): string[] {
+  return TOOL_PAGES.map((t) => t.slug);
+}
+
+/** Look up one tool. Throws on an unknown slug — a missing tool is a bug in the
+ *  registry, never a page we should render half-empty (Optimistic Path). */
+export function getToolPage(slug: string): ToolPage {
+  const found = TOOL_PAGES.find((t) => t.slug === slug);
+  if (!found) throw new Error(`Unknown tool slug: ${slug}`);
+  return found;
+}
+
+/** The tools whose value is a client-side calculator/generator. */
+export function interactiveToolPages(): ToolPage[] {
+  return TOOL_PAGES.filter((t) => t.interactive);
+}

--- a/packages/crm/tests/unit/seo/free-tools.spec.ts
+++ b/packages/crm/tests/unit/seo/free-tools.spec.ts
@@ -1,0 +1,636 @@
+// 2026-08-24 — The free-tools registry + the new tools' pure logic.
+//
+// Two jobs:
+//   1. Kill the drift bug the registry was created to fix. The slug list used to
+//      live in three places (the hub, sitemap.ts, llms.txt/route.ts) and could
+//      disagree with reality. These tests assert every registry slug has a real
+//      page directory AND a real Markdown-twin route on disk, so "listed but
+//      404s" and "shipped but uncrawlable" both fail here instead of in prod.
+//   2. Pin the math/format of the tools built in this wave, the same way
+//      calculator-math.spec.ts pins the pricing calculators.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import QRCode from "qrcode";
+
+import { TOOL_PAGES, allToolSlugs, getToolPage, interactiveToolPages } from "@/lib/seo/tools-pages";
+import { renderToolMarkdown } from "@/lib/seo/tools-markdown";
+
+import { computeCustomerLtv, encodeClvState, decodeClvState, CLV_BOUNDS } from "@/components/seo/customer-lifetime-value-calculator";
+import { composeSmsTemplate, countSmsSegments, OPT_OUT_LINE } from "@/components/seo/sms-template-generator";
+import { composeVoicemailGreeting, estimateSpokenSeconds } from "@/components/seo/voicemail-greeting-generator";
+import { composeCancellationPolicy, formatNotice, formatFee } from "@/components/seo/cancellation-policy-generator";
+import { buildLocalBusinessJsonLd, renderSchemaScript, SCHEMA_DAYS } from "@/components/seo/local-business-schema-generator";
+import { composeGbpDescription, GBP_DESCRIPTION_LIMIT, MAX_DIFFERENTIATORS } from "@/components/seo/google-business-profile-description-generator";
+import { buildReviewUrl, printPixels, PRINT_DPI, PRINT_SIZES } from "@/components/seo/google-review-qr-code-generator";
+
+const APP_DIR = join(process.cwd(), "src", "app");
+
+// ─── Registry: the anti-drift invariants ────────────────────────────────────
+
+test("every tool slug is unique", () => {
+  const slugs = allToolSlugs();
+  assert.equal(new Set(slugs).size, slugs.length);
+});
+
+test("every tool slug is URL-safe kebab-case", () => {
+  for (const slug of allToolSlugs()) {
+    assert.match(slug, /^[a-z0-9]+(?:-[a-z0-9]+)*$/, `bad slug: ${slug}`);
+  }
+});
+
+test("every registry entry has a real page directory on disk", () => {
+  for (const slug of allToolSlugs()) {
+    const page = join(APP_DIR, "(public)", "tools", slug, "page.tsx");
+    assert.ok(existsSync(page), `missing page for /tools/${slug} (expected ${page})`);
+  }
+});
+
+test("every registry entry has a Markdown twin route on disk", () => {
+  for (const slug of allToolSlugs()) {
+    const route = join(APP_DIR, "tools", `${slug}.md`, "route.ts");
+    assert.ok(existsSync(route), `missing Markdown twin for /tools/${slug}.md (expected ${route})`);
+  }
+});
+
+test("the seven tools from the 2026-08-24 wave are all registered", () => {
+  const wave = [
+    "google-review-qr-code-generator",
+    "sms-template-generator",
+    "voicemail-greeting-generator",
+    "cancellation-policy-generator",
+    "local-business-schema-generator",
+    "google-business-profile-description-generator",
+    "customer-lifetime-value-calculator",
+  ];
+  for (const slug of wave) assert.equal(getToolPage(slug).slug, slug);
+});
+
+test("getToolPage throws on an unknown slug rather than returning a half-empty page", () => {
+  assert.throws(() => getToolPage("not-a-real-tool"), /Unknown tool slug/);
+});
+
+test("every entry has non-empty title, description and summary", () => {
+  for (const tool of TOOL_PAGES) {
+    assert.ok(tool.title.trim().length > 0, tool.slug);
+    assert.ok(tool.description.trim().length > 0, tool.slug);
+    assert.ok(tool.summary.trim().length > 0, tool.slug);
+  }
+});
+
+test("the two product landers are the only non-interactive tools", () => {
+  const nonInteractive = TOOL_PAGES.filter((t) => !t.interactive).map((t) => t.slug).sort();
+  assert.deepEqual(nonInteractive, ["ai-website-generator", "free-booking-page"]);
+  assert.equal(interactiveToolPages().length, TOOL_PAGES.length - 2);
+});
+
+// ─── Markdown twins ─────────────────────────────────────────────────────────
+
+test("every Markdown twin renders, points at its HTML canonical, and has no undefined holes", () => {
+  for (const slug of allToolSlugs()) {
+    const md = renderToolMarkdown(slug);
+    assert.match(md, new RegExp(`HTML version: https://www\\.seldonframe\\.com/tools/${slug}(?:\\r?\\n|$)`));
+    assert.ok(md.startsWith(`# ${getToolPage(slug).title}`), slug);
+    assert.doesNotMatch(md, /\b(?:undefined|null|NaN)\b/, slug);
+    assert.ok(md.length > 200, slug);
+  }
+});
+
+test("a twin with a verified markdown block renders its inputs and outputs", () => {
+  const md = renderToolMarkdown("customer-lifetime-value-calculator");
+  assert.match(md, /## What you enter/);
+  assert.match(md, /## What you get back/);
+  assert.match(md, /Average ticket/);
+  assert.match(md, /## Related free tools/);
+});
+
+test("a twin without a verified markdown block stays short rather than inventing inputs", () => {
+  const md = renderToolMarkdown("missed-call-calculator");
+  assert.doesNotMatch(md, /## What you enter/);
+  assert.match(md, /## What it does/);
+});
+
+// ─── Customer lifetime value ────────────────────────────────────────────────
+
+test("computeCustomerLtv: direct revenue is ticket x visits x years", () => {
+  const r = computeCustomerLtv({ avgTicket: 150, visitsPerYear: 4, yearsRetained: 5, referrals: 0, marginPct: 50 });
+  assert.equal(r.directRevenue, 3000);
+});
+
+test("computeCustomerLtv: total always equals direct plus referral, exactly", () => {
+  for (const referrals of [0, 0.5, 1, 2.5, 5]) {
+    const r = computeCustomerLtv({ avgTicket: 175, visitsPerYear: 3.5, yearsRetained: 7, referrals, marginPct: 55 });
+    assert.equal(r.totalRevenue, r.directRevenue + r.referralRevenue, `referrals=${referrals}`);
+  }
+});
+
+test("computeCustomerLtv: zero referrals means zero referral revenue and a 1x multiplier", () => {
+  const r = computeCustomerLtv({ avgTicket: 200, visitsPerYear: 2, yearsRetained: 4, referrals: 0, marginPct: 60 });
+  assert.equal(r.referralRevenue, 0);
+  assert.equal(r.referralMultiplier, 1);
+  assert.equal(r.totalRevenue, r.directRevenue);
+});
+
+test("computeCustomerLtv: two referrals triples lifetime revenue (one generation, never compounded)", () => {
+  const base = computeCustomerLtv({ avgTicket: 100, visitsPerYear: 4, yearsRetained: 5, referrals: 0, marginPct: 50 });
+  const withRefs = computeCustomerLtv({ avgTicket: 100, visitsPerYear: 4, yearsRetained: 5, referrals: 2, marginPct: 50 });
+  assert.equal(withRefs.totalRevenue, base.totalRevenue * 3);
+  assert.equal(withRefs.referralMultiplier, 3);
+});
+
+test("computeCustomerLtv: gross profit is total revenue at the margin", () => {
+  const r = computeCustomerLtv({ avgTicket: 100, visitsPerYear: 4, yearsRetained: 5, referrals: 1, marginPct: 50 });
+  assert.equal(r.totalRevenue, 4000);
+  assert.equal(r.grossProfitLtv, 2000);
+});
+
+test("computeCustomerLtv: clamps a hand-edited permalink to the slider bounds", () => {
+  const r = computeCustomerLtv({ avgTicket: 999_999, visitsPerYear: 999, yearsRetained: 999, referrals: 999, marginPct: 999 });
+  const expectedDirect = CLV_BOUNDS.avgTicket.max * CLV_BOUNDS.visitsPerYear.max * CLV_BOUNDS.yearsRetained.max;
+  assert.equal(r.directRevenue, expectedDirect);
+  assert.equal(r.referralMultiplier, 1 + CLV_BOUNDS.referrals.max);
+});
+
+test("computeCustomerLtv: total revenue is monotonic non-decreasing in every driver", () => {
+  const low = computeCustomerLtv({ avgTicket: 100, visitsPerYear: 2, yearsRetained: 3, referrals: 0, marginPct: 50 });
+  const high = computeCustomerLtv({ avgTicket: 200, visitsPerYear: 4, yearsRetained: 6, referrals: 1, marginPct: 50 });
+  assert.ok(high.totalRevenue > low.totalRevenue);
+  assert.ok(high.grossProfitLtv > low.grossProfitLtv);
+});
+
+test("encodeClvState / decodeClvState round-trip on the five short keys", () => {
+  const state = { avgTicket: 250, visitsPerYear: 3.5, yearsRetained: 8, referrals: 1.5, marginPct: 60 };
+  const qs = encodeClvState(state);
+  const params = new URLSearchParams(qs);
+  assert.equal(params.get("lt"), "250");
+  assert.equal(params.get("lv"), "3.5");
+  assert.equal(params.get("ly"), "8");
+  assert.equal(params.get("lr"), "1.5");
+  assert.equal(params.get("lm"), "60");
+  assert.deepEqual(decodeClvState(qs), state);
+});
+
+test("decodeClvState clamps out-of-range values instead of rejecting them", () => {
+  const decoded = decodeClvState("lt=99999999&lv=0&ly=0&lr=99&lm=0");
+  assert.equal(decoded.avgTicket, CLV_BOUNDS.avgTicket.max);
+  assert.equal(decoded.visitsPerYear, CLV_BOUNDS.visitsPerYear.min);
+  assert.equal(decoded.yearsRetained, CLV_BOUNDS.yearsRetained.min);
+  assert.equal(decoded.referrals, CLV_BOUNDS.referrals.max);
+  assert.equal(decoded.marginPct, CLV_BOUNDS.marginPct.min);
+});
+
+test("decodeClvState ignores missing and non-numeric params", () => {
+  assert.deepEqual(decodeClvState(""), {});
+  assert.deepEqual(decodeClvState("lt=abc"), {});
+});
+
+// ─── SMS templates ──────────────────────────────────────────────────────────
+
+test("composeSmsTemplate keeps merge fields when no business name is given", () => {
+  const msg = composeSmsTemplate({ kind: "missed-call", industry: "home-services", tone: "warm", includeOptOut: false });
+  assert.match(msg, /\{\{first_name\}\}/);
+  assert.match(msg, /\{\{business_name\}\}/);
+});
+
+test("composeSmsTemplate substitutes the business name when one is given", () => {
+  const msg = composeSmsTemplate({
+    kind: "missed-call",
+    industry: "home-services",
+    tone: "warm",
+    businessName: "Northside Plumbing",
+    includeOptOut: false,
+  });
+  assert.match(msg, /Northside Plumbing/);
+  assert.doesNotMatch(msg, /\{\{business_name\}\}/);
+});
+
+test("composeSmsTemplate appends the opt-out line only when asked", () => {
+  const on = composeSmsTemplate({ kind: "review-request", industry: "salon", tone: "brief", includeOptOut: true });
+  const off = composeSmsTemplate({ kind: "review-request", industry: "salon", tone: "brief", includeOptOut: false });
+  assert.ok(on.endsWith(OPT_OUT_LINE));
+  assert.doesNotMatch(off, /Reply STOP/);
+  assert.equal(on, `${off}${OPT_OUT_LINE}`);
+});
+
+test("composeSmsTemplate is deterministic and leaves no unfilled industry slots", () => {
+  const industries = ["home-services", "hvac", "salon", "medspa", "dental", "cleaning", "auto", "legal"] as const;
+  const kinds = ["missed-call", "reminder", "confirmation", "review-request", "quote-followup", "on-my-way"] as const;
+  const tones = ["warm", "professional", "brief"] as const;
+  for (const industry of industries) {
+    for (const kind of kinds) {
+      for (const tone of tones) {
+        const a = composeSmsTemplate({ kind, industry, tone, includeOptOut: true });
+        const b = composeSmsTemplate({ kind, industry, tone, includeOptOut: true });
+        assert.equal(a, b);
+        // {job}/{visit}/{person} are single-brace slots; {{merge_fields}} stay.
+        assert.doesNotMatch(a, /(^|[^{])\{(job|visit|person)\}/, `${kind}/${industry}/${tone}`);
+        assert.doesNotMatch(a, /\bundefined\b/, `${kind}/${industry}/${tone}`);
+      }
+    }
+  }
+});
+
+/** Fill the merge fields the way a real send would, so segment counts are
+ *  measured against the message the carrier actually bills for. */
+function asSent(template: string): string {
+  return template
+    .replace(/\{\{first_name\}\}/g, "Sarah")
+    .replace(/\{\{business_name\}\}/g, "Northside Plumbing")
+    .replace(/\{\{appointment_time\}\}/g, "Tue at 2pm")
+    .replace(/\{\{booking_link\}\}/g, "nsplumb.co/book")
+    .replace(/\{\{tech_name\}\}/g, "Dave")
+    .replace(/\{\{review_link\}\}/g, "g.page/r/CxYz123/review");
+}
+
+test("every generated template stays GSM-7 and fits one segment once merge fields are filled", () => {
+  const industries = ["home-services", "hvac", "salon", "medspa", "dental", "cleaning", "auto", "legal"] as const;
+  const kinds = ["missed-call", "reminder", "confirmation", "review-request", "quote-followup", "on-my-way"] as const;
+  const tones = ["warm", "professional", "brief"] as const;
+  for (const industry of industries) {
+    for (const kind of kinds) {
+      for (const tone of tones) {
+        const sent = asSent(composeSmsTemplate({ kind, industry, tone, includeOptOut: true }));
+        const count = countSmsSegments(sent);
+        assert.equal(count.encoding, "GSM-7", `${kind}/${industry}/${tone} left GSM-7: ${sent}`);
+        assert.equal(count.segments, 1, `${kind}/${industry}/${tone} is ${count.billableLength} chars sent: ${sent}`);
+      }
+    }
+  }
+});
+
+test("countSmsSegments: 160 GSM-7 characters is one segment, 161 is two", () => {
+  assert.equal(countSmsSegments("a".repeat(160)).segments, 1);
+  const over = countSmsSegments("a".repeat(161));
+  assert.equal(over.segments, 2);
+  assert.equal(over.limitPerSegment, 153);
+});
+
+test("countSmsSegments: a GSM-7 extended character costs two units", () => {
+  assert.equal(countSmsSegments("[").billableLength, 2);
+  assert.equal(countSmsSegments("a").billableLength, 1);
+});
+
+test("countSmsSegments: one curly quote drops the message to UCS-2 and 70 per segment", () => {
+  const ascii = countSmsSegments("It's a test");
+  const curly = countSmsSegments("It’s a test");
+  assert.equal(ascii.encoding, "GSM-7");
+  assert.equal(curly.encoding, "UCS-2");
+  assert.equal(curly.limitPerSegment, 70);
+});
+
+test("countSmsSegments: an empty message is zero segments", () => {
+  assert.equal(countSmsSegments("").segments, 0);
+});
+
+// ─── Voicemail greetings ────────────────────────────────────────────────────
+
+const VOICEMAIL_BASE = {
+  business: "home-services" as const,
+  businessName: "Northside Plumbing",
+  hours: "Monday through Friday, 8 to 5",
+  callbackWindow: "the same day",
+  emergencyNumber: "",
+  bookingLink: "",
+  reopenDate: "",
+};
+
+test("composeVoicemailGreeting names the business and asks for the right details", () => {
+  const script = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "main" });
+  assert.match(script, /Northside Plumbing/);
+  assert.match(script, /the address/);
+  assert.match(script, /the same day/);
+});
+
+test("composeVoicemailGreeting omits optional lines entirely when they are blank", () => {
+  const bare = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "main" });
+  assert.doesNotMatch(bare, /emergency that can't wait/);
+  assert.doesNotMatch(bare, /book yourself in/);
+
+  const full = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "main", emergencyNumber: "555 0142", bookingLink: "example.com/book" });
+  assert.match(full, /555 0142/);
+  assert.match(full, /example\.com\/book/);
+});
+
+test("composeVoicemailGreeting falls back to a generic subject rather than an empty name", () => {
+  const script = composeVoicemailGreeting({ ...VOICEMAIL_BASE, businessName: "   ", kind: "after-hours" });
+  assert.match(script, /our office/);
+  assert.doesNotMatch(script, /\bundefined\b/);
+  assert.doesNotMatch(script, /\[\s*\]/);
+});
+
+test("composeVoicemailGreeting produces a distinct script for each of the four kinds", () => {
+  const kinds = ["main", "after-hours", "holiday", "emergency"] as const;
+  const scripts = kinds.map((kind) => composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind }));
+  assert.equal(new Set(scripts).size, kinds.length);
+  assert.match(scripts[3], /call 911/);
+});
+
+test("composeVoicemailGreeting: the holiday script names the reopen date only when given", () => {
+  const without = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "holiday" });
+  assert.doesNotMatch(without, /We reopen on/);
+  const withDate = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "holiday", reopenDate: "Monday, January 5th" });
+  assert.match(withDate, /We reopen on Monday, January 5th\./);
+});
+
+test("estimateSpokenSeconds scales with length and keeps a default greeting short", () => {
+  const script = composeVoicemailGreeting({ ...VOICEMAIL_BASE, kind: "main" });
+  const seconds = estimateSpokenSeconds(script);
+  assert.ok(seconds > 0 && seconds < 40, `unexpected estimate: ${seconds}s`);
+  assert.ok(estimateSpokenSeconds(`${script} ${script}`) > seconds);
+});
+
+// ─── Cancellation policy ────────────────────────────────────────────────────
+
+const POLICY_BASE = {
+  industry: "salon" as const,
+  businessName: "Rowan Studio",
+  noticeHours: 24,
+  lateFeeMode: "percent" as const,
+  lateFeeValue: 50,
+  noShowFeeMode: "flat" as const,
+  noShowFeeValue: 75,
+  depositRequired: false,
+  depositMode: "flat" as const,
+  depositValue: 50,
+};
+
+test("formatNotice reads the way a human would say it", () => {
+  assert.equal(formatNotice(2), "2 hours");
+  assert.equal(formatNotice(24), "24 hours");
+  assert.equal(formatNotice(48), "48 hours");
+  assert.equal(formatNotice(72), "72 hours");
+  assert.equal(formatNotice(168), "7 days");
+});
+
+test("formatFee returns null for a switched-off fee, never a $0 string", () => {
+  assert.equal(formatFee("none", 50), null);
+  assert.equal(formatFee("flat", 75), "$75");
+  assert.equal(formatFee("percent", 50), "50% of the service price");
+});
+
+test("composeCancellationPolicy states the notice window and both fees", () => {
+  const p = composeCancellationPolicy(POLICY_BASE);
+  assert.match(p.full, /24 hours/);
+  assert.match(p.full, /50% of the service price/);
+  assert.match(p.full, /\$75/);
+  assert.match(p.full, /Rowan Studio holds your appointment time/);
+});
+
+test("composeCancellationPolicy never emits a zero-dollar fee clause when fees are off", () => {
+  const p = composeCancellationPolicy({ ...POLICY_BASE, lateFeeMode: "none", noShowFeeMode: "none" });
+  assert.doesNotMatch(p.full, /\$0/);
+  assert.doesNotMatch(p.full, /charged \./);
+  assert.match(p.full, /there is no fee/);
+  // With no fees there is nothing to consent to beyond the notice window.
+  assert.doesNotMatch(p.checkbox, /charged/);
+});
+
+test("composeCancellationPolicy adds the deposit clause only when the toggle is on", () => {
+  const off = composeCancellationPolicy(POLICY_BASE);
+  assert.doesNotMatch(off.full, /Deposits:/);
+  const on = composeCancellationPolicy({ ...POLICY_BASE, depositRequired: true, depositValue: 40 });
+  assert.match(on.full, /Deposits: a \$40 deposit is required/);
+});
+
+test("composeCancellationPolicy switches to the first person when no business name is set", () => {
+  const p = composeCancellationPolicy({ ...POLICY_BASE, businessName: "" });
+  assert.match(p.full, /^Cancellation and no-show policy/);
+  assert.match(p.full, /We hold your appointment time/);
+  assert.match(p.checkbox, /the cancellation policy requires 24 hours notice/);
+});
+
+test("composeCancellationPolicy's short version fits in a single SMS segment for every fee combination", () => {
+  const combos = [
+    { lateFeeMode: "percent" as const, lateFeeValue: 50, noShowFeeMode: "percent" as const, noShowFeeValue: 100 },
+    { lateFeeMode: "flat" as const, lateFeeValue: 250, noShowFeeMode: "flat" as const, noShowFeeValue: 500 },
+    { lateFeeMode: "none" as const, lateFeeValue: 0, noShowFeeMode: "percent" as const, noShowFeeValue: 100 },
+    { lateFeeMode: "percent" as const, lateFeeValue: 50, noShowFeeMode: "none" as const, noShowFeeValue: 0 },
+    { lateFeeMode: "none" as const, lateFeeValue: 0, noShowFeeMode: "none" as const, noShowFeeValue: 0 },
+  ];
+  for (const noticeHours of [2, 24, 48, 168]) {
+    for (const combo of combos) {
+      const p = composeCancellationPolicy({ ...POLICY_BASE, noticeHours, ...combo });
+      const count = countSmsSegments(p.short);
+      assert.equal(count.encoding, "GSM-7", p.short);
+      assert.equal(count.segments, 1, `short version is ${count.billableLength} chars: ${p.short}`);
+    }
+  }
+});
+
+test("composeCancellationPolicy uses the industry's own words for the visit", () => {
+  const salon = composeCancellationPolicy(POLICY_BASE);
+  const trades = composeCancellationPolicy({ ...POLICY_BASE, industry: "home-services" });
+  assert.match(salon.full, /appointment time/);
+  assert.match(trades.full, /service visit time/);
+  assert.match(trades.full, /technician waits 15 minutes/);
+});
+
+// ─── LocalBusiness JSON-LD ──────────────────────────────────────────────────
+
+const SCHEMA_BASE = {
+  name: "Northside Plumbing",
+  type: "Plumber",
+  url: "https://northsideplumbing.com",
+  telephone: "+1-555-0142",
+  priceRange: "$$",
+  streetAddress: "120 Mill Street",
+  addressLocality: "Portland",
+  addressRegion: "OR",
+  postalCode: "97205",
+  addressCountry: "US",
+  latitude: "",
+  longitude: "",
+  areaServed: "",
+  hours: SCHEMA_DAYS.map((d) => ({ day: d.id, closed: d.id === "Sunday", opens: "08:00", closes: "17:00" })),
+};
+
+test("buildLocalBusinessJsonLd emits the schema.org envelope and the filled fields", () => {
+  const ld = buildLocalBusinessJsonLd(SCHEMA_BASE);
+  assert.equal(ld["@context"], "https://schema.org");
+  assert.equal(ld["@type"], "Plumber");
+  assert.equal(ld.name, "Northside Plumbing");
+  assert.deepEqual(ld.address, {
+    "@type": "PostalAddress",
+    streetAddress: "120 Mill Street",
+    addressLocality: "Portland",
+    addressRegion: "OR",
+    postalCode: "97205",
+    addressCountry: "US",
+  });
+});
+
+test("buildLocalBusinessJsonLd omits empty fields rather than emitting blanks", () => {
+  const ld = buildLocalBusinessJsonLd({ ...SCHEMA_BASE, telephone: "  ", priceRange: "", url: "" });
+  assert.equal("telephone" in ld, false);
+  assert.equal("priceRange" in ld, false);
+  assert.equal("url" in ld, false);
+  assert.equal(JSON.stringify(ld).includes('""'), false);
+});
+
+test("buildLocalBusinessJsonLd drops the address entirely when nothing is filled in", () => {
+  const ld = buildLocalBusinessJsonLd({
+    ...SCHEMA_BASE,
+    streetAddress: "",
+    addressLocality: "",
+    addressRegion: "",
+    postalCode: "",
+    addressCountry: "",
+  });
+  assert.equal("address" in ld, false);
+});
+
+test("buildLocalBusinessJsonLd excludes closed days from the opening hours", () => {
+  const ld = buildLocalBusinessJsonLd(SCHEMA_BASE);
+  const hours = ld.openingHoursSpecification as { dayOfWeek: string }[];
+  assert.equal(hours.length, 6);
+  assert.equal(hours.some((h) => h.dayOfWeek.endsWith("Sunday")), false);
+  assert.equal(hours[0].dayOfWeek, "https://schema.org/Monday");
+});
+
+test("buildLocalBusinessJsonLd emits geo only when both coordinates parse as numbers", () => {
+  assert.equal("geo" in buildLocalBusinessJsonLd(SCHEMA_BASE), false);
+  assert.equal("geo" in buildLocalBusinessJsonLd({ ...SCHEMA_BASE, latitude: "45.5231" }), false);
+  assert.equal("geo" in buildLocalBusinessJsonLd({ ...SCHEMA_BASE, latitude: "abc", longitude: "def" }), false);
+  const geo = buildLocalBusinessJsonLd({ ...SCHEMA_BASE, latitude: "45.5231", longitude: "-122.6765" }).geo;
+  assert.deepEqual(geo, { "@type": "GeoCoordinates", latitude: 45.5231, longitude: -122.6765 });
+});
+
+test("buildLocalBusinessJsonLd emits areaServed as a string for one area and a list for several", () => {
+  assert.equal(buildLocalBusinessJsonLd({ ...SCHEMA_BASE, areaServed: "Portland" }).areaServed, "Portland");
+  assert.deepEqual(buildLocalBusinessJsonLd({ ...SCHEMA_BASE, areaServed: "Portland, Beaverton , " }).areaServed, [
+    "Portland",
+    "Beaverton",
+  ]);
+});
+
+test("buildLocalBusinessJsonLd falls back to the generic type when none is set", () => {
+  assert.equal(buildLocalBusinessJsonLd({ ...SCHEMA_BASE, type: "" })["@type"], "LocalBusiness");
+});
+
+test("renderSchemaScript wraps valid, re-parseable JSON in a script tag", () => {
+  const script = renderSchemaScript(buildLocalBusinessJsonLd(SCHEMA_BASE));
+  assert.ok(script.startsWith('<script type="application/ld+json">'));
+  assert.ok(script.endsWith("</script>"));
+  const json = script.replace(/^<script type="application\/ld\+json">\n/, "").replace(/\n<\/script>$/, "");
+  assert.equal(JSON.parse(json)["@type"], "Plumber");
+});
+
+// ─── Google Business Profile description ────────────────────────────────────
+
+const GBP_BASE = {
+  businessName: "Northside Plumbing",
+  businessType: "plumbing company",
+  city: "Portland",
+  services: ["drain cleaning", "water heater repair", "leak detection"],
+  yearsInBusiness: 10,
+  differentiators: ["licensed", "same-day"],
+  tone: "warm" as const,
+};
+
+test("composeGbpDescription covers what, where, how long and what is different", () => {
+  const r = composeGbpDescription(GBP_BASE);
+  assert.match(r.text, /Northside Plumbing is a plumbing company in Portland/);
+  assert.match(r.text, /drain cleaning, water heater repair and leak detection/);
+  assert.match(r.text, /serving Portland for 10 years/);
+  assert.match(r.text, /licensed and insured/);
+  assert.match(r.text, /book online/);
+});
+
+test("composeGbpDescription never exceeds Google's 750-character limit", () => {
+  const monster = composeGbpDescription({
+    ...GBP_BASE,
+    businessName: "The Extremely Long Name Of A Plumbing Company ".repeat(4),
+    businessType: "full service residential and commercial plumbing and drain company ".repeat(3),
+    services: ["a".repeat(120), "b".repeat(120), "c".repeat(120), "d".repeat(120), "e".repeat(120)],
+    differentiators: ["licensed", "family", "same-day"],
+  });
+  assert.ok(monster.length <= GBP_DESCRIPTION_LIMIT, `got ${monster.length}`);
+  assert.equal(monster.trimmed, true);
+  assert.equal(monster.remaining, GBP_DESCRIPTION_LIMIT - monster.length);
+});
+
+test("composeGbpDescription reports remaining budget and does not trim a normal description", () => {
+  const r = composeGbpDescription(GBP_BASE);
+  assert.equal(r.length, r.text.length);
+  assert.equal(r.remaining, GBP_DESCRIPTION_LIMIT - r.length);
+  assert.equal(r.trimmed, false);
+  assert.ok(r.remaining > 0);
+});
+
+test("composeGbpDescription drops the years sentence when years is zero", () => {
+  const r = composeGbpDescription({ ...GBP_BASE, yearsInBusiness: 0 });
+  assert.doesNotMatch(r.text, /years/);
+});
+
+test("composeGbpDescription honours the differentiator cap", () => {
+  const r = composeGbpDescription({
+    ...GBP_BASE,
+    differentiators: ["licensed", "family", "same-day", "upfront", "emergency"],
+  });
+  const used = ["licensed and insured", "family owned", "Same-day appointments", "upfront pricing", "around the clock"].filter(
+    (needle) => r.text.includes(needle),
+  );
+  assert.equal(used.length, MAX_DIFFERENTIATORS);
+});
+
+test("composeGbpDescription never emits a URL, a phone number or a price", () => {
+  const r = composeGbpDescription(GBP_BASE);
+  assert.doesNotMatch(r.text, /https?:\/\//);
+  assert.doesNotMatch(r.text, /\$\d/);
+  assert.doesNotMatch(r.text, /\d{3}[-.\s]\d{4}/);
+});
+
+test("composeGbpDescription handles a business with no services or city without leaving holes", () => {
+  const r = composeGbpDescription({ ...GBP_BASE, services: [], city: "", yearsInBusiness: 0, differentiators: [] });
+  assert.doesNotMatch(r.text, /\bundefined\b/);
+  assert.doesNotMatch(r.text, /\s{2,}/);
+  assert.ok(r.text.length > 0);
+});
+
+test("composeGbpDescription changes the opening and closing with the tone", () => {
+  const texts = (["warm", "professional", "direct"] as const).map((tone) => composeGbpDescription({ ...GBP_BASE, tone }).text);
+  assert.equal(new Set(texts).size, 3);
+});
+
+// ─── Review QR code ─────────────────────────────────────────────────────────
+
+test("buildReviewUrl produces Google's direct write-a-review URL", () => {
+  assert.equal(
+    buildReviewUrl("ChIJN1t_tDeuEmsRUsoyG83frY4"),
+    "https://search.google.com/local/writereview?placeid=ChIJN1t_tDeuEmsRUsoyG83frY4",
+  );
+});
+
+test("buildReviewUrl escapes a Place ID with URL-unsafe characters", () => {
+  assert.match(buildReviewUrl("abc&def=1"), /placeid=abc%26def%3D1$/);
+});
+
+test("printPixels converts inches to pixels at 300 DPI", () => {
+  assert.equal(PRINT_DPI, 300);
+  assert.equal(printPixels(2), 600);
+  assert.equal(printPixels(3), 900);
+  assert.equal(printPixels(6), 1800);
+});
+
+test("every print size is a whole-pixel export and the ids are unique", () => {
+  const ids = PRINT_SIZES.map((s) => s.id);
+  assert.equal(new Set(ids).size, ids.length);
+  for (const size of PRINT_SIZES) {
+    assert.ok(size.inches > 0);
+    assert.equal(printPixels(size.inches) % 1, 0);
+  }
+});
+
+test("a real review URL encodes as a QR code at every error-correction level", async () => {
+  // The widget renders through qrcode's BROWSER build; this exercises the same
+  // core encoder through the node build, which is where "data too long for this
+  // error-correction level" would surface. A long Place ID is the worst case.
+  const url = buildReviewUrl("ChIJN1t_tDeuEmsRUsoyG83frY4ChIJN1t_tDeuEmsRUsoyG83frY4");
+  for (const errorCorrectionLevel of ["M", "Q", "H"] as const) {
+    const svg = await QRCode.toString(url, { type: "svg", margin: 2, errorCorrectionLevel });
+    assert.match(svg, /^<svg/);
+    assert.ok(svg.length > 500, `${errorCorrectionLevel} produced a suspiciously small SVG`);
+  }
+});


### PR DESCRIPTION
## Why

Tools are the site's deepest-engagement asset. The GoHighLevel cost calculator averages 19 views per user and 2m08s, against ~29s site-wide, and interactive pages earn AI citations that listicles do not. This wave adds seven, fixes a real drift bug in how the family is registered, and gives every tool a Markdown twin.

## Part 1 — one registry, three consumers

The slug list was hand-maintained in **three** places: the `/tools` hub, `app/sitemap.ts` and `app/llms.txt/route.ts`. Three lists that can disagree means a tool ships visible-but-uncrawlable, or listed in llms.txt while 404ing.

`packages/crm/src/lib/seo/tools-pages.ts` is now the single source of truth (slug, title, description, summary, `interactive`). The hub, sitemap and llms.txt all read it, and `tests/unit/seo/free-tools.spec.ts` asserts **every registry slug has a real page directory AND a real Markdown route on disk** — so the drift fails in CI, not in Search Console.

## Part 2 — the seven tools

All client-side, no server calls, no new dependencies.

| Tool | The wedge |
|---|---|
| `/tools/google-review-qr-code-generator` | Targets "review QR code", not "review link". Print sizes (table tent 2″ → decal 6″) exported at 300 DPI plus a vector SVG, encoded **in the browser** with the `qrcode` package already in this app. Cross-links its sibling both ways instead of duplicating it. |
| `/tools/sms-template-generator` | 6 message types × 8 industries × 3 tones, merge fields intact, live GSM-7/UCS-2 segment count. Every ranking competitor is a static listicle. |
| `/tools/voicemail-greeting-generator` | Four variants (main, after-hours, holiday, emergency). CTA is honestly "or stop sending callers to voicemail entirely". |
| `/tools/cancellation-policy-generator` | Three outputs sized for where each is actually read: booking page, reminder text, form checkbox. Cross-links the no-show calculator, which quantifies the problem this fixes. |
| `/tools/local-business-schema-generator` | Valid `LocalBusiness` JSON-LD. Empty fields are **omitted**, not emitted as blanks, which is where hand-written schema usually breaks. |
| `/tools/google-business-profile-description-generator` | Fits Google's 750-char cap by dropping optional sentences bottom-up rather than cutting mid-word. CTA into the AI website generator, which already accepts a Google paste. |
| `/tools/customer-lifetime-value-calculator` | Built for local service (ticket × visits/yr × years + referrals), not the SaaS churn formula everyone copies. |

**The LTV calculator is the internal-linking hub.** The missed-call, no-show and speed-to-lead pages each price *one lost job*; all three now link to it so the real number reads as a lost customer, not a lost ticket.

### Two bugs the tests caught before merge

- **Every SMS template ran past 160 characters** once the opt-out line was appended, which silently doubles the carrier cost of every send. Templates rewritten to a measured budget; a test now asserts every one of the 144 combinations stays GSM-7 and fits one segment *with merge fields filled the way a real send fills them*.
- **The cancellation policy's "short version" was 199 characters** in a field explicitly meant for a text message. Restructured with a compact fee formatter; pinned across 20 notice/fee combinations.

Also caught and fixed during review: the generic Markdown twin claimed "nothing you type is sent to SeldonFrame", which is **false for `/tools/website-grader`** (it scores your URL through a server route). The blanket claim is gone; per-tool privacy claims now live in the registry where they can be true one tool at a time.

## Part 3 — Markdown twins (which ones)

No tool had a `.md` twin, while every other page family does. **All 27 tools now have one**, at `app/tools/<slug>.md/route.ts`, following the established `app/best/<slug>.md` pattern.

- **The 7 new tools** get the full twin: what it computes, its exact inputs, its exact outputs, related tools.
- **The existing 20** get the short twin (title, summary, link). Deliberate: writing an "inputs" list for a widget nobody audited would put claims in front of AI crawlers that we cannot stand behind. Upgrading them is a clean follow-up, one tool at a time, as each is verified.
- llms.txt advertises them with one line covering the whole family. `alternates.types` markdown pointers were added to the 7 new pages only (adding them to the existing 20 is 20 unrelated edits).
- Added `"tool_page"` to the `MarkdownSurface` enum so these fetches group correctly in analytics instead of being logged as `"guide"`.

## Part 4 — sitemap gaps

- **`/agencies`** — added. Live, indexable, and genuinely missing.
- **`/sell`** — already present (line 94 before this PR). No change needed.
- **`/try`** — **deliberately not added.** It sets `robots: { index: false }` and `notFound()`s unless `SF_WEB_UNGATED_BUILD` is on. Sitemapping a noindex, 404-able route is the same mistake the existing `/record` entry already guards against. Flagged rather than done, since it was explicitly requested.

## Verification

- `node --test --import tsx tests/unit/seo/free-tools.spec.ts` — **65 pass, 0 fail** (registry invariants, twin rendering, LTV math + URL round-trip, SMS composition + segment counting, voicemail/policy/schema/GBP composition, QR URL + print sizing, plus a real review URL encoded at all three error-correction levels).
- `node --test --import tsx` across `free-tools`, `calculator-math`, `page-metadata`, `best-pages`, `website-grader` — **207 pass, 0 fail**.
- `pnpm exec tsc --noEmit` — clean, exit 0.
- `pnpm exec eslint` on every new and touched file — clean, exit 0. (The wider `/tools` directory has ~43 pre-existing `react/no-unescaped-entities` errors on `main`; untouched.)
- Verified `qrcode` resolves to its **browser** build when bundled for the client: 64.8 kB, no `fs`, `pngjs` or `yargs`. Without that, the client bundle would have pulled Node built-ins.

Not run: a full `next build` (needs env this worktree does not have) and a live browser pass on the seven widgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
