### PR TITLE
persona-loop: /try's build stream silently auto-reconnects and restarts the build on a dropped connection

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -167,6 +167,23 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       );
       setPhase("error");
     });
+
+    // Native connection-level failure (dropped mobile network, backgrounded
+    // tab, etc.) — distinct from the named "error" SSE event above, which
+    // only fires when the SERVER is still connected and explicitly reports a
+    // failure. Left unhandled, the browser's default EventSource behavior is
+    // to silently auto-reconnect by re-issuing this same GET, which restarts
+    // runAnonymousBuild from scratch — a second full (uncached, unguarded)
+    // workspace build with no idempotency check server-side — while the UI
+    // keeps showing "building" with no indication anything went wrong. Close
+    // instead of letting the platform retry, and surface an honest, retryable
+    // error state.
+    es.onerror = () => {
+      es.close();
+      setEventSource(null);
+      setError("Lost connection while building. Check your connection and try again.");
+      setPhase("error");
+    };
   }
 
   // Auto-submit when the hero passed ?url= directly (mirrors clients-new-form's

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -35,11 +35,19 @@ class FakeEventSource {
     if (!list) return;
     this.listeners[event] = list.filter((l) => l !== fn);
   }
+  onerror: (() => void) | null = null;
   close() {
     this.closed = true;
   }
   fire(event: string, data: unknown) {
     for (const fn of this.listeners[event] ?? []) fn({ data: JSON.stringify(data) });
+  }
+  /** Simulates a native EventSource connection-level failure (dropped
+   *  network, backgrounded tab) — distinct from a named "error" SSE event
+   *  fired via `fire("error", ...)`, which requires the server to still be
+   *  connected and able to emit it. */
+  fireNativeError() {
+    this.onerror?.();
   }
 }
 
@@ -104,6 +112,24 @@ describe("TryClient — SSE error honesty", () => {
     assert.ok(
       screen.queryAllByText("Try again").length > 0,
       "transient errors keep the retry affordance",
+    );
+  });
+
+  test("native connection drop closes the stream and shows a retryable error instead of silently reconnecting", async () => {
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("https://acme.com");
+    });
+
+    const es = FakeEventSource.last!;
+    await act(async () => {
+      es.fireNativeError();
+    });
+
+    assert.ok(es.closed, "EventSource must be closed so the browser doesn't auto-reconnect and restart the build");
+    assert.ok(
+      screen.queryAllByText("Lost connection while building. Check your connection and try again.").length > 0,
+      "connection-level failure must surface an honest, retryable error instead of leaving the build animation stuck",
     );
   });
 });


### PR DESCRIPTION
## Summary

Persona-loop nightly run — persona: solo electrician (Saturday), walking the live `/try` anonymous build funnel (paste-a-URL → real hosted workspace, no signup).

**Funnel step:** `/try` — the public, unauthenticated "paste a URL, watch it build" flow (`api/v1/web/build/stream`). The persona this represents is exactly the kind of user this route targets: on a phone, on a job, impatient — i.e. likely to background the tab or lose signal mid-build.

**First failure found (code-level, confirmed live for the surrounding funnel):** `try-client.tsx`'s `startBuild()` only listens for the server's *named* SSE event `error`:

```ts
es.addEventListener("error", (raw) => { ... }); // only fires if the server is still connected and explicitly emits this
```

It never sets `es.onerror`, which is the *native* `EventSource` hook for a connection-level failure (dropped mobile network, backgrounded tab, proxy hiccup) — a completely different thing from the named SSE event above. Per the `EventSource` spec, when the underlying connection dies without the client having called `.close()`, the browser's default behavior is to silently auto-reconnect by re-issuing the same `GET /api/v1/web/build/stream?url=...` request.

Because `runAnonymousBuild` → `createFullWorkspace` has no idempotency guard keyed on URL/session (confirmed in `run-create-from-url.ts` / `create-full.ts` — only the LLM extraction step is cached via `withUrlExtractionCache`, not workspace creation itself), a silent reconnect doesn't resume anything — it restarts the whole pipeline and can provision a **second real hosted workspace** for the same visitor's same URL, while the "Spinning up your workspace…" animation keeps showing with no indication anything went wrong. It also counts a second time against the per-IP 3-builds/24h rate limit.

The sibling authed route (`clients-new-form.tsx`, same EventSource pattern) has the identical gap, but this PR only touches the anonymous `/try` path per this loop's minimal-impact scope — the persona here never reaches the authed flow.

**Root cause:** missing `es.onerror` handler — the component only distinguishes "the server told me it failed" from "everything's fine," never "the connection itself died."

**Evidence:** verified live that the surrounding funnel is otherwise honest and well-guarded — `https://www.seldonframe.com/api/v1/web/build/stream?url=https://www.facebook.com` correctly returns a clean `extraction_failed` SSE error with no dangling workspace, and an unreachable/schemeless URL correctly returns `invalid_url` with no build attempt. The gap here is specifically the *missing* native-error path, verified by reading the `EventSource` wiring against the documented spec behavior and the orchestrator's lack of an idempotency guard.

## Fix

Add `es.onerror` in `try-client.tsx`'s `startBuild()`: closes the `EventSource` (preventing the browser's auto-reconnect) and surfaces an honest, retryable "Lost connection while building. Check your connection and try again." error state instead of leaving the animation stuck or silently double-building.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

None filed — root-caused and fixed directly per this loop's instructions.

## Testing

- [x] Targeted unit test added (`tests/unit/web-onboarding/try-client.spec.tsx`): native connection drop closes the stream and shows the retryable message, instead of leaving it open for the browser to reconnect.
- [x] `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx` — 3/3 pass
- [x] `tsc -p tsconfig.json --noEmit` — 0 errors
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migration touched)
- [ ] Manually verified in a browser (not available in this sandbox — see PR for live-funnel evidence instead)

## Screenshots / GIFs

N/A — client-side error-handling fix, no visual change to the happy path.

## Notes for reviewers

Scoped intentionally to `/try` only (the anonymous, no-signup path our persona actually uses). `clients-new-form.tsx` has the same missing-`onerror` gap on the authed create flow but is out of scope for this fix per the loop's minimal-impact rule — worth a follow-up if a reviewer wants it mirrored there.


---
_Generated by [Claude Code](https://claude.ai/code/session_0149fhT11Pa9fj1ZhQZB8vtb)_