### PR TITLE
persona-loop: /pricing leaks the homepage's own marketing title instead of a pricing one

### DIFF
--- a/packages/crm/src/app/pricing/page.tsx
+++ b/packages/crm/src/app/pricing/page.tsx
@@ -39,6 +39,7 @@
 // safety line (a standard Stripe subscription, cancelable from the
 // billing portal).
 
+import type { Metadata } from "next";
 import {
   Accordion,
   AccordionContent,
@@ -55,6 +56,25 @@ import { MarketingFooter } from "@/components/landing/marketing-footer";
 import { normalizePaidPlan } from "@/lib/auth/pricing-continuity";
 import { AnalyticsIdentityBridge } from "@/components/analytics/analytics-identity-bridge";
 import { AGENCY_PRICING_CLAIM, BUILDER_PRICING_CLAIM } from "@/lib/marketing/public-claims";
+
+// persona-loop finding (2026-09-02): this route had no metadata export, so
+// Next.js fell back to the root layout's <title>/OG tags — SeldonFrame's own
+// homepage copy ("Sell AI front offices. Deploy them in minutes.") — on the
+// one page whose entire purpose is answering "what does this cost me." Same
+// root cause already fixed for the booking and intake-form pages
+// (app/book/[orgSlug]/[bookingSlug]/page.tsx, app/forms/[id]/[formSlug]/
+// page.tsx) — mirrored here. Static export (not generateMetadata): this
+// page has no per-org dynamic content, so a fixed title/description covers
+// both SF_TIER_LADDER branches.
+export const metadata: Metadata = {
+  title: "Pricing — SeldonFrame",
+  description: `${BUILDER_PRICING_CLAIM} ${AGENCY_PRICING_CLAIM}`,
+  openGraph: {
+    title: "Pricing — SeldonFrame",
+    description: `${BUILDER_PRICING_CLAIM} ${AGENCY_PRICING_CLAIM}`,
+    type: "website",
+  },
+};
 
 // 2026-07-08 hydration-mismatch fix — "No price id lives in the client"
 // (the rule the legacy single card in pricing-shell.tsx already followed).


### PR DESCRIPTION
## Summary

`/pricing` — the live, anonymous-accessible marketing pricing page (`SF_TIER_LADDER` on in prod, confirmed via the `$29`/`$49`/`$99`/`$199`/`$299` tier prices present in the live HTML) — had no `metadata` export, so Next.js fell back to the root layout's homepage `<title>`/OG tags on the one page whose entire purpose is answering "what does this cost me."

## Persona

Med-spa owner (Wednesday in the persona-loop rotation). Non-technical, skeptical, price-sensitive, checking "what's the catch" before committing — the pricing page is exactly the surface this persona goes looking for.

## Funnel step

`https://www.seldonframe.com/` → nav "Pricing" link → `/pricing-public` (a separate, correctly-titled marketing deep-dive) → its "Compare all plans →" CTA → `https://www.seldonframe.com/pricing`.

## Verbatim evidence

```
$ curl -s https://www.seldonframe.com/pricing | grep -o '<title>[^<]*</title>'
<title>SeldonFrame — Sell AI front offices. Deploy them in minutes.</title>
```

That's the root layout's homepage title (`packages/crm/src/app/layout.tsx:49`), not anything about pricing — even though the page body itself correctly renders the Builder ($29), Managed ($49), and Agency ($99/$199/$299) tier cards. A visitor who bookmarks this page, shares the link with a business partner, or just glances at the browser tab sees SeldonFrame's own agency pitch instead of confirmation they're looking at pricing. It also means Google's search snippet and any social link-preview card for `/pricing` show the wrong title/description — a real (if quiet) SEO/trust cost on the page most likely to close a price-sensitive visitor.

## Root cause

`packages/crm/src/app/pricing/page.tsx` never exported `metadata` (confirmed: no `export const metadata` / `generateMetadata` anywhere in the file), so App Router falls through to `app/layout.tsx`'s hardcoded homepage title/description/OG tags. Same root cause the persona-loop already found and fixed for the booking page (`app/book/[orgSlug]/[bookingSlug]/page.tsx`, #148) and the public intake form (`app/forms/[id]/[formSlug]/page.tsx`, #201) — this is a third, previously-unreported instance of the same missing-metadata pattern, on a page those two PRs didn't touch.

## Fix

Added a static `export const metadata` (not `generateMetadata` — this route has no per-org dynamic content, so a fixed title/description is correct for both `SF_TIER_LADDER` branches) with title `"Pricing — SeldonFrame"` and a description built from the existing `BUILDER_PRICING_CLAIM`/`AGENCY_PRICING_CLAIM` constants in `lib/marketing/public-claims.ts` — reusing the site's single source of pricing truth rather than writing new copy. One file, 20 lines, additive only.

## Type of change

- [x] Bug fix

## Testing

- [x] Targeted unit tests: `node --import tsx --test tests/unit/landing/pricing-shell.spec.tsx tests/unit/landing/marketing-pricing.spec.ts` — 35/35 pass
- [x] `node_modules/.bin/tsc -p tsconfig.json --noEmit` — 0 `error TS` lines
- [x] `bash scripts/check-use-server.sh src` — pass
- [x] `node scripts/check-migrations-journaled.mjs` — pass (no migrations touched)
- [ ] Manually verified the change in the browser — not possible from this sandbox (no live preview deploy); verified instead by confirming the exact same fix pattern (PR #148) already shipped correctly for the sibling booking-page bug.

## Notes for reviewers

No test workspace, account, or payment was created for this finding — all evidence gathered via public `GET` requests to already-live pages (`/`, `/pricing-public`, `/pricing`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172yKAUZsHiWEJUhQi3CQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0172yKAUZsHiWEJUhQi3CQoj)_