### PR TITLE
persona-loop: /try build claims "we read that site" for pages it never fetched

### DIFF
--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,8 +236,16 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // 2026-08-26 — persona-loop finding: this used to throw "extraction_failed"
+    // (the SAME reason as "we read the page but it's missing a business
+    // name/location/phone"), which made run-create-from-url.ts's honesty-fix
+    // copy ("We read that site but couldn't find the basics we need...")
+    // literally false here — Firecrawl never got real content back (blocked
+    // by anti-bot/login-wall, e.g. a Facebook-only business page; timed out;
+    // rate-limited; or returned a blank/JS-shell doc). Distinct reason so the
+    // caller can tell "never read it" apart from "read it, fields missing."
     throw new WebFetchError(
-      "extraction_failed",
+      "fetch_blocked",
       `Firecrawl fetch failed: ${scrape.reason}${
         scrape.detail ? `: ${scrape.detail}` : ""
       }`,

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -282,6 +282,14 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         // succeed until credits are added. Remaining reasons
         // (anthropic_unauthorized, internal_error) are untouched — those ARE
         // sometimes transient.
+        // 2026-08-26 — persona-loop finding: "fetch_blocked" (Firecrawl never
+        // got real content — anti-bot/login-wall, timeout, rate-limit, or a
+        // blank/JS-shell doc; e.g. a Facebook-only business page) used to be
+        // folded into extraction_failed and inherited the "We read that
+        // site..." copy above, which is false when the site was never read.
+        // Distinct, honest copy — and unlike extraction_failed this genuinely
+        // can succeed on retry (Firecrawl's proxy strategy varies per call),
+        // so the UI's default "Try again" affordance is left in place.
         sse.error(
           422,
           reason === "extraction_failed"
@@ -292,7 +300,13 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
               }
             : reason === "credits_exhausted"
               ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
-              : { reason },
+              : reason === "fetch_blocked"
+                ? {
+                    reason,
+                    message:
+                      "We couldn't load that page to read it — it may be blocking automated visits (common for Facebook-only business pages) or briefly unreachable. Try again in a moment, paste a different URL, or describe your business instead.",
+                  }
+                : { reason },
         );
         sse.close();
         return;

--- a/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
@@ -40,6 +40,7 @@ import { parseExtraction } from "./extraction-parser";
 
 export type WebFetchErrorReason =
   | "extraction_failed"
+  | "fetch_blocked"
   | "credits_exhausted"
   | "anthropic_unauthorized"
   | "internal_error";

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,13 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  // 2026-08-26 — persona-loop finding: a Firecrawl-level failure means the
+  // site was NEVER actually read, which is a different condition from
+  // "read it, but required fields are missing" (extraction_failed below).
+  // Collapsing both into "extraction_failed" made run-create-from-url.ts's
+  // "We read that site but couldn't find..." copy false for this case (e.g.
+  // a Facebook-only business page blocking the scraper). See "fetch_blocked".
+  test("Firecrawl throws -> WebFetchError(fetch_blocked) with 'Firecrawl fetch failed' prefix", async () => {
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,14 +129,16 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "fetch_blocked" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
     );
   });
 
-  test("near-empty markdown (< 200 chars) -> WebFetchError(extraction_failed)", async () => {
+  test("near-empty markdown (< 200 chars) -> WebFetchError(fetch_blocked)", async () => {
     // JS-only SPA shell / anti-bot challenge / blank doc — Firecrawl
-    // returns markdown but well below the MIN_MARKDOWN_CHARS floor.
+    // returns markdown but well below the MIN_MARKDOWN_CHARS floor. The site
+    // was never actually read, so this must NOT surface as extraction_failed
+    // (which means "read it, fields missing") — see fetch_blocked above.
     const firecrawl = makeFakeFirecrawl(async () => ({
       markdown: "# Loading\n\nEnable JavaScript.",
       metadata: { sourceURL: "https://spa.example/", statusCode: 200 },
@@ -146,7 +154,7 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "fetch_blocked" &&
         err.message.includes("empty_content"),
     );
   });

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -235,6 +235,21 @@ describe("runCreateFromUrl", () => {
     assert.match(text, /event: error\n.*"code":422.*"reason":"anthropic_unauthorized"/);
     assert.ok(!text.includes('"message"'), "non-extraction_failed reasons must not carry a message");
   });
+
+  // 2026-08-26 — persona-loop finding: fetch_blocked is what Firecrawl
+  // throws when it never got real page content (anti-bot/login-wall,
+  // timeout, rate-limit, blank/JS-shell doc — e.g. a Facebook-only business
+  // page). Unlike extraction_failed, the site was never read, so the 422
+  // payload must NOT claim "We read that site..." — and unlike
+  // extraction_failed this genuinely can succeed on retry, so it must not
+  // be worded as a dead end.
+  test("fetch_blocked 422 carries an honest message that never claims the site was read", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("Cloudflare challenge: status 403"); (e as any).reason = "fetch_blocked"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"fetch_blocked".*"message":"/);
+    assert.ok(!text.includes("We read that site"), "must not claim to have read a site it never fetched");
+  });
 });
 
 // 2026-06-23 — Deploy-CTA → instantiate-the-clicked-agent wiring. The


### PR DESCRIPTION
## Summary

Fixes a dishonesty bug in the anonymous "paste a URL" build flow (`/try`, and its authed sibling `/clients/new`): a Firecrawl-level scrape failure (blocked by anti-bot/login-wall, timeout, rate-limit, or a blank JS-shell page) was collapsed into the exact same `extraction_failed` reason as "we successfully read the page, but it's missing a business name/location/phone." Both cases then rendered the same 2026-07-14 honesty-fix copy — **"We read that site but couldn't find the basics we need..."** — which is factually false when the scraper never got real content back.

## Persona-loop finding

- **Persona:** Wednesday → med-spa owner (non-technical, impatient, skeptical, on a phone).
- **Funnel step:** homepage hero → "Paste a URL" → `/try?url=...` → `GET /api/v1/web/build/stream`.
- **Happy-path check first:** pasted a real independent med spa's site (`spa35.com`) through the live production funnel end-to-end — build succeeded cleanly, vision check passed, claim/signup redirect wiring is correct. No bug there.
- **Went one level deeper per the brief's own hint** ("a site that is only a Facebook page"): many small/independent med spas (and local businesses generally) have no dedicated website — only a Facebook Page. Pasted a real med spa's Facebook page URL (`https://www.facebook.com/Itsasecretmedspa/`) into the same live funnel.

### Verbatim evidence

Request: `GET https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fwww.facebook.com%2FItsasecretmedspa%2F` (HTTP/2 200, `text/event-stream`)

```
event: fetching
data: {"url":"https://www.facebook.com/Itsasecretmedspa/"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```

The page visibly has a business name, address, and services listed — the claim "we read that site" is simply false: Firecrawl was blocked before any real content came back (confirmed in code below), not "read but incomplete."

### Root cause

`markdown-extractor.ts`'s `extractBusinessFactsFromUrl()` throws `WebFetchError("extraction_failed", ...)` for **every** `!scrape.ok` case from `firecrawlScrape()` — `fetch_failed`, `empty_content` (Firecrawl's own comment: "blank page / anti-bot challenge / JS-only SPA shell"), `timeout`, and `rate_limited` — discarding the distinct `scrape.reason` Firecrawl already computes. `run-create-from-url.ts`'s catch block then keys its honesty-fix copy purely off `reason === "extraction_failed"`, so every one of those genuinely-different failures inherits the "we read that site" message that was written for a different case (LLM read the page, required fields are missing).

The existing test suite even had two tests exercising exactly this collapsed path, with comments already describing it as an "anti-bot challenge" scenario — confirming this was a known-shaky seam, not a hypothetical.

### Fix

- Added a distinct `WebFetchErrorReason`: `fetch_blocked`, thrown from the `!scrape.ok` branch instead of `extraction_failed`.
- `run-create-from-url.ts` gives `fetch_blocked` its own honest copy: *"We couldn't load that page to read it — it may be blocking automated visits (common for Facebook-only business pages) or briefly unreachable. Try again in a moment, paste a different URL, or describe your business instead."*
- Unlike `extraction_failed` (a genuinely permanent, per-URL condition), a scrape failure can succeed on retry — Firecrawl's proxy strategy varies per call — so this reason is *not* added to the client's no-retry list; the existing generic "Try again" affordance in `try-client.tsx` (and the already-honest generic copy in the authed `/clients/new` flow) applies unchanged. No client-side changes were needed.
- Updated the two markdown-extractor tests that previously asserted the collapsed `extraction_failed` reason for scrape failures, and added a new SSE-level test asserting the 422 payload for `fetch_blocked` never contains the string "We read that site".

Scope: touches only the scrape-failure branch of the URL-based extraction pipeline; the paste-a-description flow (`run-create-from-paste.ts`) doesn't fetch a URL and is unaffected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] Targeted unit tests: `node --import tsx --test tests/unit/web-onboarding/{markdown-extractor,route-create-from-url,web-fetch-extractor,run-create-from-paste}.spec.ts` — 33/33 pass (3 new/updated for this change).
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 errors.
- [x] `bash scripts/check-use-server.sh src` — pass.
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched).
- [ ] Manually verified in the browser — N/A (server-side error-classification fix; verified instead via the live production SSE endpoint, see evidence above).

## Notes for reviewers

- One real workspace was created during funnel testing (`spa-35-medical-spa-15da`, from the happy-path check on `spa35.com`, a real public med spa site) before this specific bug was found — flagging per the persona-loop's "one test workspace, named PersonaLoop Test..." rule, since the URL-paste flow derives the business name from the site itself and doesn't allow overriding it before creation. No further workspaces were created after that.
- Deliberately did not change retry/rate-limit policy, did not touch the `extraction_failed` (genuinely-permanent) copy, and did not touch pricing/positioning per the standing constraints — this is a narrow, root-caused honesty fix in the error-classification path only.

---
_Generated by [Claude Code](https://claude.ai/code/session_012fpZyAwE94TbqjBwttaAxa)_