### PR TITLE
persona-loop: /try's invalid_url error is a dead end with no way to edit the URL

### DIFF
--- a/packages/crm/src/app/(public)/try/try-client.tsx
+++ b/packages/crm/src/app/(public)/try/try-client.tsx
@@ -99,6 +99,16 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
   // anthropic-error-map.ts) — a "Try again" button would be a lie. The
   // server's `message` explains it; we just suppress the retry affordance.
   const [creditsExhausted, setCreditsExhausted] = useState(false);
+  // 2026-08-31 — invalid-url dead-end fix. code:"invalid_url" (route.ts's
+  // assertPublicHttpUrl catch — unresolvable domain, blocked scheme/port,
+  // etc.) is exactly as non-retryable as extraction_failed/credits_exhausted
+  // above: the same URL will fail identically forever. Unlike those two,
+  // this one fell into the default "Try again" branch below, which
+  // resubmits the UNEDITABLE broken string (the idle-only <form> is
+  // unmounted once phase is "error") — so a visitor who typo'd their own
+  // domain saw "double-check it and try again" with no way to actually
+  // edit it. See reset()'s "Edit URL" affordance below.
+  const [invalidUrl, setInvalidUrl] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const autoSubmittedRef = useRef(false);
 
@@ -159,6 +169,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
       setRateLimited(data.code === "rate_limited");
       setExtractionFailed(isExtractionFailed);
       setCreditsExhausted(data.reason === "credits_exhausted");
+      setInvalidUrl(data.code === "invalid_url" || data.reason === "invalid_url");
       setError(
         data.message ??
           (isExtractionFailed
@@ -190,6 +201,7 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
     setRateLimited(false);
     setExtractionFailed(false);
     setCreditsExhausted(false);
+    setInvalidUrl(false);
     setBuildInput(null);
   }
 
@@ -376,6 +388,19 @@ export function TryClient({ initialUrl }: { initialUrl: string }) {
                     className="mt-3 rounded-[11px] border border-[rgba(34,29,23,.16)] bg-[#FFFDFA] px-4 py-2 text-[13.5px] font-[500] text-[#221D17]"
                   >
                     Back
+                  </button>
+                ) : invalidUrl ? (
+                  // invalid_url (unresolvable domain, blocked scheme/port, etc.)
+                  // is a property of the URL itself — retrying it verbatim can't
+                  // succeed. reset() brings the idle <form> back with the same
+                  // value still in the input so the visitor can actually fix it,
+                  // instead of a "Try again" that resubmits the identical string.
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="mt-3 rounded-[11px] border border-[rgba(34,29,23,.16)] bg-[#FFFDFA] px-4 py-2 text-[13.5px] font-[500] text-[#221D17]"
+                  >
+                    Edit URL
                   </button>
                 ) : (
                   <button

--- a/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
+++ b/packages/crm/tests/unit/web-onboarding/try-client.spec.tsx
@@ -87,6 +87,33 @@ describe("TryClient — SSE error honesty", () => {
     );
   });
 
+  test("invalid_url error shows an 'Edit URL' button (not 'Try again') and returns to an editable form", async () => {
+    render(<TryClient initialUrl="" />);
+    await act(async () => {
+      submitUrl("https://typo-domain-that-does-not-resolve.example");
+    });
+
+    const message = "That URL can't be reached — double-check it and try again.";
+    await act(async () => {
+      FakeEventSource.last!.fire("error", { code: "invalid_url", message });
+    });
+
+    assert.ok(screen.queryAllByText(message).length > 0, "honest server message must be shown");
+    assert.equal(
+      screen.queryAllByText("Try again").length,
+      0,
+      "invalid_url is non-retryable for the same string — no Try again button",
+    );
+    const editButton = screen.getByText("Edit URL");
+    await act(async () => {
+      fireEvent.click(editButton);
+    });
+    assert.ok(
+      screen.getByLabelText("Your website URL"),
+      "clicking Edit URL must bring back the editable input, not a dead end",
+    );
+  });
+
   test("internal_error still shows the generic copy WITH a 'Try again' button", async () => {
     render(<TryClient initialUrl="" />);
     await act(async () => {


### PR DESCRIPTION
## Summary

**Persona:** Monday — solo plumber, non-technical, on a phone, skeptical.

**Funnel step:** `/try` — the anonymous "paste your URL, watch it build, no signup" flow (`www.seldonframe.com` → hero URL tab → `/try`).

**First failure:** pasting a URL with a typo (very common on mobile — a fat-fingered domain, or a domain whose DNS hasn't propagated yet) lands on an error screen that says "double-check it and try again" but gives no way to actually edit the URL — the only button, "Try again", silently resubmits the exact same broken string forever.

**Verbatim evidence (live, `www.seldonframe.com`):**
```
$ curl "https://www.seldonframe.com/api/v1/web/build/stream?url=https%3A%2F%2Fthisplumbingcodoesnotexist-9f3k2x7q.com"
event: error
data: {"code":"invalid_url","message":"That URL can't be reached — double-check it and try again."}
```

**Root cause:** `route.ts`'s `assertPublicHttpUrl` catch (DNS failure / blocked scheme / blocked port) emits `code:"invalid_url"` with an honest, actionable message — but `try-client.tsx` only renders the editable `<form>` while `phase === "idle"`. Once `phase` flips to `"error"`, `invalid_url` fell into the same default branch as genuinely transient failures (`internal_error`) and got a "Try again" button that calls `startBuild(url)` — resubmitting the *identical* broken string, since the input box that could edit it no longer exists on screen.

This is the exact same non-retryable-condition-behind-a-retry-button pattern this file has already been fixed for twice — `extraction_failed` (2026-07-14) and `credits_exhausted` (2026-07-16) both got dedicated non-retryable states with an honest affordance. `invalid_url` was simply never given the same treatment.

## Fix

Track `invalid_url` as its own non-retryable state (mirroring `extractionFailed`/`creditsExhausted`) and show an **"Edit URL"** button that calls `reset()` instead of `startBuild(url)`. `reset()` brings the idle form back with the same value still in the input, so the visitor can actually correct their typo instead of hitting a dead end.

Scope: one file (`try-client.tsx`) + its existing test file. No copy/pricing/positioning changes, no security-sensitive code touched (the SSRF guard itself is unmodified — this only fixes how the client reacts to its existing, correct rejection).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Testing

- [x] Targeted unit tests: `node --import tsx --test tests/unit/web-onboarding/try-client.spec.tsx` → 3/3 pass (new `invalid_url` case + the two existing honesty regressions)
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` → zero **new** errors vs `main` (diffed against a baseline run; all remaining errors are pre-existing, in unrelated sibling packages)
- [x] `bash scripts/check-use-server.sh src` → clean
- [x] `node scripts/check-migrations-journaled.mjs` → clean (no migrations touched)
- [ ] Manually verified in a real browser (not available in this sandbox — verified via the live SSE curl repro above + unit test covering the exact DOM transition)

## Screenshots / GIFs

N/A — server-rendered SSE error state, not visually distinct beyond button/copy text (covered by the repro above).

## Notes for reviewers

No schema/env changes. The only behavior change is which button/handler renders for `code:"invalid_url"` — `reset()` (already used by the `extractionFailed`/`creditsExhausted` branches) vs. the old fallthrough to `startBuild(url)`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GduXsRdxXKYWa2xNXCkv8J)_