### PR TITLE
feat(seo): seven competitor pricing pages + podium-vs-birdeye

### DIFF
--- a/docs/superpowers/specs/2026-07-08-competitor-pricing-facts.md
+++ b/docs/superpowers/specs/2026-07-08-competitor-pricing-facts.md
@@ -331,3 +331,129 @@ public pricing URL, plans, stacked add-on costs, annual discount, quote-gating, 
 9. Linktree/Zoho USD figures — geo-served pages; hedged from 2026 sources
 
 **Rock-solid (fetched live 2026-07-08):** GoHighLevel, ClickFunnels, Keap, Kartra, Klaviyo free tier, HubSpot Pro/Enterprise, Vapi, Retell, Chatbase, Stammer, Goodcall, Vendasta, Lindy, Durable, ActiveCampaign plan names.
+
+---
+
+# Appendix — verified 2026-08-24 (seven-competitor wave)
+
+Facts for the 2026-08-24 wave: Bland AI, Birdeye, Weave, Ruby Receptionist, Thryv,
+Tidio, ElevenLabs Agents. Same rule as the July block: **no number appears on a
+page unless it appears here.** Every vendor page in this appendix was fetched
+twice on 2026-08-24 — once by a dedicated research agent, once again directly
+before publishing — and every third-party source cited was fetched too.
+
+**Verification legend for this appendix**
+- **FETCHED** = read off the vendor's own live page on 2026-08-24
+- **DERIVED** = pure arithmetic on two FETCHED numbers (e.g. plan price ÷ included minutes); never an estimate
+- **REPORTED** = third-party only; the vendor publishes no such figure. Every REPORTED number is hedged in page copy ("reported by reviewers", "third parties report") and never stated as vendor fact.
+
+---
+
+## 26. Bland AI ✅ FETCHED — quoteGated: false (Enterprise tier only)
+- pricingUrl: https://www.bland.ai/pricing (FETCHED 2026-08-24)
+- secondary vendor source: https://docs.bland.ai/platform/billing (FETCHED 2026-08-24)
+- plans (all FETCHED from the pricing page):
+  - Start — "$0/mo platform fee" + "$0.14/min" talk time + "$0.05/min" transfer time — 10 concurrent calls, 100 calls/day, 10 knowledge bases, 1 voice; includes 2 credits + an inbound number the page calls a "$15/mo value"; "No card required"
+  - Build — "$299/mo platform fee" + "$0.12/min" talk + "$0.04/min" transfer — 50 concurrent, 2,000 calls/day, 50 knowledge bases, 5 voices
+  - Scale — "$499/mo platform fee" + "$0.11/min" talk + "$0.03/min" transfer — 100 concurrent, 5,000 calls/day, 100 knowledge bases, 15 voices
+  - Enterprise — Custom, no figure published (QUOTE-GATED); platform fee "contracted to your volume"; unlimited concurrency/calls/knowledge bases/voices; on-prem/VPC, BAA, SSO, data residency available
+- meters (FETCHED from docs.bland.ai/platform/billing): SMS "$0.02" per message inbound or outbound; web widget agent messages "$0.01" each; outbound minimum "$0.015" per call; failed calls "$0.015" per call; SIP termination Twilio→Bland "$0.004/min"
+- vendor claim quoted verbatim on the page (FETCHED): "No token charges. No model-provider pass-throughs." — the per-minute rate covers LLM, STT and TTS
+- BYOT note (FETCHED): customers who bring their own Twilio pay no transfer fee
+- annualDiscount: none mentioned anywhere on the page — omitted rather than invented
+- freeTier: yes — Start plan at a $0 platform fee, pay per minute
+- ⛔ **DO NOT PUBLISH** the pre-restructure model that most third-party articles still describe (~$0.09/min base with custom voice +$0.02/min, KB lookup +$0.01/min, recording +$0.01/min). Bland restructured to plan-tiered all-in rates; neither vendor surface lists those add-ons today. The truthful "stacking" story is the platform fee, transfer time, the failed-call minimum and the SIP termination fee.
+- ⛔ dead URL, do not retry: https://docs.bland.ai/platform/pricing returns 404
+
+## 27. Birdeye ❌ QUOTE-GATED — vendor publishes ZERO dollar figures — quoteGated: true
+- pricingUrl: https://birdeye.com/pricing/ (FETCHED 2026-08-24, twice)
+- FETCHED: no dollar amount of any kind appears on the page. Headline verbatim: "Pricing built around outcomes, not seat counts." Positioning verbatim: "One platform, one contract - replace point products and pay only for what you deploy at your locations". Pricing sits behind a "GET PRICING" lead form.
+- FETCHED: the one hard structural fact — buyers self-select a **location band**: 1-3, 4-9, 10-39, 40-249, 250-999, 1000+. Pricing is per location by the vendor's own admission; no dollar amount attaches to any band.
+- FETCHED: no plan/tier NAMES are published either. The Starter/Growth/Dominate and Standard/Professional/Premium schemes circulating in the industry come from third parties and conflict with each other — **the pages use the vendor's own location bands as plan rows instead**.
+- FETCHED: https://birdeye.com/blog/what-does-birdeye-cost/ — Birdeye's own cost explainer contains zero dollar figures; describes pricing as "custom and flexible", determined by products, location count and contract structure.
+- REPORTED (https://wiserreview.com/blog/birdeye-pricing/, published 2025-11-28, updated 2026-07-09; FETCHED 2026-08-24):
+  - per-location bands "$299-$349" / "$399-$599" / "$449-$699+"
+  - volume pricing "$200-$250" per location at 10 locations
+  - "The 8% 'Innovation Fee' added at renewal"
+  - integration/setup "$500-$2,000 for complex CRM/POS integrations"
+  - add-on modules "$50-$200/month per location"
+  - SMS carrier pass-through "$0.01-$0.03 per message"
+  - "12-month annual contract billed monthly, with auto-renewal unless written cancellation notice 90 days before renewal"; early termination charges the remaining contract balance
+- REPORTED (https://www.reviewflowz.com/blog/how-much-does-birdeye-really-cost, published 2026-01-05; FETCHED 2026-08-24): $349/mo month-to-month vs $299/mo annual entry; $449/mo next tier; ~$3,600/yr single-brand. Author states outright these came from a pricing-form screenshot and past-client feedback, not documentation — **this weakness is stated in page copy**.
+- ⚠️ Source-quality note: both third parties sell against Birdeye. Where they disagree on a band (add-ons $50-$200 vs $50-$150), the pages state the SHAPE of the fee, never a precise figure.
+- freeTier: none — the pricing page is a lead form
+
+## 28. Weave ❌ MOSTLY QUOTE-GATED — one published number — quoteGated: true
+- pricingUrl: https://www.getweave.com/pricing/ (FETCHED 2026-08-24, twice with different prompts to confirm $199 is not a misread of $249)
+- FETCHED, verbatim: "Find just what you need and get the most out of Weave with simple plans and pricing, starting from $199 per month." **This $199 floor is the ONLY dollar figure Weave publishes.**
+- FETCHED: three tiers — Pro, Elite ("Most Popular"), Ultimate — each with a "Get Pricing" button and no price.
+- FETCHED, Ultimate detail verbatim: "up to 15 phones, 1:1 personalized training, and premium analytics tools"
+- FETCHED, all-plan inclusions: "Award-winning customer support" and "Expert onboarding"
+- FETCHED: no setup fee, hardware cost, per-location pricing or contract term is disclosed anywhere on the page.
+- ⚠️ **DISCREPANCY, carried explicitly in page copy:** every third party reports the Pro floor at $249-$250/mo per location, $50 ABOVE Weave's own live page. Neither figure may be published as "the price". Approved framing: *Weave advertises from $199/mo but quotes all three tiers; third parties report the real entry tier at $249-$250/mo per location and customer-reported spend at $300-$500/mo for a small practice.*
+- REPORTED (https://noshowcost.com/tools/weave-pricing, content verified 2026-04-28; FETCHED 2026-08-24 — best-sourced of the set, triangulated from G2/Capterra cost notes Jan 2025–May 2026, public webinars, and Reddit): actual spend "$300 to $400" (1-3 providers), "$400 to $500" (2-5), "$500 to $700" (multi-location), "$800 to $1,200" (enterprise multi-location); "$400 one-time port and setup"; customers "frequently mention 15 to 25 percent renewal price increases"
+- REPORTED (https://www.iplum.com/blog/weave-pricing-plans; FETCHED 2026-08-24; iPlum competes with Weave): Pro "$249/month" per location; setup "$500-$750"; forms migration "$200" upfront then "$20" per subsequent upload; "Power Pack" "$25 per user per month"; extra phone numbers "$5/month" per line; desk phones "$131.51" per device; bulk-message caps 1,500 / 3,000 / 15,000
+- REPORTED (https://emitrr.com/blog/weave-pricing/, updated 2026-08-13; Emitrr competes with Weave): "$250/month" base; setup "$750"; the same $200 / $20 forms fees; the same 1,500 / 3,000 / 15,000 caps; free Yealink VoIP phones on certain plans (**directly contradicts iPlum's $131.51 desk phones — neither hardware figure is published on any page**)
+- ⛔ **Setup-fee amount is NOT publishable.** Three sources report $400, $500-$750 and $750. The pages assert only that a one-time fee is *reported to exist* while Weave advertises onboarding as included — that gap is a DISCLOSURE claim we can make, not a fee amount we can quote.
+- ⛔ dead/blocked URLs, do not retry: https://www.g2.com/products/weave-weave/pricing (403), https://www.themolarreport.com/learn/weave-pricing (404 — the $249 figure attributed to it in search snippets was never verified against the page, so $249 rests on iPlum alone)
+- freeTier: none
+
+## 29. Ruby Receptionist ✅ FETCHED — quoteGated: false
+- pricingUrl: https://www.ruby.com/pricing/ (FETCHED 2026-08-24)
+- corroborating vendor pages: https://www.ruby.com/plans-and-pricing/ and https://www.ruby.com/faq/ (both FETCHED 2026-08-24)
+- plans, virtual receptionist (all FETCHED): "$250" / 50 minutes · "$395" / 100 minutes · "$720" / 200 minutes · "$1,725" / 500 minutes
+- plans, live chat (FETCHED, a SEPARATE meter): "$143" / 10 chats · "$335" / 30 chats · "$520" / 50 chats
+- bundles (FETCHED): receptionist + 10 chats "$115" · + 30 chats "$268" · + 50 chats "$416"; the page states the bundle is 20% off standalone chat
+- ⚠️ Two independent extractions of the same page disagreed on the middle tier NAMES (Starter/Standard/Popular/Enterprise vs Starter/Basic/Popular/Professional) while agreeing exactly on every price and minute count. **The pages therefore name each plan by its included minute count, never by a tier name.**
+- DERIVED per-minute (plan price ÷ vendor-published included minutes): $250/50 = **$5.00** · $395/100 = **$3.95** · $720/200 = **$3.60** · $1,725/500 = **$3.45**
+- DERIVED per-chat: $143/10 = **$14.30** · $335/30 = **$11.17** · $520/50 = **$10.40**
+- FETCHED vendor claim, quoted verbatim in page copy: "no additional or hidden fees for activation, onboarding, setup, customization"
+- FETCHED: optional AI enhancements are stated as available on all plans at no extra cost
+- ⛔ **Overage rate is NOT published** on /pricing/, /plans-and-pricing/ or /faq/ — all three checked and confirmed silent. Contract length, annual discount and minute-rounding method are also absent. The pages say so explicitly; that absence IS the story.
+- REPORTED, flagged stale in page copy (https://vida.io/blog/ruby-receptionists-pricing and https://oncrew.ai/blog/ruby-receptionist-alternatives-2026, both retrieved 2026-08-24): an overage ladder of $5.40 / $4.45 / $4.35 / $4.25 / $3.95 / $3.80 / $3.60 / $3.50 / $3.40 / $3.30 per minute — **quoted against a legacy lineup ("Call Ruby 50" through "Call Ruby 2,500") whose tier names and tier count do not match the four live plans.** Page copy carries only the $5.40-down-to-$3.30 range, labelled reported AND stale.
+- freeTier: none
+
+## 30. Thryv 🔶 PARTIALLY PUBLISHED — quoteGated: true (Amplify, Boosts, seats, usage)
+- pricingUrl: https://www.thryv.com/pricing/ (FETCHED 2026-08-24, twice with different prompts)
+- plans (FETCHED): Starter "$99 per month", 1 user — 60+ listing directories, digital marketing score, AI website builder, AI review management, trackable phone numbers, digital performance insights, 24/7 chat support · Signature "$399 per month" (marked "Recommended"), 5 users — adds social media management, SEO & AEO custom website, advanced listings, competitive insights & heatmap, AI lead insights, 24/7 phone & email support · Amplify "Custom", no amount displayed, button goes to demo scheduling (QUOTE-GATED)
+- ⚠️ FETCHED but UNRESOLVED: the page shows an "Annual Save 15%" / "Monthly" toggle and never states which basis the displayed $99/$399 use. Two fetches with different prompts failed to resolve it. **Page copy states the ambiguity rather than picking a side.**
+- FETCHED: Thryv Boosts (Ads, Search, Social, Brand) are described as done-for-you marketing services on Signature and Amplify — **no price disclosed anywhere** (QUOTE-GATED)
+- FETCHED: no cost is stated for a user beyond the included 1 (Starter) or 5 (Signature)
+- FETCHED: no onboarding fee, setup fee, support fee or SMS rate appears on the pricing page
+- REPORTED (https://schedulingkit.com/pricing-guides/thryv-pricing and https://tekpon.com/software/thryv/pricing/, both retrieved 2026-08-24): "$250" one-time onboarding fee on all package levels; "$9" monthly support fee; SMS "$0.015" per message; voice "$0.01" per minute; Command Center seats free/Basic, ~"$20" per seat/mo (Plus), ~"$30" per seat/mo (Professional)
+- ⛔ **NOT published on any page:** the G2 (4.2-4.6/5) vs Trustpilot (2.3/5) review-sentiment split was in the research pack but was NOT independently fetched, so it was dropped rather than published.
+- freeTier: none
+
+## 31. Tidio ✅ FETCHED — quoteGated: true (Premium; Growth/Plus quotas)
+- pricingUrl: https://www.tidio.com/pricing/ (FETCHED 2026-08-24, three times across the research and publishing passes)
+- plans (all FETCHED, verbatim price strings): Free "$0/mo." · Starter "$24.17/mo." · Growth "Starts at $49.17/mo." · Plus "Starts at $300/mo. + monthly usage" · Premium "Contact for pricing" (QUOTE-GATED)
+- included quotas (FETCHED): Free — 50 billable conversations, 50 Lyro AI conversations (one-off), 100 Flows visitors reached, 10 seats · Starter — 100 billable conversations, 50 Lyro AI conversations (one-off), 100 Flows visitors, 10 seats · Growth — up to 2,000 billable conversations, Lyro and Flows both "Custom" · Plus — custom conversations and custom seat count · Premium — Lyro "From 3,000"
+- add-ons (FETCHED, verbatim): Lyro AI Agent "Starts at $32.50/mo. From 50 Lyro AI conversations" · Flows "Starts at $24.17/mo. From 2 000 visitors reached"
+- FETCHED: annual billing advertised as "Annually (2 months free)"
+- FETCHED: the guaranteed 50% Lyro resolution rate and pay-per-resolution billing are **Premium-exclusive**
+- DERIVED: $32.50 ÷ 50 = **$0.65 per Lyro AI conversation** at the entry bundle · $24.17 ÷ 2,000 = **~$0.012 per Flows visitor** · $300 ÷ $49.17 = **~6.1x Growth→Plus step**
+- ⚠️ FETCHED but UNRESOLVED: whether $24.17 / $49.17 are true month-to-month or annual-billed-monthly. The decimals are arithmetically consistent with the annual "2 months free" discount ($29 × 10 ÷ 12 = $24.17; $59 × 10 ÷ 12 = $49.17) while the toggle read as Monthly. **The implied $29/$59 month-to-month figures are INFERRED and are NOT published anywhere.** Page copy states the ambiguity.
+- ⛔ no explicit per-conversation overage rate is published — Tidio sells bundles, not overage. Not invented.
+- freeTier: yes — $0/mo Free plan as itemised above
+
+## 32. ElevenLabs Agents ✅ FETCHED — quoteGated: false (Enterprise only)
+- pricingUrl: https://elevenlabs.io/pricing/agents (FETCHED 2026-08-24, twice)
+- secondary vendor source: https://elevenlabs.io/pricing (FETCHED 2026-08-24 — main plan ladder + the annual "pay for 10 months" 20% structure; it does NOT address agent per-minute rates)
+- plans (all FETCHED — price / included agent minutes / concurrent calls): Free "$0" / 15 / 4 · Starter "$6" / 75 / 6 · Creator "$22" (first month 50% off at "$11") / 275 / 10 · Pro "$99" / 1,238 / 20 · Scale "$299" / 3,738 / 30 · Business "$990" / 12,375 / 40 · Enterprise Custom, no figure (QUOTE-GATED)
+- rates (FETCHED, verbatim): standard overage "$0.080" per minute · burst "$0.160" per minute when exceeding the plan's concurrency limit, allowing up to 3x normal concurrency · text messages "$0.003" each
+- vendor statement quoted verbatim in page copy (FETCHED): "The LLM model and any telephony are billed separately on top, based on usage."
+- ⛔ **No LLM rate and no telephony rate is published anywhere.** All-in cost per call is therefore NOT determinable from vendor disclosures; the pages state that $0.08/min is a floor, never a total.
+- DERIVED, the strongest finding on this vendor — bundled minutes carry **zero** volume discount. Plan price ÷ included minutes at every paid tier: $6/75 = $0.0800 · $22/275 = $0.0800 · $99/1,238 = $0.0800 · $299/3,738 = $0.0800 · $990/12,375 = $0.0800. Identical to the published overage rate; the subscription is prepaid minutes at list price and a higher tier buys concurrency headroom only. Independently checkable arithmetic on the vendor's own numbers.
+- annualDiscount: FETCHED — main plan page structures annual as "pay for 10 months" (two months free, ~20%)
+- freeTier: yes — 15 agent minutes/mo, 4 concurrent calls
+- ⛔ dead URL, do not retry: https://elevenlabs.io/docs/agents-platform/pricing returns 404
+
+---
+
+## Cross-vendor notes for this wave
+
+1. **Only 3 of the 7 publish a real price book.** Bland AI, Ruby and ElevenLabs do. Tidio and Thryv publish part of one. Weave publishes exactly one number ($199 floor). Birdeye publishes nothing at all.
+2. **All the reported-only material comes from vendors' competitors.** Emitrr, iPlum, Reviewflowz, Wiserreview and NoShowCost all sell against or compare the vendors they cost out, so they have a structural incentive to inflate total cost. NoShowCost is the most defensible (it names its method and admits the vendor page is gated); Reviewflowz is the most candid about its own weakness. Where two disagree on a band, the pages publish the SHAPE of the fee, never a precise figure.
+3. **Contract lock-in is REPORTED, never vendor-published,** for both Birdeye (12-month, 90-day notice, remaining-balance ETF, ~8% renewal fee) and Weave (contract required, 15-25% renewal increases). Every mention on a page carries "reported by reviewers".
+4. **The growth-tax pattern** is structural and can be argued without quoting any unverified competitor number: Birdeye and Weave price per location with add-ons that also multiply per location; Weave layers a per-user add-on on top of that; Bland charges a platform fee that buys a discount rather than an allowance, then meters talk time, transfer time, SMS and web messages separately.
+5. **Nothing in the July 2026 block was found stale by this wave.** No fact gathered here contradicts the existing vapi / retell-ai / synthflow registry rows. Those rows still carry `verified: "July 2026"` and are due for their own re-check pass.

--- a/packages/crm/src/app/(public)/alternative-to-birdeye/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-birdeye/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-birdeye — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "birdeye";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-bland-ai/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-bland-ai/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-bland-ai — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "bland-ai";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-elevenlabs/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-elevenlabs/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-elevenlabs — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "elevenlabs";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-ruby-receptionist/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-ruby-receptionist/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-ruby-receptionist — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "ruby-receptionist";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-thryv/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-thryv/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-thryv — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "thryv";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-tidio/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-tidio/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-tidio — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "tidio";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/alternative-to-weave/page.tsx
+++ b/packages/crm/src/app/(public)/alternative-to-weave/page.tsx
@@ -1,0 +1,22 @@
+// /alternative-to-weave — static comparison page driven by the
+// alternative-pages registry (lib/seo/alternative-pages.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { AlternativePage } from "@/components/seo/alternative-page";
+import { getCompetitor, alternativePageMeta } from "@/lib/seo/alternative-pages";
+import { alternativeOgUrl } from "@/lib/seo/page-metadata";
+
+const SLUG = "weave";
+const meta = alternativePageMeta(SLUG);
+const ogUrl = alternativeOgUrl(SLUG);
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  alternates: { canonical: meta.canonical, types: { "text/markdown": `${meta.canonical}.md` } },
+  openGraph: { title: meta.title, description: meta.description, url: meta.canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title: meta.title, description: meta.description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <AlternativePage competitor={getCompetitor(SLUG)} />;
+}

--- a/packages/crm/src/app/(public)/birdeye-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/birdeye-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /birdeye-pricing — "birdeye pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "birdeye";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/bland-ai-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/bland-ai-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /bland-ai-pricing — "bland-ai pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "bland-ai";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/elevenlabs-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/elevenlabs-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /elevenlabs-pricing — "elevenlabs pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "elevenlabs";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/ruby-receptionist-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/ruby-receptionist-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /ruby-receptionist-pricing — "ruby-receptionist pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "ruby-receptionist";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/thryv-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/thryv-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /thryv-pricing — "thryv pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "thryv";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/tidio-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/tidio-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /tidio-pricing — "tidio pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "tidio";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/(public)/weave-pricing/page.tsx
+++ b/packages/crm/src/app/(public)/weave-pricing/page.tsx
@@ -1,0 +1,28 @@
+// /weave-pricing — "weave pricing" SEO page, driven by the
+// competitor-pricing registry (lib/seo/competitor-pricing.ts). Additive: no DB.
+import type { Metadata } from "next";
+import { CompetitorPricingPage } from "@/components/seo/pricing-page";
+import { getCompetitorPricing } from "@/lib/seo/competitor-pricing";
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { buildOgUrl } from "@/lib/seo/og-card";
+
+const SLUG = "weave";
+const p = getCompetitorPricing(SLUG);
+const c = getCompetitor(SLUG);
+const title = `${c.name} Pricing (August 2026) — Plans, Hidden Costs & What You'll Actually Pay`;
+const startsAt = p.plans[0]?.price ?? "quote-gated pricing";
+const description = `${c.name} pricing broken down: plans starting at ${startsAt}, the add-ons that stack on top, and what you'll actually pay. Checked ${p.verified}.`;
+const canonical = `/${SLUG}-pricing`;
+const ogUrl = buildOgUrl({ kind: "tool", name: `${c.name} Pricing (2026)`, hook: "Plans, hidden costs & what you'll actually pay" });
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical, types: { "text/markdown": `${canonical}.md` } },
+  openGraph: { title, description, url: canonical, type: "website", images: [{ url: ogUrl, width: 1200, height: 630 }] },
+  twitter: { card: "summary_large_image", title, description, images: [ogUrl] },
+};
+
+export default function Page() {
+  return <CompetitorPricingPage slug={SLUG} />;
+}

--- a/packages/crm/src/app/alternative-to-birdeye.md/route.ts
+++ b/packages/crm/src/app/alternative-to-birdeye.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-birdeye.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-birdeye.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("birdeye"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-birdeye>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-bland-ai.md/route.ts
+++ b/packages/crm/src/app/alternative-to-bland-ai.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-bland-ai.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-bland-ai.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("bland-ai"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-bland-ai>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-elevenlabs.md/route.ts
+++ b/packages/crm/src/app/alternative-to-elevenlabs.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-elevenlabs.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-elevenlabs.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("elevenlabs"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-elevenlabs>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-ruby-receptionist.md/route.ts
+++ b/packages/crm/src/app/alternative-to-ruby-receptionist.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-ruby-receptionist.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-ruby-receptionist.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("ruby-receptionist"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-ruby-receptionist>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-thryv.md/route.ts
+++ b/packages/crm/src/app/alternative-to-thryv.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-thryv.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-thryv.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("thryv"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-thryv>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-tidio.md/route.ts
+++ b/packages/crm/src/app/alternative-to-tidio.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-tidio.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-tidio.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("tidio"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-tidio>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/alternative-to-weave.md/route.ts
+++ b/packages/crm/src/app/alternative-to-weave.md/route.ts
@@ -1,0 +1,19 @@
+// /alternative-to-weave.md — the agent-legible Markdown twin of the HTML
+// comparison page (static dotted folder; no proxy rewrite needed).
+import { getCompetitor } from "@/lib/seo/alternative-pages";
+import { renderAlternativeMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "alternative_page", mode: "explicit_md", path: "/alternative-to-weave.md" });
+  const md = renderAlternativeMarkdown(getCompetitor("weave"));
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/alternative-to-weave>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/birdeye-pricing.md/route.ts
+++ b/packages/crm/src/app/birdeye-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /birdeye-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/birdeye-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("birdeye");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/birdeye-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/bland-ai-pricing.md/route.ts
+++ b/packages/crm/src/app/bland-ai-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /bland-ai-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/bland-ai-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("bland-ai");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/bland-ai-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/compare/podium-vs-birdeye.md/route.ts
+++ b/packages/crm/src/app/compare/podium-vs-birdeye.md/route.ts
@@ -1,0 +1,19 @@
+// /compare/podium-vs-birdeye.md — Markdown twin of the head-to-head page.
+import { getVsPair } from "@/lib/seo/alternative-pages-extras";
+import { renderVsMarkdown } from "@/lib/seo/alternative-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "compare_page", mode: "explicit_md", path: "/compare/podium-vs-birdeye.md" });
+  const { pair, a, b } = getVsPair("podium-vs-birdeye");
+  const md = renderVsMarkdown(pair, a, b);
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/compare/podium-vs-birdeye>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/elevenlabs-pricing.md/route.ts
+++ b/packages/crm/src/app/elevenlabs-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /elevenlabs-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/elevenlabs-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("elevenlabs");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/elevenlabs-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/ruby-receptionist-pricing.md/route.ts
+++ b/packages/crm/src/app/ruby-receptionist-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /ruby-receptionist-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/ruby-receptionist-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("ruby-receptionist");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/ruby-receptionist-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/thryv-pricing.md/route.ts
+++ b/packages/crm/src/app/thryv-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /thryv-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/thryv-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("thryv");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/thryv-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/tidio-pricing.md/route.ts
+++ b/packages/crm/src/app/tidio-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /tidio-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/tidio-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("tidio");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/tidio-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/app/weave-pricing.md/route.ts
+++ b/packages/crm/src/app/weave-pricing.md/route.ts
@@ -1,0 +1,18 @@
+// /weave-pricing.md — the agent-legible Markdown twin of the HTML
+// pricing page (static dotted folder; no proxy rewrite needed).
+import { renderCompetitorPricingMarkdown } from "@/lib/seo/competitor-pricing-markdown";
+import { logMarkdownFetch } from "@/lib/marketplace/md-analytics";
+
+export const dynamic = "force-dynamic";
+
+export function GET(req: Request): Response {
+  logMarkdownFetch(req, { surface: "pricing_page", mode: "explicit_md", path: "/weave-pricing.md" });
+  const md = renderCompetitorPricingMarkdown("weave");
+  return new Response(md, {
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      Link: '<https://www.seldonframe.com/weave-pricing>; rel="alternate"; type="text/html"',
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/packages/crm/src/components/landing/marketing-footer.tsx
+++ b/packages/crm/src/components/landing/marketing-footer.tsx
@@ -88,6 +88,14 @@ const COLUMNS: readonly Column[] = [
       { label: "Voiceflow Pricing", href: "/voiceflow-pricing" },
       { label: "Durable Pricing", href: "/durable-pricing" },
       { label: "Synthflow Pricing", href: "/synthflow-pricing" },
+      // 2026-08-24 wave — seven new competitor pricing breakdowns.
+      { label: "Bland AI Pricing", href: "/bland-ai-pricing" },
+      { label: "Birdeye Pricing", href: "/birdeye-pricing" },
+      { label: "Weave Pricing", href: "/weave-pricing" },
+      { label: "Ruby Receptionist Pricing", href: "/ruby-receptionist-pricing" },
+      { label: "Thryv Pricing", href: "/thryv-pricing" },
+      { label: "Tidio Pricing", href: "/tidio-pricing" },
+      { label: "ElevenLabs Agents Pricing", href: "/elevenlabs-pricing" },
     ],
   },
   {

--- a/packages/crm/src/components/seo/competitor-crosslinks.tsx
+++ b/packages/crm/src/components/seo/competitor-crosslinks.tsx
@@ -7,7 +7,8 @@
 // surface it's rendering on, links to whichever OTHER surfaces exist for that
 // competitor. `pricing` is the only optional leg: /<slug>-pricing only exists
 // for competitors present in BOTH lib/seo/alternative-pages.ts (COMPETITORS,
-// 26 slugs) AND lib/seo/competitor-pricing.ts (PRICING, 25 slugs) — every
+// 33 slugs as of 2026-08-24) AND lib/seo/competitor-pricing.ts (PRICING,
+// 32 slugs) — every
 // PRICING slug has a matching COMPETITOR, but "claude-projects" has no pricing
 // page (an alternative-to-only comparison, no vendor pricing page to break down).
 

--- a/packages/crm/src/lib/seo/alternative-pages-extras.ts
+++ b/packages/crm/src/lib/seo/alternative-pages-extras.ts
@@ -769,6 +769,199 @@ export const EXTRAS: Record<string, CompetitorExtras> = {
     switchNote:
       "Paste each client's website — SeldonFrame builds what your Project brief described (the Soul is the standing brief; grounded FAQ/services are the tight docs) and auto-tests retrieval on every publish. Keep your personal Projects for your own thinking; move the client-facing work to a system the client can live in.",
   },
+  // 2026-08-24 wave — extras for the seven new competitors. Same honesty rule
+  // as the rows above: a figure the vendor doesn't publish is labelled
+  // "reported", and where third-party sources disagree on a band we state the
+  // shape of the fee rather than a precise number.
+  "bland-ai": {
+    pros: [
+      "One all-in per-minute rate covering the model, transcription and voice, with no token pass-through",
+      "A genuinely free Start tier at a $0 platform fee, with no card required",
+      "Published concurrency, calls-per-day and knowledge-base limits at every tier",
+      "Enterprise options for on-prem/VPC, BAA, SSO and data residency",
+    ],
+    cons: [
+      "The $299 and $499 platform fees buy a lower rate, not minutes — you pay them before the first minute",
+      "Transfer time is a second meter at $0.05/$0.04/$0.03 a minute unless you bring your own Twilio",
+      "Failed and very short calls still bill at $0.015 each",
+      "Voice and knowledge-base caps (1/5/15 and 10/50/100) make outgrowing a tier a $299 or $499 step",
+    ],
+    chooseThem: [
+      "You're an engineering team building a custom voice product",
+      "You want one per-minute number with no model-provider reconciliation",
+      "Your CRM, calendar and client dashboard already exist somewhere else",
+    ],
+    chooseSf: [
+      "You want the CRM, website and booking calendar the agent books into",
+      "You'd rather pay the providers directly than a platform fee plus a per-minute cut",
+      "You need a whitelabel client layer, which Bland doesn't publish",
+      "You want a new client live in about 3 minutes instead of an integration project",
+    ],
+    switchNote:
+      "Your Bland agent's system prompt and knowledge base drop straight into the SeldonFrame agent's skill and knowledge. Re-point your Twilio number when you're ready to move call handling over.",
+  },
+  birdeye: {
+    pros: [
+      "One of the strongest review-generation and reputation products in the category",
+      "A mature multi-location portal with per-location rollups",
+      "One platform and one contract instead of stitching together point products",
+      "Established brand trust with multi-location businesses",
+    ],
+    cons: [
+      "No published price anywhere — the pricing page is a lead form and even Birdeye's own cost blog names no number",
+      "Priced per location by the vendor's own banding, so add-on modules multiply across your storefronts",
+      "Reviewers report a roughly 8% renewal 'Innovation Fee' and setup fees of $500–$2,000",
+      "Reviewers report a 12-month contract with 90-day cancellation notice and remaining-balance early termination",
+    ],
+    chooseThem: [
+      "Review volume across many locations is your growth engine",
+      "Centralised messaging across storefronts is the daily workflow",
+      "You have the procurement process to run a quoted annual contract",
+    ],
+    chooseSf: [
+      "You want a public, flat price you can read before any sales call",
+      "You don't want every add-on multiplied by your location count",
+      "You need the phone answered and the job booked, not just reviews collected",
+      "You want month-to-month with no 90-day cancellation window",
+    ],
+    switchNote:
+      "Export your Birdeye contacts and import them. Your review-request flow recreates as SeldonFrame's built-in review agent, firing after each completed booking.",
+  },
+  weave: {
+    pros: [
+      "Phones, texting, reviews and clinical forms in one system tuned to dental and optometry",
+      "Weave does publish a floor ($199/mo), which most of this category refuses to do",
+      "Expert onboarding and support are advertised as included on every plan",
+      "A mature product with deep practice-management integrations",
+    ],
+    cons: [
+      "All three tiers are quote-gated — the $199 floor is the only published number",
+      "Third parties report the real entry tier at $249–$250/mo per location, above Weave's own advertised floor",
+      "Onboarding is advertised as included, yet three independent third parties report a separate one-time setup fee",
+      "Reviewers report $200 to migrate existing digital forms plus $20 per upload, and 15–25% renewal increases",
+    ],
+    chooseThem: [
+      "You run a dental or optometry practice and want workflow-specific tooling",
+      "Phones and patient texting from one vendor matters more than price transparency",
+      "Your practice-management software is on Weave's integration list",
+    ],
+    chooseSf: [
+      "You want every tier priced on the page, not behind a Get Pricing button",
+      "You don't want a setup fee that isn't disclosed until the contract",
+      "You need an AI receptionist that books into a calendar you own",
+      "You're an agency — Weave has no published whitelabel layer",
+    ],
+    switchNote:
+      "Paste your practice website into SeldonFrame and the workspace rebuilds from it in about 3 minutes, intake forms included. Re-point your number once the agent is answering the way you want.",
+  },
+  "ruby-receptionist": {
+    pros: [
+      "Trained human receptionists handle messy, sensitive intake better than any AI does today",
+      "Plan prices are published openly, unlike most of this category",
+      "A strong reputation with law firms and professional services",
+      "The page states optional AI enhancements are included at no extra cost",
+    ],
+    cons: [
+      "Plan price divided by included minutes works out to $5.00 a minute at the bottom tier and $3.45 at the top",
+      "The per-minute overage rate isn't published on the pricing page, the plans page or the FAQ",
+      "Live chat is a separate $143–$520/mo subscription — receptionist minutes don't cover it",
+      "No CRM, website or booking calendar of its own, and nothing to whitelabel",
+    ],
+    chooseThem: [
+      "Your intake is high-stakes enough to need a trained human on every call",
+      "Call volume is low enough that per-minute pricing works out",
+      "You want to outsource the function rather than own a system",
+    ],
+    chooseSf: [
+      "You want every call answered instantly, 24/7, for a flat fee",
+      "You want minutes at carrier cost on your own Twilio, not $3.45–$5.00 a minute",
+      "You want calls to end in a booked job inside a CRM you own",
+      "You're an agency — you can resell SeldonFrame, you can't resell Ruby",
+    ],
+    switchNote:
+      "Run SeldonFrame as the first line (instant answer plus booking) and keep a human service for escalations if your intake needs it. The agent takes a structured message and notifies you instantly either way.",
+  },
+  thryv: {
+    pros: [
+      "Listings syndication to 60+ directories, an AI website builder and review management in one $99 plan",
+      "Two real published prices ($99 and $399), which more than half this category won't give you",
+      "24/7 support included at both published tiers",
+      "One vendor and one bill for a solo operator's whole web presence",
+    ],
+    cons: [
+      "Amplify, Boosts, extra seats and usage all have no published figure",
+      "The page never states what a user beyond the included 1 or 5 costs",
+      "Third parties report a $250 one-time onboarding fee and a $9 monthly support fee on every package",
+      "The annual/monthly toggle never says which basis the displayed $99 and $399 use",
+    ],
+    chooseThem: [
+      "Listings syndication and a business web presence are the main job",
+      "You want one vendor for website, reviews and directories",
+      "$99/mo for a single user fits how you actually work",
+    ],
+    chooseSf: [
+      "You want the AI receptionist as the core product, not an unpriced Boost",
+      "You want every tier priced on the page with no onboarding fee",
+      "You don't want to pay per seat as your team grows",
+      "You want SMS and voice at carrier cost on your own Twilio account",
+    ],
+    switchNote:
+      "Export your Thryv contacts to CSV and import them. Paste your Thryv-built site's URL and SeldonFrame rebuilds the workspace from its content, then move the domain over once it looks right.",
+  },
+  tidio: {
+    pros: [
+      "A real free tier and a genuinely cheap $24.17/mo Starter plan",
+      "Live chat, ticketing and an AI agent in one product",
+      "The Premium tier's guaranteed 50% Lyro resolution rate with pay-per-resolution billing is an honest way to sell AI",
+      "Entry pricing is published openly rather than quote-gated",
+    ],
+    cons: [
+      "Three separate meters — billable conversations, Lyro AI conversations and Flows visitors — and the plan price covers one",
+      "The 50 Lyro conversations on Free and Starter are one-off, not a monthly allowance",
+      "Growth at about $49/mo steps to Plus at $300/mo plus usage, roughly a six-fold cliff",
+      "Chat only — no phone answering, no SMS receptionist, no CRM or booking calendar",
+    ],
+    chooseThem: [
+      "You run an online store where chat deflection is the goal",
+      "Your conversation volume is predictable enough to plan around three meters",
+      "The Lyro resolution guarantee at the top tier is worth the price to you",
+    ],
+    chooseSf: [
+      "Your clients lose money on unanswered phones, not unanswered chats",
+      "You want one AI brain across voice, SMS and web chat",
+      "You want the bot to book into a real calendar and write to a real CRM",
+      "You don't want three meters to run out of",
+    ],
+    switchNote:
+      "Point SeldonFrame at the same website you trained Tidio on. The agent grounds itself on the same content, and the site, CRM and booking calendar build alongside it.",
+  },
+  elevenlabs: {
+    pros: [
+      "The best voice quality in the category, and a real free tier at 15 agent minutes",
+      "The pricing page says plainly that the LLM and telephony bill separately on top — plenty of rivals bury that",
+      "Published per-minute, burst and text-message rates you can check yourself",
+      "Concurrency limits are stated per tier rather than negotiated",
+    ],
+    cons: [
+      "The all-in cost of a call isn't determinable — no LLM or telephony rate is published anywhere",
+      "Bundled minutes carry no volume discount: every paid tier divides out to exactly $0.080/min, the same as overage",
+      "Burst pricing doubles the rate to $0.160/min the moment you exceed concurrency",
+      "No CRM, website, booking calendar or whitelabel layer",
+    ],
+    chooseThem: [
+      "Voice fidelity is the differentiator in what you're building",
+      "You already own the model, telephony and business system around the agent",
+      "You want a published per-minute rate you can verify without a sales call",
+    ],
+    chooseSf: [
+      "You want an all-in cost you can actually calculate before you quote a client",
+      "You want the CRM, website and booking calendar the agent books into",
+      "You don't want a burst rate that doubles at your busiest hour",
+      "You need a whitelabel client layer, which ElevenLabs doesn't publish",
+    ],
+    switchNote:
+      "Your agent's prompt and knowledge base carry across into the SeldonFrame agent's skill and knowledge. Bring your own AI key and Twilio number so the model and telephony bills land in accounts you control.",
+  },
 };
 
 export function getExtras(slug: string): CompetitorExtras {
@@ -817,6 +1010,10 @@ export const VS_PAIRS: VsPair[] = [
   { a: "hubspot", b: "clickfunnels", angle: "Enterprise CRM vs solo-operator funnel builder — completely different budgets and audiences, but neither ships a native phone or SMS receptionist." },
   { a: "klaviyo", b: "hubspot", angle: "Ecommerce email/SMS specialist vs general-purpose enterprise CRM — Klaviyo assumes a Shopify cart, HubSpot assumes a sales team; neither answers a phone." },
   { a: "kartra", b: "gohighlevel", angle: "Creator all-in-one vs agency toolbox — Kartra sells courses and memberships, GoHighLevel sells to agencies serving local businesses; neither has a native AI receptionist in the base plan." },
+  // 2026-08-24 — the two quote-gated local-business reputation platforms.
+  // Added to KEPT_VS_SLUGS below because it's a live head-to-head query, not a
+  // folded pair: both vendors refuse to publish a price, which is the story.
+  { a: "podium", b: "birdeye", angle: "The two quote-gated reputation platforms for local business: Podium's pricing page has no numbers and Birdeye's is a lead form — and Birdeye's own form bands you by location count, so both bills scale with how many places you operate." },
 ];
 
 export function vsSlug(pair: VsPair): string {
@@ -844,6 +1041,9 @@ export const KEPT_VS_SLUGS: string[] = [
   "keap-vs-activecampaign",
   "klaviyo-vs-hubspot",
   "vapi-vs-retell-ai",
+  // 2026-08-24 — new pair, kept from the start rather than folded: it's a
+  // fresh page with no 0-click history to consolidate away.
+  "podium-vs-birdeye",
 ];
 
 /** Whether a third-party `/compare/<a>-vs-<b>` pair keeps its standalone page. */

--- a/packages/crm/src/lib/seo/alternative-pages.ts
+++ b/packages/crm/src/lib/seo/alternative-pages.ts
@@ -1632,6 +1632,389 @@ export const COMPETITORS: Competitor[] = [
       },
     ],
   },
+  // 2026-08-24 wave — seven new competitors. Every price below was fetched
+  // from the vendor's own live pricing page on 2026-08-24; anything a vendor
+  // does not publish is carried as "reported" with the reporter named. See the
+  // appended 2026-08-24 section of
+  // docs/superpowers/specs/2026-07-08-competitor-pricing-facts.md.
+  {
+    slug: "bland-ai",
+    name: "Bland AI",
+    category: "voice AI API",
+    audience: "solo",
+    pricingSourceUrl: "https://www.bland.ai/pricing",
+    oneLiner:
+      "Bland AI is a developer-first platform for building AI phone agents, priced as a monthly platform fee plus an all-in per-minute rate.",
+    heroSub:
+      "Bland's per-minute rate really is all-in, but the platform fee sits underneath it and the agent still has nowhere to put the job. SeldonFrame ships the receptionist plus the website, CRM and booking calendar it books into. Builder is $29/mo for one business you operate; Agency plans start at $99/mo for client delivery.",
+    intro: [
+      "Most people looking for a Bland AI alternative hit the same wall: the platform fee is not a minute allowance. Build is $299 a month and Scale is $499 a month before your first minute, and talk time then meters on top at $0.12 or $0.11. Transferring a call to a human opens a second meter. Failed calls still bill at $0.015 each. Voices and knowledge bases are hard-capped per tier, so outgrowing a cap is a whole tier step rather than a small add-on. And after all of that you still have no CRM, no calendar and no client dashboard.",
+      "That said, Bland deserves credit on the thing most voice platforms fudge. Its page says \"No token charges. No model-provider pass-throughs.\" and the per-minute rate genuinely covers the model, transcription and voice in one number, which is more honest than the itemised stacks several rivals publish. If you're an engineering team building a custom voice product, that clarity is worth a lot. But an agency putting receptionists in front of local businesses needs the whole front office, not a clean per-minute rate.",
+    ],
+    them: {
+      bestFor: "Engineering teams building custom AI phone agents",
+      pricingModel: "$0/$299/$499 per month platform fee + $0.14/$0.12/$0.11 per minute talk time, with transfer time metered separately",
+      aiReceptionist: "Voice agents only — you design, wire and maintain them yourself",
+      frontOffice: "None — no CRM, website or booking calendar behind the agent",
+      whitelabel: "None — no agency dashboard or client workspaces published",
+      aiCosts: "Folded into the per-minute rate (no token pass-through), but the platform fee is charged on top of it",
+      resale: "No published reseller program",
+    },
+    switchReasons: [
+      {
+        title: "The platform fee isn't minutes",
+        body: "Build and Scale cost $299 or $499 a month before a single minute is spoken, and talk time meters on top. SeldonFrame takes no per-minute cut at all: usage runs on your own AI and Twilio keys at raw provider cost.",
+      },
+      {
+        title: "Transfers open a second meter",
+        body: "Handing a call to a human bills again at $0.05, $0.04 or $0.03 a minute unless you bring your own Twilio, and bridging your own Twilio in carries a $0.004 per minute SIP termination fee. On SeldonFrame the call path is yours end to end.",
+      },
+      {
+        title: "A voice agent isn't a front office",
+        body: "After the Bland agent takes the call, the CRM record, the calendar slot and the client's website are still your problem. SeldonFrame's receptionist books straight into the workspace's own calendar and CRM.",
+      },
+      {
+        title: "Nothing to hand your clients",
+        body: "Bland publishes no whitelabel layer or client workspaces. SeldonFrame gives every client a branded portal your agency runs, from $99/mo.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Bland if you're an engineering team building a custom voice product and you want one all-in per-minute rate with no model pass-through to reconcile.",
+    faq: [
+      {
+        q: "Does SeldonFrame charge a platform fee and a per-minute rate like Bland?",
+        a: "No. Calls run through your own Twilio number at carrier rates and your own AI key at provider cost, so there's no per-minute platform cut and no separate transfer meter. Builder is $29/mo for one business you operate; Agency plans start at $99/mo for client delivery.",
+      },
+      {
+        q: "Can I whitelabel it for my clients?",
+        a: "Yes, on the agency plan (from $99/mo). Per-client workspaces, a branded portal and custom domains are included, and an agent template deploys to every client in one click.",
+      },
+    ],
+  },
+  {
+    slug: "birdeye",
+    name: "Birdeye",
+    category: "reputation & messaging platform",
+    audience: "solo",
+    pricingSourceUrl: "https://birdeye.com/pricing/",
+    oneLiner:
+      "Birdeye is a reviews, messaging and reputation platform for local and multi-location businesses, sold entirely through a sales quote.",
+    heroSub:
+      "Birdeye won't tell you the price, and everything it sells is banded by location count. SeldonFrame's pricing is public and flat, and you can build the whole workspace free before you talk to anyone.",
+    intro: [
+      "Most people looking for a Birdeye alternative hit the same wall: there is no price to look at. The pricing page is a form behind a GET PRICING button, and even Birdeye's own blog post about what Birdeye costs names no number. What the page does reveal is the shape: you pick a location band, from 1 to 3 up to 1000 or more, so pricing is per location by the vendor's own admission and anything you add multiplies across your locations. Reviewers report an entry tier around $299 to $349 a month per location, a roughly 8% renewal fee, setup fees of $500 to $2,000 and a 12-month contract needing 90 days of written cancellation notice, but every one of those figures is reported by third parties rather than published by Birdeye.",
+      "That said, Birdeye is a serious product. It's one of the strongest review-generation and multi-location messaging platforms in the category, the location portal is mature, and a brand running dozens of storefronts on review volume gets real value from it. But a local service business that needs its phone answered and its jobs booked shouldn't have to sit through a discovery call to find out what the software costs.",
+    ],
+    them: {
+      bestFor: "Multi-location brands running on review volume and centralised messaging",
+      pricingModel: "Quote-only — no dollar figure published anywhere; the form bands buyers into 1-3, 4-9, 10-39, 40-249, 250-999 and 1000+ locations",
+      aiReceptionist: "Not verifiable from the pricing page — Birdeye publishes no per-tier feature list or price",
+      frontOffice: "Reviews, messaging and listings; the pricing page publishes no feature matrix to check what a tier includes",
+      whitelabel: "Not published — sold direct to businesses through a quote",
+      aiCosts: "Not disclosed; nothing on the pricing page itemises AI or messaging usage",
+      resale: "Not published",
+    },
+    switchReasons: [
+      {
+        title: "A public price beats a discovery call",
+        body: "Birdeye's pricing page is a lead form, and its own cost explainer names no number either. SeldonFrame's prices are on the page, flat, and cancel-anytime.",
+      },
+      {
+        title: "Per-location pricing multiplies everything",
+        body: "Birdeye's own form bands you by location count, and reviewers report add-on modules priced per location too. SeldonFrame's plan doesn't multiply by how many places you operate.",
+      },
+      {
+        title: "No 12-month contract",
+        body: "Reviewers describe a 12-month contract billed monthly, 90 days of written cancellation notice and early termination charged at the remaining balance. SeldonFrame is month-to-month, and the free build-first flow is the trial.",
+      },
+      {
+        title: "Reviews are included, not the whole product",
+        body: "SeldonFrame's review-request agent fires automatically once a job is completed, over the same SMS and email rails as the receptionist that booked it.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Birdeye if you're a multi-location brand whose growth engine is review volume and centralised messaging at scale, and you have the procurement patience for a quoted contract.",
+    faq: [
+      {
+        q: "How much does Birdeye cost?",
+        a: "Birdeye publishes no price. Its pricing page is a lead form and its own blog post on the subject names no figure either. Third-party reviewers report roughly $299 to $349 a month per location for an entry tier, but one of those authors is explicit that the number came from a pricing-form screenshot and past-client feedback rather than any Birdeye document.",
+      },
+      {
+        q: "Can I try SeldonFrame without talking to sales?",
+        a: "Yes. Paste in your website and SeldonFrame builds the workspace free in about 3 minutes, before you ever create an account.",
+      },
+    ],
+  },
+  {
+    slug: "weave",
+    name: "Weave",
+    category: "practice communications platform",
+    audience: "solo",
+    pricingSourceUrl: "https://www.getweave.com/pricing/",
+    oneLiner:
+      "Weave is a phones, messaging, reviews and digital-forms platform built for dental, optometry and other small healthcare practices.",
+    heroSub:
+      "Weave advertises one number and quotes the rest. SeldonFrame's price is public at every tier, and the AI receptionist, website, CRM and booking calendar all live in the same workspace.",
+    intro: [
+      "Most people looking for a Weave alternative hit the same wall: only one number is public. The pricing page says plans start from $199 a month, then puts a Get Pricing button on Pro, Elite and Ultimate alike. Third parties consistently report the real entry tier higher, at $249 to $250 a month per location, and customer-reported spend at $300 to $500 a month for a small practice. Reviewers also report digital-forms migration at $200 up front and $20 per upload after that, a Power Pack analytics add-on at $25 per user per month, and renewal increases of 15 to 25%.",
+      "That said, Weave is a genuinely good fit for the practices it serves. Phones, texting, reviews and clinical forms in one system tuned to dental and optometry workflows is a real product, and practices like it. The honest criticism isn't the price, it's the disclosure: Weave lists expert onboarding as included with every plan while three independent third parties report a separate one-time setup fee, and no tier price, contract term or hardware cost appears anywhere on the page.",
+    ],
+    them: {
+      bestFor: "Dental, optometry and small healthcare practices wanting phones plus messaging in one system",
+      pricingModel: "Advertised from $199/mo; all three tiers are quote-gated, and third parties report the real entry tier at $249-$250/mo per location",
+      aiReceptionist: "Not verifiable from the pricing page — Weave publishes no per-tier feature pricing",
+      frontOffice: "Practice phones, messaging, reviews and digital forms; no website builder or agent-driven booking is published on the pricing page",
+      whitelabel: "Not published",
+      aiCosts: "Not disclosed on the pricing page",
+      resale: "Not published",
+    },
+    switchReasons: [
+      {
+        title: "One published number isn't pricing",
+        body: "Weave advertises from $199 a month and then quotes all three tiers. SeldonFrame's plan prices are on the page and don't change after a call.",
+      },
+      {
+        title: "Onboarding: included, or a fee?",
+        body: "Weave lists expert onboarding as included on every plan, while three independent third parties report a separate one-time setup fee anyway. SeldonFrame charges no setup fee, and the workspace builds itself from your website in about 3 minutes.",
+      },
+      {
+        title: "No per-item drip fees",
+        body: "Reviewers report $200 to migrate your existing digital forms and $20 for each upload after that, plus $25 per user per month for the analytics add-on. SeldonFrame's intake forms are part of the workspace.",
+      },
+      {
+        title: "Renewal shouldn't be a surprise",
+        body: "Customers report renewal increases of 15 to 25%. SeldonFrame is month-to-month at a published price, cancel anytime.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Weave if you run a dental or optometry practice and want phones, texting, reviews and clinical forms tuned to that exact workflow from one vendor.",
+    faq: [
+      {
+        q: "How much does Weave actually cost?",
+        a: "Weave publishes exactly one figure: plans start from $199 a month. Every tier carries a Get Pricing button instead of a price. Third parties report the real entry tier at $249 to $250 a month per location and customer-reported spend at $300 to $500 a month for a small practice, but none of that comes from Weave.",
+      },
+      {
+        q: "Does SeldonFrame charge a setup fee?",
+        a: "No. Paste in your website and the workspace builds free in about 3 minutes, before you create an account. There's no onboarding fee and no forms-migration charge.",
+      },
+    ],
+  },
+  {
+    slug: "ruby-receptionist",
+    name: "Ruby Receptionist",
+    category: "virtual receptionist service",
+    audience: "solo",
+    pricingSourceUrl: "https://www.ruby.com/pricing/",
+    oneLiner:
+      "Ruby is a live virtual-receptionist service. Trained humans answer your calls, billed by the minute against a monthly plan.",
+    heroSub:
+      "Ruby's cheapest plan works out to $5.00 a minute, and the overage rate isn't published anywhere. SeldonFrame answers every call for a flat monthly fee, with minutes at carrier cost on your own Twilio number.",
+    intro: [
+      "Most people looking for a Ruby alternative hit the same wall: the arithmetic. Plans run $250, $395, $720 and $1,725 a month for 50, 100, 200 and 500 receptionist minutes, which works out to $5.00, $3.95, $3.60 and $3.45 a minute. Live chat is a separate subscription on top at $143, $335 or $520 a month. And the one number that decides a busy month, the per-minute overage rate, doesn't appear on Ruby's pricing page, its plans page or its FAQ, even though the pricing page says there are no additional or hidden fees.",
+      "That said, Ruby is genuinely good at what it does. Real trained receptionists handle messy, sensitive calls in a way no AI matches yet, its reputation with law firms and professional services is well earned, and the plan prices themselves are published openly, which more than half this category can't claim. If your intake is high-stakes and low-volume, a human service can be exactly right. But if the job is answering every call, qualifying the lead and booking it, $3.45 to $5.00 a minute is a lot of money for a receptionist that stops when the minutes run out.",
+    ],
+    them: {
+      bestFor: "Firms wanting trained humans on high-stakes, low-volume intake",
+      pricingModel: "$250-$1,725/mo for 50-500 receptionist minutes ($5.00 down to $3.45 a minute); live chat is a separate $143-$520/mo subscription; the overage rate is not published",
+      aiReceptionist: "Human receptionists rather than an AI agent; the page says optional AI enhancements are included at no extra cost",
+      frontOffice: "None — no CRM, website or booking calendar of its own",
+      whitelabel: "No — a service, not a platform you can resell",
+      aiCosts: "Not applicable — you're buying human minutes",
+      resale: "No",
+    },
+    switchReasons: [
+      {
+        title: "Minutes at carrier cost, not $3.45 to $5.00",
+        body: "Ruby's own plan prices divided by their own included minutes give $5.00 a minute at the bottom tier and $3.45 at the top. SeldonFrame's calls run through your own Twilio number at carrier rates, under a flat platform fee.",
+      },
+      {
+        title: "No unpublished overage rate",
+        body: "Ruby's pricing page, plans page and FAQ all publish no per-minute charge for going past your included minutes. On SeldonFrame there's no minute allowance to exceed in the first place.",
+      },
+      {
+        title: "Chat is included, not a second subscription",
+        body: "Ruby sells live chat as its own plan at $143 to $520 a month. SeldonFrame's agent handles voice, SMS and web chat on the same brain, with missed-call text-back included.",
+      },
+      {
+        title: "The call ends in a booked job",
+        body: "Ruby takes a message and passes it on. SeldonFrame's receptionist checks real availability, books into the workspace calendar and logs the lead in the CRM.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Ruby if your intake is genuinely high-stakes and your volume is low enough that a trained human on every call is worth $3.45 to $5.00 a minute.",
+    faq: [
+      {
+        q: "How much does Ruby cost per minute?",
+        a: "Ruby publishes plan prices rather than per-minute rates, but the division is straightforward: $250 for 50 minutes is $5.00 a minute, $395 for 100 is $3.95, $720 for 200 is $3.60 and $1,725 for 500 is $3.45. The rate for going past your included minutes isn't published on any Ruby page I checked.",
+      },
+      {
+        q: "Does SeldonFrame use real people like Ruby?",
+        a: "No. SeldonFrame's receptionist is an AI agent with a deterministic tool bridge for the parts that must never be improvised — checking availability, booking, taking messages. When a call needs a person, it takes a structured message and notifies you instantly.",
+      },
+    ],
+  },
+  {
+    slug: "thryv",
+    name: "Thryv",
+    category: "small-business software suite",
+    audience: "solo",
+    pricingSourceUrl: "https://www.thryv.com/pricing/",
+    oneLiner:
+      "Thryv is an all-in-one small-business platform covering listings, websites, reviews, messaging and a light CRM.",
+    heroSub:
+      "Thryv publishes two prices and gates the rest. SeldonFrame's price is public at every tier, and the AI receptionist is the product rather than an unpriced Boost you have to ask about.",
+    intro: [
+      "Most people looking for a Thryv alternative hit the same wall: the published price isn't the whole price. Starter is $99 a month with 1 user and Signature is $399 a month with 5, and the page never says what a sixth user costs. Amplify has no price at all. Thryv Boosts, the done-for-you marketing services, carry no figure anywhere on the page. Third parties report a $250 one-time onboarding fee and a $9 monthly support fee on every package, plus Command Center seats at roughly $20 to $30 each and usage at $0.015 a text and $0.01 a voice minute, none of which Thryv publishes.",
+      "That said, Thryv covers a lot of ground for a small business. Listings syndication to 60-plus directories, an AI website builder, review management and trackable phone numbers inside one $99 plan is real value for a solo operator who wants a single vendor and a single bill. But if what you need is an AI that answers the phone and books the job, that shouldn't arrive as an unpriced Boost you have to book a demo to hear about.",
+    ],
+    them: {
+      bestFor: "Solo operators and small teams wanting listings, a website and reviews from one vendor",
+      pricingModel: "$99/mo (1 user) and $399/mo (5 users) published; Amplify, Boosts, extra seats and usage are all quote-gated",
+      aiReceptionist: "AI features across the website builder and review management; no flat-priced phone receptionist appears on the pricing page",
+      frontOffice: "Listings, AI website builder, reviews, trackable numbers and a light CRM",
+      whitelabel: "Not published",
+      aiCosts: "Not itemised on the pricing page",
+      resale: "Not published",
+    },
+    switchReasons: [
+      {
+        title: "Two published prices isn't a price list",
+        body: "Amplify is a demo call, Boosts carry no figure anywhere, and nothing on the page says what a sixth user costs. Every SeldonFrame tier is priced in the open.",
+      },
+      {
+        title: "No onboarding fee to discover later",
+        body: "Third parties report a $250 one-time onboarding fee and a $9 monthly support fee on every Thryv package. SeldonFrame charges neither, and the workspace builds free before you sign up.",
+      },
+      {
+        title: "The receptionist is the product",
+        body: "SeldonFrame's AI answers calls, SMS and web chat, qualifies the lead and books the job into a real calendar. It isn't a marketing service you buy separately.",
+      },
+      {
+        title: "Bring your own key, pay provider cost",
+        body: "Reviewers report Thryv metering SMS at $0.015 and voice at $0.01 a minute. On SeldonFrame those run through your own Twilio account at carrier rates, with no platform markup.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Thryv if you want listings syndication, a website, reviews and a light CRM from one vendor on one bill, and $99 a month for a single user fits how you work.",
+    faq: [
+      {
+        q: "How much does Thryv really cost?",
+        a: "Thryv publishes $99 a month for Starter (1 user) and $399 a month for Signature (5 users). Amplify, the Boosts add-ons, extra seats and usage all have no published figure. Third parties report a $250 one-time onboarding fee and a $9 monthly support fee on top, but Thryv doesn't publish either.",
+      },
+      {
+        q: "Does SeldonFrame charge per user?",
+        a: "No. The plan price covers the workspace, not a seat count, so adding people to your team doesn't change the bill.",
+      },
+    ],
+  },
+  {
+    slug: "tidio",
+    name: "Tidio",
+    category: "customer service chat platform",
+    audience: "solo",
+    pricingSourceUrl: "https://www.tidio.com/pricing/",
+    oneLiner:
+      "Tidio is a live-chat and AI-agent platform for online stores and support teams, metered across conversations, AI conversations and automation visitors.",
+    heroSub:
+      "Tidio's plan price covers one of three meters. SeldonFrame's agent answers calls, SMS and web chat on one brain, with AI usage on your own key at raw provider cost.",
+    intro: [
+      "Most people looking for a Tidio alternative hit the same wall: three meters, one price. The plan covers billable conversations. Lyro AI conversations are counted separately and sold as an add-on from $32.50 a month for 50, which works out to $0.65 an AI conversation. Flows visitors reached are a third meter, from $24.17 a month for 2,000. The 50 free Lyro conversations on Free and Starter are labelled one-off rather than monthly. And the step from Growth at about $49 a month to Plus at $300 a month plus usage is roughly six-fold, with Premium carrying no published price at all.",
+      "That said, Tidio is a well-built product. Live chat, ticketing and an AI agent in one place with a real free tier and a genuinely cheap Starter plan is a good deal for a small store. Its Premium tier's guaranteed 50% Lyro resolution rate with pay-per-resolution billing is also a more honest way to sell AI than most of the category manages. But a local service business doesn't lose money on unanswered chats. It loses it on unanswered phones.",
+    ],
+    them: {
+      bestFor: "Online stores and support teams deflecting chat volume",
+      pricingModel: "Free, $24.17/mo Starter, from $49.17/mo Growth, from $300/mo plus usage on Plus, Premium quote-only; Lyro AI and Flows are separately metered add-ons",
+      aiReceptionist: "Chat only — no phone answering and no SMS receptionist",
+      frontOffice: "None — no CRM, website builder or booking calendar",
+      whitelabel: "No agency or whitelabel program published",
+      aiCosts: "Lyro AI conversations metered separately from plan conversations, sold in bundles from $32.50/mo",
+      resale: "No agency reseller program published",
+    },
+    switchReasons: [
+      {
+        title: "One meter, not three",
+        body: "Tidio counts billable conversations, Lyro AI conversations and Flows visitors separately, and running out of any one forces an upgrade or a paid add-on. SeldonFrame runs on your own AI key at provider cost, so there's no platform meter to exhaust.",
+      },
+      {
+        title: "Calls are where the money is",
+        body: "Tidio can't answer the phone. SeldonFrame's receptionist handles voice, SMS and web chat with the same brain, and missed-call text-back turns a missed ring into a booked job.",
+      },
+      {
+        title: "No six-fold plan cliff",
+        body: "Growth starts at about $49 a month and the next tier up starts at $300 plus usage. SeldonFrame's tiers step in flat, published increments with no usage billing on top.",
+      },
+      {
+        title: "The bot can actually book",
+        body: "SeldonFrame's agent reads real availability from the workspace calendar, books into it and logs the lead in the CRM. That's the whole point of it, not a custom action you build yourself.",
+      },
+    ],
+    whenTheyWin:
+      "Choose Tidio if you're running an online store where chat deflection is the goal, volume is predictable, and the Lyro resolution guarantee at the top tier is worth the price.",
+    faq: [
+      {
+        q: "How much does Tidio cost with the AI agent?",
+        a: "The plan price covers live-chat conversations only. Lyro AI is a separate add-on from $32.50 a month for 50 AI conversations, which works out to $0.65 each, and the 50 Lyro conversations included on Free and Starter are one-off rather than monthly. Flows visitors are a third meter from $24.17 a month for 2,000.",
+      },
+      {
+        q: "Is there a message limit on SeldonFrame?",
+        a: "SeldonFrame doesn't sell message credits. Conversations run on your own AI key at provider cost, so there's no platform allowance to outgrow.",
+      },
+    ],
+  },
+  {
+    slug: "elevenlabs",
+    name: "ElevenLabs Agents",
+    category: "voice AI platform",
+    audience: "solo",
+    pricingSourceUrl: "https://elevenlabs.io/pricing/agents",
+    oneLiner:
+      "ElevenLabs Agents is the conversational-agent product built on ElevenLabs' voice models, priced by agent minutes with the model and telephony billed on top.",
+    heroSub:
+      "The $0.08 a minute headline is a floor, not a total: ElevenLabs bills the model and the phone line separately on top and publishes no rate for either. SeldonFrame runs AI and telephony on your own keys at raw provider cost, with the front office included.",
+    intro: [
+      "Most people looking for an ElevenLabs Agents alternative hit the same wall: the headline rate isn't the bill. ElevenLabs states that the LLM model and any telephony are billed separately on top based on usage, and publishes no rate for either, so the all-in cost of a call can't be worked out from the pricing page. The bundled minutes carry no volume discount either: divide any paid tier by its included minutes and you land on exactly $0.080, the same as the published overage rate. And going past your concurrency limit doesn't block the call, it doubles the rate to $0.160 a minute, which happens precisely when volume spikes.",
+      "That said, ElevenLabs is exceptional at the thing it's famous for. The voices are the best in the category, the free tier is real, and the pricing page is unusually straight about the fact that the model and telephony bill on top, which plenty of rivals bury. If you're building a voice product and voice quality is the product, it's a strong choice. But an agency putting receptionists in front of local businesses needs the CRM, the calendar and the client portal too.",
+    ],
+    them: {
+      bestFor: "Teams building voice agents where voice quality is the product",
+      pricingModel: "$0-$990/mo for 15-12,375 agent minutes (exactly $0.080/min at every paid tier), $0.080/min overage, $0.160/min burst; LLM and telephony billed separately on top with no published rate",
+      aiReceptionist: "Voice agents you design, wire and maintain yourself",
+      frontOffice: "None — no CRM, website or booking calendar",
+      whitelabel: "None — no agency dashboard or client workspaces published",
+      aiCosts: "The LLM is billed separately on top, based on usage, with no published rate",
+      resale: "No published reseller program",
+    },
+    switchReasons: [
+      {
+        title: "The headline rate isn't the bill",
+        body: "ElevenLabs bills the model and telephony separately on top of $0.08 a minute and publishes no rate for either. On SeldonFrame you hold both accounts yourself, so you can see and cap every dollar.",
+      },
+      {
+        title: "Prepaid minutes at list price",
+        body: "Every paid ElevenLabs tier divides out to exactly $0.080 a minute, identical to the overage rate, so upgrading buys concurrency headroom rather than a cheaper minute. SeldonFrame's platform fee is flat and doesn't meter minutes at all.",
+      },
+      {
+        title: "Spikes shouldn't cost double",
+        body: "Exceeding your concurrency limit bills at $0.160 a minute, twice the standard rate, at exactly the moment the phone is busiest. SeldonFrame's concurrency is whatever your own Twilio account supports.",
+      },
+      {
+        title: "A voice agent isn't a front office",
+        body: "After the agent takes the call, the CRM record, the calendar slot and the client's website are still your problem. SeldonFrame includes all three in every workspace, and the agent books real jobs into them.",
+      },
+    ],
+    whenTheyWin:
+      "Choose ElevenLabs Agents if voice quality is the differentiator in what you're building and you already have the model, telephony and business system sorted out around it.",
+    faq: [
+      {
+        q: "Is SeldonFrame's voice quality comparable to ElevenLabs?",
+        a: "SeldonFrame's receptionist runs on modern realtime voice models with a deterministic tool bridge for the parts that must never be improvised — checking availability, booking, taking messages. ElevenLabs is still the benchmark for raw voice fidelity; SeldonFrame optimises for a call that ends in a booked job.",
+      },
+      {
+        q: "What do voice minutes cost on SeldonFrame?",
+        a: "You connect your own Twilio number and your own AI key, so calls cost whatever the providers charge. SeldonFrame doesn't meter minutes, doesn't mark them up, and has no burst rate.",
+      },
+    ],
+  },
 ];
 
 export function getCompetitor(slug: string): Competitor {

--- a/packages/crm/src/lib/seo/competitor-pricing.ts
+++ b/packages/crm/src/lib/seo/competitor-pricing.ts
@@ -518,6 +518,165 @@ export const PRICING: CompetitorPricing[] = [
     bottomLine:
       "Smith.ai's pricing pages hide numbers behind forms, so every figure here is third-party reported, not confirmed. The pattern is clear either way: it's a per-call service, so growth in call volume grows your bill proportionally — there's no flat platform fee.",
   },
+  // 2026-08-24 wave — seven new competitors, all fetched from the vendor's own
+  // live pricing page today; see the appended 2026-08-24 section of
+  // docs/superpowers/specs/2026-07-08-competitor-pricing-facts.md for every
+  // number below with its source URL and its fetched/reported tag.
+  {
+    slug: "bland-ai",
+    pricingUrl: "https://www.bland.ai/pricing",
+    verified: "August 2026",
+    quoteGated: false,
+    freeTier: "Yes — the Start plan has a $0/mo platform fee (2 credits plus an inbound number the page calls a \"$15/mo value\"), then bills per minute; the page says no card is required",
+    plans: [
+      { name: "Start", price: "$0/mo platform fee + $0.14/min talk time", whoFor: "Trying it out or running low volume", limits: ["10 concurrent calls, 100 calls/day", "10 knowledge bases, 1 voice", "Transfer time billed separately at $0.05/min"] },
+      { name: "Build", price: "$299/mo platform fee + $0.12/min talk time", whoFor: "Teams running steady call volume", limits: ["50 concurrent calls, 2,000 calls/day", "50 knowledge bases, 5 voices", "Transfer time billed separately at $0.04/min"] },
+      { name: "Scale", price: "$499/mo platform fee + $0.11/min talk time", whoFor: "High-volume deployments", limits: ["100 concurrent calls, 5,000 calls/day", "100 knowledge bases, 15 voices", "Transfer time billed separately at $0.03/min"] },
+      { name: "Enterprise", price: "Custom — talk to sales", whoFor: "Contact-centre scale", limits: ["Platform fee contracted to your volume", "Unlimited concurrency, calls, knowledge bases and voices", "On-prem/VPC, BAA, SSO and data residency available"] },
+    ],
+    stacks: [
+      { label: "The platform fee buys a rate, not minutes", detail: "The $299 and $499 are platform fees, not minute allowances. You pay them before the first minute, and then talk time meters on top at $0.12 or $0.11 a minute." },
+      { label: "Transfer time is a second meter", detail: "Handing a call to a human bills separately at $0.05, $0.04 or $0.03 a minute by tier, on top of talk time. Bland's page says customers who bring their own Twilio pay no transfer fee, but bridging your own Twilio in carries a $0.004/min SIP termination fee per Bland's billing docs." },
+      { label: "SMS, web messages and calls that never connect", detail: "Bland's billing docs list SMS at $0.02 a message in either direction, web widget agent messages at $0.01 each, an outbound minimum of $0.015 a call, and $0.015 for failed calls. You pay for calls that never connected." },
+      { label: "Voices and knowledge bases are hard caps, not add-ons", detail: "Each tier caps you at 1, 5 or 15 voices and 10, 50 or 100 knowledge bases. Bland publishes no per-voice or per-knowledge-base price, so going past a cap is a whole tier step of $299 or $499." },
+    ],
+    bottomLine:
+      "Bland's per-minute rate is genuinely all-in on the AI side. The page says \"No token charges. No model-provider pass-throughs.\" and the rate covers the model, transcription and voice. What it does not cover is the platform fee underneath it, $299 or $499 a month before your first minute, plus transfer time as a second meter and per-message SMS. Older write-ups describing a $0.09/min base with custom-voice and knowledge-base surcharges describe a pricing model Bland no longer runs.",
+  },
+  {
+    slug: "birdeye",
+    pricingUrl: "https://birdeye.com/pricing/",
+    verified: "August 2026",
+    quoteGated: true,
+    freeTier: "None — the pricing page is a \"GET PRICING\" lead form",
+    plans: [
+      { name: "1–3 locations", price: "Quote-gated — contact sales", whoFor: "Single-location and small multi-location businesses", limits: ["Birdeye publishes no dollar figure for any band", "Third parties report an entry tier around $299–$349/mo per location — reported by reviewers, not published by Birdeye"] },
+      { name: "4–9 locations", price: "Quote-gated — contact sales", whoFor: "Small chains", limits: ["Third parties report a mid tier around $399–$599/mo per location — reported, not published by Birdeye"] },
+      { name: "10–39 locations", price: "Quote-gated — contact sales", whoFor: "Multi-location brands", limits: ["Third parties report volume pricing near $200–$250/mo per location at 10 locations — reported, not published by Birdeye"] },
+      { name: "40–249, 250–999 and 1000+ locations", price: "Quote-gated — contact sales", whoFor: "Enterprise multi-location", limits: ["Birdeye's own form segments buyers into these three bands", "No published figure at any size"] },
+    ],
+    stacks: [
+      { label: "Every price is per location, so add-ons multiply", detail: "The one hard structural fact Birdeye does publish is that buyers pick a location band, from 1–3 up to 1000+. Reviewers report add-on modules priced per location too, at $50–$200/mo each in one source and $50–$150/mo in another. The bands disagree, so treat the shape as the claim and not the figure." },
+      { label: "A renewal fee, as reviewers report it", detail: "One third-party breakdown updated July 2026 reports an \"Innovation Fee\" of roughly 8% applied at renewal. Birdeye publishes no fee schedule of any kind, so this is a reviewer report, not a documented term." },
+      { label: "Setup and integration, as reviewers report it", detail: "The same source reports integration and setup fees of $500–$2,000 depending on complexity, and SMS carrier fees passed through at $0.01–$0.03 a message. Neither number appears on any Birdeye page." },
+      { label: "The contract is the real term", detail: "Reviewers describe a 12-month contract billed monthly, auto-renewing unless you give written cancellation notice 90 days before renewal, with early termination charged at the remaining contract balance. If that is accurate, the monthly figure a rep quotes you is effectively an annual commitment. Birdeye does not publish contract terms." },
+    ],
+    bottomLine:
+      "Birdeye publishes no prices at all. The pricing page is a form, and even Birdeye's own blog post about what Birdeye costs names no number. What the page does show is that pricing is per location and banded from 1–3 up to 1000+ locations, so anything you add multiplies across your locations. Third-party reports put an entry tier near $299 to $349 a month per location, but one of those authors is explicit that the figure came from a pricing-form screenshot and past-client hearsay rather than any document.",
+  },
+  {
+    slug: "weave",
+    pricingUrl: "https://www.getweave.com/pricing/",
+    verified: "August 2026",
+    quoteGated: true,
+    freeTier: "None — every tier is a \"Get Pricing\" quote",
+    plans: [
+      { name: "Pro", price: "Quote-gated — advertised \"from $199 per month\"", whoFor: "Single-location practices", limits: ["Third parties report the real entry tier at $249–$250/mo per location, above Weave's own advertised floor", "Reported at 1,500 bulk messages/mo — not confirmed on the vendor page"] },
+      { name: "Elite (\"Most Popular\")", price: "Quote-gated — no figure published", whoFor: "Busier practices", limits: ["Reported at 3,000 bulk messages/mo — not confirmed on the vendor page"] },
+      { name: "Ultimate", price: "Quote-gated — no figure published", whoFor: "Larger or multi-location practices", limits: ["\"up to 15 phones, 1:1 personalized training, and premium analytics tools\" — the only tier detail Weave publishes", "Reported at 15,000 bulk messages/mo"] },
+    ],
+    stacks: [
+      { label: "Onboarding: advertised as included, reported as a fee", detail: "Weave lists \"Expert onboarding\" as included with every plan. Three independent third parties report a separate one-time setup fee anyway, at $400, at $500–$750, and at $750. They disagree on the amount, which is why no single figure belongs here. What they agree on is that a one-time fee exists and that Weave does not disclose one." },
+      { label: "Digital forms migration", detail: "Two sources independently report $200 up front for the initial upload of your existing digital forms, then $20 per upload after that. Classic per-item drip pricing, and none of it appears on Weave's page." },
+      { label: "Per-user and per-line add-ons", detail: "One source reports a \"Power Pack\" analytics add-on at $25 per user per month and extra phone numbers at $5 a month per line. That is per-user pricing stacked on a per-location subscription, so it scales with headcount inside each location. Reported, not published." },
+      { label: "Contract length and renewal increases", detail: "Reviewers report that a contract is usually required with possible early-termination fees, and customers report renewal increases of 15–25%. Weave publishes no contract term at all, so both are reports rather than documented terms." },
+    ],
+    bottomLine:
+      "Weave advertises plans \"starting from $199 per month\" and then puts a Get Pricing button on all three tiers, so that floor is the only number it publishes. Third parties consistently report the real entry tier higher, at $249 to $250 a month per location, and customer-reported spend at $300 to $500 a month for a small practice. The sharpest gap is not the price, it's the disclosure: Weave lists expert onboarding as included on every plan while three independent third parties report a separate one-time setup fee.",
+  },
+  {
+    slug: "ruby-receptionist",
+    pricingUrl: "https://www.ruby.com/pricing/",
+    verified: "August 2026",
+    quoteGated: false,
+    freeTier: "None",
+    plans: [
+      { name: "Virtual receptionist, 50 minutes", price: "$250/mo", whoFor: "Low-volume offices", limits: ["50 receptionist minutes included", "Works out to $5.00 a minute"] },
+      { name: "Virtual receptionist, 100 minutes", price: "$395/mo", whoFor: "Small practices", limits: ["100 receptionist minutes included", "Works out to $3.95 a minute"] },
+      { name: "Virtual receptionist, 200 minutes", price: "$720/mo", whoFor: "Busier offices", limits: ["200 receptionist minutes included", "Works out to $3.60 a minute"] },
+      { name: "Virtual receptionist, 500 minutes", price: "$1,725/mo", whoFor: "High call volume", limits: ["500 receptionist minutes included", "Works out to $3.45 a minute"] },
+      { name: "Live chat, 10 chats", price: "$143/mo", whoFor: "Adding website chat", limits: ["A separate meter from receptionist minutes", "Works out to $14.30 a chat"] },
+      { name: "Live chat, 30 chats", price: "$335/mo", whoFor: "Steady chat volume", limits: ["Works out to $11.17 a chat"] },
+      { name: "Live chat, 50 chats", price: "$520/mo", whoFor: "High chat volume", limits: ["Works out to $10.40 a chat"] },
+    ],
+    stacks: [
+      { label: "Live chat is a second subscription", detail: "Receptionist minutes do not cover chats. Ruby sells chat as its own plan at $143, $335 or $520 a month for 10, 30 or 50 chats, or bundled onto a receptionist plan at $115, $268 or $416 a month. The page states the bundle is 20% off standalone chat." },
+      { label: "The overage rate is the number Ruby doesn't publish", detail: "Ruby says there are \"no additional or hidden fees for activation, onboarding, setup, customization\" — and yet /pricing/, /plans-and-pricing/ and /faq/ all publish no per-minute charge for going past your included minutes. Third-party sources report an overage ladder running from about $5.40 down to $3.30 a minute, but every one of those figures is quoted against a legacy lineup (\"Call Ruby 50\" through \"Call Ruby 2,500\") whose tier names and tier count no longer match the four plans on the live page. Treat them as reported and stale, not as Ruby's current rate." },
+      { label: "How minutes are counted isn't disclosed", detail: "None of the three Ruby pages I checked states how partial minutes are rounded, what the contract length is, or whether annual billing carries a discount. Ruby does note that optional AI enhancements are available on all plans at no extra cost." },
+    ],
+    bottomLine:
+      "Ruby's plan prices are fully public, and dividing each one by its included minutes gives a real cost of $5.00 a minute at the bottom tier down to $3.45 at the top. The number Ruby doesn't publish anywhere is the overage rate, which is exactly the number that decides your bill in a busy month. Live chat is a separate subscription on top of that.",
+  },
+  {
+    slug: "thryv",
+    pricingUrl: "https://www.thryv.com/pricing/",
+    verified: "August 2026",
+    quoteGated: true,
+    freeTier: "None",
+    annualNote: "The page shows an \"Annual Save 15%\" and \"Monthly\" toggle but never states which basis the displayed $99 and $399 use. I fetched the page twice with different prompts and could not resolve it, so treat the billing basis as unknown.",
+    plans: [
+      { name: "Starter", price: "$99/mo", whoFor: "Solo operators", limits: ["1 user", "Posts to 60+ listing directories, AI website builder, AI review management, trackable phone numbers", "24/7 chat support"] },
+      { name: "Signature (marked \"Recommended\")", price: "$399/mo", whoFor: "Small teams", limits: ["5 users", "Adds social media management, an SEO and AEO custom website, advanced listings, competitive insights and AI lead insights", "24/7 phone and email support"] },
+      { name: "Amplify", price: "Custom — talk to sales", whoFor: "Businesses buying done-for-you marketing", limits: ["No amount displayed; the button goes to demo scheduling"] },
+    ],
+    stacks: [
+      { label: "Thryv Boosts have no price anywhere", detail: "Ads Boosts, Search Boosts, Social Boosts and Brand Boosts are described as done-for-you marketing services available on Signature and Amplify. The pricing page discloses no figure for any of them." },
+      { label: "Extra users aren't priced", detail: "Starter includes 1 user and Signature includes 5. The page never says what a sixth user costs, so team growth has no published price." },
+      { label: "Onboarding and support fees, as reviewers report them", detail: "Third-party breakdowns report a $250 one-time onboarding fee on every package level and a $9 monthly support fee. Thryv publishes neither on its pricing page, so both are reported rather than documented." },
+      { label: "Per-seat and per-message usage, as reviewers report it", detail: "The same sources report Command Center seats at roughly $20 per seat per month on Plus and $30 on Professional above a free tier, SMS at $0.015 a message and voice at $0.01 a minute. None of these rates appears on Thryv's pricing page." },
+    ],
+    bottomLine:
+      "Thryv publishes two real numbers, $99 and $399 a month, and gates everything else. Amplify is a demo call, Boosts carry no price anywhere on the page, and nothing states what a sixth user costs. Third parties report a $250 one-time onboarding fee and a $9 monthly support fee on every package plus per-seat and per-message usage, but Thryv publishes none of that, so treat those figures as reported.",
+  },
+  {
+    slug: "tidio",
+    pricingUrl: "https://www.tidio.com/pricing/",
+    verified: "August 2026",
+    quoteGated: true,
+    freeTier: "Yes — a $0/mo Free plan with 50 billable conversations, 100 Flows visitors reached, and a one-off (not monthly) 50 Lyro AI conversations",
+    annualNote: "The page advertises \"Annually (2 months free)\". The displayed $24.17 and $49.17 are arithmetically consistent with an annual-billed monthly rate, yet the toggle read as Monthly when I checked, and the page never resolves which basis those decimals use.",
+    plans: [
+      { name: "Free", price: "$0/mo", whoFor: "Trying it out", limits: ["50 billable conversations", "50 Lyro AI conversations, one-off rather than monthly", "100 Flows visitors reached", "10 seats"] },
+      { name: "Starter", price: "$24.17/mo", whoFor: "Solo operators", limits: ["100 billable conversations", "50 Lyro AI conversations, one-off rather than monthly", "100 Flows visitors reached", "10 seats"] },
+      { name: "Growth", price: "Starts at $49.17/mo", whoFor: "Small support teams", limits: ["Up to 2,000 billable conversations", "Lyro and Flows quotas both listed as Custom"] },
+      { name: "Plus", price: "Starts at $300/mo + monthly usage", whoFor: "Larger support orgs", limits: ["Custom billable conversations and custom seat count", "Usage bills on top of the $300 floor, so the real bill isn't determinable from the page"] },
+      { name: "Premium", price: "Contact for pricing — quote-gated", whoFor: "High-volume AI deflection", limits: ["Lyro from 3,000 conversations", "The guaranteed 50% Lyro resolution rate and pay-per-resolution billing are Premium-only"] },
+    ],
+    stacks: [
+      { label: "Three meters, not one", detail: "Billable conversations, Lyro AI conversations and Flows visitors reached are counted independently. The plan price covers the first one. Running out of either of the other two forces an upgrade or a paid add-on." },
+      { label: "Lyro AI is an add-on", detail: "The standalone Lyro add-on is listed at \"Starts at $32.50/mo. From 50 Lyro AI conversations\", which works out to $0.65 per AI conversation at the entry bundle. The 50 Lyro conversations on Free and Starter are labelled one-off, so they're a grant and not a monthly allowance." },
+      { label: "Flows is its own add-on", detail: "The standalone Flows add-on is listed at \"Starts at $24.17/mo. From 2 000 visitors reached\", which works out to about $0.012 per visitor reached at the entry bundle." },
+      { label: "The Growth-to-Plus cliff", detail: "Growth starts at $49.17 a month and the next tier up starts at $300 a month plus monthly usage. That's roughly a six-fold step, and the Plus bill isn't determinable from the page because usage sits on top of the floor." },
+      { label: "Resolution-based billing is top-tier only", detail: "The guaranteed 50% Lyro resolution rate and pay-per-resolution billing are Premium features. Below that you pay per conversation whether Lyro resolved it or not." },
+    ],
+    bottomLine:
+      "Tidio's entry pricing is public and cheap, but the plan price only buys one of three meters. Live-chat conversations, Lyro AI conversations and Flows visitors are counted separately, and running out of any one of them means an upgrade or a paid add-on. The step from Growth at about $49 a month to Plus at $300 a month plus usage is roughly six-fold, and Premium carries no published price at all.",
+  },
+  {
+    slug: "elevenlabs",
+    pricingUrl: "https://elevenlabs.io/pricing/agents",
+    verified: "August 2026",
+    quoteGated: false,
+    freeTier: "Yes — 15 agent minutes a month at $0, with 4 concurrent calls",
+    annualNote: "Annual billing on the main plan page is structured as paying for 10 months, which works out to two months free (about 20% off).",
+    plans: [
+      { name: "Free", price: "$0/mo", whoFor: "Trying the agent product", limits: ["15 agent minutes", "4 concurrent calls"] },
+      { name: "Starter", price: "$6/mo", whoFor: "Hobby projects", limits: ["75 agent minutes", "6 concurrent calls"] },
+      { name: "Creator", price: "$22/mo (first month 50% off at $11)", whoFor: "Solo builders", limits: ["275 agent minutes", "10 concurrent calls"] },
+      { name: "Pro", price: "$99/mo", whoFor: "Small production deployments", limits: ["1,238 agent minutes", "20 concurrent calls"] },
+      { name: "Scale", price: "$299/mo", whoFor: "Growing call volume", limits: ["3,738 agent minutes", "30 concurrent calls"] },
+      { name: "Business", price: "$990/mo", whoFor: "High-volume deployments", limits: ["12,375 agent minutes", "40 concurrent calls"] },
+      { name: "Enterprise", price: "Custom — talk to sales", whoFor: "Large orgs", limits: ["No published price"] },
+    ],
+    stacks: [
+      { label: "The model and the phone line are billed on top", detail: "ElevenLabs states it plainly: \"The LLM model and any telephony are billed separately on top, based on usage.\" No LLM rate and no telephony rate is published anywhere on the agents pricing page, so the all-in cost of a call can't be worked out from the vendor's own disclosures. The $0.08 a minute headline is a floor, not a total." },
+      { label: "Bundled minutes carry no volume discount", detail: "Divide each plan price by its included minutes and every paid tier lands on exactly $0.080 a minute: $6 over 75, $22 over 275, $99 over 1,238, $299 over 3,738 and $990 over 12,375. That's the same as the published overage rate, so the subscription is prepaid minutes at list price and a higher tier buys concurrency headroom rather than a cheaper minute." },
+      { label: "Burst pricing doubles the rate at your busiest moment", detail: "Going past your plan's concurrency limit doesn't block the call, it bills at $0.160 a minute (up to 3x normal concurrency). That's double the standard rate, and it triggers exactly when call volume spikes. Concurrency, at 4, 6, 10, 20, 30 or 40 lines, is the real gating constraint per tier." },
+      { label: "Text messages", detail: "Text messages bill at $0.003 each on top of everything above." },
+    ],
+    bottomLine:
+      "ElevenLabs publishes its agent-minute price openly, and the arithmetic is unusually clean: every paid tier divides out to exactly $0.08 a minute, the same as the overage rate, so the subscription is prepaid minutes at list price and the tier only buys concurrency. What the page doesn't price is the model. ElevenLabs says the LLM and telephony are billed separately on top and publishes no rate for either, so $0.08 a minute is a floor and not a total.",
+  },
 ];
 
 export function getCompetitorPricing(slug: string): CompetitorPricing {

--- a/packages/crm/src/lib/seo/pricing-index.ts
+++ b/packages/crm/src/lib/seo/pricing-index.ts
@@ -83,6 +83,15 @@ export const SF_TIER_MAP: Record<string, { band: [SfTierId, SfTierId]; rationale
   durable: { band: ["builder", "builder"], rationale: "Solo AI website + mini-CRM — cheapest comparison tier." },
   "my-ai-front-desk": { band: ["builder", "managed"], rationale: "Single-location AI receptionist." },
   "smith-ai": { band: ["managed", "agency_starter"], rationale: "Per-call receptionist service scales with call volume/locations, small-agency shaped at the high end." },
+  // 2026-08-24 wave — seven new registry rows need their SF band here (1:1
+  // coverage is enforced by pricing-index.spec.ts).
+  "bland-ai": { band: ["builder", "builder"], rationale: "Usage-based voice API with a platform fee on top — not a front office; same shape as Vapi and Retell, cheapest comparison tier." },
+  birdeye: { band: ["agency_starter", "agency_growth"], rationale: "Priced per location by the vendor's own banding — multi-location rollups are the practical use case, same shape as Podium." },
+  weave: { band: ["builder", "managed"], rationale: "Single-practice communications suite (phones, messaging, forms) — solo/small-team shaped." },
+  "ruby-receptionist": { band: ["builder", "managed"], rationale: "Per-minute answering service for one business — solo/small-office shaped." },
+  thryv: { band: ["builder", "managed"], rationale: "SMB all-in-one with 1 or 5 users included — solo/small-team shaped." },
+  tidio: { band: ["builder", "managed"], rationale: "Solo/small-team chat + AI agent tool, same shape as Chatbase." },
+  elevenlabs: { band: ["builder", "builder"], rationale: "Usage-based voice agent minutes with LLM and telephony passed through — cheapest comparison tier, same as Vapi and Retell." },
 };
 
 // ─── chart series types ─────────────────────────────────────────────────────
@@ -121,8 +130,8 @@ export type SfBandPoint = {
 
 const DEFAULT_VISIBLE_SLUGS = new Set(["hubspot", "gohighlevel", "salesforce", "keap", "activecampaign"]);
 // pipedrive is named in the brief but has no competitor-pricing registry
-// entry (25-entry registry doesn't include it) — omitted rather than
-// fabricated; see the build report for the honest reason.
+// entry (the registry, 32 rows as of 2026-08-24, doesn't include it) —
+// omitted rather than fabricated; see the build report for the honest reason.
 
 /** Parse a lead numeric MONTHLY dollar amount out of a plan price string,
  *  e.g. "$97/mo" -> 97, "listed at ~$49/mo (annual, 1,000 contacts)" -> 49,
@@ -249,6 +258,13 @@ function vendorDisplayName(slug: string): string {
     durable: "Durable",
     "my-ai-front-desk": "My AI Front Desk",
     "smith-ai": "Smith.ai",
+    "bland-ai": "Bland AI",
+    birdeye: "Birdeye",
+    weave: "Weave",
+    "ruby-receptionist": "Ruby Receptionist",
+    thryv: "Thryv",
+    tidio: "Tidio",
+    elevenlabs: "ElevenLabs Agents",
   };
   return overrides[slug] ?? slug;
 }

--- a/packages/crm/tests/unit/seo/competitor-pricing.spec.ts
+++ b/packages/crm/tests/unit/seo/competitor-pricing.spec.ts
@@ -13,8 +13,10 @@ import { renderCompetitorPricingMarkdown } from "../../../src/lib/seo/competitor
 
 // ─── registry shape ─────────────────────────────────────────────────────────
 
-test("PRICING has exactly 25 entries", () => {
-  assert.equal(PRICING.length, 25);
+// 25 → 32 on 2026-08-24: the seven-competitor wave (Bland AI, Birdeye, Weave,
+// Ruby Receptionist, Thryv, Tidio, ElevenLabs Agents).
+test("PRICING has exactly 32 entries", () => {
+  assert.equal(PRICING.length, 32);
 });
 
 test("PRICING slugs are unique", () => {


### PR DESCRIPTION
Extends the competitor-pricing family (the site's best-performing content per page) by seven vendors, each on the established three-surface pattern, plus one head-to-head compare.

## What shipped

| Vendor | Pricing page | Alternative-to | SeldonFrame-vs | quoteGated |
|---|---|---|---|---|
| Bland AI | `/bland-ai-pricing` | `/alternative-to-bland-ai` | `/compare/seldonframe-vs-bland-ai` | false |
| Birdeye | `/birdeye-pricing` | `/alternative-to-birdeye` | `/compare/seldonframe-vs-birdeye` | **true** |
| Weave | `/weave-pricing` | `/alternative-to-weave` | `/compare/seldonframe-vs-weave` | **true** |
| Ruby Receptionist | `/ruby-receptionist-pricing` | `/alternative-to-ruby-receptionist` | `/compare/seldonframe-vs-ruby-receptionist` | false |
| Thryv | `/thryv-pricing` | `/alternative-to-thryv` | `/compare/seldonframe-vs-thryv` | **true** |
| Tidio | `/tidio-pricing` | `/alternative-to-tidio` | `/compare/seldonframe-vs-tidio` | **true** |
| ElevenLabs Agents | `/elevenlabs-pricing` | `/alternative-to-elevenlabs` | `/compare/seldonframe-vs-elevenlabs` | false |

Plus `/compare/podium-vs-birdeye` (VS_PAIRS + KEPT_VS_SLUGS), every `.md` twin, and seven footer links in the Pricing guides column. Sitemap and llms.txt pick all of it up from the registries with no edit.

## Never-lies gate: every published number, with its source

Everything below is also in the appended, dated 2026-08-24 section of `docs/superpowers/specs/2026-07-08-competitor-pricing-facts.md`, tagged **FETCHED** (read off the vendor's own live page) / **DERIVED** (arithmetic on two FETCHED numbers) / **REPORTED** (third-party only, hedged in copy). A number that isn't in that file doesn't appear on a page.

I re-fetched every vendor page myself on 2026-08-24 before publishing, on top of the research pass — so each one below was read twice.

### Bland AI — FETCHED, https://www.bland.ai/pricing + https://docs.bland.ai/platform/billing
- Platform fees $0 / $299 / $499; talk time $0.14 / $0.12 / $0.11 per min; transfer time $0.05 / $0.04 / $0.03 per min
- Limits: 10/50/100 concurrent, 100/2,000/5,000 calls per day, 10/50/100 knowledge bases, 1/5/15 voices
- Start includes 2 credits + an inbound number the page calls a "$15/mo value"; "No card required"
- Billing docs: SMS $0.02/msg, web widget messages $0.01, outbound minimum $0.015/call, failed calls $0.015/call, SIP termination $0.004/min
- Verbatim vendor claim quoted on the page: "No token charges. No model-provider pass-throughs."
- **Deliberately NOT published:** the pre-restructure ~$0.09/min base with custom-voice / KB-lookup / recording surcharges that most third-party articles still describe. Neither vendor surface lists those today.

### Birdeye — vendor publishes ZERO dollar figures
- FETCHED, https://birdeye.com/pricing/: no price of any kind; headline "Pricing built around outcomes, not seat counts."; location bands 1-3 / 4-9 / 10-39 / 40-249 / 250-999 / 1000+ behind a GET PRICING form. **The plan rows on the page use those vendor bands, not third-party tier names** (the industry's two naming schemes conflict).
- FETCHED, https://birdeye.com/blog/what-does-birdeye-cost/: Birdeye's own cost explainer names no number either.
- REPORTED, https://wiserreview.com/blog/birdeye-pricing/ (pub 2025-11-28, updated 2026-07-09): $299-$349 / $399-$599 / $449-$699+ per location; $200-$250 per location at 10 locations; ~8% "Innovation Fee" at renewal; $500-$2,000 integration/setup; $50-$200/mo per-location add-ons; $0.01-$0.03 per SMS; 12-month contract, 90-day written cancellation notice, remaining-balance early termination
- REPORTED, https://www.reviewflowz.com/blog/how-much-does-birdeye-really-cost (pub 2026-01-05): $349/mo month-to-month vs $299/mo annual. **That author's own caveat — the figure came from a pricing-form screenshot and past-client feedback, not documentation — is carried into the page copy.**
- Add-on band disagreement ($50-$200 vs $50-$150) is published as the SHAPE of the fee, never a figure.

### Weave — one published number, everything else gated
- FETCHED, https://www.getweave.com/pricing/ (fetched twice to confirm $199 isn't a misread of $249): verbatim "starting from $199 per month"; Pro / Elite ("Most Popular") / Ultimate all carry a "Get Pricing" button; Ultimate detail "up to 15 phones, 1:1 personalized training, and premium analytics tools"; "Expert onboarding" listed as included on every plan; no setup fee, contract term or hardware cost disclosed anywhere.
- REPORTED, https://noshowcost.com/tools/weave-pricing (verified 2026-04-28; best-sourced — triangulates G2/Capterra cost notes Jan 2025-May 2026, webinars, Reddit): actual spend $300-$400 / $400-$500 / $500-$700 / $800-$1,200; "$400 one-time port and setup"; 15-25% renewal increases
- REPORTED, https://www.iplum.com/blog/weave-pricing-plans: Pro $249/mo per location; setup $500-$750; forms $200 + $20 per upload; Power Pack $25/user/mo; extra numbers $5/mo/line; bulk-message caps 1,500 / 3,000 / 15,000
- REPORTED, https://emitrr.com/blog/weave-pricing/ (updated 2026-08-13): $250/mo base; setup $750; same forms and bulk-message figures
- **The $249-$250 figure is never published as Weave's price** (the vendor contradicts it) and **$199 is never published as what practices pay** (every reported data point is higher). The page states both sides. The setup-fee AMOUNT is not publishable — three sources say $400, $500-$750 and $750 — so the page asserts only the disclosure gap: Weave advertises onboarding as included while three independent third parties report a separate one-time fee.

### Ruby Receptionist — FETCHED, https://www.ruby.com/pricing/ (+ /plans-and-pricing/ and /faq/)
- Receptionist: $250 / 50 min, $395 / 100 min, $720 / 200 min, $1,725 / 500 min
- Live chat (a separate meter): $143 / 10 chats, $335 / 30, $520 / 50. Bundles $115 / $268 / $416, stated 20% off standalone chat
- DERIVED per minute: $5.00, $3.95, $3.60, $3.45. DERIVED per chat: $14.30, $11.17, $10.40
- Verbatim vendor claim quoted: "no additional or hidden fees for activation, onboarding, setup, customization"
- **The overage rate is not published on any of the three pages I checked** — the page says so, and that absence is the story. The reported $5.40-down-to-$3.30 ladder is carried only as reported AND stale, because every source quotes it against a legacy "Call Ruby 50"-through-"Call Ruby 2,500" lineup whose tier count doesn't match the four live plans.
- Two extractions of the same page disagreed on the middle tier NAMES while agreeing exactly on prices and minutes, so **plans are named by their included minute count, never by a tier name**.

### Thryv — FETCHED, https://www.thryv.com/pricing/ (fetched twice)
- Starter $99/mo (1 user); Signature $399/mo (5 users, "Recommended"); Amplify "Custom", demo-scheduling button
- "Annual Save 15%" / "Monthly" toggle exists but the page **never states which basis $99/$399 use** — two fetches failed to resolve it, so the page states the ambiguity rather than picking a side
- No onboarding fee, setup fee, support fee, SMS rate or Boosts price appears anywhere on the page
- REPORTED, https://schedulingkit.com/pricing-guides/thryv-pricing + https://tekpon.com/software/thryv/pricing/: $250 one-time onboarding; $9/mo support; SMS $0.015; voice $0.01/min; Command Center seats ~$20 (Plus) / ~$30 (Professional) per seat/mo
- **Deliberately NOT published:** the G2 4.2-4.6/5 vs Trustpilot 2.3/5 sentiment split — it was in the research pack but I did not fetch those aggregators myself, so it was dropped.

### Tidio — FETCHED, https://www.tidio.com/pricing/
- Free $0/mo; Starter $24.17/mo; Growth "Starts at $49.17/mo."; Plus "Starts at $300/mo. + monthly usage"; Premium "Contact for pricing"
- Quotas: 50 / 100 / up-to-2,000 billable conversations; 50 Lyro AI conversations on Free and Starter explicitly **one-off, not monthly**; 100 Flows visitors; 10 seats
- Add-ons verbatim: Lyro "Starts at $32.50/mo. From 50 Lyro AI conversations"; Flows "Starts at $24.17/mo. From 2 000 visitors reached"
- Premium-exclusive: guaranteed 50% Lyro resolution rate + pay-per-resolution billing. Annual advertised as "Annually (2 months free)"
- DERIVED: $0.65 per Lyro AI conversation; ~$0.012 per Flows visitor; ~6.1x Growth-to-Plus step
- **Ambiguity stated, not resolved:** whether $24.17/$49.17 are month-to-month or annual-billed-monthly. The implied $29/$59 month-to-month figures are INFERRED and appear nowhere.

### ElevenLabs Agents — FETCHED, https://elevenlabs.io/pricing/agents (+ https://elevenlabs.io/pricing)
- Free $0 / 15 min / 4 concurrent; Starter $6 / 75 / 6; Creator $22 (first month $11) / 275 / 10; Pro $99 / 1,238 / 20; Scale $299 / 3,738 / 30; Business $990 / 12,375 / 40; Enterprise custom
- Overage $0.080/min; burst $0.160/min at up to 3x concurrency; text messages $0.003 each; annual = "pay for 10 months" (~20%)
- Verbatim vendor statement quoted: "The LLM model and any telephony are billed separately on top, based on usage." **No LLM or telephony rate is published**, so the page says $0.08/min is a floor and never a total.
- DERIVED, the strongest finding: bundled minutes carry zero volume discount. $6/75, $22/275, $99/1,238, $299/3,738 and $990/12,375 all equal exactly $0.0800 — identical to the overage rate. Checkable arithmetic on the vendor's own numbers.

## Tests

- `node --test --import tsx packages/crm/tests/unit/seo/*.spec.ts *.spec.tsx` — **1798 pass, 0 fail** (31 suites)
- `pnpm exec tsc --noEmit` from `packages/crm` — clean, no output

`competitor-pricing.spec.ts` count updated 25 → 32 (the only test edit). `SF_TIER_MAP` in `pricing-index.ts` gained the seven rows its 1:1-coverage spec requires, and two now-stale registry-count comments were corrected.

## Not touched
tools, best-pages, guides, `sitemap.ts`, `llms.txt` — all confirmed registry-generated, so the new pages appear without editing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
