### PR TITLE
persona-loop: fetch_blocked no longer masquerades as extraction_failed on /try

### DIFF
--- a/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/markdown-extractor.ts
@@ -236,6 +236,28 @@ export async function extractBusinessFactsFromUrl(params: {
         "FIRECRAWL_API_KEY not set on this deployment",
       );
     }
+    // 2026-09-01 — persona-loop finding. fetch_failed/timeout/rate_limited
+    // mean the scrape never reached the page (network error, anti-bot
+    // block, upstream timeout) — most commonly hit on facebook.com
+    // business pages, a common "website" for a solo trade business with
+    // no real site of their own. That's a different failure than
+    // empty_content (page loaded, had nothing on it): here we never read
+    // the page, so it must NOT be reported as "we read that site but
+    // couldn't find X" (a false claim) or treated as permanent (a
+    // network hiccup or a temporary anti-bot challenge can succeed on
+    // retry, unlike a genuinely info-less site).
+    if (
+      scrape.reason === "fetch_failed" ||
+      scrape.reason === "timeout" ||
+      scrape.reason === "rate_limited"
+    ) {
+      throw new WebFetchError(
+        "fetch_blocked",
+        `Firecrawl fetch failed: ${scrape.reason}${
+          scrape.detail ? `: ${scrape.detail}` : ""
+        }`,
+      );
+    }
     throw new WebFetchError(
       "extraction_failed",
       `Firecrawl fetch failed: ${scrape.reason}${

--- a/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
+++ b/packages/crm/src/lib/web-onboarding/run-create-from-url.ts
@@ -282,6 +282,13 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
         // succeed until credits are added. Remaining reasons
         // (anthropic_unauthorized, internal_error) are untouched — those ARE
         // sometimes transient.
+        // 2026-09-01 — persona-loop finding. fetch_blocked means the scraper
+        // never reached the page (network error, timeout, anti-bot block —
+        // e.g. facebook.com business pages, a common "website" for a solo
+        // trade business). Unlike extraction_failed it's often transient, so
+        // this message stays retryable (falls through to the default `Try
+        // again` UI) instead of borrowing the "couldn't find the basics"
+        // copy, which would falsely claim we read a page we never reached.
         sse.error(
           422,
           reason === "extraction_failed"
@@ -292,7 +299,13 @@ export async function runCreateFromUrl(input: RunInput): Promise<RunResult> {
               }
             : reason === "credits_exhausted"
               ? { reason, message: CREDITS_EXHAUSTED_UI_MESSAGE }
-              : { reason },
+              : reason === "fetch_blocked"
+                ? {
+                    reason,
+                    message:
+                      "That site didn't load for us just now — it may be blocking automated visits, or it timed out. Try again in a moment.",
+                  }
+                : { reason },
         );
         sse.close();
         return;

--- a/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
+++ b/packages/crm/src/lib/web-onboarding/web-fetch-extractor.ts
@@ -40,6 +40,15 @@ import { parseExtraction } from "./extraction-parser";
 
 export type WebFetchErrorReason =
   | "extraction_failed"
+  // 2026-09-01 — persona-loop finding. The scraper never reached the page
+  // at all (network error, timeout, rate-limited, anti-bot block — e.g.
+  // facebook.com business pages, which is a common "website" for a solo
+  // trade business with no real site). Was previously collapsed into
+  // extraction_failed, so the UI told the visitor "we read that site but
+  // couldn't find [it]" for a site we never actually read, and hid the
+  // retry button on a transient failure that might well succeed on a
+  // second try. See markdown-extractor.ts's `!scrape.ok` branch.
+  | "fetch_blocked"
   | "credits_exhausted"
   | "anthropic_unauthorized"
   | "internal_error";

--- a/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/markdown-extractor.spec.ts
@@ -108,7 +108,14 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
     assert.ok(userMsg.includes("URL: https://acme.com"), "URL in user message");
   });
 
-  test("Firecrawl throws -> WebFetchError(extraction_failed) with 'Firecrawl fetch failed' prefix", async () => {
+  // 2026-09-01 — persona-loop finding. A Firecrawl throw means the scrape
+  // never reached the page at all (network error, anti-bot block — e.g. a
+  // facebook.com business page, a common "website" for a solo trade
+  // business with no real site). That must NOT collapse into
+  // extraction_failed: the UI's extraction_failed copy claims "we read
+  // that site" (false here) and hides the retry button on what is often a
+  // transient failure. See markdown-extractor.ts's `!scrape.ok` branch.
+  test("Firecrawl throws -> WebFetchError(fetch_blocked) with 'Firecrawl fetch failed' prefix", async () => {
     const firecrawl = makeFakeFirecrawl(async () => {
       throw new Error("Cloudflare challenge: status 403");
     });
@@ -123,8 +130,25 @@ describe("extractBusinessFactsFromUrl (markdown-extractor)", () => {
         }),
       (err: unknown) =>
         err instanceof WebFetchError &&
-        err.reason === "extraction_failed" &&
+        err.reason === "fetch_blocked" &&
         err.message.includes("Firecrawl fetch failed: fetch_failed"),
+    );
+  });
+
+  test("Firecrawl times out -> WebFetchError(fetch_blocked), same branch as fetch_failed", async () => {
+    const firecrawl = makeFakeFirecrawl(async () => {
+      throw new Error("Request timed out after 45000ms");
+    });
+    const { client } = makeFakeAnthropic({ content: [{ type: "text", text: "{}" }] });
+    await assert.rejects(
+      () =>
+        extractBusinessFactsFromUrl({
+          url: "https://acme.com/slow",
+          byokKey: "sk-ant-test",
+          firecrawlClient: firecrawl,
+          anthropicClient: client,
+        }),
+      (err: unknown) => err instanceof WebFetchError && err.reason === "fetch_blocked",
     );
   });
 

--- a/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
+++ b/packages/crm/tests/unit/web-onboarding/route-create-from-url.spec.ts
@@ -235,6 +235,23 @@ describe("runCreateFromUrl", () => {
     assert.match(text, /event: error\n.*"code":422.*"reason":"anthropic_unauthorized"/);
     assert.ok(!text.includes('"message"'), "non-extraction_failed reasons must not carry a message");
   });
+
+  // 2026-09-01 — persona-loop finding. fetch_blocked means the scrape never
+  // reached the page (network error, timeout, anti-bot block — e.g. a
+  // facebook.com business page, a common "website" for a solo trade
+  // business). Unlike extraction_failed/credits_exhausted, this is often
+  // transient, so the message must stay honest ("didn't load", not "we
+  // read that site") AND must NOT be tagged extraction_failed/
+  // credits_exhausted (both of which suppress the retry affordance on the
+  // /try client — see try-client.tsx's error branch).
+  test("fetch_blocked 422 carries an honest, retryable `message`", async () => {
+    const deps = { ...baseDeps(), extractBusinessFactsFromUrl: async () => { const e = new Error("Cloudflare challenge: status 403"); (e as any).reason = "fetch_blocked"; (e as any).name = "WebFetchError"; throw e; } };
+    const sse = await runCreateFromUrl({ deps, body: { url: "https://x.com" }, sessionUser: { id: "u1", primaryOrgId: "o1" } });
+    const text = await readAll(sse.stream);
+    assert.match(text, /event: error\n.*"code":422.*"reason":"fetch_blocked".*"message":"/);
+    assert.match(text, /didn't load/i, "the message must say the site didn't load, not that it lacked info");
+    assert.doesNotMatch(text, /we read that site/i, "must not falsely claim the site was read");
+  });
 });
 
 // 2026-06-23 — Deploy-CTA → instantiate-the-clicked-agent wiring. The


### PR DESCRIPTION
## Summary

**Persona:** HVAC business owner (Tuesday rotation) — non-technical, on a phone, skeptical, no real website of their own.

**Funnel step:** `/try` — the public, unauthenticated "paste a URL, watch it build" flow promised as "no signup required."

**Verbatim evidence:** live `GET https://www.seldonframe.com/api/v1/web/build/stream?url=https://www.facebook.com/exampleplumbingco` (a very common "website" for a solo trade business with no real site of their own):

```
event: fetching
data: {"url":"https://www.facebook.com/exampleplumbingco"}

event: error
data: {"code":422,"reason":"extraction_failed","message":"We read that site but couldn't find the basics we need — a business name, location, and phone number. Try a different URL, or describe your business instead."}
```

The scrape never actually reached the page (Firecrawl was blocked/threw — Facebook doesn't allow anonymous scraping) — but the error copy claims "We read that site," and the UI (`try-client.tsx`) hides the "Try again" button for `extraction_failed`, treating it as a permanent dead end. In reality a scrape block/timeout/rate-limit is often transient, unlike a genuinely info-less site.

**Root cause:** `markdown-extractor.ts`'s `!scrape.ok` branch collapsed every Firecrawl failure reason (`fetch_failed`, `timeout`, `rate_limited`, `empty_content`) into the same `WebFetchError("extraction_failed", ...)`, so a scrape that never happened got the exact same "we read it and it had nothing" treatment as a scrape that succeeded but genuinely found no phone/name/location. This directly undercuts the codebase's own established "honesty fix" pattern (see the 2026-07-14 extraction_failed and 2026-07-16 credits_exhausted fixes in the same files) — different failure causes need different, honest copy and different retry affordances.

**Fix (smallest honest fix, no architecture change):**
- Added a new `fetch_blocked` reason (`web-fetch-extractor.ts`) for scrape outcomes that mean the page was never reached (`fetch_failed` / `timeout` / `rate_limited`), separate from `extraction_failed` (page read, content genuinely insufficient) and `empty_content`.
- `markdown-extractor.ts` now throws `fetch_blocked` instead of `extraction_failed` for those three reasons.
- `run-create-from-url.ts` attaches an honest, retryable message for `fetch_blocked`: *"That site didn't load for us just now — it may be blocking automated visits, or it timed out. Try again in a moment."*
- No frontend changes needed: `try-client.tsx`'s error handler only special-cases `reason === "extraction_failed"` / `"credits_exhausted"` / `code === "rate_limited"`; anything else (now including `fetch_blocked`) already falls through to the generic error UI, which shows the server-provided message **and** the "Try again" button — exactly the behavior we want.
- Scoped to the URL-build path only (`markdown-extractor.ts` / `run-create-from-url.ts`, used by both `/try` and the authed `/clients/new`) — `paste-extractor.ts` (raw-text paste, no URL fetch) is untouched.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Related issue

N/A — found live via the nightly persona-loop routine, not a filed issue.

## Testing

- [x] Targeted unit tests (`node --import tsx --test`) — 29/29 pass, including 3 new tests covering the `fetch_blocked` branch and its honest/retryable message
- [x] `tsc -p tsconfig.json --noEmit` — 0 errors
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)
- [ ] Manually verified in the browser — not applicable, backend error-classification change only; verified live instead via the SSE endpoint (see evidence above)

## Screenshots / GIFs

N/A — no UI changes; the visible effect is a copy/behavior change in an existing error state (message text + retry button visibility), driven entirely by server-side reason classification.

## Notes for reviewers

- No env/schema changes.
- Did **not** touch pricing, positioning, or security-sensitive code (SSRF guard, auth, org-scoping) per persona-loop's hard rules.
- Did **not** attempt to wire a public anonymous "describe your business" build route — that's the pre-existing, deliberately-documented deviation in `try-client.tsx`'s file header (a larger architectural change, out of scope for a one-fix persona-loop PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01DkCjY1qxY7ay3YrN8DnPEy)_